### PR TITLE
Fixed crashes caused by adjustment bar

### DIFF
--- a/Stitch/App/ViewModel/StoreDelegate.swift
+++ b/Stitch/App/ViewModel/StoreDelegate.swift
@@ -9,4 +9,12 @@ import Foundation
 
 protocol StoreDelegate: AnyObject {
     var documentLoader: DocumentLoader { get }
+
+    @MainActor
+    func saveUndoHistory(undoActions: [Action],
+                         redoActions: [Action])
+    
+    @MainActor
+    func saveUndoHistory(undoEvents: [@MainActor () -> ()],
+                         redoEvents: [@MainActor () -> ()])
 }

--- a/Stitch/Graph/Menu/NumberAdjustmentBar/AdjustmentBarPopoverView.swift
+++ b/Stitch/Graph/Menu/NumberAdjustmentBar/AdjustmentBarPopoverView.swift
@@ -25,7 +25,6 @@ let ADJUSTMENT_BAR_POPOVER_BACKGROUND_COLOR: Color = Color(.adjustmentBarPopover
 let ADJUSTMENT_BAR_POPOVER_BUTTON_BACKGROUND_COLOR: Color = Color(.adjustmentBarPopoverButtonBackground)
 
 struct AdjustmentBarPopoverView: View {
-    @Environment(StitchStore.self) private var store
     @Bindable var graph: GraphState
 
     // Value heled in Redux, which won't trigger re-renders
@@ -86,11 +85,11 @@ struct AdjustmentBarPopoverView: View {
                                         isCommitting: true)
 
             // Only persist when we close
-            Task.detached(priority: .background) { [weak store, weak graph] in
+            Task(priority: .background) { [weak graph] in
                 // TODO: test undo on adjustment bar close
-                let _ = await graph?.encodeProject()
-                await store?.saveUndoHistory(undoEvents: [undoEvent],
-                                             redoEvents: [])
+                let _ = graph?.encodeProject()
+                graph?.storeDelegate?.saveUndoHistory(undoActions: [undoEvent],
+                                                      redoActions: [])
             }
         } // .onDisappear
     }

--- a/Stitch/Home/Util/ProjectDestructiveActions.swift
+++ b/Stitch/Home/Util/ProjectDestructiveActions.swift
@@ -48,8 +48,8 @@ extension StitchStore {
             }
             // self.alertState.deletedProjectId = projectId
 
-            self.saveUndoHistory(undoEvents: undoEvents,
-                                 redoEvents: redoEvents)
+            self.saveUndoHistory(undoActions: undoEvents,
+                                 redoActions: redoEvents)
 
         case .failure(let error):
             log("StitchStore: deleteProject: failure")


### PR DESCRIPTION
Resolves #6304

Two different crashes:
1. Using `StitchStore` as an `Environment` object in the adjustment bar view seems to create issues despite correct assignment of `StitchStore` as an environment object. Seems like a SwiftUI bug.
2. A separate issue where casting callbacks which assume `MainActor` thread safety.