### PR TITLE
Select layer in sidebar to shows properties in inspector

### DIFF
--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -25,14 +25,20 @@ struct LayerInspectorView: View {
     // TODO: property sidebar changes when multiple sidebar layers are selected
     @MainActor
     var selectedLayerNode: NodeViewModel? {
-        guard let firstSidebarLayerId = graph.orderedSidebarLayers.first?.id else {
-            log("LayerInspectorView: No sidebar layers")
+        
+        guard !graph.orderedSidebarLayers.isEmpty else {
             return nil
         }
+     
+        // Take the last (most-recently) tapped sidebar layer; or the first non-selected layer.
+        let inspectedLayer = graph.sidebarSelectionState.nonEditModeSelections.last?.id ?? graph.orderedSidebarLayers.first?.id
         
-        guard let node = graph.getNodeViewModel(firstSidebarLayerId),
+        //selectedSidebarItems.last ?? graph.orderedSidebarLayers.first
+                
+        guard let inspectedLayerId = inspectedLayer,
+              let node = graph.getNodeViewModel(inspectedLayerId),
               node.layerNode.isDefined else {
-            log("LayerInspectorView: No node for sidebar layer id \(firstSidebarLayerId)")
+            log("LayerInspectorView: No node for sidebar layer \(inspectedLayer)")
             return nil
         }
         

--- a/Stitch/Graph/Sidebar/Model/Gesture/SidebarSelectionState.swift
+++ b/Stitch/Graph/Sidebar/Model/Gesture/SidebarSelectionState.swift
@@ -7,12 +7,18 @@
 
 import Foundation
 import StitchSchemaKit
+import OrderedCollections
 
+typealias OrderedLayerNodeIdSet = OrderedSet<LayerNodeId>
 typealias SidebarSelections = LayerIdSet
 typealias NonEmptySidebarSelections = NonEmptyLayerIdSet
 
 // if a group is selected,
 struct SidebarSelectionState: Codable, Equatable, Hashable {
+    
+    // For inspector, not layer-group creation etc.
+    var nonEditModeSelections = OrderedLayerNodeIdSet()
+    
     // items selected because directly clicked
     var primary = SidebarSelections()
 

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
@@ -8,7 +8,33 @@
 import Foundation
 import StitchSchemaKit
 import SwiftUI
+import OrderedCollections
 
+// Sidebar layer 'tapped' while not in
+struct SidebarItemTapped: GraphEvent {
+    
+    let id: LayerNodeId
+    
+    func handle(state: GraphState) {
+        let alreadySelected = state.sidebarSelectionState
+            .nonEditModeSelections.contains(id)
+    
+        // TODO: support multiple selections and filter property inspector appropriately
+        if alreadySelected {
+            state.sidebarSelectionState.nonEditModeSelections = .init()
+        } else {
+            state.sidebarSelectionState.nonEditModeSelections = .init([id])
+        }
+        
+        
+        // TODO: better: allow multiple selections via cmd+click, not single click
+//        if alreadySelected {
+//            state.sidebarSelectionState.nonEditModeSelections.remove(id)
+//        } else {
+//            state.sidebarSelectionState.nonEditModeSelections.append(id)
+//        }
+    }
+}
 
 // group or top level
 struct SidebarItemSelected: GraphEvent {

--- a/Stitch/Graph/Sidebar/Util/SidebarListItemGroupActions.swift
+++ b/Stitch/Graph/Sidebar/Util/SidebarListItemGroupActions.swift
@@ -27,18 +27,38 @@ extension GraphState {
             }
         }
     }
+    
+    // for non-edit-mode selections
+    func deselectDescendantsOfClosedGroup(_ closedParentId: LayerNodeId) {
+        
+        // Remove any non-edit-mode selected children; we don't want the 'selected sidebar layer' to be hidden
+        let closedParent = retrieveItem(closedParentId.asItemId,
+                                        self.sidebarListState.masterList.items)
+        
+        let descendants = getDescendants(closedParent,
+                                         self.sidebarListState.masterList.items)
+        
+        for childen in descendants {
+            self.sidebarSelectionState.nonEditModeSelections.remove(childen.id.asLayerNodeId)
+        }
+    }
 }
+
+
 
 struct SidebarListItemGroupClosed: GraphEventWithResponse {
 
-    let closedParent: LayerNodeId
+    let closedParentId: LayerNodeId
     
     func handle(state: GraphState) -> GraphResponse {
 
         var expanded = state.getSidebarExpandedItems()
         
+        // Remove any non-edit-mode selected children; we don't want the 'selected sidebar layer' to be hidden
+        state.deselectDescendantsOfClosedGroup(closedParentId)
+                        
         state.sidebarListState.masterList = onSidebarListItemGroupClosed(
-            closedId: closedParent.asItemId,
+            closedId: closedParentId.asItemId,
             state.sidebarListState.masterList)
         
         //        // also need to remove id from sidebar's expandedSet

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemChevronView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemChevronView.swift
@@ -39,7 +39,7 @@ struct SidebarListItemChevronView: View {
                 if isClosed {
                     dispatch(SidebarListItemGroupOpened(openedParent: parentId))
                 } else {
-                    dispatch(SidebarListItemGroupClosed(closedParent: parentId))
+                    dispatch(SidebarListItemGroupClosed(closedParentId: parentId))
                 }
             }
             .animation(.linear, value: rotationZ)

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemView.swift
@@ -32,6 +32,14 @@ struct SidebarListItemView: View {
         proposedGroup?.parentId == item.id
     }
 
+    var layerNodeId: LayerNodeId {
+        item.id.asLayerNodeId
+    }
+    
+    var isNonEditModeSelected: Bool {
+        graph.sidebarSelectionState.nonEditModeSelections.contains(layerNodeId)
+    }
+        
     var body: some View {
 
         HStack {
@@ -39,7 +47,7 @@ struct SidebarListItemView: View {
                 graph: graph,
                 name: name,
                 layer: layer,
-                nodeId: item.id.asLayerNodeId,
+                nodeId: layerNodeId,
                 selection: selection,
                 isHidden: isHidden,
                 isBeingEdited: isBeingEdited)
@@ -49,7 +57,10 @@ struct SidebarListItemView: View {
 
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(.ultraThinMaterial.opacity(isBeingDragged ? 1 : 0))        
+        .background(Color.white.opacity(0.001)) // for hit area
+        .background(.ultraThinMaterial.opacity(isBeingDragged ? 1 : 0))
+        .background(.thinMaterial.opacity(isNonEditModeSelected ? 1 : 0))
+        
         //        #if DEV_DEBUG
         //        .background(.blue.opacity(0.5)) // DEBUG
         //        #endif
@@ -59,7 +70,7 @@ struct SidebarListItemView: View {
         // we need to place the SwiftUI TapGesture below the swipe menu.
         .gesture(TapGesture().onEnded({ _ in
             if !isBeingEdited {
-                dispatch(JumpToNodeOnGraph(id: item.id.id))
+                dispatch(SidebarItemTapped(id: layerNodeId))
             }
         }))
         

--- a/Stitch/Graph/Sidebar/View/iPadProjectSidebarView.swift
+++ b/Stitch/Graph/Sidebar/View/iPadProjectSidebarView.swift
@@ -34,9 +34,9 @@ struct ProjectSidebarView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: .zero) {
-
+            
             // Catalyst only
-            #if targetEnvironment(macCatalyst)
+#if targetEnvironment(macCatalyst)
             VStack {
                 HStack(spacing: .zero) {
                     // Padding HStack
@@ -48,38 +48,36 @@ struct ProjectSidebarView: View {
                     .padding([.top, .horizontal])
                 }
             }
-//            .padding(.bottom)
+            //            .padding(.bottom)
             .background(SIDEBAR_BODY_COLOR.ignoresSafeArea())
             // Higher z-index here for scroll view
             .zIndex(2)
-            #endif
+#endif
             
             SidebarListView(graph: graph,
                             isBeingEdited: isEditing,
                             syncStatus: syncStatus)
-//#if !targetEnvironment(macCatalyst)
-//            .padding(.top)
-//#endif
+            //#if !targetEnvironment(macCatalyst)
+            //            .padding(.top)
+            //#endif
             .zIndex(1)
         }
         .background(SIDEBAR_BODY_COLOR.ignoresSafeArea())
-
+        
         // Needed so that sidebar-footer does not rise up when iPad full keyboard on-screen
         .edgesIgnoringSafeArea(.bottom)
-
+        
         // iPad only
         // TODO: why is .navigationTitle ignored on Catalyst?
-        #if !targetEnvironment(macCatalyst)
+#if !targetEnvironment(macCatalyst)
         .navigationTitle("Stitch")
         .toolbar {
-        SidebarEditButtonView(isEditing: $isEditing)
+            SidebarEditButtonView(isEditing: $isEditing)
         }
         .toolbarBackground(.visible, for: .automatic)
-        #endif
-        .onChange(of: self.isEditing) { oldValue, newValue in
-            if !newValue {
-                graph.sidebarSelectionState = .init()
-            }
+#endif
+        .onChange(of: self.isEditing) { _, newValue in
+            dispatch(SidebarEditModeToggled(isEditing: newValue))
         }
     }
 
@@ -88,5 +86,19 @@ struct ProjectSidebarView: View {
             .font(.largeTitle)
             .bold()
 
+    }
+}
+
+struct SidebarEditModeToggled: GraphEvent {
+    let isEditing: Bool
+    
+    func handle(state: GraphState) {
+        if isEditing {
+            state.sidebarSelectionState.nonEditModeSelections = .init()
+        }
+        
+        if !isEditing {
+            state.sidebarSelectionState = .init()
+        }
     }
 }


### PR DESCRIPTION
Note: this is "non-edit-mode selection"; resets when sidebar edit mode toggled on.

Currently only allow a single layer in sidebar to be selected at a time. TODO: allow multiple selections and filter properties inspector appropriately.

Note the important behavior of removing a selection if we collapsed its layer group.

https://github.com/StitchDesign/Stitch/assets/18562836/79c7c27f-7e5b-499d-92b8-af3c3178f909

