### PR TITLE
Property sidebar: conditional display for sizing scenarios; proper LayerGroup padding

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -685,6 +685,7 @@
 		ECB9A86D2AEB4944006E65EE /* LightnessSliderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECB9A86C2AEB4944006E65EE /* LightnessSliderView.swift */; };
 		ECB9A86F2AEB4950006E65EE /* AlphaSliderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECB9A86E2AEB4950006E65EE /* AlphaSliderView.swift */; };
 		ECBB853F25E9BA5500C1EE40 /* PreviewText.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBB853E25E9BA5500C1EE40 /* PreviewText.swift */; };
+		ECBC61A92C3E049500A6EBF0 /* StitchSchemaKit in Resources */ = {isa = PBXBuildFile; fileRef = ECBC61A82C3E049500A6EBF0 /* StitchSchemaKit */; };
 		ECBC95FB27613D9200508966 /* evalTests+2.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBC95FA27613D9200508966 /* evalTests+2.swift */; };
 		ECBD32FD2988A31E00C778BE /* ImpureEvaluation.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBD32FC2988A31E00C778BE /* ImpureEvaluation.swift */; };
 		ECBD32FF2988A36F00C778BE /* PureEvaluation.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBD32FE2988A36F00C778BE /* PureEvaluation.swift */; };
@@ -1580,6 +1581,7 @@
 		ECB9A86C2AEB4944006E65EE /* LightnessSliderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightnessSliderView.swift; sourceTree = "<group>"; };
 		ECB9A86E2AEB4950006E65EE /* AlphaSliderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlphaSliderView.swift; sourceTree = "<group>"; };
 		ECBB853E25E9BA5500C1EE40 /* PreviewText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewText.swift; sourceTree = "<group>"; };
+		ECBC61A82C3E049500A6EBF0 /* StitchSchemaKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = StitchSchemaKit; path = ../../../StitchSchemaKit; sourceTree = "<group>"; };
 		ECBC95FA27613D9200508966 /* evalTests+2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "evalTests+2.swift"; sourceTree = "<group>"; };
 		ECBD32FC2988A31E00C778BE /* ImpureEvaluation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImpureEvaluation.swift; sourceTree = "<group>"; };
 		ECBD32FE2988A36F00C778BE /* PureEvaluation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PureEvaluation.swift; sourceTree = "<group>"; };
@@ -1825,6 +1827,7 @@
 			children = (
 				EC15E425260271C6006F2E08 /* Stitch.entitlements */,
 				200BD863254F66EE00692903 /* Info.plist */,
+				ECBC61A82C3E049500A6EBF0 /* StitchSchemaKit */,
 				B5617A7B2C175C3C00B53DAF /* App */,
 				ECB33C5926F12F5E0069885B /* Home */,
 				B56FFB522C195EA000623CC7 /* Graph */,
@@ -4371,6 +4374,7 @@
 				200BD85F254F66EE00692903 /* Assets.xcassets in Resources */,
 				ECB15BA72695FCC700A1E1DA /* pj_eating.mov in Resources */,
 				EC7ADBFE2683EC9D00A8B318 /* fur_elise.mp3 in Resources */,
+				ECBC61A92C3E049500A6EBF0 /* StitchSchemaKit in Resources */,
 				E416861228A3FC9600731889 /* Vintage Toy Robot.usdz in Resources */,
 				EC7ADBFF2683EC9D00A8B318 /* fur_elise.m4a in Resources */,
 				ECB15BA52695F8D100A1E1DA /* gracie_short.mov in Resources */,

--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -685,7 +685,6 @@
 		ECB9A86D2AEB4944006E65EE /* LightnessSliderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECB9A86C2AEB4944006E65EE /* LightnessSliderView.swift */; };
 		ECB9A86F2AEB4950006E65EE /* AlphaSliderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECB9A86E2AEB4950006E65EE /* AlphaSliderView.swift */; };
 		ECBB853F25E9BA5500C1EE40 /* PreviewText.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBB853E25E9BA5500C1EE40 /* PreviewText.swift */; };
-		ECBC61AB2C3E0C2A00A6EBF0 /* StitchSchemaKit in Resources */ = {isa = PBXBuildFile; fileRef = ECBC61AA2C3E0C2A00A6EBF0 /* StitchSchemaKit */; };
 		ECBC95FB27613D9200508966 /* evalTests+2.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBC95FA27613D9200508966 /* evalTests+2.swift */; };
 		ECBD32FD2988A31E00C778BE /* ImpureEvaluation.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBD32FC2988A31E00C778BE /* ImpureEvaluation.swift */; };
 		ECBD32FF2988A36F00C778BE /* PureEvaluation.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBD32FE2988A36F00C778BE /* PureEvaluation.swift */; };
@@ -1581,7 +1580,6 @@
 		ECB9A86C2AEB4944006E65EE /* LightnessSliderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightnessSliderView.swift; sourceTree = "<group>"; };
 		ECB9A86E2AEB4950006E65EE /* AlphaSliderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlphaSliderView.swift; sourceTree = "<group>"; };
 		ECBB853E25E9BA5500C1EE40 /* PreviewText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewText.swift; sourceTree = "<group>"; };
-		ECBC61AA2C3E0C2A00A6EBF0 /* StitchSchemaKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = StitchSchemaKit; path = ../../../StitchSchemaKit; sourceTree = "<group>"; };
 		ECBC95FA27613D9200508966 /* evalTests+2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "evalTests+2.swift"; sourceTree = "<group>"; };
 		ECBD32FC2988A31E00C778BE /* ImpureEvaluation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImpureEvaluation.swift; sourceTree = "<group>"; };
 		ECBD32FE2988A36F00C778BE /* PureEvaluation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PureEvaluation.swift; sourceTree = "<group>"; };
@@ -1827,7 +1825,6 @@
 			children = (
 				EC15E425260271C6006F2E08 /* Stitch.entitlements */,
 				200BD863254F66EE00692903 /* Info.plist */,
-				ECBC61AA2C3E0C2A00A6EBF0 /* StitchSchemaKit */,
 				B5617A7B2C175C3C00B53DAF /* App */,
 				ECB33C5926F12F5E0069885B /* Home */,
 				B56FFB522C195EA000623CC7 /* Graph */,
@@ -4374,7 +4371,6 @@
 				200BD85F254F66EE00692903 /* Assets.xcassets in Resources */,
 				ECB15BA72695FCC700A1E1DA /* pj_eating.mov in Resources */,
 				EC7ADBFE2683EC9D00A8B318 /* fur_elise.mp3 in Resources */,
-				ECBC61AB2C3E0C2A00A6EBF0 /* StitchSchemaKit in Resources */,
 				E416861228A3FC9600731889 /* Vintage Toy Robot.usdz in Resources */,
 				EC7ADBFF2683EC9D00A8B318 /* fur_elise.m4a in Resources */,
 				ECB15BA52695F8D100A1E1DA /* gracie_short.mov in Resources */,
@@ -5943,7 +5939,7 @@
 			repositoryURL = "https://github.com/StitchDesign/StitchSchemaKit.git";
 			requirement = {
 				kind = exactVersion;
-				version = 19.0.0;
+				version = 20.0.0;
 			};
 		};
 		B50F416C2C1EB4830082262F /* XCRemoteSwiftPackageReference "StitchEngine" */ = {

--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -685,7 +685,7 @@
 		ECB9A86D2AEB4944006E65EE /* LightnessSliderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECB9A86C2AEB4944006E65EE /* LightnessSliderView.swift */; };
 		ECB9A86F2AEB4950006E65EE /* AlphaSliderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECB9A86E2AEB4950006E65EE /* AlphaSliderView.swift */; };
 		ECBB853F25E9BA5500C1EE40 /* PreviewText.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBB853E25E9BA5500C1EE40 /* PreviewText.swift */; };
-		ECBC61A92C3E049500A6EBF0 /* StitchSchemaKit in Resources */ = {isa = PBXBuildFile; fileRef = ECBC61A82C3E049500A6EBF0 /* StitchSchemaKit */; };
+		ECBC61AB2C3E0C2A00A6EBF0 /* StitchSchemaKit in Resources */ = {isa = PBXBuildFile; fileRef = ECBC61AA2C3E0C2A00A6EBF0 /* StitchSchemaKit */; };
 		ECBC95FB27613D9200508966 /* evalTests+2.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBC95FA27613D9200508966 /* evalTests+2.swift */; };
 		ECBD32FD2988A31E00C778BE /* ImpureEvaluation.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBD32FC2988A31E00C778BE /* ImpureEvaluation.swift */; };
 		ECBD32FF2988A36F00C778BE /* PureEvaluation.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBD32FE2988A36F00C778BE /* PureEvaluation.swift */; };
@@ -1581,7 +1581,7 @@
 		ECB9A86C2AEB4944006E65EE /* LightnessSliderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightnessSliderView.swift; sourceTree = "<group>"; };
 		ECB9A86E2AEB4950006E65EE /* AlphaSliderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlphaSliderView.swift; sourceTree = "<group>"; };
 		ECBB853E25E9BA5500C1EE40 /* PreviewText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewText.swift; sourceTree = "<group>"; };
-		ECBC61A82C3E049500A6EBF0 /* StitchSchemaKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = StitchSchemaKit; path = ../../../StitchSchemaKit; sourceTree = "<group>"; };
+		ECBC61AA2C3E0C2A00A6EBF0 /* StitchSchemaKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = StitchSchemaKit; path = ../../../StitchSchemaKit; sourceTree = "<group>"; };
 		ECBC95FA27613D9200508966 /* evalTests+2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "evalTests+2.swift"; sourceTree = "<group>"; };
 		ECBD32FC2988A31E00C778BE /* ImpureEvaluation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImpureEvaluation.swift; sourceTree = "<group>"; };
 		ECBD32FE2988A36F00C778BE /* PureEvaluation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PureEvaluation.swift; sourceTree = "<group>"; };
@@ -1827,7 +1827,7 @@
 			children = (
 				EC15E425260271C6006F2E08 /* Stitch.entitlements */,
 				200BD863254F66EE00692903 /* Info.plist */,
-				ECBC61A82C3E049500A6EBF0 /* StitchSchemaKit */,
+				ECBC61AA2C3E0C2A00A6EBF0 /* StitchSchemaKit */,
 				B5617A7B2C175C3C00B53DAF /* App */,
 				ECB33C5926F12F5E0069885B /* Home */,
 				B56FFB522C195EA000623CC7 /* Graph */,
@@ -4374,7 +4374,7 @@
 				200BD85F254F66EE00692903 /* Assets.xcassets in Resources */,
 				ECB15BA72695FCC700A1E1DA /* pj_eating.mov in Resources */,
 				EC7ADBFE2683EC9D00A8B318 /* fur_elise.mp3 in Resources */,
-				ECBC61A92C3E049500A6EBF0 /* StitchSchemaKit in Resources */,
+				ECBC61AB2C3E0C2A00A6EBF0 /* StitchSchemaKit in Resources */,
 				E416861228A3FC9600731889 /* Vintage Toy Robot.usdz in Resources */,
 				EC7ADBFF2683EC9D00A8B318 /* fur_elise.m4a in Resources */,
 				ECB15BA52695F8D100A1E1DA /* gracie_short.mov in Resources */,

--- a/Stitch/Graph/LayerInspector/LayerInspectorState.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorState.swift
@@ -26,6 +26,8 @@ extension LayerInspectorView {
     // TODO: better?: make the LayerInputTypeSet enum CaseIterable and have the enum ordering as the source of truth for this order
     @MainActor
     static let allInputs: LayerInputTypeSet = Self.required
+        .union(Self.positioning)
+        .union(Self.sizing)
         .union(Self.common)
         .union(Self.groupLayer)
         .union(Self.unknown)
@@ -38,22 +40,34 @@ extension LayerInspectorView {
     
     @MainActor
     static let required: LayerInputTypeSet = [
-        .position,
-        .size,
         .scale,
-        .anchoring,
         .opacity,
-        .zIndex,
         .pivot, // pivot point for scaling; put with
+    ]
+    
+    @MainActor
+    static let positioning: LayerInputTypeSet = [
+        .position,
+        .anchoring,
+        .zIndex,
+        // .offset // TO BE ADED
+    ]
+    
+    @MainActor
+    static let sizing: LayerInputTypeSet = [
         
-            // Min and max size
-            .minSize,
-        .maxSize,
-        
-            // Aspect Ratio
+        // .sizingScenario // TO BE ADDED
+
+        // Aspect Ratio
         .widthAxis,
         .heightAxis,
-        .contentMode
+        .contentMode, // Don't show?
+
+        .size,
+
+            // Min and max size
+        .minSize,
+        .maxSize,
     ]
     
     // Includes some
@@ -129,15 +143,18 @@ extension LayerInspectorView {
     static let groupLayer: LayerInputTypeSet = [
         .backgroundColor, // actually for many layers?
         .isClipped,
+        
         .orientation,
+        
         .padding,
         .spacing, // added
+        
         // Grid
         .spacingBetweenGridColumns,
         .spacingBetweenGridRows,
         .itemAlignmentWithinGridCell
     ]
-     
+    
     // TODO: what are these inputs?
     @MainActor
     static let unknown: LayerInputTypeSet = [

--- a/Stitch/Graph/LayerInspector/LayerInspectorState.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorState.swift
@@ -56,7 +56,7 @@ extension LayerInspectorView {
     @MainActor
     static let sizing: LayerInputTypeSet = [
         
-        // .sizingScenario // TO BE ADDED
+        .sizingScenario,
 
         // Aspect Ratio
         .widthAxis,
@@ -100,7 +100,6 @@ extension LayerInspectorView {
         .video,
         .model3D,
         .fitStyle,
-        
         
         // Progress Indicator
         .progressIndicatorStyle,

--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -106,23 +106,6 @@ struct LayerInspectorView: View {
             // TODO: remove?
             Text(node.displayTitle).font(.title2)
             
-//            Menu {
-//                ForEach(SizingScenario.allCases, id: \.self) {
-//                    sizingScenario in
-////                    Button(sizingScenario.rawValue)
-//                    Button {
-//                        graph.sizingScenarioUpdated(
-//                            layerId: node.id,
-//                            scenario: sizingScenario)
-//                    } label: {
-//                        Text(sizingScenario.rawValue)
-//                    }
-//
-//                }
-//            } label: {
-//                Text(                layerNode.previewLayerViewModels.first?.sizingScenario.rawValue ?? "None")
-//            }
-            
             section("Required", Self.required)
             
             section("Sizing", Self.sizing)

--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -182,10 +182,17 @@ struct LayerInspectorInputsSectionView: View {
         
         Section(isExpanded: $expanded) {
             ForEach(layerInputs) { layerInput in
-                if inputsList.contains(layerInput) {
+                
+                let inputListContainsInput = inputsList.contains(layerInput)
+                
+                let rowObserver = layerNode[keyPath: layerInput.layerNodeKeyPath]
+                
+                let allFieldsBlockedOut = rowObserver.fieldValueTypes.first?.fieldObservers.allSatisfy(\.isBlockedOut) ?? false
+                
+                if inputsList.contains(layerInput) && !allFieldsBlockedOut {
                     LayerInspectorPortView(
                         layerProperty: .layerInput(LayerInputOnGraphId(node: node.id, keyPath: layerInput)),
-                        rowObserver: layerNode[keyPath: layerInput.layerNodeKeyPath],
+                        rowObserver: rowObserver,
                         node: node,
                         layerNode: layerNode,
                         graph: graph)

--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -106,22 +106,22 @@ struct LayerInspectorView: View {
             // TODO: remove?
             Text(node.displayTitle).font(.title2)
             
-            Menu {
-                ForEach(SizingScenario.allCases, id: \.self) {
-                    sizingScenario in
-//                    Button(sizingScenario.rawValue)
-                    Button {
-                        graph.sizingScenarioUpdated(
-                            layerId: node.id,
-                            scenario: sizingScenario)
-                    } label: {
-                        Text(sizingScenario.rawValue)
-                    }
-
-                }
-            } label: {
-                Text(                layerNode.previewLayerViewModels.first?.sizingScenario.rawValue ?? "None")
-            }
+//            Menu {
+//                ForEach(SizingScenario.allCases, id: \.self) {
+//                    sizingScenario in
+////                    Button(sizingScenario.rawValue)
+//                    Button {
+//                        graph.sizingScenarioUpdated(
+//                            layerId: node.id,
+//                            scenario: sizingScenario)
+//                    } label: {
+//                        Text(sizingScenario.rawValue)
+//                    }
+//
+//                }
+//            } label: {
+//                Text(                layerNode.previewLayerViewModels.first?.sizingScenario.rawValue ?? "None")
+//            }
             
             section("Required", Self.required)
             

--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -64,24 +64,24 @@ struct LayerInspectorView: View {
                          .padding(.bottom, -20)
             #endif
             
-                         .onAppear {
-#if DEV_DEBUG
-                             let listedLayers = Self.required
-                                 .union(Self.common)
-                                 .union(Self.groupLayer)
-                                 .union(Self.unknown)
-                                 .union(Self.text)
-                                 .union(Self.stroke)
-                                 .union(Self.rotation)
-                                 .union(Self.shadow)
-                                 .union(Self.effects)
-                             
-                             let allLayers = LayerInputType.allCases.toSet
-                             let diff = allLayers.subtracting(listedLayers)
-                             log("diff: \(diff)")
-                             assert(diff.count == 0)
-#endif
-                         }
+//                         .onAppear {
+//#if DEV_DEBUG
+//                             let listedLayers = Self.required
+//                                 .union(Self.common)
+//                                 .union(Self.groupLayer)
+//                                 .union(Self.unknown)
+//                                 .union(Self.text)
+//                                 .union(Self.stroke)
+//                                 .union(Self.rotation)
+//                                 .union(Self.shadow)
+//                                 .union(Self.effects)
+//                             
+//                             let allLayers = LayerInputType.allCases.toSet
+//                             let diff = allLayers.subtracting(listedLayers)
+//                             log("diff: \(diff)")
+//                             assert(diff.count == 0)
+//#endif
+//                         }
         } else {
             // Empty List, so have same background
             List { }
@@ -106,7 +106,29 @@ struct LayerInspectorView: View {
             // TODO: remove?
             Text(node.displayTitle).font(.title2)
             
+            Menu {
+                ForEach(SizingScenario.allCases, id: \.self) {
+                    sizingScenario in
+//                    Button(sizingScenario.rawValue)
+                    Button {
+                        graph.sizingScenarioUpdated(
+                            layerId: node.id,
+                            scenario: sizingScenario)
+                    } label: {
+                        Text(sizingScenario.rawValue)
+                    }
+
+                }
+            } label: {
+                Text(                layerNode.previewLayerViewModels.first?.sizingScenario.rawValue ?? "None")
+            }
+            
             section("Required", Self.required)
+            
+            section("Sizing", Self.sizing)
+            
+            section("Positioning", Self.positioning)
+            
             section("Common", Self.common)
             
             if layerNode.layer.supportsGroupInputs {

--- a/Stitch/Graph/Node/Layer/Type/3DModelLayerNode/Model3DLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/3DModelLayerNode/Model3DLayerNode.swift
@@ -55,7 +55,7 @@ struct Model3DLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.minAndMaxSize)
+        .union(.sizing)
 
         static func createEphemeralObserver() -> NodeEphemeralObservable? {
         MediaEvalOpObserver()

--- a/Stitch/Graph/Node/Layer/Type/AngularGradientNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/AngularGradientNode.swift
@@ -29,7 +29,7 @@ struct AngularGradientLayerNode: LayerNodeDefinition {
     ])
         .union(.layerEffects)
         .union(.aspectRatio)
-        .union(.minAndMaxSize)
+        .union(.sizing)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/CanvasSketchLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/CanvasSketchLayerNode.swift
@@ -43,7 +43,7 @@ struct CanvasSketchLayerNode: LayerNodeDefinition {
         .union(.strokeInputs)
         .union(.layerEffects)
         .union(.aspectRatio)
-        .union(.minAndMaxSize)
+        .union(.sizing)
 
         static func createEphemeralObserver() -> NodeEphemeralObservable? {
         MediaEvalOpObserver()

--- a/Stitch/Graph/Node/Layer/Type/ColorFillLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/ColorFillLayerNode.swift
@@ -25,7 +25,7 @@ struct ColorFillLayerNode: LayerNodeDefinition {
     ])
         .union(.layerEffects)
         .union(.aspectRatio)
-        .union(.minAndMaxSize)
+        .union(.sizing)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/GroupLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/GroupLayerNode.swift
@@ -103,9 +103,7 @@ struct GroupLayerNode: LayerNodeDefinition {
             opacity: viewModel.opacity.getNumber ?? 1,
             pivot: viewModel.pivot.getAnchoring ?? .defaultPivot,
             orientation: viewModel.orientation.getOrientation ?? .defaultOrientation,
-            
-            // TODO: update once StitchPadding is saved in schema
-            padding: viewModel.padding.getPoint4D?.toStitchPadding ?? .zero,
+            padding: viewModel.padding.getPadding ?? .defaultPadding,
             spacing: viewModel.spacing.getStitchSpacing ?? .defaultStitchSpacing,
             cornerRadius: viewModel.cornerRadius.getNumber ?? .zero,
             blurRadius: viewModel.blur.getNumber ?? .zero,

--- a/Stitch/Graph/Node/Layer/Type/GroupLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/GroupLayerNode.swift
@@ -77,7 +77,7 @@ struct GroupLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.minAndMaxSize)
+        .union(.sizing)
         .union(.paddingAndSpacing)
     
     static func content(graph: GraphState,

--- a/Stitch/Graph/Node/Layer/Type/HitAreaLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/HitAreaLayerNode.swift
@@ -24,7 +24,7 @@ struct HitAreaLayerNode: LayerNodeDefinition {
         .setupMode
     ])
         .union(.aspectRatio)
-        .union(.minAndMaxSize)
+        .union(.sizing)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/LinearGradientNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/LinearGradientNode.swift
@@ -30,7 +30,7 @@ struct LinearGradientLayerNode: LayerNodeDefinition {
     ])
         .union(.layerEffects)
         .union(.aspectRatio)
-        .union(.minAndMaxSize)
+        .union(.sizing)
     
     
     static func content(graph: GraphState,

--- a/Stitch/Graph/Node/Layer/Type/MapLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/MapLayerNode.swift
@@ -43,7 +43,7 @@ struct MapLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.minAndMaxSize)
+        .union(.sizing)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/OvalLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/OvalLayerNode.swift
@@ -52,7 +52,7 @@ struct OvalLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.minAndMaxSize)
+        .union(.sizing)
     
     
     static func content(graph: GraphState,

--- a/Stitch/Graph/Node/Layer/Type/ProgressIndicatorLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/ProgressIndicatorLayerNode.swift
@@ -30,7 +30,7 @@ struct ProgressIndicatorLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.minAndMaxSize)
+        .union(.sizing)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/RadialGradientNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/RadialGradientNode.swift
@@ -29,7 +29,7 @@ struct RadialGradientLayerNode: LayerNodeDefinition {
     ])
         .union(.layerEffects)
         .union(.aspectRatio)
-        .union(.minAndMaxSize)
+        .union(.sizing)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/RealityView/RealityNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/RealityView/RealityNode.swift
@@ -35,7 +35,7 @@ struct RealityViewLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.minAndMaxSize)
+        .union(.sizing)
 
         static func createEphemeralObserver() -> NodeEphemeralObservable? {
         MediaEvalOpObserver()

--- a/Stitch/Graph/Node/Layer/Type/RectangleLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/RectangleLayerNode.swift
@@ -65,7 +65,7 @@ struct RectangleLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.minAndMaxSize)
+        .union(.sizing)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/SFSymbolLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/SFSymbolLayerNode.swift
@@ -37,7 +37,7 @@ struct SFSymbolLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.minAndMaxSize)
+        .union(.sizing)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/ShapeLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/ShapeLayerNode.swift
@@ -50,9 +50,10 @@ extension LayerInputTypeSet {
     ]
     
     @MainActor
-    static let minAndMaxSize: LayerInputTypeSet = [
+    static let sizing: LayerInputTypeSet = [
         .minSize,
-        .maxSize
+        .maxSize,
+        .sizingScenario
     ]
     
     // LayerGroup only?
@@ -174,7 +175,7 @@ struct ShapeLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.minAndMaxSize)
+        .union(.sizing)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/SwitchLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/SwitchLayerNode.swift
@@ -39,7 +39,7 @@ struct SwitchLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.minAndMaxSize)
+        .union(.sizing)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/TextFieldLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/TextFieldLayerNode.swift
@@ -47,7 +47,7 @@ struct TextFieldLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.minAndMaxSize)
+        .union(.sizing)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/TextLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/TextLayerNode.swift
@@ -59,7 +59,7 @@ struct TextLayerNode: LayerNodeDefinition {
     .union(.strokeInputs)
     .union(.typography)
     .union(.aspectRatio)
-    .union(.minAndMaxSize)
+    .union(.sizing)
     
     
     

--- a/Stitch/Graph/Node/Layer/Type/VideoLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/VideoLayerNode.swift
@@ -33,7 +33,7 @@ struct VideoLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.minAndMaxSize)
+        .union(.sizing)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/VideoStreamingLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/VideoStreamingLayerNode.swift
@@ -38,7 +38,7 @@ struct VideoStreamingLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.minAndMaxSize)
+        .union(.sizing)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/VisualMedia.swift
+++ b/Stitch/Graph/Node/Layer/Type/VisualMedia.swift
@@ -34,7 +34,7 @@ struct ImageLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.minAndMaxSize)
+        .union(.sizing)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Util/LayerEvalHelpers.swift
+++ b/Stitch/Graph/Node/Layer/Util/LayerEvalHelpers.swift
@@ -9,16 +9,48 @@ import Foundation
 import SwiftUI
 import StitchSchemaKit
 
+extension Double {
+    static let defaultWidthAxisRatio = 1.0
+    static let defaultHeightAxisRatio = 1.0
+}
+
 // TODO: tech debt: do this for shadow-data, rotation-data, layer-effect-data
 extension LayerViewModel {
+    
+    var getMinWidth: LayerDimension? {
+        self.minSize.getSize?.width
+    }
+    
+    var getMaxWidth: LayerDimension? {
+        self.maxSize.getSize?.width
+    }
+    
+    var getMinHeight: LayerDimension? {
+        self.minSize.getSize?.height
+    }
+    
+    var getMaxHeight: LayerDimension? {
+        self.maxSize.getSize?.height
+    }
+    
+    var getSizingScenario: SizingScenario {
+        self.sizingScenario.getSizingScenario ?? .defaultSizingScenario
+    }
+    
+    func getAspectRatioData() -> AspectRatioData {
+        .init(widthAxis: self.widthAxis.getNumber ?? .defaultWidthAxisRatio,
+              heightAxis: self.heightAxis.getNumber ?? .defaultHeightAxisRatio,
+              contentMode: (self.contentMode.getContentMode ?? .defaultContentMode).toSwiftUIContent)
+    }
+    
     func getLayerStrokeData() -> LayerStrokeData {
-        LayerStrokeData(stroke: self.strokePosition.getLayerStroke ?? .defaultStroke,
-                        color: self.strokeColor.getColor ?? .black,
-                        width: self.strokeWidth.getNumber ?? .zero,
-                        strokeStart: self.strokeStart.getNumber ?? .zero,
-                        strokeEnd: self.strokeEnd.getNumber ?? 1.0,
-                        strokeLineCap: self.strokeLineCap.getStrokeLineCap ?? .defaultStrokeLineCap,
-                        strokeLineJoin: self.strokeLineJoin.getStrokeLineJoin ?? .defaultStrokeLineJoin)
+        .init(stroke: self.strokePosition.getLayerStroke ?? .defaultStroke,
+              color: self.strokeColor.getColor ?? .black,
+              width: self.strokeWidth.getNumber ?? .zero,
+              strokeStart: self.strokeStart.getNumber ?? .zero,
+              strokeEnd: self.strokeEnd.getNumber ?? 1.0,
+              strokeLineCap: self.strokeLineCap.getStrokeLineCap ?? .defaultStrokeLineCap,
+              strokeLineJoin: self.strokeLineJoin.getStrokeLineJoin ?? .defaultStrokeLineJoin)
     }
 }
 

--- a/Stitch/Graph/Node/Layer/Util/LayerNodeEntityUtils.swift
+++ b/Stitch/Graph/Node/Layer/Util/LayerNodeEntityUtils.swift
@@ -96,6 +96,8 @@ extension LayerNodeEntity {
          spacingBetweenGridRowsPort: NodeConnectionType = .values([]),
          itemAlignmentWithinGridCellPort: NodeConnectionType = .values([]),
          
+         sizingScenarioPort: NodeConnectionType = .values([]),
+         
          widthAxisPort: NodeConnectionType = .values([]),
          heightAxisPort: NodeConnectionType = .values([]),
          contentModePort: NodeConnectionType = .values([]),
@@ -200,6 +202,8 @@ extension LayerNodeEntity {
             spacingBetweenGridColumnsPort: spacingBetweenGridColumnsPort,
             spacingBetweenGridRowsPort: spacingBetweenGridRowsPort,
             itemAlignmentWithinGridCellPort: itemAlignmentWithinGridCellPort,
+            
+            sizingScenarioPort: sizingScenarioPort,
             
             widthAxisPort: widthAxisPort,
             heightAxisPort: heightAxisPort,

--- a/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
+++ b/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
@@ -120,6 +120,7 @@ final class LayerNodeViewModel {
     @MainActor var minSizePort: NodeRowObserver
     @MainActor var maxSizePort: NodeRowObserver
     @MainActor var spacingPort: NodeRowObserver
+    @MainActor var sizingScenarioPort: NodeRowObserver
 
     weak var nodeDelegate: NodeDelegate?
 

--- a/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
+++ b/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
@@ -252,6 +252,7 @@ final class LayerNodeViewModel {
         self.minSizePort = .empty(.minSize, layer: schema.layer)
         self.maxSizePort = .empty(.maxSize, layer: schema.layer)
         self.spacingPort = .empty(.spacing, layer: schema.layer)
+        self.sizingScenarioPort = .empty(.sizingScenario, layer: schema.layer)
         
         let graphNode = schema.layer.layerGraphNode
         

--- a/Stitch/Graph/Node/Model/RowData/LayerInputType.swift
+++ b/Stitch/Graph/Node/Model/RowData/LayerInputType.swift
@@ -208,6 +208,8 @@ extension LayerInputType {
             return .size(.LAYER_DEFAULT_SIZE)
         case .spacing:
             return .spacing(.defaultStitchSpacing)
+        case .sizingScenario:
+            return .sizingScenario(.auto)
         }
     }
     
@@ -402,6 +404,9 @@ extension LayerInputType {
         
         case .spacing:
             return \.spacingPort
+            
+        case .sizingScenario:
+            return \.sizingScenarioPort
         }
     }
     
@@ -631,6 +636,8 @@ extension LayerViewModel {
             return self.maxSize
         case .spacing:
             return self.spacing
+        case .sizingScenario:
+            return self.sizingScenario
         }
     }
     
@@ -823,6 +830,8 @@ extension LayerViewModel {
             self.maxSize = value
         case .spacing:
             self.spacing = value
+        case .sizingScenario:
+            self.sizingScenario = value
         }
     }
 }
@@ -1010,6 +1019,8 @@ extension LayerInputType {
             return \.maxSizePort
         case .spacing:
             return \.spacingPort
+        case .sizingScenario:
+            return \.sizingScenarioPort
         }
     }
         
@@ -1200,6 +1211,8 @@ extension LayerInputType {
             return "Max Size"
         case .spacing:
             return "Spacing"
+        case .sizingScenario:
+            return "Sizing Scenario"
         }
     }
     

--- a/Stitch/Graph/Node/Port/Model/Field/FieldGroupType.swift
+++ b/Stitch/Graph/Node/Port/Model/Field/FieldGroupType.swift
@@ -24,7 +24,14 @@ extension FieldGroupType {
             return [POINT3D_X_LABEL, POINT3D_Y_LABEL, POINT3D_Z_LABEL]
         case .xYZW:
             return [POINT3D_X_LABEL, POINT3D_Y_LABEL, POINT3D_Z_LABEL, POINT4D_W_LABEL]
-        default:
+        case .padding:
+            return [
+                PADDING_TOP_FIELD_LABEL,
+                PADDING_RIGHT_FIELD_LABEL,
+                PADDING_BOTTOM_FIELD_LABEL,
+                PADDING_LEFT_FIELD_LABEL
+            ]
+        case .dropdown, .bool, .asyncMedia, .number, .string, .readOnly, .layerDimension, .pulse, .color, .json, .assignedLayer, .anchoring:
             return [""]
         }
     }

--- a/Stitch/Graph/Node/Port/Model/Field/FieldGroupType.swift
+++ b/Stitch/Graph/Node/Port/Model/Field/FieldGroupType.swift
@@ -10,8 +10,7 @@ import StitchSchemaKit
 
 /// Represents each individual field grouping encompassing an entire port value) (i.e. x + y coordinate)
 enum FieldGroupType {
-    case hW, xY, xYZ, xYZW, dropdown, bool, asyncMedia, number, string,
-         readOnly, layerDimension, pulse, color, json, assignedLayer, anchoring
+    case hW, xY, xYZ, xYZW, padding, dropdown, bool, asyncMedia, number, string, readOnly, layerDimension, pulse, color, json, assignedLayer, anchoring
 }
 
 extension FieldGroupType {
@@ -41,6 +40,9 @@ extension FieldGroupType {
         case .xYZW:
             return [.number(.zero), .number(.zero), .number(.zero), .number(.zero)]
 
+        case .padding:
+            return [.number(.zero), .number(.zero), .number(.zero), .number(.zero)]
+            
         case .number:
             return [.number(.zero)]
 

--- a/Stitch/Graph/Node/Port/Model/Field/NodeRowType.swift
+++ b/Stitch/Graph/Node/Port/Model/Field/NodeRowType.swift
@@ -16,6 +16,7 @@ enum NodeRowType: Equatable {
          position,
          point3D,
          point4D,
+         padding,
          shapeCommand(ShapeCommandFieldType),
          singleDropdown(SingleDropdownKind),
          textFontDropdown, // TODO: special case because nested?
@@ -37,7 +38,7 @@ extension NodeRowType {
     // TODO: smarter / easier to way to do this?
     var inputUsesTextField: Bool {
         switch self {
-          case .size, .position, .point3D, .point4D, .layerDimension, .number, .string:
+        case .size, .position, .point3D, .point4D, .padding, .layerDimension, .number, .string:
             return true
         case .readOnly, .shapeCommand, .singleDropdown, .textFontDropdown, .bool, .asyncMedia, .pulse, .color, .json, .assignedLayer, .anchoring:
             return false
@@ -54,6 +55,8 @@ extension NodeRowType {
             return .point3D(.init(x: 0, y: 0, z: 0))
         case .point4D:
             return .point4D(.init(x: 0, y: 0, z: 0, w: 0))
+        case .padding:
+            return .padding(.zero)
         case .shapeCommand:
             return .shapeCommand(ShapeCommand.defaultFalseShapeCommand)
         case .singleDropdown(let singleDropdownKind):

--- a/Stitch/Graph/Node/Port/Model/Field/SingleDropdownKind.swift
+++ b/Stitch/Graph/Node/Port/Model/Field/SingleDropdownKind.swift
@@ -10,7 +10,7 @@ import StitchSchemaKit
 import Vision
 
 enum SingleDropdownKind {
-    case textAlignment, textVerticalAlignment, textDecoration, blendMode, fitStyle, animationCurve, cameraDirection, cameraOrientation, deviceOrientation, plane, scrollMode, lightType, networkRequestType, layerStroke, textTransform, dateAndTimeFormat, scrollJumpStyle, scrollDecelerationRate, delayStyle, shapeCoordinates, shapeCommandType, orientation, vnImageCropAndScale, mapType, progressIndicatorStyle, mobileHapticStyle, strokeLineCap, strokeLineJoin, contentMode, spacing
+    case textAlignment, textVerticalAlignment, textDecoration, blendMode, fitStyle, animationCurve, cameraDirection, cameraOrientation, deviceOrientation, plane, scrollMode, lightType, networkRequestType, layerStroke, textTransform, dateAndTimeFormat, scrollJumpStyle, scrollDecelerationRate, delayStyle, shapeCoordinates, shapeCommandType, orientation, vnImageCropAndScale, mapType, progressIndicatorStyle, mobileHapticStyle, strokeLineCap, strokeLineJoin, contentMode, spacing, sizingScenario
 }
 
 extension SingleDropdownKind {
@@ -78,6 +78,14 @@ extension SingleDropdownKind {
         // TODO: replace? StitchSpacing is "number filed or dropdown"
         case .spacing:
             return [.spacing(.between), .spacing(.evenly)]
+        case .sizingScenario:
+            return SizingScenario.choices
         }
+    }
+}
+
+extension SizingScenario: PortValueEnum {
+    static var portValueTypeGetter: PortValueTypeGetter<Self> {
+        PortValue.sizingScenario
     }
 }

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Layer/LayerDimensionUtils.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Layer/LayerDimensionUtils.swift
@@ -182,6 +182,15 @@ extension LayerDimension {
         }
     }
 
+    var isNumber: Bool {
+        switch self {
+        case .number:
+            return true
+        default:
+            return false
+        }
+    }
+    
     var getNumber: CGFloat? {
         switch self {
         case .number(let x):

--- a/Stitch/Graph/Node/Port/Util/Field/FieldCoercers.swift
+++ b/Stitch/Graph/Node/Port/Util/Field/FieldCoercers.swift
@@ -78,6 +78,7 @@ extension PortValue {
             }
 
             return .size(newSize)
+            
         case .position(let position):
             guard let newPosition = positionParent(position, fieldIndex, fieldValue.stringValue) else {
                 log("parseInputEdit error: unable to parse position")
@@ -99,6 +100,13 @@ extension PortValue {
             }
             return .point4D(newPoint4D)
 
+        case .padding(let x):
+            guard let newPadding = paddingParent(x, fieldIndex, fieldValue.stringValue) else {
+                log("parseInputEdit error: unable to parse padding")
+                return self
+            }
+            return .padding(newPadding)
+            
         case .layerDimension:
             switch fieldValue.layerDimensionField {
             case .none:
@@ -207,6 +215,52 @@ func point4DParent(_ point4D: Point4D,
                            w: number)
         } else {
             log("point4DParent: valid edit \(edit) but unexpected field index \(fieldIndex) ")
+            return nil
+        }
+    }
+    return nil // did not have a valid edit
+}
+
+// Put in namespace
+let PADDING_TOP_FIELD_INDEX = 0
+let PADDING_RIGHT_FIELD_INDEX = 1
+let PADDING_BOTTOM_FIELD_INDEX = 2
+let PADDING_LEFT_FIELD_INDEX = 3
+
+let PADDING_TOP_FIELD_LABEL = "T"
+let PADDING_RIGHT_FIELD_LABEL = "R"
+let PADDING_BOTTOM_FIELD_LABEL = "B"
+let PADDING_LEFT_FIELD_LABEL = "L"
+
+func paddingParent(_ padding: StitchPadding,
+                   _ fieldIndex: Int,
+                   _ edit: String) -> StitchPadding? {
+
+    let number = toNumber(edit)
+
+    if let number = number {
+        if fieldIndex == PADDING_TOP_FIELD_INDEX {
+            return StitchPadding(top: number,
+                                 right: padding.right,
+                                 bottom: padding.bottom,
+                                 left: padding.left)
+        } else if fieldIndex == PADDING_RIGHT_FIELD_INDEX {
+            return StitchPadding(top: padding.top,
+                                 right: number,
+                                 bottom: padding.bottom,
+                                 left: padding.left)
+        } else if fieldIndex == PADDING_BOTTOM_FIELD_INDEX {
+            return StitchPadding(top: padding.top,
+                                 right: padding.right,
+                                 bottom: number,
+                                 left: padding.left)
+        } else if fieldIndex == PADDING_LEFT_FIELD_INDEX {
+            return StitchPadding(top: padding.top,
+                                 right: padding.right,
+                                 bottom: padding.bottom,
+                                 left: number)
+        } else {
+            log("paddingParent: valid edit \(edit) but unexpected field index \(fieldIndex) ")
             return nil
         }
     }

--- a/Stitch/Graph/Node/Port/Util/Field/FieldCoercers.swift
+++ b/Stitch/Graph/Node/Port/Util/Field/FieldCoercers.swift
@@ -218,18 +218,39 @@ func sizeParent(_ size: LayerSize,
                 _ fieldIndex: Int,
                 _ edit: String) -> LayerSize? {
 
-    if let dimension = LayerDimension.fromUserEdit(edit: edit) {
-
-        if fieldIndex == 0 {
-            return LayerSize(width: dimension,
+    if let dimension = LayerLengthDimension(edit: edit, fieldIndex: fieldIndex) {
+        switch dimension.lengthDimension {
+        case .width:
+            return LayerSize(width: dimension.layerDimension,
                              height: size.height)
-        } else if fieldIndex == 1 {
+        case .height:
             return LayerSize(width: size.width,
-                             height: dimension)
-        } else {
-            fatalError() // we had valid edit but unexpected field index
+                             height: dimension.layerDimension)
         }
     }
+    
+    return nil
+}
 
-    return nil // did not have a valid edit
+struct LayerLengthDimension: Codable, Equatable {
+    var layerDimension: LayerDimension
+    var lengthDimension: LengthDimension
+}
+
+extension LayerLengthDimension {
+
+    init?(edit: String, fieldIndex: Int) {
+        if let dimension = LayerDimension.fromUserEdit(edit: edit) {
+            self.layerDimension = dimension
+            if fieldIndex == WIDTH_FIELD_INDEX {
+                self.lengthDimension = .width
+            } else if fieldIndex == HEIGHT_FIELD_INDEX {
+                self.lengthDimension = .height
+            } else {
+                fatalErrorIfDebug() // had valid edit but unexpected field index
+                return nil
+            }
+        }
+        return nil // did not have a valid edit
+    }
 }

--- a/Stitch/Graph/Node/Port/Util/Field/FieldCoercers.swift
+++ b/Stitch/Graph/Node/Port/Util/Field/FieldCoercers.swift
@@ -218,7 +218,7 @@ func sizeParent(_ size: LayerSize,
                 _ fieldIndex: Int,
                 _ edit: String) -> LayerSize? {
 
-    if let dimension = LayerLengthDimension(edit: edit, fieldIndex: fieldIndex) {
+    if let dimension = LayerLengthDimension.fromUserEdit(edit: edit, fieldIndex: fieldIndex) {
         switch dimension.lengthDimension {
         case .width:
             return LayerSize(width: dimension.layerDimension,
@@ -239,18 +239,22 @@ struct LayerLengthDimension: Codable, Equatable {
 
 extension LayerLengthDimension {
 
-    init?(edit: String, fieldIndex: Int) {
-        if let dimension = LayerDimension.fromUserEdit(edit: edit) {
-            self.layerDimension = dimension
-            if fieldIndex == WIDTH_FIELD_INDEX {
-                self.lengthDimension = .width
-            } else if fieldIndex == HEIGHT_FIELD_INDEX {
-                self.lengthDimension = .height
-            } else {
-                fatalErrorIfDebug() // had valid edit but unexpected field index
-                return nil
-            }
+    static func fromUserEdit(edit: String, fieldIndex: Int) -> Self? {
+        
+        guard let dimension = LayerDimension.fromUserEdit(edit: edit) else {
+            return nil
         }
-        return nil // did not have a valid edit
+        
+        if fieldIndex == WIDTH_FIELD_INDEX {
+            return .init(layerDimension: dimension,
+                         lengthDimension: .width)
+        } else if fieldIndex == HEIGHT_FIELD_INDEX {
+            return .init(layerDimension: dimension,
+                         lengthDimension: .height)
+        } else {
+            // had valid edit but unexpected field index
+            fatalErrorIfDebug()
+            return nil
+        }
     }
 }

--- a/Stitch/Graph/Node/Port/Util/Field/FieldValueUtils.swift
+++ b/Stitch/Graph/Node/Port/Util/Field/FieldValueUtils.swift
@@ -28,7 +28,11 @@ extension PortValue {
         case .point4D:
             let point4D = self.getPoint4D ?? .zero
             return [point4D.fieldValues]
-
+        
+        case .padding:
+            let padding = self.getPadding ?? .zero
+            return [padding.fieldValues]
+            
         case .shapeCommand(let shapeCommandType):
             let shapeCommandValue = self.shapeCommand ?? .defaultFalseShapeCommand
 
@@ -205,6 +209,11 @@ extension PortValue {
                 let value = self.getStitchSpacing ?? .defaultStitchSpacing
                 return [[.dropdown(value.display,
                                    [.spacing(.evenly), .spacing(.between)])]]
+            case .sizingScenario:
+                let value = self.getSizingScenario ?? .defaultSizingScenario
+                return [[.dropdown(value.rawValue,
+                                   SizingScenario.choices)]]
+                
             } // case .singleDropdown
             
         case .textFontDropdown:

--- a/Stitch/Graph/Node/Port/Util/Field/FieldValueUtils.swift
+++ b/Stitch/Graph/Node/Port/Util/Field/FieldValueUtils.swift
@@ -14,9 +14,11 @@ extension PortValue {
     func createFieldValues(nodeIO: NodeIO,
                            importedMediaObject: StitchMediaObject?) -> [FieldValues] {
         switch self.getNodeRowType(nodeIO: nodeIO) {
+        
         case .size:
             let size = self.getSize ?? .zero
             return [size.fieldValues]
+        
         case .position:
             let position = self.getPosition ?? .zero
             return [position.fieldValues]
@@ -59,7 +61,9 @@ extension PortValue {
             }
 
         case .singleDropdown(let singleDropdownKind):
+            
             switch singleDropdownKind {
+            
             case .textAlignment:
                 let textAlignment = self.getLayerTextAlignment?.display ?? .empty
                 let choices = LayerTextAlignment.choices

--- a/Stitch/Graph/Node/Port/Util/Field/FieldViewModelTypeUtils.swift
+++ b/Stitch/Graph/Node/Port/Util/Field/FieldViewModelTypeUtils.swift
@@ -31,6 +31,8 @@ extension PortValue {
             return .point3D
         case .point4D:
             return .point4D
+        case .padding:
+            return .padding
         case .shapeCommand(let shapeCommand):
             switch nodeIO {
             case .input:
@@ -153,6 +155,8 @@ extension PortValue {
             // TODO: need new kind of field that supports text + dropdown; will be reused with LayerDimension field as well
         case .spacing:
             return .singleDropdown(.spacing)
+        case .sizingScenario:
+            return .singleDropdown(.sizingScenario)
         }
     }
 

--- a/Stitch/Graph/Node/Port/Util/Field/TabKeyPressActions.swift
+++ b/Stitch/Graph/Node/Port/Util/Field/TabKeyPressActions.swift
@@ -170,7 +170,7 @@ extension Layer {
             $0.getDefaultValue(for: layer).getNodeRowType(nodeIO: .input).inputUsesTextField
         })
         
-        // filtering the property sidebar's master list down to only those inputs that are both (1) for this layer and (2) actually use tex-field
+        // filtering the property sidebar's master list down to only those inputs that are both (1) for this layer and (2) actually use text-field
         let layerInputs = LayerInspectorView.allInputs.filter { masterListInput in
             thisLayersTextUsingInputs.contains(masterListInput)
         }

--- a/Stitch/Graph/Node/Port/Util/InputEdit/InputCommittedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/InputEdit/InputCommittedActions.swift
@@ -92,10 +92,8 @@ extension GraphState {
 
             
             if let sizingScenario = value.getSizingScenario {
-                self.sizingScenarioUpdated(layerId: nodeViewModel.id,
-                                           scenario: sizingScenario)
+                nodeViewModel.sizingScenarioUpdated(scenario: sizingScenario)
             }
-            
             
             let newCommandType = value.shapeCommandType
 

--- a/Stitch/Graph/Node/Port/Util/InputEdit/InputCommittedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/InputEdit/InputCommittedActions.swift
@@ -90,6 +90,13 @@ extension GraphState {
             nodeViewModel.removeIncomingEdge(at: input,
                                              activeIndex: self.activeIndex)
 
+            
+            if let sizingScenario = value.getSizingScenario {
+                self.sizingScenarioUpdated(layerId: nodeViewModel.id,
+                                           scenario: sizingScenario)
+            }
+            
+            
             let newCommandType = value.shapeCommandType
 
             // If we changed the command type on a ShapeCommand input,

--- a/Stitch/Graph/Node/Port/Util/InputEdit/InputCommittedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/InputEdit/InputCommittedActions.swift
@@ -92,7 +92,7 @@ extension GraphState {
 
             
             if let sizingScenario = value.getSizingScenario {
-                nodeViewModel.sizingScenarioUpdated(scenario: sizingScenario)
+                nodeViewModel.sizingScenarioUpdated(scenario: sizingScenario, activeIndex: self.activeIndex)
             }
             
             let newCommandType = value.shapeCommandType

--- a/Stitch/Graph/Node/Port/Util/InputEdit/InputEditedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/InputEdit/InputEditedActions.swift
@@ -72,25 +72,11 @@ struct InputEdited: GraphEventWithResponse {
         // If we edited a field on a layer-size input, we may need to block or unblock certain other fields.
         // Note: this logic is very similar to `sizeParent`
         if let layerSize = newValue.getSize,
-           let dimension = LayerLengthDimension(edit: fieldValue.stringValue, fieldIndex: fieldIndex) {
+           let dimension = LayerLengthDimension.fromUserEdit(edit: fieldValue.stringValue, fieldIndex: fieldIndex) {
             
-            state.layerDimensionUpdated(
-                layerId: nodeViewModel.id,
+            nodeViewModel.layerDimensionUpdated(
                 newValue: dimension.layerDimension,
                 dimension: dimension.lengthDimension)
-//
-//            
-//            if fieldIndex == WIDTH_FIELD_INDEX {
-//                state.layerDimensionUpdated(layerId: nodeViewModel.id,
-//                                            newValue: layerSize.width,
-//                                            dimension: .width)
-//            } else if fieldIndex == HEIGHT_FIELD_INDEX {
-//                state.layerDimensionUpdated(layerId: nodeViewModel.id,
-//                                            newValue: layerSize.height,
-//                                            dimension: .height)
-//            } else {
-//                fatalErrorIfDebug()
-//            }
         }
                 
         state.calculate(nodeViewModel.id)

--- a/Stitch/Graph/Node/Port/Util/InputEdit/InputEditedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/InputEdit/InputEditedActions.swift
@@ -69,6 +69,30 @@ struct InputEdited: GraphEventWithResponse {
             inputObserver.setValuesInInput([newValue])
         }
         
+        // If we edited a field on a layer-size input, we may need to block or unblock certain other fields.
+        // Note: this logic is very similar to `sizeParent`
+        if let layerSize = newValue.getSize,
+           let dimension = LayerLengthDimension(edit: fieldValue.stringValue, fieldIndex: fieldIndex) {
+            
+            state.layerDimensionUpdated(
+                layerId: nodeViewModel.id,
+                newValue: dimension.layerDimension,
+                dimension: dimension.lengthDimension)
+//
+//            
+//            if fieldIndex == WIDTH_FIELD_INDEX {
+//                state.layerDimensionUpdated(layerId: nodeViewModel.id,
+//                                            newValue: layerSize.width,
+//                                            dimension: .width)
+//            } else if fieldIndex == HEIGHT_FIELD_INDEX {
+//                state.layerDimensionUpdated(layerId: nodeViewModel.id,
+//                                            newValue: layerSize.height,
+//                                            dimension: .height)
+//            } else {
+//                fatalErrorIfDebug()
+//            }
+        }
+                
         state.calculate(nodeViewModel.id)
 
         if isCommitting {

--- a/Stitch/Graph/Node/Port/Util/InputEdit/InputEditedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/InputEdit/InputEditedActions.swift
@@ -71,7 +71,8 @@ struct InputEdited: GraphEventWithResponse {
         
         // If we edited a field on a layer-size input, we may need to block or unblock certain other fields.
         // Note: this logic is very similar to `sizeParent`
-        if let layerSize = newValue.getSize,
+        if newValue.getSize.isDefined,
+           coordinate.keyPath == .size, // Only look at size (not min/max size) changes
            let dimension = LayerLengthDimension.fromUserEdit(edit: fieldValue.stringValue, fieldIndex: fieldIndex) {
             
             nodeViewModel.layerDimensionUpdated(

--- a/Stitch/Graph/Node/Port/Util/PortValue/CoercerUtils.swift
+++ b/Stitch/Graph/Node/Port/Util/PortValue/CoercerUtils.swift
@@ -166,6 +166,10 @@ extension PortValues {
             return contentModeCoercer(values)
         case .spacing:
             return spacingCoercer(values)
+        case .padding:
+            return paddingCoercer(values)
+        case .sizingScenario:
+            return sizingScenarioCoercer(values)
         }
     }
 }

--- a/Stitch/Graph/Node/Port/Util/PortValue/Coercers.swift
+++ b/Stitch/Graph/Node/Port/Util/PortValue/Coercers.swift
@@ -938,6 +938,26 @@ func contentModeCoercer(_ values: PortValues) -> PortValues {
         .map(PortValue.contentMode)
 }
 
+extension PortValue {
+    // Takes any PortValue, and returns a MobileHapticStyle
+    func coerceToSizingScenario() -> SizingScenario {
+        switch self {
+        case .sizingScenario(let x):
+            return x
+        case .number(let x):
+            return SizingScenario.fromNumber(x)
+                .getSizingScenario ?? .defaultSizingScenario
+        default:
+            return .defaultSizingScenario
+        }
+    }
+}
+
+func sizingScenarioCoercer(_ values: PortValues) -> PortValues {
+    values
+        .map { $0.coerceToSizingScenario() }
+        .map(PortValue.sizingScenario)
+}
 
 extension PortValue {
     // Takes any PortValue, and returns a MobileHapticStyle
@@ -946,6 +966,7 @@ extension PortValue {
         case .spacing(let x):
             return x
         default:
+            // TODO: smarter coercion of other PortValues
             return .defaultStitchSpacing
         }
     }
@@ -955,4 +976,23 @@ func spacingCoercer(_ values: PortValues) -> PortValues {
     values
         .map { $0.coerceToStitchSpacing() }
         .map(PortValue.spacing)
+}
+
+extension PortValue {
+    // Takes any PortValue, and returns a MobileHapticStyle
+    func coerceToStitchPadding() -> StitchPadding {
+        switch self {
+        case .padding(let x):
+            return x
+        default:
+            // TODO: smarter coercion of other PortValues
+            return .defaultPadding
+        }
+    }
+}
+
+func paddingCoercer(_ values: PortValues) -> PortValues {
+    values
+        .map { $0.coerceToStitchPadding() }
+        .map(PortValue.padding)
 }

--- a/Stitch/Graph/Node/Port/Util/PortValue/FieldValueHelpers.swift
+++ b/Stitch/Graph/Node/Port/Util/PortValue/FieldValueHelpers.swift
@@ -38,3 +38,14 @@ extension Point4D {
         [.number(self.x), .number(self.y), .number(self.z), .number(self.w)]
     }
 }
+
+extension StitchPadding {
+    var fieldValues: FieldValues {
+        [
+            .number(self.top),
+            .number(self.right),
+            .number(self.bottom),
+            .number(self.left)
+        ]
+    }
+}

--- a/Stitch/Graph/Node/Port/Util/PortValue/PortValueDefaults.swift
+++ b/Stitch/Graph/Node/Port/Util/PortValue/PortValueDefaults.swift
@@ -190,6 +190,10 @@ extension PortValue {
             return .contentMode(.defaultContentMode)
         case .spacing:
             return .spacing(.defaultStitchSpacing)
+        case .padding:
+            return .padding(.zero)
+        case .sizingScenario:
+            return .sizingScenario(.defaultSizingScenario)
         }
     }
 }

--- a/Stitch/Graph/Node/Port/Util/PortValue/PortValueDisplay.swift
+++ b/Stitch/Graph/Node/Port/Util/PortValue/PortValueDisplay.swift
@@ -18,6 +18,13 @@ let Y = "y"
 let Z = "z"
 let W = "w"
 
+let TOP = "Top"
+let RIGHT = "Right"
+let BOTTOM = "Bottom"
+let LEFT = "Left"
+
+
+
 extension LayerSize {
     var asLayerDictionary: [String: String] {
         [
@@ -53,6 +60,17 @@ extension Point4D {
             Y: self.y,
             Z: self.z,
             W: self.w
+        ]
+    }
+}
+
+extension StitchPadding {
+    var asDictionary: [String: Double] {
+        [
+            TOP: self.top,
+            RIGHT: self.right,
+            BOTTOM: self.bottom,
+            LEFT: self.left
         ]
     }
 }
@@ -172,6 +190,10 @@ extension PortValue {
             return x.rawValue
         case .spacing(let x):
             return x.display
+        case .padding(let x):
+            return x.asDictionary.description
+        case .sizingScenario(let x):
+            return x.rawValue
 
         /*
          See https://github.com/vpl-codesign/stitch/issues/3022

--- a/Stitch/Graph/Node/Port/Util/PortValue/PortValueUtils.swift
+++ b/Stitch/Graph/Node/Port/Util/PortValue/PortValueUtils.swift
@@ -93,6 +93,13 @@ extension PortValue {
         default: return nil
         }
     }
+    
+    var getPadding: StitchPadding? {
+        switch self {
+        case .padding(let x): return x
+        default: return nil
+        }
+    }
 
     var getMatrix: StitchMatrix? {
         switch self {
@@ -461,5 +468,22 @@ extension PortValue {
         default:
             return nil
         }
+    }
+    
+    var getSizingScenario: SizingScenario? {
+        switch self {
+        case .sizingScenario(let x):
+            return x
+        default:
+            return nil
+        }
+    }
+}
+
+extension SizingScenario {
+    static let defaultSizingScenario: Self = .auto
+    
+    var display: String {
+        self.rawValue
     }
 }

--- a/Stitch/Graph/Node/Port/View/Field/Media/VideoDisplayView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/Media/VideoDisplayView.swift
@@ -58,13 +58,16 @@ struct VideoDisplayView: View {
             }
         }
         .opacity(opacity)
-        .onAppear {
-            fatalErrorIfDebug()
-        }
-//        .modifier(PreviewCommonSizeModifier(
-//            viewModel: layerViewModel,
-//            size: size,
-//            parentSize: parentSize,
-//            frameAlignment: .center))
+        .modifier(PreviewCommonSizeModifier(
+            viewModel: layerViewModel,
+            aspectRatio: layerViewModel.getAspectRatioData(),
+            size: size,
+            minWidth: layerViewModel.getMinWidth,
+            maxWidth: layerViewModel.getMaxWidth,
+            minHeight: layerViewModel.getMinHeight,
+            maxHeight: layerViewModel.getMaxHeight,
+            parentSize: parentSize,
+            sizingScenario: layerViewModel.getSizingScenario,
+            frameAlignment: .center))
     }
 }

--- a/Stitch/Graph/Node/Port/View/Field/Media/VideoDisplayView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/Media/VideoDisplayView.swift
@@ -58,10 +58,13 @@ struct VideoDisplayView: View {
             }
         }
         .opacity(opacity)
-        .modifier(PreviewCommonSizeModifier(
-            viewModel: layerViewModel,
-            size: size,
-            parentSize: parentSize,
-            frameAlignment: .center))
+        .onAppear {
+            fatalErrorIfDebug()
+        }
+//        .modifier(PreviewCommonSizeModifier(
+//            viewModel: layerViewModel,
+//            size: size,
+//            parentSize: parentSize,
+//            frameAlignment: .center))
     }
 }

--- a/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
@@ -83,20 +83,20 @@ struct NodeFieldsView: View {
         
     var fields: some View {
         ForEach(fieldGroupViewModel.fieldObservers) { (fieldViewModel: FieldViewModel) in
-            self.valueEntryView(fieldViewModel)
-                .overlay {
-                    if fieldViewModel.isBlockedOut {
-                        Color.black.opacity(0.3)
-                            .cornerRadius(4)
-                            .allowsHitTesting(false)
-                    } else {
-                        Color.clear
-                    }
-                }
+//            self.valueEntryView(fieldViewModel)
+//                .overlay {
+//                    if fieldViewModel.isBlockedOut {
+//                        Color.black.opacity(0.3)
+//                            .cornerRadius(4)
+//                            .allowsHitTesting(false)
+//                    } else {
+//                        Color.clear
+//                    }
+//                }
             
-//            if !fieldViewModel.isBlockedOut {
-//                self.valueEntryView(fieldViewModel)
-//            }
+            if !fieldViewModel.isBlockedOut {
+                self.valueEntryView(fieldViewModel)
+            }
         }
         .allowsHitTesting(!isForPropertyAlreadyOnGraph)
     }

--- a/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
@@ -50,12 +50,20 @@ struct NodeFieldsView: View {
     }
     
     var body: some View {
-        // Only non-nil for ShapeCommands i.e. `lineTo`, `curveTo` etc. ?
-        if let groupLabel = label {
-            StitchTextView(string: groupLabel)
+        
+        if allFieldsBlockedOut {
+            EmptyView()
+        } else {
+            
+            // Only non-nil for ShapeCommands i.e. `lineTo`, `curveTo` etc. ?
+            if let groupLabel = label {
+                StitchTextView(string: groupLabel)
+            }
+            
+            fieldsStack
         }
         
-        fieldsStack
+       
     }
     
     @ViewBuilder
@@ -65,16 +73,30 @@ struct NodeFieldsView: View {
                 fields
             }
         } else {
-            if let groupLabel = label {
-                StitchTextView(string: groupLabel)
-            }
             fields
         }
     }
     
+    var allFieldsBlockedOut: Bool {
+        fieldGroupViewModel.fieldObservers.allSatisfy(\.isBlockedOut)
+    }
+        
     var fields: some View {
         ForEach(fieldGroupViewModel.fieldObservers) { (fieldViewModel: FieldViewModel) in
             self.valueEntryView(fieldViewModel)
+                .overlay {
+                    if fieldViewModel.isBlockedOut {
+                        Color.black.opacity(0.3)
+                            .cornerRadius(4)
+                            .allowsHitTesting(false)
+                    } else {
+                        Color.clear
+                    }
+                }
+            
+//            if !fieldViewModel.isBlockedOut {
+//                self.valueEntryView(fieldViewModel)
+//            }
         }
         .allowsHitTesting(!isForPropertyAlreadyOnGraph)
     }

--- a/Stitch/Graph/Node/Port/ViewModel/FieldGroupTypeViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/FieldGroupTypeViewModel.swift
@@ -77,6 +77,9 @@ extension FieldGroupTypeViewModelList {
 
         case .point4D:
             self = [.init(type: .xYZW, coordinate: coordinate)]
+            
+        case .padding:
+            self = [.init(type: .padding, coordinate: coordinate)]
 
         case .shapeCommand(let shapeCommand):
             switch shapeCommand {

--- a/Stitch/Graph/Node/Port/ViewModel/FieldViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/FieldViewModel.swift
@@ -23,6 +23,10 @@ class FieldViewModel {
     // eg "X" vs "Y" for .position parent-value
     var fieldLabel: String
 
+    // e.g. Layer's size-scenario is "Constrain Height",
+    // so we "block out" the Height fields on the Layer: size.height, minSize.height, maxSize.height
+    var isBlockedOut: Bool = false
+    
     init(fieldValue: FieldValue,
          coordinate: NodeIOCoordinate,
          fieldIndex: Int,

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -37,7 +37,10 @@ final class NodeRowObserver: Identifiable, Sendable {
     // NodeIO type cannot be changed over the life of a row, and is important enough that we should not let it default to some value
     let nodeIOType: NodeIO
     
-    // Holds view models for fields
+    // Holds view models for fields;
+    // Note: this is [FieldGroupTypeViewModel] where a single `FieldGroupTypeViewModel` containers a list: `fieldObservers: [FieldViewModel]`
+    // Vast majority of inputs have single `FieldGroupTypeViewModel`;
+    // only ShapeCommands have more than one `FieldGroupTypeViewModel`.
     var fieldValueTypes = FieldGroupTypeViewModelList()
     
     // Connected upstream node, if input

--- a/Stitch/Graph/Node/Util/NodeTypeUtils.swift
+++ b/Stitch/Graph/Node/Util/NodeTypeUtils.swift
@@ -110,7 +110,7 @@ extension UserVisibleType {
             return "Progress Style"
         case .mobileHapticStyle:
             return "Haptic Style"
-        case .strokeLineCap, .strokeLineJoin, .contentMode, .spacing:
+        case .strokeLineCap, .strokeLineJoin, .contentMode, .spacing, .padding, .sizingScenario:
             return self.rawValue
         }
     }
@@ -242,6 +242,10 @@ func portValueToNodeType(_ value: PortValue) -> UserVisibleType {
         return .contentMode
     case .spacing:
         return .spacing
+    case .padding:
+        return .padding
+    case .sizingScenario:
+        return .sizingScenario
     }
 
 }
@@ -361,6 +365,10 @@ extension UserVisibleType {
             return .contentMode(.defaultContentMode)
         case .spacing:
             return .spacing(.defaultStitchSpacing)
+        case .padding:
+            return .padding(.defaultPadding)
+        case .sizingScenario:
+            return .sizingScenario(.defaultSizingScenario)
         }
     }
 

--- a/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
@@ -23,9 +23,7 @@ extension NodeViewModel {
                 
         switch newValue {
             
-        case .number,
-            // TODO: treat parent-percent as allowing min/max; e.g. "Width is 50% of parent, but never less than 100 and never greater than 1000"
-                .parentPercent:
+        case .number:
             // block min and max along this given dimension
             switch dimension {
             case .width:
@@ -35,7 +33,7 @@ extension NodeViewModel {
                 stitch.blockMinAndMaxHeightFields()
             }
             
-        case .auto, .fill, .hug:
+        case .auto, .fill, .hug, .parentPercent:
             switch dimension {
             case .width:
                 stitch.unblockMinAndMaxWidthFields()

--- a/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
@@ -13,6 +13,42 @@ let HEIGHT_FIELD_INDEX = 1
 
 extension GraphState {
     
+    // When LayerDimension is `pt` or `parent percent`, disable the min/max along that same dimension.
+    //
+    @MainActor
+    func layerDimensionUpdated(layerId: NodeId,
+                               newValue: LayerDimension,
+                               dimension: LengthDimension) {
+        
+        guard let stitch = self.getNode(layerId) else {
+            fatalErrorIfDebug("could not find layer for id \(layerId)")
+            return
+        }
+        
+        switch newValue {
+            
+        case .number,
+            // TODO: treat parent-percent as allowing min/max; e.g. "Width is 50% of parent, but never less than 100 and never greater than 1000"
+                .parentPercent:
+            // block min and max along this given dimension
+            switch dimension {
+            case .width:
+                // Note: the width (non-min/max width) field must have already been unblocked for us to be able to edit the width layer dimension
+                stitch.blockMinAndMaxWidthFields()
+            case .height:
+                stitch.blockMinAndMaxHeightFields()
+            }
+            
+        case .auto, .fill, .hug:
+            switch dimension {
+            case .width:
+                stitch.unblockMinAndMaxWidthFields()
+            case .height:
+                stitch.unblockMinAndMaxHeightFields()
+            }
+        }
+    }
+    
     // Assumes input was already updated via e.g. PickerOptionSelected
     @MainActor
     func sizingScenarioUpdated(layerId: NodeId,
@@ -22,105 +58,227 @@ extension GraphState {
         log("sizingScenarioUpdated: scenario: \(scenario)")
         
         guard let stitch = self.getNode(layerId) else {
-            fatalErrorIfDebug("could not find layer for id \(layerId)")
+            fatalErrorIfDebug("sizingScenarioUpdated: could not find layer for id \(layerId)")
             return
         }
                 
         // NOTE: does this work with loops? What is the relationship between a loop of fields
-        guard let sizeInputFields = stitch.getInputRowObserver(for: .keyPath(.size))?.fieldValueTypes.first?.fieldObservers,
-
-                // min/max inputs
-              let minSizeInputFields = stitch.getInputRowObserver(for: .keyPath(.minSize))?.fieldValueTypes.first?.fieldObservers,
-              let maxSizeInputFields = stitch.getInputRowObserver(for: .keyPath(.maxSize))?.fieldValueTypes.first?.fieldObservers,
-
-                // Aspect ratio inputs
-              let widthAxisInput = stitch.getInputRowObserver(for: .keyPath(.widthAxis))?.fieldValueTypes.first?.fieldObservers.first,
-              let heightAxisInput = stitch.getInputRowObserver(for: .keyPath(.heightAxis))?.fieldValueTypes.first?.fieldObservers.first,
-              let contentModeInput = stitch.getInputRowObserver(for: .keyPath(.contentMode))?.fieldValueTypes.first?.fieldObservers.first else {
-            
-            fatalErrorIfDebug("could not find required input for sizing scenario")
-            return
-        }
+        
+//        guard let sizeInputFields = stitch.getInputRowObserver(for: .keyPath(.size))?.fieldValueTypes.first?.fieldObservers,
+//
+//                // min/max inputs
+//              let minSizeInputFields = stitch.getInputRowObserver(for: .keyPath(.minSize))?.fieldValueTypes.first?.fieldObservers,
+//              let maxSizeInputFields = stitch.getInputRowObserver(for: .keyPath(.maxSize))?.fieldValueTypes.first?.fieldObservers,
+//
+//                // Aspect ratio inputs
+//              let widthAxisInput = stitch.getInputRowObserver(for: .keyPath(.widthAxis))?.fieldValueTypes.first?.fieldObservers.first,
+//              let heightAxisInput = stitch.getInputRowObserver(for: .keyPath(.heightAxis))?.fieldValueTypes.first?.fieldObservers.first,
+//              let contentModeInput = stitch.getInputRowObserver(for: .keyPath(.contentMode))?.fieldValueTypes.first?.fieldObservers.first else {
+//            
+//            fatalErrorIfDebug("sizingScenarioUpdated: could not find required input for sizing scenario")
+//            return
+//        }
+        
         
         switch scenario {
             
         case .auto:
             // TODO: unblock e.g. min/max width when width set to grow/hug (will be a different action / scenario?)
-            
+                        
             // if sizing scenario is auto, unblock the width and height fields:
-            sizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = false
-            sizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = false
+            stitch.unblockSizeInput()
+            
+//            sizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = false
+//            sizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = false
+            
             
             // ... and block the min and max width and height (until width and height are set to grow or hug)
-            minSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = true
-            maxSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = true
-            minSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = true
-            maxSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = true
+            stitch.blockMinAndMaxSizeInputs()
+            
+//            minSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = true
+//            maxSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = true
+//            minSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = true
+//            maxSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = true
                         
             // ... and block the aspect ratio inputs:
-            widthAxisInput.isBlockedOut = true
-            heightAxisInput.isBlockedOut = true
-            contentModeInput.isBlockedOut = true
+            stitch.blockAspectRatio()
+            
+//            widthAxisInput.isBlockedOut = true
+//            heightAxisInput.isBlockedOut = true
+//            contentModeInput.isBlockedOut = true
             
         case .constrainHeight:
             // if height is constrained, block-out the height inputs (height, min height, max height):
-            sizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = true
-            minSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = true
-            maxSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = true
+            stitch.blockHeightFields()
+            
+//            sizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = true
+//            minSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = true
+//            maxSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = true
+            
             
             // ... and unblock the width fields:
-            sizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = false
-            minSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = false
-            maxSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = false
+            stitch.unblockWidthFields()
+            
+//            sizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = false
+//            minSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = false
+//            maxSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = false
+            
             
             // ... and unblock the aspect ratio inputs:
-            widthAxisInput.isBlockedOut = false
-            heightAxisInput.isBlockedOut = false
-            contentModeInput.isBlockedOut = false
+            stitch.unblockAspectRatio()
+            
+//            widthAxisInput.isBlockedOut = false
+//            heightAxisInput.isBlockedOut = false
+//            contentModeInput.isBlockedOut = false
             
         case .constrainWidth:
             // if width is constrained, block-out the width inputs (width, min width, max width):
-            sizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = true
-            minSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = true
-            maxSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = true
+            stitch.blockWidthFields()
+            
+//            sizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = true
+//            minSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = true
+//            maxSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = true
             
             // ... and unblock the height fields:
-            sizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = false
-            minSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = false
-            maxSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = false
+            stitch.unblockHeightFields()
+            
+//            sizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = false
+//            minSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = false
+//            maxSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = false
             
             // ... and unblock the aspect ratio inputs:
-            widthAxisInput.isBlockedOut = false
-            heightAxisInput.isBlockedOut = false
-            contentModeInput.isBlockedOut = false
+            stitch.unblockAspectRatio()
+            
+//            widthAxisInput.isBlockedOut = false
+//            heightAxisInput.isBlockedOut = false
+//            contentModeInput.isBlockedOut = false
         }
     }
 }
 
 extension NodeViewModel {
-    func blockMinAndMaxHeight() {
-        
+    
+    @MainActor
+    func getLayerInputFields(_ key: LayerInputType) -> FieldViewModels? {
+        self.getInputRowObserver(for: .keyPath(key))?.fieldValueTypes.first?.fieldObservers
     }
     
-    func unblockMinAndMaxHeight() {
+    @MainActor
+    func getLayerInputField(_ key: LayerInputType) -> FieldViewModel? {
+        self.getLayerInputFields(key)?.first
+    }
+   
+    @MainActor
+    func setBlockStatus(_ input: LayerInputType,
+                        fieldIndex: Int? = nil,
+                        isBlocked: Bool) {
         
+        guard let fields = self.getLayerInputFields(input) else {
+            fatalErrorIfDebug("setBlockStatus: Could not retrieve fields for input \(input)")
+            return
+        }
+        
+        // If we have a particular field-index, then we're modifiyng a particular field,
+        // like height or width.
+        if let fieldIndex = fieldIndex {
+            guard let field = fields[safeIndex: fieldIndex] else {
+                fatalErrorIfDebug("setBlockStatus: Could not retrieve field \(fieldIndex) for input \(input)")
+                return
+            }
+            field.isBlockedOut = isBlocked
+        }
+        // Else we're changing the whole input
+        else {
+            fields.forEach { $0.isBlockedOut = isBlocked }
+            return
+        }
+    }
+        
+    // SizingScenario = Auto
+    
+    @MainActor
+    func unblockSizeInput() {
+        setBlockStatus(.size, isBlocked: false)
     }
     
-    func blockMinAndMaxWidth() {
-        
+    @MainActor
+    func blockMinAndMaxSizeInputs() {
+        setBlockStatus(.minSize, isBlocked: true)
+        setBlockStatus(.maxSize, isBlocked: true)
     }
     
-    func unblockMinAndMaxWidth() {
-        
-    }
-    
+    @MainActor
     func blockAspectRatio() {
-        
+        [LayerInputType.widthAxis, .heightAxis, .contentMode]
+            .forEach {
+                setBlockStatus($0, isBlocked: true)
+            }
+    }
+
+    // SizingScenario = ConstrainHeight
+
+    @MainActor func blockHeightFields() {
+        setBlockStatus(.size, fieldIndex: HEIGHT_FIELD_INDEX, isBlocked: true)
+        setBlockStatus(.minSize, fieldIndex: HEIGHT_FIELD_INDEX, isBlocked: true)
+        setBlockStatus(.maxSize, fieldIndex: HEIGHT_FIELD_INDEX, isBlocked: true)
     }
     
-    func unblockAspectRatio() {
-        
+    @MainActor func unblockWidthFields() {
+        setBlockStatus(.size, fieldIndex: WIDTH_FIELD_INDEX, isBlocked: false)
+        setBlockStatus(.minSize, fieldIndex: WIDTH_FIELD_INDEX, isBlocked: false)
+        setBlockStatus(.maxSize, fieldIndex: WIDTH_FIELD_INDEX, isBlocked: false)
     }
+    
+    @MainActor
+    func unblockAspectRatio() {
+        setBlockStatus(.widthAxis, isBlocked: false)
+        setBlockStatus(.heightAxis, isBlocked: false)
+        setBlockStatus(.contentMode, isBlocked: false)
+    }
+    
+    // SizingScenario = ConstrainWidth
+    
+    @MainActor func blockWidthFields() {
+        setBlockStatus(.size, fieldIndex: WIDTH_FIELD_INDEX, isBlocked: true)
+        setBlockStatus(.minSize, fieldIndex: WIDTH_FIELD_INDEX, isBlocked: true)
+        setBlockStatus(.maxSize, fieldIndex: WIDTH_FIELD_INDEX, isBlocked: true)
+    }
+    
+    @MainActor func unblockHeightFields() {
+        setBlockStatus(.size, fieldIndex: HEIGHT_FIELD_INDEX, isBlocked: false)
+        setBlockStatus(.minSize, fieldIndex: HEIGHT_FIELD_INDEX, isBlocked: false)
+        setBlockStatus(.maxSize, fieldIndex: HEIGHT_FIELD_INDEX, isBlocked: false)
+    }
+    
+    
+    // SizingScenario = Auto, LayerDimension = Point, Width
+    
+    @MainActor func blockMinAndMaxWidthFields() {
+        setBlockStatus(.minSize, fieldIndex: WIDTH_FIELD_INDEX, isBlocked: true)
+        setBlockStatus(.maxSize, fieldIndex: WIDTH_FIELD_INDEX, isBlocked: true)
+    }
+        
+    // SizingScenario = Auto, LayerDimension = Point, Height
+    
+    @MainActor func blockMinAndMaxHeightFields() {
+        setBlockStatus(.minSize, fieldIndex: HEIGHT_FIELD_INDEX, isBlocked: true)
+        setBlockStatus(.maxSize, fieldIndex: HEIGHT_FIELD_INDEX, isBlocked: true)
+    }
+    
+    // SizingScenario = Auto, LayerDimension = Auto/Hug/Fill etc., Width
+    
+    @MainActor func unblockMinAndMaxWidthFields() {
+        setBlockStatus(.minSize, fieldIndex: WIDTH_FIELD_INDEX, isBlocked: false)
+        setBlockStatus(.maxSize, fieldIndex: WIDTH_FIELD_INDEX, isBlocked: false)
+    }
+    
+    // SizingScenario = Auto, LayerDimension = Auto/Hug/Fill etc., Height
+    
+    @MainActor func unblockMinAndMaxHeightFields() {
+        setBlockStatus(.minSize, fieldIndex: HEIGHT_FIELD_INDEX, isBlocked: false)
+        setBlockStatus(.maxSize, fieldIndex: HEIGHT_FIELD_INDEX, isBlocked: false)
+    }
+    
 }
 
 extension StitchPadding {    

--- a/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
@@ -24,10 +24,10 @@ extension GraphState {
             return
         }
         
-        // Update the layer's per-index view models
-        layer.previewLayerViewModels.forEach { (layerViewModel: LayerViewModel) in
-            layerViewModel.sizingScenario = scenario
-        }
+//        // Update the layer's per-index view models
+//        layer.previewLayerViewModels.forEach { (layerViewModel: LayerViewModel) in
+//            layerViewModel.sizingScenario = scenario
+//        }
         
         // NOTE: does this work with loops? What is the relationship between a loop of fields
         guard let sizeInputFields = stitch.getInputRowObserver(for: .keyPath(.size))?.fieldValueTypes.first?.fieldObservers,
@@ -127,19 +127,22 @@ extension NodeViewModel {
 }
 
 extension StitchPadding {    
-    static let zero: Self = StitchPadding()
-    static let defaultPadding = .zero
+    static let zero: StitchPadding = .init(top: .zero,
+                                           right: .zero,
+                                           bottom: .zero,
+                                           left: .zero)
+    
+    static let defaultPadding = Self.zero
 }
 
 extension Point4D {
     var toStitchPadding: StitchPadding {
         .init(top: self.x,
-              bottom: self.y,
-              left: self.z,
-              right: self.w)
+              right: self.y,
+              bottom: self.z,
+              left: self.w)
     }
 }
-                            
                             
 extension StitchSpacing {
     

--- a/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
@@ -11,20 +11,16 @@ import StitchSchemaKit
 let WIDTH_FIELD_INDEX = 0
 let HEIGHT_FIELD_INDEX = 1
 
-extension GraphState {
+extension NodeViewModel {
     
     // When LayerDimension is `pt` or `parent percent`, disable the min/max along that same dimension.
     //
     @MainActor
-    func layerDimensionUpdated(layerId: NodeId,
-                               newValue: LayerDimension,
+    func layerDimensionUpdated(newValue: LayerDimension,
                                dimension: LengthDimension) {
         
-        guard let stitch = self.getNode(layerId) else {
-            fatalErrorIfDebug("could not find layer for id \(layerId)")
-            return
-        }
-        
+        let stitch = self
+                
         switch newValue {
             
         case .number,
@@ -51,34 +47,13 @@ extension GraphState {
     
     // Assumes input was already updated via e.g. PickerOptionSelected
     @MainActor
-    func sizingScenarioUpdated(layerId: NodeId,
-                               scenario: SizingScenario) {
+    func sizingScenarioUpdated(scenario: SizingScenario) {
         
-        log("sizingScenarioUpdated: layerId: \(layerId)")
         log("sizingScenarioUpdated: scenario: \(scenario)")
         
-        guard let stitch = self.getNode(layerId) else {
-            fatalErrorIfDebug("sizingScenarioUpdated: could not find layer for id \(layerId)")
-            return
-        }
+        let stitch = self
                 
         // NOTE: does this work with loops? What is the relationship between a loop of fields
-        
-//        guard let sizeInputFields = stitch.getInputRowObserver(for: .keyPath(.size))?.fieldValueTypes.first?.fieldObservers,
-//
-//                // min/max inputs
-//              let minSizeInputFields = stitch.getInputRowObserver(for: .keyPath(.minSize))?.fieldValueTypes.first?.fieldObservers,
-//              let maxSizeInputFields = stitch.getInputRowObserver(for: .keyPath(.maxSize))?.fieldValueTypes.first?.fieldObservers,
-//
-//                // Aspect ratio inputs
-//              let widthAxisInput = stitch.getInputRowObserver(for: .keyPath(.widthAxis))?.fieldValueTypes.first?.fieldObservers.first,
-//              let heightAxisInput = stitch.getInputRowObserver(for: .keyPath(.heightAxis))?.fieldValueTypes.first?.fieldObservers.first,
-//              let contentModeInput = stitch.getInputRowObserver(for: .keyPath(.contentMode))?.fieldValueTypes.first?.fieldObservers.first else {
-//            
-//            fatalErrorIfDebug("sizingScenarioUpdated: could not find required input for sizing scenario")
-//            return
-//        }
-        
         
         switch scenario {
             
@@ -88,70 +63,31 @@ extension GraphState {
             // if sizing scenario is auto, unblock the width and height fields:
             stitch.unblockSizeInput()
             
-//            sizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = false
-//            sizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = false
-            
-            
             // ... and block the min and max width and height (until width and height are set to grow or hug)
             stitch.blockMinAndMaxSizeInputs()
-            
-//            minSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = true
-//            maxSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = true
-//            minSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = true
-//            maxSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = true
                         
             // ... and block the aspect ratio inputs:
             stitch.blockAspectRatio()
             
-//            widthAxisInput.isBlockedOut = true
-//            heightAxisInput.isBlockedOut = true
-//            contentModeInput.isBlockedOut = true
-            
         case .constrainHeight:
             // if height is constrained, block-out the height inputs (height, min height, max height):
             stitch.blockHeightFields()
-            
-//            sizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = true
-//            minSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = true
-//            maxSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = true
-            
-            
+                        
             // ... and unblock the width fields:
             stitch.unblockWidthFields()
             
-//            sizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = false
-//            minSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = false
-//            maxSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = false
-            
-            
             // ... and unblock the aspect ratio inputs:
             stitch.unblockAspectRatio()
-            
-//            widthAxisInput.isBlockedOut = false
-//            heightAxisInput.isBlockedOut = false
-//            contentModeInput.isBlockedOut = false
             
         case .constrainWidth:
             // if width is constrained, block-out the width inputs (width, min width, max width):
             stitch.blockWidthFields()
             
-//            sizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = true
-//            minSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = true
-//            maxSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = true
-            
             // ... and unblock the height fields:
             stitch.unblockHeightFields()
             
-//            sizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = false
-//            minSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = false
-//            maxSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = false
-            
             // ... and unblock the aspect ratio inputs:
             stitch.unblockAspectRatio()
-            
-//            widthAxisInput.isBlockedOut = false
-//            heightAxisInput.isBlockedOut = false
-//            contentModeInput.isBlockedOut = false
         }
     }
 }

--- a/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
@@ -126,31 +126,9 @@ extension NodeViewModel {
     }
 }
 
-
-enum SizingScenario: String, Equatable, Hashable, Codable, CaseIterable {
-    case auto = "Auto", // manually specify both H and W
-         constrainHeight = "Constrain Height", // manually specify W; H will follow
-         constrainWidth = "Constrain Width" // manually specify H; W will follow
-}
-
-// TODO: combine with Point4D ? Or will the names `x, y, z, w` be too unfamiliar vers `top`, `bottom` etc.; e.g. does `x` refer to `left` or `right`?
-struct StitchPadding: Equatable, Hashable, Codable {
-    var top: CGFloat = .zero
-    var bottom: CGFloat = .zero
-    var left: CGFloat = .zero
-    var right: CGFloat = .zero
-
-}
-
-extension StitchPadding {
-    init(_ number: CGFloat) {
-        self.top = number
-        self.bottom = number
-        self.left = number
-        self.right = number
-    }
-    
-    static let zero: Self = Self.init(0)
+extension StitchPadding {    
+    static let zero: Self = StitchPadding()
+    static let defaultPadding = .zero
 }
 
 extension Point4D {

--- a/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
@@ -21,17 +21,11 @@ extension GraphState {
         log("sizingScenarioUpdated: layerId: \(layerId)")
         log("sizingScenarioUpdated: scenario: \(scenario)")
         
-        guard let stitch = self.getNode(layerId),
-              let layer = stitch.layerNode else {
+        guard let stitch = self.getNode(layerId) else {
             fatalErrorIfDebug("could not find layer for id \(layerId)")
             return
         }
-        
-//        // Update the layer's per-index view models
-//        layer.previewLayerViewModels.forEach { (layerViewModel: LayerViewModel) in
-//            layerViewModel.sizingScenario = scenario
-//        }
-        
+                
         // NOTE: does this work with loops? What is the relationship between a loop of fields
         guard let sizeInputFields = stitch.getInputRowObserver(for: .keyPath(.size))?.fieldValueTypes.first?.fieldObservers,
 

--- a/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
@@ -18,6 +18,9 @@ extension GraphState {
     func sizingScenarioUpdated(layerId: NodeId,
                                scenario: SizingScenario) {
         
+        log("sizingScenarioUpdated: layerId: \(layerId)")
+        log("sizingScenarioUpdated: scenario: \(scenario)")
+        
         guard let stitch = self.getNode(layerId),
               let layer = stitch.layerNode else {
             fatalErrorIfDebug("could not find layer for id \(layerId)")

--- a/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
@@ -8,6 +8,130 @@
 import SwiftUI
 import StitchSchemaKit
 
+let WIDTH_FIELD_INDEX = 0
+let HEIGHT_FIELD_INDEX = 1
+
+extension GraphState {
+    
+    // Assumes input was already updated via e.g. PickerOptionSelected
+    @MainActor
+    func sizingScenarioUpdated(layerId: NodeId,
+                               scenario: SizingScenario) {
+        
+        guard let stitch = self.getNode(layerId),
+              let layer = stitch.layerNode else {
+            fatalErrorIfDebug("could not find layer for id \(layerId)")
+            return
+        }
+        
+        // Update the layer's per-index view models
+        layer.previewLayerViewModels.forEach { (layerViewModel: LayerViewModel) in
+            layerViewModel.sizingScenario = scenario
+        }
+        
+        // NOTE: does this work with loops? What is the relationship between a loop of fields
+        guard let sizeInputFields = stitch.getInputRowObserver(for: .keyPath(.size))?.fieldValueTypes.first?.fieldObservers,
+
+                // min/max inputs
+              let minSizeInputFields = stitch.getInputRowObserver(for: .keyPath(.minSize))?.fieldValueTypes.first?.fieldObservers,
+              let maxSizeInputFields = stitch.getInputRowObserver(for: .keyPath(.maxSize))?.fieldValueTypes.first?.fieldObservers,
+
+                // Aspect ratio inputs
+              let widthAxisInput = stitch.getInputRowObserver(for: .keyPath(.widthAxis))?.fieldValueTypes.first?.fieldObservers.first,
+              let heightAxisInput = stitch.getInputRowObserver(for: .keyPath(.heightAxis))?.fieldValueTypes.first?.fieldObservers.first,
+              let contentModeInput = stitch.getInputRowObserver(for: .keyPath(.contentMode))?.fieldValueTypes.first?.fieldObservers.first else {
+            
+            fatalErrorIfDebug("could not find required input for sizing scenario")
+            return
+        }
+        
+        switch scenario {
+            
+        case .auto:
+            // TODO: unblock e.g. min/max width when width set to grow/hug (will be a different action / scenario?)
+            
+            // if sizing scenario is auto, unblock the width and height fields:
+            sizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = false
+            sizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = false
+            
+            // ... and block the min and max width and height (until width and height are set to grow or hug)
+            minSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = true
+            maxSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = true
+            minSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = true
+            maxSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = true
+                        
+            // ... and block the aspect ratio inputs:
+            widthAxisInput.isBlockedOut = true
+            heightAxisInput.isBlockedOut = true
+            contentModeInput.isBlockedOut = true
+            
+        case .constrainHeight:
+            // if height is constrained, block-out the height inputs (height, min height, max height):
+            sizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = true
+            minSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = true
+            maxSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = true
+            
+            // ... and unblock the width fields:
+            sizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = false
+            minSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = false
+            maxSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = false
+            
+            // ... and unblock the aspect ratio inputs:
+            widthAxisInput.isBlockedOut = true
+            heightAxisInput.isBlockedOut = true
+            contentModeInput.isBlockedOut = true
+            
+        case .constrainWidth:
+            // if width is constrained, block-out the width inputs (width, min width, max width):
+            sizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = true
+            minSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = true
+            maxSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = true
+            
+            // ... and unblock the height fields:
+            sizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = false
+            minSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = false
+            maxSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = false
+            
+            // ... and unblock the aspect ratio inputs:
+            widthAxisInput.isBlockedOut = true
+            heightAxisInput.isBlockedOut = true
+            contentModeInput.isBlockedOut = true
+        }
+    }
+}
+
+extension NodeViewModel {
+    func blockMinAndMaxHeight() {
+        
+    }
+    
+    func unblockMinAndMaxHeight() {
+        
+    }
+    
+    func blockMinAndMaxWidth() {
+        
+    }
+    
+    func unblockMinAndMaxWidth() {
+        
+    }
+    
+    func blockAspectRatio() {
+        
+    }
+    
+    func unblockAspectRatio() {
+        
+    }
+}
+
+
+enum SizingScenario: String, Equatable, Hashable, Codable, CaseIterable {
+    case auto = "Auto", // manually specify both H and W
+         constrainHeight = "Constrain Height", // manually specify W; H will follow
+         constrainWidth = "Constrain Width" // manually specify H; W will follow
+}
 
 // TODO: combine with Point4D ? Or will the names `x, y, z, w` be too unfamiliar vers `top`, `bottom` etc.; e.g. does `x` refer to `left` or `right`?
 struct StitchPadding: Equatable, Hashable, Codable {

--- a/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
@@ -152,19 +152,11 @@ extension NodeViewModel {
     @MainActor
     func updateMinMaxWidthFieldsBlockingPerWidth(activeIndex: ActiveIndex) {
         
+        // Check the input itself (the value at the active-index), not the field view model.
         guard let widthIsNumber = self.getInputRowObserver(for: .keyPath(.size))?.getActiveValue(activeIndex: activeIndex).getSize?.width.isNumber else {
             fatalErrorIfDebug("updateMinMaxWidthFieldsBlockingPerWidth: no field?")
-            // default to blocking these fields ?
-//            self.blockMinAndMaxWidthFields()
             return
         }
-        
-//        guard let widthIsNumber = self.getLayerInputFields(.size)?[safe: WIDTH_FIELD_INDEX]?.fieldValue.layerDimensionField else {
-//            log("updateMinMaxWidthFieldsBlockingPerWidth: no field?")
-//            // default to blocking these fields ?
-//            self.blockMinAndMaxWidthFields()
-//            return
-//        }
         
         if !widthIsNumber {
             self.unblockMinAndMaxWidthFields()
@@ -175,15 +167,10 @@ extension NodeViewModel {
     
     @MainActor
     func updateMinMaxHeightFieldsBlockingPerHeight(activeIndex: ActiveIndex) {
-//        guard let heightIsNumber = self.getLayerInputFields(.size)?[safe: HEIGHT_FIELD_INDEX]?.fieldValue.layerDimensionField else {
-//            log("updateMinMaxHeightFieldsBlockingPerHeight: no field?")
-//            self.blockMinAndMaxWidthFields()
-//            return
-//        }
-        
+
+        // Check the input itself (the value at the active-index), not the field view model.
         guard let heightIsNumber = self.getInputRowObserver(for: .keyPath(.size))?.getActiveValue(activeIndex: activeIndex).getSize?.height.isNumber else {
             fatalErrorIfDebug("updateMinMaxHeightFieldsBlockingPerHeight: no field?")
-            // default to blocking these fields ?
             return
         }
         

--- a/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
@@ -77,9 +77,9 @@ extension GraphState {
             maxSizeInputFields[safe: WIDTH_FIELD_INDEX]?.isBlockedOut = false
             
             // ... and unblock the aspect ratio inputs:
-            widthAxisInput.isBlockedOut = true
-            heightAxisInput.isBlockedOut = true
-            contentModeInput.isBlockedOut = true
+            widthAxisInput.isBlockedOut = false
+            heightAxisInput.isBlockedOut = false
+            contentModeInput.isBlockedOut = false
             
         case .constrainWidth:
             // if width is constrained, block-out the width inputs (width, min width, max width):
@@ -93,9 +93,9 @@ extension GraphState {
             maxSizeInputFields[safe: HEIGHT_FIELD_INDEX]?.isBlockedOut = false
             
             // ... and unblock the aspect ratio inputs:
-            widthAxisInput.isBlockedOut = true
-            heightAxisInput.isBlockedOut = true
-            contentModeInput.isBlockedOut = true
+            widthAxisInput.isBlockedOut = false
+            heightAxisInput.isBlockedOut = false
+            contentModeInput.isBlockedOut = false
         }
     }
 }

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommon.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommon.swift
@@ -30,15 +30,33 @@ struct PreviewCommonModifier: ViewModifier {
 //        size.width
 //    }
     
-    let minWidth: NumericalLayerDimension? = nil
-    let maxWidth: NumericalLayerDimension? = nil
+//    let minWidth: NumericalLayerDimension? = nil
+//    let maxWidth: NumericalLayerDimension? = nil
+    
+    var minWidth: NumericalLayerDimension? {
+        .number(layerViewModel.minSize.getSize!.asAlgebraicCGSize.width)
+    }
+    
+    var maxWidth: NumericalLayerDimension? {
+        .number(layerViewModel.maxSize.getSize!.asAlgebraicCGSize.width)
+    }
 
 //    var height: LayerDimension {
 //        size.height
 //    }
     
-    let minHeight: NumericalLayerDimension? = nil
-    let maxHeight: NumericalLayerDimension? = nil
+//    let minHeight: NumericalLayerDimension? = nil
+//    let maxHeight: NumericalLayerDimension? = nil
+    
+    var minHeight: NumericalLayerDimension? {
+//        layerViewModel.minSize.height
+        .number(layerViewModel.minSize.getSize!.asAlgebraicCGSize.height)
+    }
+    
+    var maxHeight: NumericalLayerDimension? {
+//        layerViewModel.maxSize.height
+        .number(layerViewModel.maxSize.getSize!.asAlgebraicCGSize.height)
+    }
         
     let scale: Double
     let anchoring: Anchoring
@@ -82,6 +100,7 @@ struct PreviewCommonModifier: ViewModifier {
                     minHeight: minHeight,
                     maxHeight: maxHeight,
                     parentSize: parentSize,
+                    sizingScenario: layerViewModel.sizingScenario.getSizingScenario ?? .defaultSizingScenario,
                     frameAlignment: frameAlignment))
         
             // Only for MapLayer, specifically for thumbnail-creation edge case

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommon.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommon.swift
@@ -33,29 +33,29 @@ struct PreviewCommonModifier: ViewModifier {
 //    let minWidth: NumericalLayerDimension? = nil
 //    let maxWidth: NumericalLayerDimension? = nil
     
-    var minWidth: NumericalLayerDimension? {
-        .number(layerViewModel.minSize.getSize!.asAlgebraicCGSize.width)
+    var minWidth: LayerDimension? {
+        layerViewModel.minSize.getSize!.width
     }
     
-    var maxWidth: NumericalLayerDimension? {
-        .number(layerViewModel.maxSize.getSize!.asAlgebraicCGSize.width)
+    var maxWidth: LayerDimension? {
+        layerViewModel.maxSize.getSize!.width
     }
 
 //    var height: LayerDimension {
 //        size.height
 //    }
     
-//    let minHeight: NumericalLayerDimension? = nil
-//    let maxHeight: NumericalLayerDimension? = nil
+//    let minHeight: LayerDimension? = nil
+//    let maxHeight: LayerDimension? = nil
     
-    var minHeight: NumericalLayerDimension? {
+    var minHeight: LayerDimension? {
 //        layerViewModel.minSize.height
-        .number(layerViewModel.minSize.getSize!.asAlgebraicCGSize.height)
+        layerViewModel.minSize.getSize!.height
     }
     
-    var maxHeight: NumericalLayerDimension? {
+    var maxHeight: LayerDimension? {
 //        layerViewModel.maxSize.height
-        .number(layerViewModel.maxSize.getSize!.asAlgebraicCGSize.height)
+        layerViewModel.maxSize.getSize!.height
     }
         
     let scale: Double

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommon.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommon.swift
@@ -20,43 +20,10 @@ struct PreviewCommonModifier: ViewModifier {
     let rotationZ: CGFloat
     
 //    let aspectRatio: AspectRatioData?  = nil
-    let constraint: LengthDimension? = nil
+    let constraint: LengthDimension? = nil // No longer uses?
     
     // should receive LayerSize, so can use `nil` for a .frame dimension when we have LayerDimension.fill/grow
     let size: LayerSize
-    
-    // TODO: can be `nil` if we're using min/max width etc.
-//    var width: LayerDimension {
-//        size.width
-//    }
-    
-//    let minWidth: NumericalLayerDimension? = nil
-//    let maxWidth: NumericalLayerDimension? = nil
-    
-    var minWidth: LayerDimension? {
-        layerViewModel.minSize.getSize!.width
-    }
-    
-    var maxWidth: LayerDimension? {
-        layerViewModel.maxSize.getSize!.width
-    }
-
-//    var height: LayerDimension {
-//        size.height
-//    }
-    
-//    let minHeight: LayerDimension? = nil
-//    let maxHeight: LayerDimension? = nil
-    
-    var minHeight: LayerDimension? {
-//        layerViewModel.minSize.height
-        layerViewModel.minSize.getSize!.height
-    }
-    
-    var maxHeight: LayerDimension? {
-//        layerViewModel.maxSize.height
-        layerViewModel.maxSize.getSize!.height
-    }
         
     let scale: Double
     let anchoring: Anchoring
@@ -92,21 +59,14 @@ struct PreviewCommonModifier: ViewModifier {
         content
             .modifier(PreviewCommonSizeModifier(
                     viewModel: layerViewModel,
-                    
-                    aspectRatio: .init(
-                        widthAxis: layerViewModel.widthAxis.getNumber!,
-                        heightAxis: layerViewModel.heightAxis.getNumber!,
-                        contentMode: layerViewModel.contentMode.getContentMode!.toSwiftUIContent),
-                    
-                    //aspectRatio,
-                    constraint: constraint,
+                    aspectRatio: layerViewModel.getAspectRatioData(),
                     size: size,
-                    minWidth: minWidth,
-                    maxWidth: maxWidth,
-                    minHeight: minHeight,
-                    maxHeight: maxHeight,
+                    minWidth: layerViewModel.getMinWidth,
+                    maxWidth: layerViewModel.getMaxWidth,
+                    minHeight: layerViewModel.getMinHeight,
+                    maxHeight: layerViewModel.getMaxHeight,
                     parentSize: parentSize,
-                    sizingScenario: layerViewModel.sizingScenario.getSizingScenario ?? .defaultSizingScenario,
+                    sizingScenario: layerViewModel.getSizingScenario,
                     frameAlignment: frameAlignment))
         
             // Only for MapLayer, specifically for thumbnail-creation edge case

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommon.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommon.swift
@@ -19,7 +19,7 @@ struct PreviewCommonModifier: ViewModifier {
     let rotationY: CGFloat
     let rotationZ: CGFloat
     
-    let aspectRatio: AspectRatioData? = nil
+//    let aspectRatio: AspectRatioData?  = nil
     let constraint: LengthDimension? = nil
     
     // should receive LayerSize, so can use `nil` for a .frame dimension when we have LayerDimension.fill/grow
@@ -92,7 +92,13 @@ struct PreviewCommonModifier: ViewModifier {
         content
             .modifier(PreviewCommonSizeModifier(
                     viewModel: layerViewModel,
-                    aspectRatio: aspectRatio,
+                    
+                    aspectRatio: .init(
+                        widthAxis: layerViewModel.widthAxis.getNumber!,
+                        heightAxis: layerViewModel.heightAxis.getNumber!,
+                        contentMode: layerViewModel.contentMode.getContentMode!.toSwiftUIContent),
+                    
+                    //aspectRatio,
                     constraint: constraint,
                     size: size,
                     minWidth: minWidth,

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonSizeModifier.swift
@@ -1,5 +1,5 @@
 //
-//  PreviewCommonSizeModifier2.swift
+//  PreviewCommonSizeModifier.swift
 //  Stitch
 //
 //  Created by Christian J Clampitt on 7/3/24.
@@ -7,15 +7,9 @@
 
 import SwiftUI
 import StitchSchemaKit
-
+ 
 extension LayerDimension {
-    func asFrameDimension(_ parentLength: CGFloat,
-                          constrained: Bool = false) -> CGFloat? {
-
-           if constrained {
-               return nil // i.e. unspecified, just like .fill, .hug, .auto
-           }
-           
+    func asFrameDimension(_ parentLength: CGFloat) -> CGFloat? {
            switch self {
                // fill or hug = no set value along this dimension
            case .fill, .hug,
@@ -40,38 +34,20 @@ struct PreviewCommonSizeModifier: ViewModifier {
     
     @Bindable var viewModel: LayerViewModel
     
-    // TODO: actually pass these properties down
-    var aspectRatio: AspectRatioData //? = nil
+    let aspectRatio: AspectRatioData
+    let size: LayerSize
     
-    // If a dimension is constrained, then we use .unspecified for that dimension.
-    var constraint: LengthDimension? = nil
+    var width: LayerDimension { size.width }
+    let minWidth: LayerDimension?
+    let maxWidth: LayerDimension?
     
-    // TODO: remove once properties are actually passed down
-    var size: LayerSize
-    
-        // Can actually be optional, if
-    var width: LayerDimension {
-        size.width
-    }
-    
-    // TODO: actually pass these properties down
-//    let minWidth: NumericalLayerDimension? // = nil
-    let minWidth: LayerDimension? // = nil
-//    let maxWidth: NumericalLayerDimension? // = nil
-    let maxWidth: LayerDimension? // = nil
-    
-    var height: LayerDimension {
-        size.height
-    }
-    
-//    let minHeight: NumericalLayerDimension? // = nil
-    let minHeight: LayerDimension? // = nil
-//    let maxHeight: NumericalLayerDimension? // = nil
-    let maxHeight: LayerDimension? // = nil
+    var height: LayerDimension { size.height }
+    let minHeight: LayerDimension?
+    let maxHeight: LayerDimension?
     
     let parentSize: CGSize
-    
-    var sizingScenario: SizingScenario
+
+    let sizingScenario: SizingScenario
         
     /*
      Only for:
@@ -102,10 +78,8 @@ struct PreviewCommonSizeModifier: ViewModifier {
                     alignment: frameAlignment,
                     usesParentPercentForWidth: usesParentPercentForWidth,
                     usesParentPercentForHeight: usesParentPercentForHeight,
-                    width: width.asFrameDimension(parentSize.width,
-                                                   constrained: false),
-                    height: height.asFrameDimension(parentSize.height,
-                                                     constrained: false),
+                    width: width.asFrameDimension(parentSize.width),
+                    height: height.asFrameDimension(parentSize.height),
                     minWidth: minWidth?.asFrameDimension(parentSize.width),
                     maxWidth: maxWidth?.asFrameDimension(parentSize.width),
                     minHeight: minHeight?.asFrameDimension(parentSize.height),
@@ -128,10 +102,6 @@ struct PreviewCommonSizeModifier: ViewModifier {
                     
                     usesParentPercentForWidth: usesParentPercentForWidth,
                     usesParentPercentForHeight: usesParentPercentForHeight,
-                    
-                    /// SHOULD NOT USE THE `CONSTRAINED` PARAM BECAUSE THAT IS COMPLETELY WRONG!! LOL
-//                    width: width.asFrameDimension(parentSize.width,
-//                                                   constrained: true),
                     width: width.asFrameDimension(parentSize.width),
                     height: nil,
                     minWidth: minWidth?.asFrameDimension(parentSize.width),
@@ -148,10 +118,8 @@ struct PreviewCommonSizeModifier: ViewModifier {
             logInView("case .constrainWidth")
             // i.e. only allow us to specify height and aspect ratio
             content
-            
             // apply `.aspectRatio` separately from `.frame(width:)` and `.frame(height:)`
                 .modifier(PreviewAspectRatioModifier(data: aspectRatio))
-            
                 .modifier(LayerSizeModifier(
                     alignment: frameAlignment,
                     usesParentPercentForWidth: usesParentPercentForWidth,
@@ -164,35 +132,8 @@ struct PreviewCommonSizeModifier: ViewModifier {
                     maxHeight: maxHeight?.asFrameDimension(parentSize.height)
                 ))
             
-//            // apply `.aspectRatio` separately from `.frame(width:)` and `.frame(height:)`
-//                .modifier(PreviewAspectRatioModifier(data: aspectRatio))
-            
             // place the LayerSizeReader after the .aspectRatio modifier ?
                 .modifier(LayerSizeReader(viewModel: viewModel))
         }
-        
-//        content
-//            .modifier(LayerSizeModifier(
-//                alignment: frameAlignment,
-//
-//                width: width?.asFrameDimension(parentSize.width,
-//                                               constrained: constraint == .width),
-//                
-//                height: height?.asFrameDimension(parentSize.height,
-//                                                 constrained: constraint == .height),
-//                
-//                minWidth: minWidth?.asFrameDimension(parentSize.width),
-//                maxWidth: maxWidth?.asFrameDimension(parentSize.width),
-//                
-//                minHeight: minHeight?.asFrameDimension(parentSize.height),
-//                maxHeight: maxHeight?.asFrameDimension(parentSize.height)
-//            ))
-//        
-//        // apply `.aspectRatio` separately from `.frame(width:)` and `.frame(height:)`
-//            .modifier(PreviewAspectRatioModifier(data: aspectRatio))
-//        
-//        // place the LayerSizeReader after the .aspectRatio modifier ?
-//            .modifier(LayerSizeReader(viewModel: viewModel))
     }
-    
 }

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonSizeModifier.swift
@@ -94,10 +94,10 @@ struct PreviewCommonSizeModifier: ViewModifier {
                                                    constrained: false),
                     height: height.asFrameDimension(parentSize.height,
                                                      constrained: false),
-                    minWidth: nil,
-                    maxWidth: nil,
-                    minHeight: nil,
-                    maxHeight: nil
+                    minWidth: minWidth?.asFrameDimension(parentSize.width),
+                    maxWidth: maxWidth?.asFrameDimension(parentSize.width),
+                    minHeight: minHeight?.asFrameDimension(parentSize.height),
+                    maxHeight: maxHeight?.asFrameDimension(parentSize.height)
                 ))
                         
             // place the LayerSizeReader after the .aspectRatio modifier ?

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonSizeModifier.swift
@@ -41,7 +41,7 @@ struct PreviewCommonSizeModifier: ViewModifier {
     @Bindable var viewModel: LayerViewModel
     
     // TODO: actually pass these properties down
-    var aspectRatio: AspectRatioData? = nil
+    var aspectRatio: AspectRatioData //? = nil
     
     // If a dimension is constrained, then we use .unspecified for that dimension.
     var constraint: LengthDimension? = nil
@@ -107,6 +107,10 @@ struct PreviewCommonSizeModifier: ViewModifier {
             logInView("case .constrainHeight")
             // i.e. only allow us to specify width and aspect ratio
             content
+            
+            // apply `.aspectRatio` separately from `.frame(width:)` and `.frame(height:)`
+                .modifier(PreviewAspectRatioModifier(data: aspectRatio))
+            
                 .modifier(LayerSizeModifier(
                     alignment: frameAlignment,
                     
@@ -120,9 +124,7 @@ struct PreviewCommonSizeModifier: ViewModifier {
                     minHeight: nil,
                     maxHeight: nil
                 ))
-            
-            // apply `.aspectRatio` separately from `.frame(width:)` and `.frame(height:)`
-                .modifier(PreviewAspectRatioModifier(data: aspectRatio))
+           
             
             // place the LayerSizeReader after the .aspectRatio modifier ?
                 .modifier(LayerSizeReader(viewModel: viewModel))
@@ -131,19 +133,22 @@ struct PreviewCommonSizeModifier: ViewModifier {
             logInView("case .constrainWidth")
             // i.e. only allow us to specify height and aspect ratio
             content
+            
+            // apply `.aspectRatio` separately from `.frame(width:)` and `.frame(height:)`
+                .modifier(PreviewAspectRatioModifier(data: aspectRatio))
+            
                 .modifier(LayerSizeModifier(
                     alignment: frameAlignment,
                     width: nil,
-                    height: height.asFrameDimension(parentSize.height,
-                                                     constrained: true),
+                    height: height.asFrameDimension(parentSize.height),
                     minWidth: nil,
                     maxWidth: nil,
                     minHeight: minHeight?.asFrameDimension(parentSize.height),
                     maxHeight: maxHeight?.asFrameDimension(parentSize.height)
                 ))
             
-            // apply `.aspectRatio` separately from `.frame(width:)` and `.frame(height:)`
-                .modifier(PreviewAspectRatioModifier(data: aspectRatio))
+//            // apply `.aspectRatio` separately from `.frame(width:)` and `.frame(height:)`
+//                .modifier(PreviewAspectRatioModifier(data: aspectRatio))
             
             // place the LayerSizeReader after the .aspectRatio modifier ?
                 .modifier(LayerSizeReader(viewModel: viewModel))

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonSizeModifier.swift
@@ -85,21 +85,15 @@ struct PreviewCommonSizeModifier: ViewModifier {
                     minHeight: minHeight?.asFrameDimension(parentSize.height),
                     maxHeight: maxHeight?.asFrameDimension(parentSize.height)
                 ))
-                        
-            // place the LayerSizeReader after the .aspectRatio modifier ?
                 .modifier(LayerSizeReader(viewModel: viewModel))
             
         case .constrainHeight:
             logInView("case .constrainHeight")
-            // i.e. only allow us to specify width and aspect ratio
             content
-            
             // apply `.aspectRatio` separately from `.frame(width:)` and `.frame(height:)`
                 .modifier(PreviewAspectRatioModifier(data: aspectRatio))
-            
                 .modifier(LayerSizeModifier(
                     alignment: frameAlignment,
-                    
                     usesParentPercentForWidth: usesParentPercentForWidth,
                     usesParentPercentForHeight: usesParentPercentForHeight,
                     width: width.asFrameDimension(parentSize.width),
@@ -109,14 +103,10 @@ struct PreviewCommonSizeModifier: ViewModifier {
                     minHeight: nil,
                     maxHeight: nil
                 ))
-           
-            
-            // place the LayerSizeReader after the .aspectRatio modifier ?
                 .modifier(LayerSizeReader(viewModel: viewModel))
             
         case .constrainWidth:
             logInView("case .constrainWidth")
-            // i.e. only allow us to specify height and aspect ratio
             content
             // apply `.aspectRatio` separately from `.frame(width:)` and `.frame(height:)`
                 .modifier(PreviewAspectRatioModifier(data: aspectRatio))
@@ -131,8 +121,6 @@ struct PreviewCommonSizeModifier: ViewModifier {
                     minHeight: minHeight?.asFrameDimension(parentSize.height),
                     maxHeight: maxHeight?.asFrameDimension(parentSize.height)
                 ))
-            
-            // place the LayerSizeReader after the .aspectRatio modifier ?
                 .modifier(LayerSizeReader(viewModel: viewModel))
         }
     }

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonSizeModifier.swift
@@ -55,15 +55,19 @@ struct PreviewCommonSizeModifier: ViewModifier {
     }
     
     // TODO: actually pass these properties down
-    let minWidth: NumericalLayerDimension? // = nil
-    let maxWidth: NumericalLayerDimension? // = nil
+//    let minWidth: NumericalLayerDimension? // = nil
+    let minWidth: LayerDimension? // = nil
+//    let maxWidth: NumericalLayerDimension? // = nil
+    let maxWidth: LayerDimension? // = nil
     
     var height: LayerDimension {
         size.height
     }
     
-    let minHeight: NumericalLayerDimension? // = nil
-    let maxHeight: NumericalLayerDimension? // = nil
+//    let minHeight: NumericalLayerDimension? // = nil
+    let minHeight: LayerDimension? // = nil
+//    let maxHeight: NumericalLayerDimension? // = nil
+    let maxHeight: LayerDimension? // = nil
     
     let parentSize: CGSize
     
@@ -80,16 +84,24 @@ struct PreviewCommonSizeModifier: ViewModifier {
     // `.frame(alignment:)` only matters if there is a size gap between the layer and its frame; can happen for Text, TextField, ProgressIndicator and other native views which do not resize just by .frame
     let frameAlignment: Alignment
 
+    var usesParentPercentForWidth: Bool {
+        width.isParentPercentage
+    }
+    
+    var usesParentPercentForHeight: Bool {
+        height.isParentPercentage
+    }
+    
     func body(content: Content) -> some View {
         
         switch sizingScenario {
         case .auto:
             logInView("case .auto")
-            // i.e. disallow min and max sizes
-            // TODO: allow min and max length when that length = grow/hug/nil
             content
                 .modifier(LayerSizeModifier(
                     alignment: frameAlignment,
+                    usesParentPercentForWidth: usesParentPercentForWidth,
+                    usesParentPercentForHeight: usesParentPercentForHeight,
                     width: width.asFrameDimension(parentSize.width,
                                                    constrained: false),
                     height: height.asFrameDimension(parentSize.height,
@@ -113,6 +125,9 @@ struct PreviewCommonSizeModifier: ViewModifier {
             
                 .modifier(LayerSizeModifier(
                     alignment: frameAlignment,
+                    
+                    usesParentPercentForWidth: usesParentPercentForWidth,
+                    usesParentPercentForHeight: usesParentPercentForHeight,
                     
                     /// SHOULD NOT USE THE `CONSTRAINED` PARAM BECAUSE THAT IS COMPLETELY WRONG!! LOL
 //                    width: width.asFrameDimension(parentSize.width,
@@ -139,6 +154,8 @@ struct PreviewCommonSizeModifier: ViewModifier {
             
                 .modifier(LayerSizeModifier(
                     alignment: frameAlignment,
+                    usesParentPercentForWidth: usesParentPercentForWidth,
+                    usesParentPercentForHeight: usesParentPercentForHeight,
                     width: nil,
                     height: height.asFrameDimension(parentSize.height),
                     minWidth: nil,

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
@@ -45,8 +45,8 @@ struct LayerSizeModifier: ViewModifier {
 //                          alignment: alignment)
 //        } else {
             content
-            .aspectRatio(CGSize(width: 1, height: 2),
-                         contentMode: .fit)
+//            .aspectRatio(CGSize(width: 1, height: 2),
+//                         contentMode: .fit)
             .frame(width: width?.atleastZero(),
                           height: height?.atleastZero(),
                           alignment: alignment)

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import StitchSchemaKit
 
 extension CGFloat {
     func atleastZero() -> CGFloat {
@@ -23,6 +24,9 @@ struct LayerSizeModifier: ViewModifier {
 
     let alignment: Alignment
     
+    let usesParentPercentForWidth: Bool
+    let usesParentPercentForHeight: Bool
+    
     // nil = dimension is unspecified
     
     let width: CGFloat?
@@ -32,6 +36,28 @@ struct LayerSizeModifier: ViewModifier {
     let maxWidth: CGFloat?
     let minHeight: CGFloat?
     let maxHeight: CGFloat?
+    
+//    var finalMinWidth: CGFloat? {
+//        // no matter what is passed in, if we are using parent-percent al
+//    }
+//    var finalMaxWidth: CGFloat? {
+//        // no matter what is passed in, if we are using parent-percent al
+//    }
+//    var finalMinHeight: CGFloat? {
+//        // no matter what is passed in, if we are using parent-percent al
+//    }
+//    var finalMaxHeight: CGFloat? {
+//        // no matter what is passed in, if we are using parent-percent al
+//    }
+//
+    
+//    let width: LayerDimension?
+//    let height: LayerDimension?
+//        
+//    let minWidth: LayerDimension?
+//    let maxWidth: LayerDimension?
+//    let minHeight: LayerDimension?
+//    let maxHeight: LayerDimension?
     
     var someMinMaxDefined: Bool {
         minWidth.isDefined || maxWidth.isDefined || minHeight.isDefined || maxHeight.isDefined
@@ -43,7 +69,9 @@ struct LayerSizeModifier: ViewModifier {
     var someDimensionFixed: Bool {
         width.isDefined || height.isDefined
     }
-        
+            
+    
+    
     func body(content: Content) -> some View {
         logInView("LayerSizeModifier: width: \(width)")
         logInView("LayerSizeModifier: height: \(height)")
@@ -51,31 +79,55 @@ struct LayerSizeModifier: ViewModifier {
         logInView("LayerSizeModifier: maxWidth: \(maxWidth)")
         logInView("LayerSizeModifier: minHeight: \(minHeight)")
         logInView("LayerSizeModifier: maxHeight: \(maxHeight)")
-        
+                
         // Width is pt, but height is auto (so can use min/max height)
         if let width = width, !height.isDefined {
+            logInView("LayerSizeModifier: defined width but not height")
+            
+            // How to handle case where "set width, but non-nil min and max width passed down"
+            
             content
+            // parent percentage supports min/max along a dimension
+                .frame(minWidth: usesParentPercentForWidth ? minWidth : nil)
+                .frame(maxWidth: usesParentPercentForWidth ? maxWidth : nil)
                 .frame(width: width)
                 .frame(minHeight: minHeight, maxHeight: maxHeight)
+            
             // ^^ this will mess up the `alignment` for views like `Text`, `ProgressIndicator` etc.
             // Do you need an additional `pos: adjustPosition` modifier specifically for something like `Text` ?
         } 
         
         // Height is pt, but width is auto (so can use min/max width)
         else if let height = height, !width.isDefined {
+            logInView("LayerSizeModifier: defined height but not width")
+            
             content
+                .frame(minHeight: usesParentPercentForHeight ? minHeight : nil)
+                .frame(maxHeight: usesParentPercentForHeight ? maxHeight : nil)
                 .frame(height: height)
                 .frame(minWidth: minWidth, maxWidth: maxWidth)
-        } 
+        }
         
         // Both height and width are pt (so no min/max size at all)
         else if let width = width, let height = height {
+            logInView("LayerSizeModifier: defined width and height")
+            
+            
             content
-                .frame(width: width, height: height)
-        } 
+//                .frame(width: width, height: height)
+            
+                .frame(minWidth: usesParentPercentForWidth ? minWidth : nil)
+                .frame(maxWidth: usesParentPercentForWidth ? maxWidth : nil)
+                .frame(width: width)
+            
+                .frame(minHeight: usesParentPercentForHeight ? minHeight : nil)
+                .frame(maxHeight: usesParentPercentForHeight ? maxHeight : nil)
+                .frame(height: height)
+        }
         
         // Both height and width are auto, so use min/max height and width
-        else if someDimensionFixed {
+        else if someMinMaxDefined {
+            logInView("LayerSizeModifier: defined min-max")
             content.frame(minWidth: minWidth,
                           maxWidth: maxWidth,
                           minHeight: minHeight,
@@ -85,6 +137,7 @@ struct LayerSizeModifier: ViewModifier {
         
         // Default case
         else {
+            logInView("LayerSizeModifier: default")
             content.frame(width: width,
                           height: height,
                           alignment: alignment)

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
@@ -37,16 +37,21 @@ struct LayerSizeModifier: ViewModifier {
         
         // If we have at least one min-max dimension,
         // we cannot use the `.frame(width:height:)` API
-        if someMinMaxDefined {
-            content.frame(minWidth: minWidth?.atleastZero(),
-                          maxWidth: maxWidth?.atleastZero(),
-                          minHeight: minHeight?.atleastZero(),
-                          maxHeight: maxHeight?.atleastZero(),
-                          alignment: alignment)
-        } else {
-            content.frame(width: width?.atleastZero(),
+//        if someMinMaxDefined {
+//            content.frame(minWidth: minWidth?.atleastZero(),
+//                          maxWidth: maxWidth?.atleastZero(),
+//                          minHeight: minHeight?.atleastZero(),
+//                          maxHeight: maxHeight?.atleastZero(),
+//                          alignment: alignment)
+//        } else {
+            content
+            .aspectRatio(CGSize(width: 1, height: 2),
+                         contentMode: .fit)
+            .frame(width: width?.atleastZero(),
                           height: height?.atleastZero(),
                           alignment: alignment)
-        }
+//            .aspectRatio(CGSize(width: 1, height: 2),
+//                         contentMode: .fit)
+//        }
     }
 }

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
@@ -11,6 +11,10 @@ extension CGFloat {
     func atleastZero() -> CGFloat {
         CGFloat.maximum(self, .zero)
     }
+    
+    func atleastOne() -> CGFloat {
+        CGFloat.maximum(self, 1.0)
+    }
 }
 
 // Directly calling SwiftUI's .frame API
@@ -33,25 +37,39 @@ struct LayerSizeModifier: ViewModifier {
         minWidth.isDefined || maxWidth.isDefined || minHeight.isDefined || maxHeight.isDefined
     }
     
+    // If user provided a pt  dimension (width or height),
+    // then we must use SwiftUI's `.frame(width:height:)`.
+    // Note that grow/hug for a dimension = `nil`, and so we can instead provide
+    var someDimensionFixed: Bool {
+        width.isDefined || height.isDefined
+    }
+    
     func body(content: Content) -> some View {
         
-        // If we have at least one min-max dimension,
-        // we cannot use the `.frame(width:height:)` API
-//        if someMinMaxDefined {
-//            content.frame(minWidth: minWidth?.atleastZero(),
-//                          maxWidth: maxWidth?.atleastZero(),
-//                          minHeight: minHeight?.atleastZero(),
-//                          maxHeight: maxHeight?.atleastZero(),
-//                          alignment: alignment)
-//        } else {
+        if someDimensionFixed {
             content
-//            .aspectRatio(CGSize(width: 1, height: 2),
-//                         contentMode: .fit)
-            .frame(width: width?.atleastZero(),
-                          height: height?.atleastZero(),
+                .frame(width: width?.atleastZero(),
+                       height: height?.atleastZero(),
+                       alignment: alignment)
+            
+        } else {
+                        
+            // If we have at least one min-max dimension,
+            // we cannot use the `.frame(width:height:)` API
+            //        if someMinMaxDefined {
+            content.frame(minWidth: minWidth?.atleastZero(),
+                          maxWidth: maxWidth?.atleastOne(),
+                          minHeight: minHeight?.atleastZero(),
+                          maxHeight: maxHeight?.atleastOne(),
                           alignment: alignment)
-//            .aspectRatio(CGSize(width: 1, height: 2),
-//                         contentMode: .fit)
-//        }
+        }
+        
+        
+        //        } else {
+        //            content
+        //            .frame(width: width?.atleastZero(),
+        //                          height: height?.atleastZero(),
+        //                          alignment: alignment)
+        //        }
     }
 }

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
@@ -22,13 +22,14 @@ extension CGFloat {
 // NOTE: it is the responsibility of the caller to make sure that sensible nil/non-nil params are passed in
 struct LayerSizeModifier: ViewModifier {
 
+    // TODO: non-frame-growing views like `Text`, `ProgressIndicator` etc. need .frame(width:height:alignment:) to be properly positioned with their frame; such views' dimennsions cannot be split up across separate `.frame(width:)`, `.frame(height:)` calls.
+    // Do you need an additional `pos: adjustPosition` modifier specifically for something like `Text` ?
     let alignment: Alignment
     
     let usesParentPercentForWidth: Bool
     let usesParentPercentForHeight: Bool
     
     // nil = dimension is unspecified
-    
     let width: CGFloat?
     let height: CGFloat?
         
@@ -37,69 +38,35 @@ struct LayerSizeModifier: ViewModifier {
     let minHeight: CGFloat?
     let maxHeight: CGFloat?
     
-//    var finalMinWidth: CGFloat? {
-//        // no matter what is passed in, if we are using parent-percent al
-//    }
-//    var finalMaxWidth: CGFloat? {
-//        // no matter what is passed in, if we are using parent-percent al
-//    }
-//    var finalMinHeight: CGFloat? {
-//        // no matter what is passed in, if we are using parent-percent al
-//    }
-//    var finalMaxHeight: CGFloat? {
-//        // no matter what is passed in, if we are using parent-percent al
-//    }
-//
-    
-//    let width: LayerDimension?
-//    let height: LayerDimension?
-//        
-//    let minWidth: LayerDimension?
-//    let maxWidth: LayerDimension?
-//    let minHeight: LayerDimension?
-//    let maxHeight: LayerDimension?
-    
     var someMinMaxDefined: Bool {
         minWidth.isDefined || maxWidth.isDefined || minHeight.isDefined || maxHeight.isDefined
     }
-    
-    // If user provided a pt  dimension (width or height),
-    // then we must use SwiftUI's `.frame(width:height:)`.
-    // Note that grow/hug for a dimension = `nil`, and so we can instead provide
-    var someDimensionFixed: Bool {
-        width.isDefined || height.isDefined
-    }
-            
-    
-    
+        
     func body(content: Content) -> some View {
-        logInView("LayerSizeModifier: width: \(width)")
-        logInView("LayerSizeModifier: height: \(height)")
-        logInView("LayerSizeModifier: minWidth: \(minWidth)")
-        logInView("LayerSizeModifier: maxWidth: \(maxWidth)")
-        logInView("LayerSizeModifier: minHeight: \(minHeight)")
-        logInView("LayerSizeModifier: maxHeight: \(maxHeight)")
-                
+        // logInView("LayerSizeModifier: width: \(width)")
+        // logInView("LayerSizeModifier: height: \(height)")
+        // logInView("LayerSizeModifier: minWidth: \(minWidth)")
+        // logInView("LayerSizeModifier: maxWidth: \(maxWidth)")
+        // logInView("LayerSizeModifier: minHeight: \(minHeight)")
+        // logInView("LayerSizeModifier: maxHeight: \(maxHeight)")
+               
+        // TODO: the below conditionals can be simplified, but are currently evolving; will be cleaned up after final iterations on conditional input logic
+        
         // Width is pt, but height is auto (so can use min/max height)
         if let width = width, !height.isDefined {
-            logInView("LayerSizeModifier: defined width but not height")
-            
-            // How to handle case where "set width, but non-nil min and max width passed down"
+            // logInView("LayerSizeModifier: defined width but not height")
             
             content
-            // parent percentage supports min/max along a dimension
+            // Note: parent-percentage supports min/max along a dimension
                 .frame(minWidth: usesParentPercentForWidth ? minWidth : nil)
                 .frame(maxWidth: usesParentPercentForWidth ? maxWidth : nil)
                 .frame(width: width)
                 .frame(minHeight: minHeight, maxHeight: maxHeight)
-            
-            // ^^ this will mess up the `alignment` for views like `Text`, `ProgressIndicator` etc.
-            // Do you need an additional `pos: adjustPosition` modifier specifically for something like `Text` ?
-        } 
+        }
         
         // Height is pt, but width is auto (so can use min/max width)
         else if let height = height, !width.isDefined {
-            logInView("LayerSizeModifier: defined height but not width")
+            // logInView("LayerSizeModifier: defined height but not width")
             
             content
                 .frame(minHeight: usesParentPercentForHeight ? minHeight : nil)
@@ -110,16 +77,12 @@ struct LayerSizeModifier: ViewModifier {
         
         // Both height and width are pt (so no min/max size at all)
         else if let width = width, let height = height {
-            logInView("LayerSizeModifier: defined width and height")
-            
+            // logInView("LayerSizeModifier: defined width and height")
             
             content
-//                .frame(width: width, height: height)
-            
                 .frame(minWidth: usesParentPercentForWidth ? minWidth : nil)
                 .frame(maxWidth: usesParentPercentForWidth ? maxWidth : nil)
                 .frame(width: width)
-            
                 .frame(minHeight: usesParentPercentForHeight ? minHeight : nil)
                 .frame(maxHeight: usesParentPercentForHeight ? maxHeight : nil)
                 .frame(height: height)
@@ -127,7 +90,7 @@ struct LayerSizeModifier: ViewModifier {
         
         // Both height and width are auto, so use min/max height and width
         else if someMinMaxDefined {
-            logInView("LayerSizeModifier: defined min-max")
+            // logInView("LayerSizeModifier: defined min-max")
             content.frame(minWidth: minWidth,
                           maxWidth: maxWidth,
                           minHeight: minHeight,
@@ -135,40 +98,12 @@ struct LayerSizeModifier: ViewModifier {
                           alignment: alignment)
         } 
         
-        // Default case
+        // Default
         else {
-            logInView("LayerSizeModifier: default")
+            // logInView("LayerSizeModifier: default")
             content.frame(width: width,
                           height: height,
                           alignment: alignment)
         }
-
-                
-//
-//        if someDimensionFixed {
-//            content
-//                .frame(width: width?.atleastZero(),
-//                       height: height?.atleastZero(),
-//                       alignment: alignment)
-//            
-//        } else {
-//                        
-//            // If we have at least one min-max dimension,
-//            // we cannot use the `.frame(width:height:)` API
-//            //        if someMinMaxDefined {
-//            content.frame(minWidth: minWidth?.atleastZero(),
-//                          maxWidth: maxWidth?.atleastOne(),
-//                          minHeight: minHeight?.atleastZero(),
-//                          maxHeight: maxHeight?.atleastOne(),
-//                          alignment: alignment)
-//        }
-//        
-        
-        //        } else {
-        //            content
-        //            .frame(width: width?.atleastZero(),
-        //                          height: height?.atleastZero(),
-        //                          alignment: alignment)
-        //        }
     }
 }

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
@@ -43,27 +43,73 @@ struct LayerSizeModifier: ViewModifier {
     var someDimensionFixed: Bool {
         width.isDefined || height.isDefined
     }
-    
-    func body(content: Content) -> some View {
         
-        if someDimensionFixed {
+    func body(content: Content) -> some View {
+        logInView("LayerSizeModifier: width: \(width)")
+        logInView("LayerSizeModifier: height: \(height)")
+        logInView("LayerSizeModifier: minWidth: \(minWidth)")
+        logInView("LayerSizeModifier: maxWidth: \(maxWidth)")
+        logInView("LayerSizeModifier: minHeight: \(minHeight)")
+        logInView("LayerSizeModifier: maxHeight: \(maxHeight)")
+        
+        // Width is pt, but height is auto (so can use min/max height)
+        if let width = width, !height.isDefined {
             content
-                .frame(width: width?.atleastZero(),
-                       height: height?.atleastZero(),
-                       alignment: alignment)
-            
-        } else {
-                        
-            // If we have at least one min-max dimension,
-            // we cannot use the `.frame(width:height:)` API
-            //        if someMinMaxDefined {
-            content.frame(minWidth: minWidth?.atleastZero(),
-                          maxWidth: maxWidth?.atleastOne(),
-                          minHeight: minHeight?.atleastZero(),
-                          maxHeight: maxHeight?.atleastOne(),
+                .frame(width: width)
+                .frame(minHeight: minHeight, maxHeight: maxHeight)
+            // ^^ this will mess up the `alignment` for views like `Text`, `ProgressIndicator` etc.
+            // Do you need an additional `pos: adjustPosition` modifier specifically for something like `Text` ?
+        } 
+        
+        // Height is pt, but width is auto (so can use min/max width)
+        else if let height = height, !width.isDefined {
+            content
+                .frame(height: height)
+                .frame(minWidth: minWidth, maxWidth: maxWidth)
+        } 
+        
+        // Both height and width are pt (so no min/max size at all)
+        else if let width = width, let height = height {
+            content
+                .frame(width: width, height: height)
+        } 
+        
+        // Both height and width are auto, so use min/max height and width
+        else if someDimensionFixed {
+            content.frame(minWidth: minWidth,
+                          maxWidth: maxWidth,
+                          minHeight: minHeight,
+                          maxHeight: maxHeight,
+                          alignment: alignment)
+        } 
+        
+        // Default case
+        else {
+            content.frame(width: width,
+                          height: height,
                           alignment: alignment)
         }
-        
+
+                
+//
+//        if someDimensionFixed {
+//            content
+//                .frame(width: width?.atleastZero(),
+//                       height: height?.atleastZero(),
+//                       alignment: alignment)
+//            
+//        } else {
+//                        
+//            // If we have at least one min-max dimension,
+//            // we cannot use the `.frame(width:height:)` API
+//            //        if someMinMaxDefined {
+//            content.frame(minWidth: minWidth?.atleastZero(),
+//                          maxWidth: maxWidth?.atleastOne(),
+//                          minHeight: minHeight?.atleastZero(),
+//                          maxHeight: maxHeight?.atleastOne(),
+//                          alignment: alignment)
+//        }
+//        
         
         //        } else {
         //            content

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
@@ -105,18 +105,21 @@ struct PreviewGroupLayer: View {
     var body: some View {
 
         groupLayer
-            .onAppear(perform: {
-                fatalErrorIfDebug()
-            })
         
         // TODO: add "child alignment" input on Group Layer node? or find some other solution for how a group with an orientation can position children that have static sizes
         // TODO: don't need this if we're using the "hug" case in `LayerGroupPositionModifier` ?
         
-//            .modifier(PreviewCommonSizeModifier(
-//                viewModel: layerViewModel,
-//                size: size,
-//                parentSize: parentSize,
-//                frameAlignment: anchoring.toAlignment))
+            .modifier(PreviewCommonSizeModifier(
+                viewModel: layerViewModel,
+                aspectRatio: layerViewModel.getAspectRatioData(),
+                size: size,
+                minWidth: layerViewModel.getMinWidth,
+                maxWidth: layerViewModel.getMaxWidth,
+                minHeight: layerViewModel.getMinHeight,
+                maxHeight: layerViewModel.getMaxHeight,
+                parentSize: parentSize,
+                sizingScenario: layerViewModel.getSizingScenario,
+                frameAlignment: anchoring.toAlignment))
 
             .background(backgroundColor)
         

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
@@ -105,14 +105,18 @@ struct PreviewGroupLayer: View {
     var body: some View {
 
         groupLayer
+            .onAppear(perform: {
+                fatalErrorIfDebug()
+            })
         
         // TODO: add "child alignment" input on Group Layer node? or find some other solution for how a group with an orientation can position children that have static sizes
         // TODO: don't need this if we're using the "hug" case in `LayerGroupPositionModifier` ?
-            .modifier(PreviewCommonSizeModifier(
-                viewModel: layerViewModel,
-                size: size,
-                parentSize: parentSize,
-                frameAlignment: anchoring.toAlignment))
+        
+//            .modifier(PreviewCommonSizeModifier(
+//                viewModel: layerViewModel,
+//                size: size,
+//                parentSize: parentSize,
+//                frameAlignment: anchoring.toAlignment))
 
             .background(backgroundColor)
         

--- a/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
@@ -16,6 +16,9 @@ final class LayerViewModel {
     let interactiveLayer: InteractiveLayer
     weak var nodeDelegate: NodeDelegate?
     
+    // TODO: use `PortValue.sizingScenario` and retrieve from actual
+    var sizingScenario: SizingScenario = .constrainHeight
+    
     // Size of the layer as read by layer's background GeometryReader,
     // see `LayerSizeReader`.
     var readSize: CGSize = .zero

--- a/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
@@ -17,7 +17,7 @@ final class LayerViewModel {
     weak var nodeDelegate: NodeDelegate?
     
     // TODO: use `PortValue.sizingScenario` and retrieve from actual
-    var sizingScenario: SizingScenario = .constrainHeight
+//    var sizingScenario: SizingScenario = .constrainHeight
     
     // Size of the layer as read by layer's background GeometryReader,
     // see `LayerSizeReader`.
@@ -113,6 +113,8 @@ final class LayerViewModel {
     var spacingBetweenGridRows: PortValue
     var itemAlignmentWithinGridCell: PortValue
 
+    var sizingScenario: PortValue
+    
     var widthAxis: PortValue
     var heightAxis: PortValue
     var contentMode: PortValue
@@ -242,6 +244,8 @@ final class LayerViewModel {
         self.minSize = LayerInputType.minSize.getDefaultValue(for: layer)
         self.maxSize = LayerInputType.maxSize.getDefaultValue(for: layer)
         self.spacing = LayerInputType.spacing.getDefaultValue(for: layer)
+        
+        self.sizingScenario = LayerInputType.sizingScenario.getDefaultValue(for: layer)
         
         self.nodeDelegate = nodeDelegate
         self.interactiveLayer.delegate = self

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -99,8 +99,8 @@ final class GraphUIState {
     var isFullScreenMode: Bool = GraphUIState.isPhoneDevice
     
     #if DEV_DEBUG
-//    var showsLayerInspector = true  during dev
-        var showsLayerInspector = false // during dev
+    var showsLayerInspector = true //  during dev
+//        var showsLayerInspector = false // during dev
     #else
     var showsLayerInspector = false
     #endif

--- a/stitch.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/stitch.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "fa62414f3ffde63efcf96a3e2f8f06cdb8551ff9a33d61d5f1fa2ad8c3db93d0",
   "pins" : [
     {
       "identity" : "audiokit",
@@ -53,15 +52,6 @@
       "state" : {
         "branch" : "main",
         "revision" : "087eb20926ffac4ecbbe03f4db362c3f13f05afe"
-      }
-    },
-    {
-      "identity" : "stitchschemakit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StitchDesign/StitchSchemaKit.git",
-      "state" : {
-        "revision" : "1ea446642cc54b7c7143f5efdecb2c3ceec91a26",
-        "version" : "19.0.0"
       }
     },
     {
@@ -136,5 +126,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/stitch.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/stitch.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "fa62414f3ffde63efcf96a3e2f8f06cdb8551ff9a33d61d5f1fa2ad8c3db93d0",
   "pins" : [
     {
       "identity" : "audiokit",
@@ -52,6 +53,15 @@
       "state" : {
         "branch" : "main",
         "revision" : "087eb20926ffac4ecbbe03f4db362c3f13f05afe"
+      }
+    },
+    {
+      "identity" : "stitchschemakit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/StitchDesign/StitchSchemaKit.git",
+      "state" : {
+        "revision" : "e0c0e0991311b770aba3530081da1d272da88e3e",
+        "version" : "20.0.0"
       }
     },
     {
@@ -126,5 +136,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }


### PR DESCRIPTION
SizingScenario = Auto vs Constrain Height vs Constrain Width

A specified "Point" LayerDimension disabled min and max; all other LayerDimension cases (i.e. "non-specified" like auto/fill/hug) allow min and max.

Padding now has proper labels and is per side.

Followup: 
- fields are not created with proper blocking/unblocking; only happens when user manually edits an input/field; **will be updated once fields refactor is in** 
- see PreviewGroup gotchas https://github.com/StitchDesign/Stitch--Old/issues/6301


https://github.com/StitchDesign/Stitch/assets/18562836/f15eb342-b0fb-43f3-a809-43cd8afcab73



https://github.com/StitchDesign/Stitch/assets/18562836/fd72831e-fed4-4f29-a71c-f9787df799f0

