### PR TITLE
Vertically stack fields in LayerInspector

### DIFF
--- a/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
@@ -50,10 +50,29 @@ struct NodeFieldsView: View {
     }
     
     var body: some View {
+        // Only non-nil for ShapeCommands i.e. `lineTo`, `curveTo` etc. ?
         if let groupLabel = label {
             StitchTextView(string: groupLabel)
         }
-
+        
+        fieldsStack
+    }
+    
+    @ViewBuilder
+    var fieldsStack: some View {
+        if forPropertySidebar {
+            VStack {
+                fields
+            }
+        } else {
+            if let groupLabel = label {
+                StitchTextView(string: groupLabel)
+            }
+            fields
+        }
+    }
+    
+    var fields: some View {
         ForEach(fieldGroupViewModel.fieldObservers) { (fieldViewModel: FieldViewModel) in
             self.valueEntryView(fieldViewModel)
         }

--- a/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
+++ b/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
@@ -51,7 +51,8 @@ struct NodeInputOutputView: View {
 
     var body: some View {
         let coordinate = rowData.id
-        HStack(spacing: NODE_COMMON_SPACING) {
+//        HStack(spacing: NODE_COMMON_SPACING) {
+        HStack(alignment: .firstTextBaseline, spacing: NODE_COMMON_SPACING) {
             if forPropertySidebar {
                 Image(systemName: "plus.circle")
                     .resizable()
@@ -83,6 +84,12 @@ struct NodeInputOutputView: View {
                 }
                 
                 labelView
+                
+                // TODO: fields in layer-inspector flush with right screen edge?
+                //                if forPropertySidebar {
+                //                    Spacer()
+                //                }
+                
                 inputOutputRow(coordinate: coordinate)
 
             case .output(let outputCoordinate):
@@ -90,6 +97,9 @@ struct NodeInputOutputView: View {
                 // Property sidebar always shows labels on left side, never right
                 if forPropertySidebar {
                     labelView
+                    
+                    // TODO: fields in layer-inspector flush with right screen edge?
+                    //                    Spacer()
                 }
                 
                 // Hide outputs for value node
@@ -107,7 +117,13 @@ struct NodeInputOutputView: View {
                 }
             }
         }
-        .frame(height: NODE_ROW_HEIGHT)
+//        .frame(height: NODE_ROW_HEIGHT)
+        
+        // Don't specify height for layer inspector property row, so that multifields can be shown vertically
+        .frame(height: forPropertySidebar ? nil : NODE_ROW_HEIGHT)
+        
+        .padding([.top, .bottom], forPropertySidebar ? 8 : 0)
+        
         .onChange(of: self.graphUI.activeIndex) {
             let oldViewValue = self.rowData.activeValue
             let newViewValue = self.rowData.getActiveValue(activeIndex: self.graphUI.activeIndex)

--- a/Stitch/Graph/Node/Port/ViewModel/FieldGroupTypeViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/FieldGroupTypeViewModel.swift
@@ -15,6 +15,7 @@ final class FieldGroupTypeViewModel: ObservableObject {
     let type: FieldGroupType
     @Published var fieldObservers: FieldViewModels
 
+    // Only used for ShapeCommand cases? e.g. `.curveTo` has "PointTo", "CurveFrom" etc. 'groups of fields'
     let groupLabel: String?
 
     // Since this could be one of many in a node's row


### PR DESCRIPTION
Some of this UI will be revised when packed vs unpacked multifields work is in, but it's a decent start.

<img width="1440" alt="Screenshot 2024-07-08 at 9 00 10 AM" src="https://github.com/StitchDesign/Stitch/assets/18562836/b07ec152-f938-4717-8166-a41ff1e0b9ca">
<img width="1440" alt="Screenshot 2024-07-08 at 9 00 04 AM" src="https://github.com/StitchDesign/Stitch/assets/18562836/f59ebfe8-f4c0-4d87-9a79-242192173958">
