### PR TITLE
Do not displace graph canvas when inspector opened

### DIFF
--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -52,11 +52,17 @@ struct LayerInspectorView: View {
             UIKitWrapper(ignoresKeyCommands: false,
                          name: "LayerInspectorView") {
                 selectedLayerView(node, layerNode)
-                    .frame(idealHeight: .infinity)
+//                    .frame(idealHeight: .infinity)
             }
+
+            // TODO: need UIKitWrapper to detect keypresses; alternatively, place UIKitWrapper on the sections themselves?
             // Takes care of the mysterious white top padding UIKitWrapper introduces
-            // TODO: compare on various iPads (using simulator?); -40 seems perfect for Catalyst
+            #if targetEnvironment(macCatalyst)
                          .padding(.top, -40)
+            #else
+                         .padding(.top, -60)
+                         .padding(.bottom, -20)
+            #endif
             
 //            selectedLayerView(node, layerNode)
 //                .onAppear {

--- a/Stitch/Graph/View/GraphBaseView.swift
+++ b/Stitch/Graph/View/GraphBaseView.swift
@@ -92,48 +92,16 @@ struct GraphBaseView: View {
         } // GraphGestureView
     }
 
-    //    var nodesMap: some View {
-    //        if let rect = graphState.graphBounds(
-    //            graphUI.zoom,
-    //            graphView: graphUI.frame,
-    //            graphOffset: graphUI.graphMovement.graphOffset.localPosition,
-    //            groupNodeFocused: graphUI.groupNodeFocused) {
-    //
-    //            return Rectangle().fill(.cyan.opacity(0.5))
-    //                .frame(width: rect.width + 0,
-    //                       height: rect.height + 0)
-    //                // places view in top-left corner of parent, and offsets from there;
-    //                // we use .position since the individual nodes use .position
-    //                .position(rect.origin)
-    //                // places view in center of parent, and offsets from there
-    //                //            .offset(rect.origin)
-    //                .eraseToAnyView()
-    //        } else {
-    //            return EmptyView().eraseToAnyView()
-    //        }
-    //    }
-
     @ViewBuilder
     @MainActor
     var nodesAndCursor: some View {
-        ZStack(alignment: .top) {
+        ZStack {
             #if DEV_DEBUG
             // Use `ZStack { ...` instead of `ZStack(alignment: .top) { ...`
             // to get in exact screen center.
             Circle().fill(.cyan.opacity(0.5))
                 .frame(width: 60, height: 60)
             #endif
-
-            // Temporarily removed; may be added back in future.
-            //                #if DEV_DEBUG
-            //                GridTilingView(scale: zoom,
-            //                               offset: localPosition,
-            //                               tileLength: graphUI.gridImageLength,
-            //                               graphUIFrame: graphUI.frame)
-            //                    .opacity(zoom)
-            //                    .zIndex(-1)
-            //                //                .hidden(zoom < GRID_SCALE_MINIMUM)
-            //                #endif
 
             nodesView
 
@@ -150,13 +118,16 @@ struct GraphBaseView: View {
             // To cover top safe area that we don't ignore on iPad and that is gesture-inaccessbile
             Stitch.APP_BACKGROUND_COLOR
                 .edgesIgnoringSafeArea(.all).zIndex(-10)
-
-        } // Zstack
-        .inspector(isPresented: FeatureFlags.USE_LAYER_INSPECTOR ? $graphUI.showsLayerInspector : .constant(false)) {
-            LayerInspectorView(graph: graph)
-            // TODO: setting an inspector width DOES move over the graph view content
-                .inspectorColumnWidth(LayerInspectorView.LAYER_INSPECTOR_WIDTH)
-        }
+            
+            // IMPORTANT: applying .inspector outside of this ZStack causes displacement of graph contents when graph zoom != 1
+            Circle().fill(Stitch.APP_BACKGROUND_COLOR.opacity(0.001))
+                .frame(width: 1, height: 1)
+                .inspector(isPresented: FeatureFlags.USE_LAYER_INSPECTOR ? $graphUI.showsLayerInspector : .constant(false)) {
+                    LayerInspectorView(graph: graph)
+                    // TODO: setting an inspector width DOES move over the graph view content
+                        .inspectorColumnWidth(LayerInspectorView.LAYER_INSPECTOR_WIDTH)
+                }
+        } // ZStack
         .coordinateSpace(name: Self.coordinateNamespace)
         .background {
             GeometryReader { geometry in


### PR DESCRIPTION
Caused problems with insert node animation.

Also, nodes moved to left if we were zoomed out; to the right if we were zoomed in. 



## before


https://github.com/StitchDesign/Stitch/assets/18562836/f4b6eabe-40fb-4ef4-8870-a075d1fcaa20



## after


https://github.com/StitchDesign/Stitch/assets/18562836/7613c4d7-acb1-4b62-9c62-3792edda8ec7


