### PR TITLE
DEMO: reading size and origin of view inside the inspector

### DIFF
--- a/Stitch/Graph/Node/Port/View/PortView.swift
+++ b/Stitch/Graph/Node/Port/View/PortView.swift
@@ -69,8 +69,13 @@ struct PortEntryView: View {
                 }
                 .background {
                     GeometryReader { geometry in
-//                        let frame = geometry.frame(in: .named(GraphBaseView.coordinateNamespace))
-                        let frame = geometry.frame(in: .named(NodesView.coordinateNameSpace))
+                        // if we use GraphBaseView coord-space, we start messed up -- but do we handle graph scroll well?
+                        // and what happens if we move a node?
+                        let frame = geometry.frame(in: .named(GraphBaseView.coordinateNamespace))
+                        
+                        // Starts out properly, but gets messed up after graph scroll or zoom
+                        // NOTE: moving a node DOES NOT mess up
+//                        let frame = geometry.frame(in: .named(NodesView.coordinateNameSpace))
                         let origin = frame.origin
                         logInView("PortEntryView: rowObserver.nodeIOType: \(rowObserver.nodeIOType)")
                         logInView("PortEntryView: frame: \(frame)")


### PR DESCRIPTION
looks promising?

## a node's PortEntryView and the inspector's view sharing same coordinate space 

compare e.g. the origin of the input and output on the Value node, vs the origin of the Rectangle ('TEXT') inside the inspector view; Value node's ports' origin.x are all smaller (i.e. to the west / left) of the Rectangle

node input origin = 325,127
node output origin = 544,127

inspector’s blue rectangle: 
* origin = 637,284
* size = 100x100

<img width="1063" alt="image" src="https://github.com/StitchDesign/Stitch/assets/18562836/ee44f24f-9bb4-4237-8121-9206e29245a2">


## inspector open

<img width="1440" alt="Screenshot 2024-06-16 at 1 25 42 PM" src="https://github.com/StitchDesign/Stitch/assets/18562836/0e6943c1-e874-45fa-a1d5-31e38424df78">

## inspector closed

<img width="1440" alt="Screenshot 2024-06-16 at 1 25 20 PM" src="https://github.com/StitchDesign/Stitch/assets/18562836/f5bcc9fc-f380-4f97-94f8-a57ce180f2ba">

