### PR TITLE
Use shorter layer input labels in property sidebar

### DIFF
--- a/Stitch/App/LLMRecording/LLMActions/LLMActionUtil.swift
+++ b/Stitch/App/LLMRecording/LLMActions/LLMActionUtil.swift
@@ -133,7 +133,7 @@ extension NodeIOCoordinate {
         
             // If we have a LayerNode input, use that label
         case .keyPath(let x):
-            return x.label
+            return x.label()
             
             // If we have a PatchNode input/output, or LayerNode output,
             // try to find the label per node definitions

--- a/Stitch/Graph/Node/Model/Definition/NodeDefinition.swift
+++ b/Stitch/Graph/Node/Model/Definition/NodeDefinition.swift
@@ -46,7 +46,6 @@ protocol LayerNodeDefinition: NodeDefinition {
     
     static var inputDefinitions: LayerInputTypeSet { get }
     
-    
     @MainActor
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Model/Definition/NodeInfo.swift
+++ b/Stitch/Graph/Node/Model/Definition/NodeInfo.swift
@@ -70,6 +70,7 @@ extension NodeInfo {
 struct NodeInputDefinition: Encodable {
     var defaultValues: PortValues
     let label: String
+//    var shortLabel: String? = nil // for property sidebar
     var isTypeStatic = false
     
     // Specifically for layers

--- a/Stitch/Graph/Node/Model/Definition/NodeRowDefinitions.swift
+++ b/Stitch/Graph/Node/Model/Definition/NodeRowDefinitions.swift
@@ -42,7 +42,7 @@ extension NodeRowDefinitions {
          layer: Layer) {
         let inputs = layerInputs.map { layerInput in
             NodeInputDefinition(defaultValues: [layerInput.getDefaultValue(for: layer)],
-                                label: layerInput.label,
+                                label: layerInput.label(),
                                 layerInputType: layerInput)
         }
         

--- a/Stitch/Graph/Node/Model/Definition/NodeRowLegacyDefinitions.swift
+++ b/Stitch/Graph/Node/Model/Definition/NodeRowLegacyDefinitions.swift
@@ -1509,7 +1509,7 @@ extension NodeKind {
                         ),
                         .init(
                             defaultValues: [.number(0)],
-                            label: LayerInputType.position.label
+                            label: LayerInputType.position.label()
                         ),
                         .init(
                             defaultValues: [.number(0)],
@@ -1817,7 +1817,7 @@ extension NodeKind {
                     inputs: [
                         .init(
                             defaultValues: [.position(StitchPosition.zero)],
-                            label: LayerInputType.position.label
+                            label: LayerInputType.position.label()
                         ),
                         .init(
                             defaultValues: [.number(10)],
@@ -1837,11 +1837,11 @@ extension NodeKind {
                     inputs: [
                         .init(
                             defaultValues: [.position(CGRect.defaultOval.origin.toCGSize)],
-                            label: LayerInputType.position.label
+                            label: LayerInputType.position.label()
                         ),
                         .init(
                             defaultValues: [.size(CGRect.defaultOval.size.toLayerSize)],
-                            label: LayerInputType.size.label
+                            label: LayerInputType.size.label()
                         )
                     ],
                     outputs: [
@@ -1857,11 +1857,11 @@ extension NodeKind {
                     inputs: [
                         .init(
                             defaultValues: [.position(CGRect.defaultRoundedRectangle.rect.origin.toCGSize)],
-                            label: LayerInputType.position.label
+                            label: LayerInputType.position.label()
                         ),
                         .init(
                             defaultValues: [.size(CGRect.defaultRoundedRectangle.rect.size.toLayerSize)],
-                            label: LayerInputType.size.label
+                            label: LayerInputType.size.label()
                         ),
                         .init(
                             defaultValues: [.number(CGRect.defaultRoundedRectangle.cornerRadius)],
@@ -1934,7 +1934,7 @@ extension NodeKind {
                             type: .string
                         ),
                         .init(
-                            label: LayerInputType.size.label,
+                            label: LayerInputType.size.label(),
                             type: .size
                         )
                     ]
@@ -1986,7 +1986,7 @@ extension NodeKind {
                             type: .bool
                         ),
                         .init(
-                            label: LayerInputType.position.label,
+                            label: LayerInputType.position.label(),
                             type: .position
                         ),
                         .init(
@@ -2019,7 +2019,7 @@ extension NodeKind {
                         ),
                         .init(
                             defaultValues: [.position(StitchPosition.zero)],
-                            label: LayerInputType.position.label
+                            label: LayerInputType.position.label()
                         ),
                         .init(
                             defaultValues: [.number(0)],
@@ -2035,7 +2035,7 @@ extension NodeKind {
                         ),
                         .init(
                             defaultValues: [.size(defaultTextSize)],
-                            label: LayerInputType.size.label
+                            label: LayerInputType.size.label()
                         ),
                         .init(
                             defaultValues: [defaultOpacity],
@@ -2043,15 +2043,15 @@ extension NodeKind {
                         ),
                         .init(
                             defaultValues: [.number(1)],
-                            label: LayerInputType.scale.label
+                            label: LayerInputType.scale.label()
                         ),
                         .init(
                             defaultValues: [.anchoring(.defaultAnchoring)],
-                            label: LayerInputType.anchoring.label
+                            label: LayerInputType.anchoring.label()
                         ),
                         .init(
                             defaultValues: [.number(0)],
-                            label: LayerInputType.zIndex.label
+                            label: LayerInputType.zIndex.label()
                         ),
                         .init(
                             defaultValues: [.number(36)],
@@ -2099,7 +2099,7 @@ extension NodeKind {
                         ),
                         .init(
                             defaultValues: [.position(StitchPosition.zero)],
-                            label: LayerInputType.position.label
+                            label: LayerInputType.position.label()
                         ),
                         .init(
                             defaultValues: [.number(0)],
@@ -2115,7 +2115,7 @@ extension NodeKind {
                         ),
                         .init(
                             defaultValues: [.size(defaultTextSize)],
-                            label: LayerInputType.size.label
+                            label: LayerInputType.size.label()
                         ),
                         .init(
                             defaultValues: [defaultOpacity],
@@ -2123,15 +2123,15 @@ extension NodeKind {
                         ),
                         .init(
                             defaultValues: [.number(1)],
-                            label: LayerInputType.scale.label
+                            label: LayerInputType.scale.label()
                         ),
                         .init(
                             defaultValues: [.anchoring(.defaultAnchoring)],
-                            label: LayerInputType.anchoring.label
+                            label: LayerInputType.anchoring.label()
                         ),
                         .init(
                             defaultValues: [.number(0)],
-                            label: LayerInputType.zIndex.label
+                            label: LayerInputType.zIndex.label()
                         ),
                         .init(
                             defaultValues: [.number(36)],
@@ -2177,7 +2177,7 @@ extension NodeKind {
                         ),
                         .init(
                             defaultValues: [.position(StitchPosition.zero)],
-                            label: LayerInputType.position.label
+                            label: LayerInputType.position.label()
                         ),
                         .init(
                             defaultValues: [.number(0)],
@@ -2193,7 +2193,7 @@ extension NodeKind {
                         ),
                         .init(
                             defaultValues: [.size(.LAYER_DEFAULT_SIZE)],
-                            label: LayerInputType.size.label
+                            label: LayerInputType.size.label()
                         ),
                         .init(
                             defaultValues: [defaultOpacity],
@@ -2201,15 +2201,15 @@ extension NodeKind {
                         ),
                         .init(
                             defaultValues: [.number(1)],
-                            label: LayerInputType.scale.label
+                            label: LayerInputType.scale.label()
                         ),
                         .init(
                             defaultValues: [.anchoring(.defaultAnchoring)],
-                            label: LayerInputType.anchoring.label
+                            label: LayerInputType.anchoring.label()
                         ),
                         .init(
                             defaultValues: [.number(0)],
-                            label: LayerInputType.zIndex.label
+                            label: LayerInputType.zIndex.label()
                         ),
                         .init(
                             defaultValues: [.layerStroke(.defaultStroke)],
@@ -2240,15 +2240,15 @@ extension NodeKind {
                     inputs: [
                         .init(
                             defaultValues: [.position(StitchPosition.zero)],
-                            label: LayerInputType.position.label
+                            label: LayerInputType.position.label()
                         ),
                         .init(
                             defaultValues: [.size(DEFAULT_GROUP_SIZE)],
-                            label: LayerInputType.size.label
+                            label: LayerInputType.size.label()
                         ),
                         .init(
                             defaultValues: [.number(0)],
-                            label: LayerInputType.zIndex.label
+                            label: LayerInputType.zIndex.label()
                         ),
                         .init(
                             defaultValues: [.bool(true)],
@@ -2256,11 +2256,11 @@ extension NodeKind {
                         ),
                         .init(
                             defaultValues: [.number(1)],
-                            label: LayerInputType.scale.label
+                            label: LayerInputType.scale.label()
                         ),
                         .init(
                             defaultValues: [.anchoring(.defaultAnchoring)],
-                            label: LayerInputType.anchoring.label
+                            label: LayerInputType.anchoring.label()
                         ),
                         .init(
                             defaultValues: [.number(0)],
@@ -2335,11 +2335,11 @@ extension NodeKind {
                         ),
                         .init(
                             defaultValues: [.position(StitchPosition.zero)],
-                            label: LayerInputType.position.label
+                            label: LayerInputType.position.label()
                         ),
                         .init(
                             defaultValues: [.size(defaultHitAreaSize)],
-                            label: LayerInputType.size.label
+                            label: LayerInputType.size.label()
                         ),
                         .init(
                             defaultValues: [.anchoring(.defaultAnchoring)],
@@ -2347,7 +2347,7 @@ extension NodeKind {
                         ),
                         .init(
                             defaultValues: [.number(0)],
-                            label: LayerInputType.zIndex.label
+                            label: LayerInputType.zIndex.label()
                         ),
                         .init(
                             defaultValues: [.bool(true)],

--- a/Stitch/Graph/Node/Model/RowData/LayerInputType.swift
+++ b/Stitch/Graph/Node/Model/RowData/LayerInputType.swift
@@ -950,7 +950,11 @@ extension LayerInputType {
         }
     }
     
-    var label: String {
+//    var label: String {
+    
+    // shortLabel = used for property sidebar
+    func label(_ useShortLabel: Bool = false) -> String {
+//    func label(_ useShortLabel: Bool) -> String {
         switch self {
             // Required everywhere
         case .position:
@@ -1030,20 +1034,19 @@ extension LayerInputType {
             return "Shape"
             
         case .strokePosition:
-            return "Stroke Position"
+            return useShortLabel ? "Position" : "Stroke Position"
         case .strokeWidth:
-            return "Stroke Width"
+            return useShortLabel ? "Width" : "Stroke Width"
         case .strokeColor:
-            return "Stroke Color"
+            return useShortLabel ? "Color" : "Stroke Color"
         case .strokeStart:
-            return "Stroke Start"
+            return useShortLabel ? "Start" : "Stroke Start"
         case .strokeEnd:
-            return "Stroke End"
+            return useShortLabel ? "End" : "Stroke End"
         case .strokeLineCap:
-            return "Stroke Line Cap"
+            return useShortLabel ? "Line Cap" : "Stroke Line Cap"
         case .strokeLineJoin:
-            return "Stroke Line Join"
-            
+            return useShortLabel ? "Line Join" : "Stroke Line Join"
         case .coordinateSystem:
             return "Coordinate System"
 
@@ -1103,13 +1106,13 @@ extension LayerInputType {
             return "End Radius"
             
         case .shadowColor:
-            return "Shadow Color"
+            return useShortLabel ? "Color" : "Shadow Color"
         case .shadowOpacity:
-            return "Shadow Opacity"
+            return useShortLabel ? "Opacity" : "Shadow Opacity"
         case .shadowRadius:
-            return "Shadow Radius"
+            return useShortLabel ? "Radius" : "Shadow Radius"
         case .shadowOffset:
-            return "Shadow Offset"
+            return useShortLabel ? "Offset" : "Shadow Offset"
         case .sfSymbol:
             return "SF Symbol"
             

--- a/Stitch/Graph/Node/Patch/Type/Interaction/DragInteractionPatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/DragInteractionPatchNode.swift
@@ -50,7 +50,7 @@ struct DragInteractionNode: PatchNodeDefinition {
             ],
             outputs: [
                 .init(
-                    label: LayerInputType.position.label,
+                    label: LayerInputType.position.label(),
                     type: .position
                 ),
                 .init(

--- a/Stitch/Graph/Node/Patch/Type/Interaction/PressInteractionPatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/PressInteractionPatchNode.swift
@@ -42,7 +42,7 @@ struct PressInteractionNode: PatchNodeDefinition {
                     type: .pulse
                 ),
                 .init(
-                    label: LayerInputType.position.label,
+                    label: LayerInputType.position.label(),
                     type: .position
                 ),
                 .init(

--- a/Stitch/Graph/Node/Patch/Type/Interaction/Scroll/ScrollInteractionNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/Scroll/ScrollInteractionNode.swift
@@ -127,7 +127,7 @@ struct ScrollInteractionNode: PatchNodeDefinition {
             ],
             outputs: [
                 .init(
-                    label: LayerInputType.position.label,
+                    label: LayerInputType.position.label(),
                     type: .position
                 )
             ]

--- a/Stitch/Graph/Node/Patch/Type/Math/MathExpressionNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Math/MathExpressionNode.swift
@@ -28,7 +28,7 @@ struct MathExpressionPatchNode: PatchNodeDefinition {
 @MainActor
 func mathExpressionEval(node: PatchNode) -> EvalResult {
  
-    let labels = node.getRowObservers(.input).map { $0.label }
+    let labels = node.getRowObservers(.input).map { $0.label() }
     
     guard let patchNode = node.patchNode,
           let formula = patchNode.mathExpression else {

--- a/Stitch/Graph/Node/Patch/Type/Media/CameraFeedNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Media/CameraFeedNode.swift
@@ -71,7 +71,7 @@ struct CameraFeedPatchNode: PatchNodeDefinition {
                     type: .media
                 ),
                 .init(
-                    label: LayerInputType.size.label,
+                    label: LayerInputType.size.label(),
                     type: .size
                 )
             ]

--- a/Stitch/Graph/Node/Patch/Type/Shape/LayerInfoNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Shape/LayerInfoNode.swift
@@ -36,15 +36,15 @@ struct LayerInfoPatchNode: PatchNodeDefinition {
                     type: .bool
                 ),
                 .init(
-                    label: LayerInputType.position.label,
+                    label: LayerInputType.position.label(),
                     type: .position
                 ),
                 .init(
-                    label: LayerInputType.size.label,
+                    label: LayerInputType.size.label(),
                     type: .size
                 ),
                 .init(
-                    label: LayerInputType.scale.label,
+                    label: LayerInputType.scale.label(),
                     type: .number
                 ),
                 .init(
@@ -52,11 +52,11 @@ struct LayerInfoPatchNode: PatchNodeDefinition {
                     type: .anchoring
                 ),
                 .init(
-                    label: LayerInputType.opacity.label,
+                    label: LayerInputType.opacity.label(),
                     type: .number
                 ),
                 .init(
-                    label: LayerInputType.zIndex.label,
+                    label: LayerInputType.zIndex.label(),
                     type: .number
                 ),
                 .init(

--- a/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
+++ b/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
@@ -28,7 +28,7 @@ struct NodeInputOutputView: View {
 
     @MainActor
     var label: String {
-        self.rowData.label
+        self.rowData.label(forLayerProperty)
     }
 
     var isSplitter: Bool {

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
@@ -139,7 +139,7 @@ extension NodeRowObserver {
     }
     
     @MainActor
-    var label: String {
+    func label(_ useShortLabel: Bool = false) -> String {
         switch id.portType {
         case .portIndex(let portId):
             if self.nodeIOType == .input,
@@ -159,7 +159,7 @@ extension NodeRowObserver {
             : rowDefinitions.outputs[safe: portId]?.label ?? ""
             
         case .keyPath(let keyPath):
-            return keyPath.label
+            return keyPath.label(useShortLabel)
         }
     }
     

--- a/Stitch/Graph/Sidebar/Util/SidebarListItemGroupActions.swift
+++ b/Stitch/Graph/Sidebar/Util/SidebarListItemGroupActions.swift
@@ -44,8 +44,6 @@ extension GraphState {
     }
 }
 
-
-
 struct SidebarListItemGroupClosed: GraphEventWithResponse {
 
     let closedParentId: LayerNodeId


### PR DESCRIPTION
Compare e.g. layer's shadow inputs' labels 

<img width="1231" alt="Screenshot 2024-06-18 at 11 27 42 AM" src="https://github.com/StitchDesign/Stitch/assets/18562836/49d2aa5f-e8e4-43bb-85d9-110591d7b9c9">
