### PR TITLE
Use light gray border around color circles

### DIFF
--- a/Stitch/Graph/Node/Port/View/Field/ValueButton/ColorOrbValueButtonView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/ValueButton/ColorOrbValueButtonView.swift
@@ -22,7 +22,7 @@ struct ColorOrbValueButtonView: View {
     let currentColor: Color // the current color, from input
     let hasIncomingEdge: Bool
     let graph: GraphState
-
+    
     var body: some View {
 
         // logInView("ColorOrbValueButtonView: body: currentColor.asHexDisplay: \(currentColor.asHexDisplay)")
@@ -46,11 +46,12 @@ struct ColorOrbValueButtonView: View {
             }
         }
 
-        StitchColorPickerView(coordinate: id, chosenColor: binding, 
+        StitchColorPickerView(coordinate: id, 
+                              chosenColor: binding,
                               graph: graph)
-            .onAppear {
-                self.colorState = currentColor
-            }
+        .onAppear {
+            self.colorState = currentColor
+        }
             //            .id(self.viewId)
             // ^^ this might be happening too late?
             // better to set via `.init` ?

--- a/Stitch/Graph/Node/Port/View/Field/ValueButton/StitchColorPicker/StitchColorPickerView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/ValueButton/StitchColorPicker/StitchColorPickerView.swift
@@ -8,6 +8,20 @@
 import SwiftUI
 import StitchSchemaKit
 
+let COLOR_ORB_WRAPPING_COLOR = Color(uiColor: UIColor.systemGray3)
+
+struct ColorOrbWrapperModifier: ViewModifier {
+    
+    func body(content: Content) -> some View {
+        content
+            .padding(2)
+            .background {
+//                Circle().fill(.white) // original
+                Circle().fill(COLOR_ORB_WRAPPING_COLOR)
+            }
+    }
+}
+
 struct StitchColorPickerOrb: View {
 
     let chosenColor: Color
@@ -16,10 +30,7 @@ struct StitchColorPickerOrb: View {
         Circle().fill(chosenColor)
             .frame(width: NODE_ROW_HEIGHT, // req'd for e.g. ports that have labels
                    height: NODE_ROW_HEIGHT)
-            .padding(2)
-            .background {
-                Circle().fill(.white)
-            }
+            .modifier(ColorOrbWrapperModifier())
     }
 }
 
@@ -202,6 +213,7 @@ struct StitchColorPickerView: View {
         Circle().fill(color)
             //            .stroke(.black)
             .frame(width: 50)
+            .modifier(ColorOrbWrapperModifier())
             .onTapGesture {
 
                 // When user manually clicks a pre-selected color,
@@ -248,8 +260,16 @@ struct StitchColorPickerView: View {
 }
 
 #Preview {
-    StitchColorPickerView(coordinate: .fakeInputCoordinate,
-                          chosenColor: .constant(.red),
-                          graph: .init(id: .init(), store: nil))
-        .scaleEffect(2)
+    
+    VStack(spacing: 100) {
+        
+        StitchColorPickerOrb(chosenColor: .green)
+            .scaleEffect(2)
+        
+        StitchColorPickerView(coordinate: .fakeInputCoordinate,
+                              chosenColor: .constant(.red),
+                              graph: .init(id: .init(), store: nil))
+            .scaleEffect(2)
+    }
+    
 }


### PR DESCRIPTION
... so that white color does not get lost on light mode; was noticeable especially on light mode property sidebar. 


![IMG_2652](https://github.com/StitchDesign/Stitch/assets/18562836/d9727d77-420a-4228-8272-95a2e13b5c97)
![IMG_2653](https://github.com/StitchDesign/Stitch/assets/18562836/0ba8c072-6386-4b3a-9c48-9bcc9190c79f)
