### PR TITLE
LayerGroup padding and spacing; deselect property when its row added to canvas

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -410,6 +410,7 @@
 		EC3A6C472C20C27300CCBACC /* NodeRowObserverSchemaObserverIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC3A6C462C20C27300CCBACC /* NodeRowObserverSchemaObserverIdentifiable.swift */; };
 		EC3A6C492C20C2A400CCBACC /* NodeRowObserverExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC3A6C482C20C2A400CCBACC /* NodeRowObserverExtensions.swift */; };
 		EC3A6C4B2C20C4FD00CCBACC /* NodeRowObserverCachedViewDataExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC3A6C4A2C20C4FD00CCBACC /* NodeRowObserverCachedViewDataExtensions.swift */; };
+		EC3B27D82C34495A00865843 /* PreviewLayersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC3B27D72C34495A00865843 /* PreviewLayersView.swift */; };
 		EC3BAABE299D83190047EFF7 /* StitchRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC3BAABD299D83190047EFF7 /* StitchRootView.swift */; };
 		EC4081252C0114060047989F /* StitchCustomURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC4081242C0114060047989F /* StitchCustomURL.swift */; };
 		EC4081272C014CD70047989F /* StitchRootModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC4081262C014CD70047989F /* StitchRootModifier.swift */; };
@@ -1303,6 +1304,7 @@
 		EC3A6C462C20C27300CCBACC /* NodeRowObserverSchemaObserverIdentifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeRowObserverSchemaObserverIdentifiable.swift; sourceTree = "<group>"; };
 		EC3A6C482C20C2A400CCBACC /* NodeRowObserverExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeRowObserverExtensions.swift; sourceTree = "<group>"; };
 		EC3A6C4A2C20C4FD00CCBACC /* NodeRowObserverCachedViewDataExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeRowObserverCachedViewDataExtensions.swift; sourceTree = "<group>"; };
+		EC3B27D72C34495A00865843 /* PreviewLayersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewLayersView.swift; sourceTree = "<group>"; };
 		EC3BAABD299D83190047EFF7 /* StitchRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StitchRootView.swift; sourceTree = "<group>"; };
 		EC4081242C0114060047989F /* StitchCustomURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StitchCustomURL.swift; sourceTree = "<group>"; };
 		EC4081262C014CD70047989F /* StitchRootModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StitchRootModifier.swift; sourceTree = "<group>"; };
@@ -3486,6 +3488,7 @@
 			isa = PBXGroup;
 			children = (
 				B59660A62C1A52D500BE75D7 /* PreviewLayerView.swift */,
+				EC3B27D72C34495A00865843 /* PreviewLayersView.swift */,
 				EC0957DB27208C1200B4027F /* GeneratePreview.swift */,
 				B55500E32C1BABBC0081C3F1 /* CommonModifier */,
 				B55500DA2C1BA96D0081C3F1 /* Type */,
@@ -5044,6 +5047,7 @@
 				EC0957DC27208C1200B4027F /* GeneratePreview.swift in Sources */,
 				EC4081292C014E310047989F /* VersionedURL.swift in Sources */,
 				EC22972D268D337900E6DC8D /* MicrophoneFeedNode.swift in Sources */,
+				EC3B27D82C34495A00865843 /* PreviewLayersView.swift in Sources */,
 				B56FFB3C2C18F3C700623CC7 /* StitchFileError.swift in Sources */,
 				ECB90B7629689A8300CF2F45 /* BouncyConverterUtils.swift in Sources */,
 				B539C2E62B92BDA900C6CEC3 /* CameraFeedActor.swift in Sources */,

--- a/Stitch/Graph/LayerInspector/LayerInspectorActions.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorActions.swift
@@ -78,6 +78,8 @@ extension GraphState {
             parentGroupNodeId: self.groupNodeFocused,
             nodeDelegate: node)
         
+        self.graphUI.propertySidebar.selectedProperties = nil
+        
         self.maybeCreateLLMAddLayerInput(nodeId, coordinate)
     }
 }
@@ -102,7 +104,7 @@ struct LayerOutputAddedToGraph: GraphEventWithResponse {
         state.layerOutputAddedToGraph(node: node,
                                       output: output,
                                       portId: coordinate.portId)
-        
+                
         return .shouldPersist
     }
 }
@@ -123,20 +125,20 @@ extension GraphState {
             parentGroupNodeId: self.groupNodeFocused,
             nodeDelegate: node)
         
+        self.graphUI.propertySidebar.selectedProperties = nil
+        
         self.maybeCreateLLMAddLayerOutput(node.id, portId)
     }
 }
 
 extension GraphUIState {
     func layerPropertyTapped(_ property: LayerInspectorRowId) {
-        let alreadySelected = self.propertySidebar.selectedProperties.contains(property)
+        let alreadySelected = self.propertySidebar.selectedProperties == property
                 
         if alreadySelected {
-//            self.propertySidebar.selectedProperties.remove(property)
-            self.propertySidebar.selectedProperties = .init()
+            self.propertySidebar.selectedProperties = nil
         } else {
-//            self.propertySidebar.selectedProperties.insert(property)
-            self.propertySidebar.selectedProperties = .init([property])
+            self.propertySidebar.selectedProperties = property
         }
     }
 }

--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -21,8 +21,7 @@ struct LayerInspectorPortView: View {
     // Is this property-row selected?
     @MainActor
     var propertyRowIsSelected: Bool {
-        graph.graphUI.propertySidebar
-            .selectedProperties.contains(layerProperty)
+        graph.graphUI.propertySidebar.selectedProperties == layerProperty
     }
     
     var isOnGraphAlready: Bool {

--- a/Stitch/Graph/LayerInspector/LayerInspectorState.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorState.swift
@@ -17,11 +17,9 @@ enum LayerInspectorRowId: Equatable, Hashable {
 typealias LayerInspectorRowIdSet = Set<LayerInspectorRowId>
 
 struct PropertySidebarState: Equatable {
-    // Which rows in the property sidebar are currently selected
-    var selectedProperties = LayerInspectorRowIdSet()
+    var selectedProperties: LayerInspectorRowId?
 }
 
-// MARK: each one of these corresponds to a section
 extension LayerInspectorView {
     // TODO: fill these out
         

--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -186,7 +186,9 @@ struct LayerInspectorInputsSectionView: View {
                 withAnimation {
                     self.expanded.toggle()
                     layerInputs.forEach {
-                        graph.graphUI.propertySidebar.selectedProperties.remove(.layerInput($0))
+                        if graph.graphUI.propertySidebar.selectedProperties == .layerInput($0) {
+                            graph.graphUI.propertySidebar.selectedProperties = nil
+                        }
                     }
                 }
             }

--- a/Stitch/Graph/Node/Layer/Type/GroupLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/GroupLayerNode.swift
@@ -107,7 +107,10 @@ struct GroupLayerNode: LayerNodeDefinition {
             opacity: viewModel.opacity.getNumber ?? 1,
             pivot: viewModel.pivot.getAnchoring ?? .defaultPivot,
             orientation: viewModel.orientation.getOrientation ?? .defaultOrientation,
-            padding: viewModel.padding.asCGFloat,
+            
+            // TODO: update once StitchPadding is saved in schema
+            padding: .init(viewModel.padding.asCGFloat),
+            
             cornerRadius: viewModel.cornerRadius.getNumber ?? .zero,
             blurRadius: viewModel.blur.getNumber ?? .zero,
             blendMode: viewModel.blendMode.getBlendMode ?? .defaultBlendMode,

--- a/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
@@ -7,9 +7,52 @@
 
 import SwiftUI
 
+
+// TODO: combine with Point4D ? Or will the names `x, y, z, w` be too unfamiliar vers `top`, `bottom` etc.; e.g. does `x` refer to `left` or `right`?
+struct StitchPadding: Equatable, Hashable, Codable {
+    var top: CGFloat = .zero
+    var bottom: CGFloat = .zero
+    var left: CGFloat = .zero
+    var right: CGFloat = .zero
+}
+
+extension StitchPadding {
+    init(_ number: CGFloat) {
+        self.top = number
+        self.bottom = number
+        self.left = number
+        self.right = number
+    }
+}
+                            
+                            
+enum StitchSpacing: Equatable, Hashable, Codable {
+    case point(CGFloat), evenly, between
+    
+    static let defaultStitchSpacing: Self = .point(.zero)
+    
+    var isEvenly: Bool {
+        self == .evenly
+    }
+    
+    var isBetween: Bool {
+        self == .between
+    }
+    
+    // TODO: how to handle `evenly` and `between` spacing in adaptive grid?
+    var asPointSpacing: CGFloat {
+        switch self {
+        case .evenly, .between:
+            return .zero
+        case .point(let x):
+            return x
+        }
+    }
+}
+
 struct PreviewGridData: Equatable {
-    var horizontalSpacingBetweenColumns: CGFloat = 0.0
-    var verticalSpacingBetweenRows: CGFloat = 0.0
+    var horizontalSpacingBetweenColumns: StitchSpacing = .defaultStitchSpacing
+    var verticalSpacingBetweenRows: StitchSpacing = .defaultStitchSpacing
     
     var alignmentOfItemWithinGridCell: Alignment = .center
     

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonModifierWithoutFrame.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonModifierWithoutFrame.swift
@@ -83,7 +83,7 @@ struct PreviewCommonModifierWithoutFrame: ViewModifier {
         // should be BEFORE .scale, .position, .offset and .rotation, so that border can be affected by those changes; but AFTER layer-effects, so that e.g. masking or blur does
             .modifier(PreviewSidebarHighlightModifier(
                 nodeId: interactiveLayer.id.layerNodeId,
-                highlightedSidebarLayers: graph.graphUI.highlightedSidebbarLayers,
+                highlightedSidebarLayers: graph.graphUI.highlightedSidebarLayers,
                 scale: scale))
 
             .modifier(PreviewLayerRotationModifier(

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
@@ -11,12 +11,18 @@ import StitchSchemaKit
 extension LayerViewModel {
     var getGridData: PreviewGridData? {
         guard self.layer == .group else {
+            fatalErrorIfDebug()
             return nil
         }
         
+        // TODO: update when StitchSpacing is added as a PortValue in schema
+        let horizontalSpacingBetweenColumns = self.spacingBetweenGridColumns.getNumber.map { StitchSpacing.point($0) } ?? .defaultStitchSpacing
+        
+        let verticalSpacingBetweenRows = self.spacingBetweenGridRows.getNumber.map { StitchSpacing.point($0) } ?? .defaultStitchSpacing
+        
         return .init(
-            horizontalSpacingBetweenColumns: self.spacingBetweenGridColumns.getNumber ?? .zero,
-            verticalSpacingBetweenRows: self.spacingBetweenGridRows.getNumber ?? .zero,
+            horizontalSpacingBetweenColumns: horizontalSpacingBetweenColumns,
+            verticalSpacingBetweenRows: verticalSpacingBetweenRows,
             alignmentOfItemWithinGridCell: (self.itemAlignmentWithinGridCell.getAnchoring ?? .centerCenter).toAlignment
         )
     }
@@ -48,7 +54,7 @@ struct PreviewGroupLayer: View {
     let pivot: Anchoring
 
     let orientation: StitchOrientation
-    let padding: CGFloat
+    let padding: StitchPadding
     
     let cornerRadius: CGFloat
     let blurRadius: CGFloat
@@ -115,7 +121,7 @@ struct PreviewGroupLayer: View {
         
             .modifier(PreviewSidebarHighlightModifier(
                 nodeId: interactiveLayer.id.layerNodeId,
-                highlightedSidebarLayers: graph.graphUI.highlightedSidebbarLayers,
+                highlightedSidebarLayers: graph.graphUI.highlightedSidebarLayers,
                 scale: scale))
                 
             .modifier(PreviewLayerRotationModifier(
@@ -156,7 +162,7 @@ struct PreviewGroupLayer: View {
                           parentSize: _size,
                           parentId: interactiveLayer.id.layerNodeId,
                           parentOrientation: orientation,
-                          parentOrientationPadding: padding,
+                          parentPadding: padding,
                           parentCornerRadius: cornerRadius,
                           // i.e. if this view (a LayerGroup) uses .hug, then its children will not use their own .position values.
                           parentUsesHug: usesHug,

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewShapeLayer.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewShapeLayer.swift
@@ -74,7 +74,7 @@ struct PreviewShapeLayer: View {
                 .opacity(opacity)
                 .modifier(PreviewSidebarHighlightModifier(
                     nodeId: interactiveLayer.id.layerNodeId,
-                    highlightedSidebarLayers: graph.graphUI.highlightedSidebbarLayers,
+                    highlightedSidebarLayers: graph.graphUI.highlightedSidebarLayers,
                     scale: scale))
             // order of .blur vs other modiifers doesn't matter?
                 .blur(radius: blurRadius)
@@ -107,7 +107,7 @@ struct PreviewShapeLayer: View {
                 .opacity(opacity)
                 .modifier(PreviewSidebarHighlightModifier(
                     nodeId: interactiveLayer.id.layerNodeId,
-                    highlightedSidebarLayers: graph.graphUI.highlightedSidebbarLayers,
+                    highlightedSidebarLayers: graph.graphUI.highlightedSidebarLayers,
                     scale: scale))
                 .modifier(PreviewCommonModifierWithoutFrame(
                     graph: graph,

--- a/Stitch/Graph/Sidebar/Util/Gesture/SidebarListItemActions.swift
+++ b/Stitch/Graph/Sidebar/Util/Gesture/SidebarListItemActions.swift
@@ -12,7 +12,7 @@ struct SidebarLayerHovered: GraphUIEvent {
     let layer: LayerNodeId
     
     func handle(state: GraphUIState) {
-        state.highlightedSidebbarLayers.insert(layer)
+        state.highlightedSidebarLayers.insert(layer)
     }
 }
 
@@ -20,7 +20,7 @@ struct SidebarLayerHoverEnded: GraphUIEvent {
     let layer: LayerNodeId
     
     func handle(state: GraphUIState) {
-        state.highlightedSidebbarLayers.remove(layer)
+        state.highlightedSidebarLayers.remove(layer)
     }
 }
 

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -40,7 +40,7 @@ final class GraphUIState {
     var lastMomentumRunTime: TimeInterval = .zero
     
     // e.g. user is hovering over or has selected a layer in the sidebar, which we then highlight in the preview window itself
-    var highlightedSidebbarLayers: LayerIdSet = .init()
+    var highlightedSidebarLayers: LayerIdSet = .init()
 
     var edgeEditingState: EdgeEditingState?
 


### PR DESCRIPTION
Demo of padding. Spacing (px vs evenly vs between) can be shown properly when schema's PortValue is updated.


https://github.com/StitchDesign/Stitch/assets/18562836/7bd36218-b039-45d6-8d23-50b4ca73df54

