### PR TITLE
Updating default text sizes

### DIFF
--- a/Stitch/Graph/Node/Layer/Type/TextLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/TextLayerNode.swift
@@ -19,6 +19,10 @@ extension LayerSize {
     static let LAYER_DEFAULT_SIZE: Self = .init(width: 100, height: 100)
 }
 
+extension LayerSize {
+    static let DEFAULT_TEXT_LABEL_SIZE: Self = .init(width: 100, height: 100)
+}
+
 extension Color {
     static let LAYER_DEFAULT_COLOR: Color = STITCH_PURPLE
 }

--- a/Stitch/Graph/Node/Model/RowData/LayerInputType.swift
+++ b/Stitch/Graph/Node/Model/RowData/LayerInputType.swift
@@ -33,8 +33,10 @@ extension LayerInputType {
                 return .size(LayerSize.DEFAULT_MAP_SIZE)
             case .videoStreaming:
                 return .size(LayerSize.DEFAULT_VIDEO_STREAMING_SIZE)
-            case .textField, .text:
+            case .textField:
                 return .size(LayerSize.DEFAULT_TEXT_FIELD_SIZE)
+            case .text:
+                return .size(LayerSize.DEFAULT_TEXT_LABEL_SIZE)
             case .group:
                 return .size(.init(width: .hug, height: .hug))
             default:


### PR DESCRIPTION
Ensuring that both the Text Input and Text Layer nodes have appropriately sized default text values

![CleanShot 2024-07-13 at 14 41 31@2x](https://github.com/user-attachments/assets/b2b3ca66-3720-4059-bcaa-33352c14c62c)
