### PR TITLE
Fixed output port hover; row view model ID refactor

### DIFF
--- a/Stitch/Graph/Edge/View/EditMode/EdgeEditModeViewModifier.swift
+++ b/Stitch/Graph/Edge/View/EditMode/EdgeEditModeViewModifier.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct EdgeEditModeViewModifier: ViewModifier {
 
     @Bindable var graphState: GraphState
-    let portId: Int?
+    let portId: Int
     let nodeId: CanvasItemId?
     let nodeIOType: NodeIO
     let forPropertySidebar: Bool
@@ -23,8 +23,7 @@ struct EdgeEditModeViewModifier: ViewModifier {
 
     func body(content: Content) -> some View {
                 
-        if let portId = portId,
-           let nodeId = nodeId,
+        if let nodeId = nodeId,
             nodeIOType == .output,
            !forPropertySidebar {
             content

--- a/Stitch/Graph/LayerInspector/PaddingFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/PaddingFlyoutView.swift
@@ -64,15 +64,24 @@ struct PaddingFlyoutView: View {
                        forPropertySidebar: true,
                        // TODO: fix
                        propertyIsAlreadyOnGraph: false) { portViewModel, isMultiField in
-            InputValueEntry(graph: graph,
-                            rowViewModel: rowViewModel,
-                            viewModel: portViewModel,
-                            nodeKind: .layer(layer),
-                            isCanvasItemSelected: false,
-                            hasIncomingEdge: hasIncomingEdge,
-                            forPropertySidebar: true,
-                            // TODO: fix
-                            propertyIsAlreadyOnGraph: false)
+            
+            if let coordinate = rowViewModel.rowDelegate?.id {
+                InputValueEntry(graph: graph,
+                                rowViewModel: rowViewModel,
+                                viewModel: portViewModel,
+                                rowObserverId: coordinate,
+                                nodeKind: .layer(layer),
+                                isCanvasItemSelected: false,
+                                hasIncomingEdge: hasIncomingEdge,
+                                forPropertySidebar: true,
+                                // TODO: fix
+                                propertyIsAlreadyOnGraph: false)
+            } else {
+                Color.clear
+                    .onAppear {
+                        fatalErrorIfDebug()
+                    }
+            }
         }
     }
 }

--- a/Stitch/Graph/Menu/NumberAdjustmentBar/AdjustmentBarPopoverView.swift
+++ b/Stitch/Graph/Menu/NumberAdjustmentBar/AdjustmentBarPopoverView.swift
@@ -31,6 +31,7 @@ struct AdjustmentBarPopoverView: View {
     let stateNumber: Double
     let fieldValueNumberType: FieldValueNumberType
     let fieldCoordinate: FieldCoordinate
+    let rowObserverCoordinate: NodeIOCoordinate
     @Binding var isPopoverOpen: Bool
 
     @State private var currentStepScale: AdjustmentBarStepScale = .normal
@@ -82,7 +83,7 @@ struct AdjustmentBarPopoverView: View {
             let undoEvent = {
                 graph.inputEdited(fieldValue: fieldValue,
                                   fieldIndex: fieldCoordinate.fieldIndex,
-                                  coordinate: fieldCoordinate.rowId.coordinate,
+                                  coordinate: rowObserverCoordinate,
                                   isCommitting: true)
             }
 
@@ -112,7 +113,7 @@ struct AdjustmentBarPopoverView: View {
 
                 graph.inputEdited(fieldValue: .layerDimension(.auto),
                                   fieldIndex: fieldCoordinate.fieldIndex,
-                                  coordinate: fieldCoordinate.rowId.coordinate,
+                                  coordinate: rowObserverCoordinate,
                                   isCommitting: false)
             } label: {
                 Image(systemName: "bolt.badge.a.fill")
@@ -211,6 +212,7 @@ struct AdjustmentBarPopoverView: View {
             fieldValueNumberType: fieldValueNumberType,
             centerSelectionDisabled: centerSelectionDisabled,
             fieldCoordinate: fieldCoordinate,
+            rowObserverCoordinate: rowObserverCoordinate,
             currentlySelectedNumber: barNumber,
             numberLineMiddle: barNumber)
     }

--- a/Stitch/Graph/Menu/NumberAdjustmentBar/WideAdjustmentBarView.swift
+++ b/Stitch/Graph/Menu/NumberAdjustmentBar/WideAdjustmentBarView.swift
@@ -41,6 +41,7 @@ struct WideAdjustmentBarView: View {
     // true just when tearing down view
     let centerSelectionDisabled: Bool
     let fieldCoordinate: FieldCoordinate
+    let rowObserverCoordinate: NodeIOCoordinate
 
     @State var scrollCenter: CGPoint?
     @State var isScrollingFromTap = false // replace with just `manuallyClickedNumber`?
@@ -146,7 +147,7 @@ struct WideAdjustmentBarView: View {
                                 // updates input via redux
                                 graph.inputEdited(fieldValue: fieldValueNumberType.createFieldValueForAdjustmentBar(from: n.number),
                                                   fieldIndex: self.fieldCoordinate.fieldIndex,
-                                                  coordinate: self.fieldCoordinate.rowId.coordinate,
+                                                  coordinate: rowObserverCoordinate,
                                                   isCommitting: false)
                             }
                     } // ForEach
@@ -365,7 +366,7 @@ struct WideAdjustmentBarView: View {
                     // log("Auto select center: pref.number: \(pref.number)")
                     graph.inputEdited(fieldValue: fieldValue,
                                       fieldIndex: pref.field.fieldIndex,
-                                      coordinate: pref.field.rowId.coordinate,
+                                      coordinate: rowObserverCoordinate,
                                       // We don't persist changes from auto-selectiong the center value during scroll
                                       isCommitting: false)
                 }

--- a/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
+++ b/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
@@ -31,9 +31,8 @@ final class InputLayerNodeRowData {
         let itemType: GraphItemType = FeatureFlags.USE_LAYER_INSPECTOR ? .layerInspector : .node
         self.inspectorRowViewModel = .init(id: .init(graphItemType: itemType,
                                                      nodeId: rowObserver.id.nodeId,
-                                                     portType: rowObserver.id.portType),
+                                                     portId: 0),
                                            activeValue: rowObserver.activeValue,
-                                           nodeRowIndex: nil,
                                            rowDelegate: rowObserver,
                                            // specifically not a row view model for canvas
                                            canvasItemDelegate: nil)
@@ -55,9 +54,8 @@ final class OutputLayerNodeRowData {
         let itemType: GraphItemType = FeatureFlags.USE_LAYER_INSPECTOR ? .layerInspector : .node
         self.inspectorRowViewModel = .init(id: .init(graphItemType: itemType,
                                                      nodeId: rowObserver.id.nodeId,
-                                                     portType: rowObserver.id.portType),
+                                                     portId: 0),
                                            activeValue: rowObserver.activeValue,
-                                           nodeRowIndex: nil,
                                            rowDelegate: rowObserver,
                                            // specifically not a row view model for canvas
                                            canvasItemDelegate: nil)

--- a/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
+++ b/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
@@ -286,7 +286,7 @@ final class LayerNodeViewModel {
             if FeatureFlags.USE_LAYER_INSPECTOR {
                 layerData.inspectorRowViewModel.id = .init(graphItemType: .layerInspector,
                                                            nodeId: id.nodeId,
-                                                           portType: .keyPath(inputType))
+                                                           portId: 0)
             }
             
             // Update row observer

--- a/Stitch/Graph/Node/Port/Model/Field/FieldCoordinate.swift
+++ b/Stitch/Graph/Node/Port/Model/Field/FieldCoordinate.swift
@@ -20,7 +20,7 @@ struct FieldCoordinate: Hashable {
         .init(
             rowId: .init(graphItemType: .node, 
                          nodeId: .init(),
-                         portType: .portIndex(0)),
+                         portId: 0),
             fieldIndex: 0)
     }
 }

--- a/Stitch/Graph/Node/Port/View/Field/InputView/EditJSONEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/EditJSONEntry.swift
@@ -19,6 +19,7 @@ struct EditJSONEntry: View {
 
     @Bindable var graph: GraphState
     let coordinate: FieldCoordinate
+    let rowObserverCoordinate: NodeIOCoordinate
     let json: StitchJSON? // nil helps with perf?
     @Binding var isPressed: Bool
 
@@ -60,8 +61,7 @@ struct EditJSONEntry: View {
                         if let json = json?.value,
                            let edit = getCleanedJSON(internalEditString),
                            !areEqualJsons(edit, json) {
-                            graph.jsonEditCommitted(input: .init(portType: coordinate.rowId.portType,
-                                                                 nodeId: coordinate.rowId.nodeId),
+                            graph.jsonEditCommitted(input: rowObserverCoordinate,
                                                     json: edit)
                         }
                     }

--- a/Stitch/Graph/Node/Port/View/Field/InputView/FieldValueNumberView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/FieldValueNumberView.swift
@@ -16,6 +16,7 @@ struct FieldValueNumberView: View {
     let fieldValue: FieldValue
     let fieldValueNumberType: FieldValueNumberType
     let fieldCoordinate: FieldCoordinate
+    let rowObserverCoordinate: NodeIOCoordinate
     let isCanvasItemSelected: Bool
     let hasIncomingEdge: Bool
     let choices: [String]?
@@ -35,6 +36,7 @@ struct FieldValueNumberView: View {
                 graph: graph,
                 value: isButtonPressed ? fieldValue.numberValue : .zero,
                 fieldCoordinate: fieldCoordinate,
+                rowObserverCoordinate: rowObserverCoordinate,
                 fieldValueNumberType: fieldValueNumberType,
                 adjustmentBarSessionId: adjustmentBarSessionId,
                 isPressed: $isButtonPressed)

--- a/Stitch/Graph/Node/Port/View/Field/ValueButton/NumberValueButtonView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/ValueButton/NumberValueButtonView.swift
@@ -29,6 +29,7 @@ struct NumberValueButtonView: View {
     @Bindable var graph: GraphState
     let value: Double
     let fieldCoordinate: FieldCoordinate
+    let rowObserverCoordinate: NodeIOCoordinate
     let fieldValueNumberType: FieldValueNumberType
     let adjustmentBarSessionId: AdjustmentBarSessionId
     @Binding var isPressed: Bool
@@ -49,6 +50,7 @@ struct NumberValueButtonView: View {
                 graph: graph,
                 numberValue: value,
                 fieldCoordinate: fieldCoordinate,
+                rowObserverCoordinate: rowObserverCoordinate,
                 isPressed: $isPressed,
                 fieldValueNumberType: fieldValueNumberType))
     }
@@ -58,6 +60,7 @@ struct AdjustmentBarViewModifier: ViewModifier {
     @Bindable var graph: GraphState
     let numberValue: Double
     let fieldCoordinate: FieldCoordinate
+    let rowObserverCoordinate: NodeIOCoordinate
     @Binding var isPressed: Bool
     let fieldValueNumberType: FieldValueNumberType
 
@@ -72,6 +75,7 @@ struct AdjustmentBarViewModifier: ViewModifier {
                     stateNumber: numberValue,
                     fieldValueNumberType: fieldValueNumberType,
                     fieldCoordinate: fieldCoordinate,
+                    rowObserverCoordinate: rowObserverCoordinate,
                     isPopoverOpen: self.$isPressed
                 )
                 #if !targetEnvironment(macCatalyst)

--- a/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
+++ b/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
@@ -90,7 +90,7 @@ struct NodeInputOutputView<NodeRowObserverType: NodeRowObserver,
                                             newValue: newViewValue)
         }
         .modifier(EdgeEditModeViewModifier(graphState: graph,
-                                           portId: rowData.id.coordinate.portId,
+                                           portId: rowData.id.portId,
                                            nodeId: self.rowData.canvasItemDelegate?.id,
                                            nodeIOType: NodeRowType.nodeIO,
                                            forPropertySidebar: forPropertySidebar))
@@ -134,6 +134,7 @@ struct NodeInputView: View {
         InputValueEntry(graph: graph,
                         rowViewModel: rowData,
                         viewModel: portViewModel,
+                        rowObserverId: rowObserver.id,
                         nodeKind: nodeKind,
                         isCanvasItemSelected: isCanvasItemSelected,
                         hasIncomingEdge: rowObserver.upstreamOutputObserver.isDefined,
@@ -159,7 +160,7 @@ struct NodeInputView: View {
                                     showPopover: $showPopover)
                 }
                 
-                let isPaddingLayerInputRow = rowData.id.portType.keyPath == .padding
+                let isPaddingLayerInputRow = rowData.rowDelegate?.id.keyPath == .padding
                 let hidePaddingFieldsOnPropertySidebar = isPaddingLayerInputRow && forPropertySidebar
                 
                 if hidePaddingFieldsOnPropertySidebar {
@@ -309,7 +310,7 @@ struct NodeRowPortView<NodeRowObserverType: NodeRowObserver>: View {
     @Binding var showPopover: Bool
     
     var coordinate: NodeIOPortType {
-        self.rowViewModel.id.portType
+        self.rowObserver.id.portType
     }
     
     //    @MainActor

--- a/Stitch/Graph/Node/Port/ViewModel/FieldGroupTypeViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/FieldGroupTypeViewModel.swift
@@ -181,7 +181,7 @@ extension NodeRowViewModel {
         }
         
         if let node = self.nodeDelegate,
-           let layerInput = self.id.portType.keyPath {
+           let layerInput = self.rowDelegate?.id.portType.keyPath {
             node.blockOrUnlockFields(newValue: portValue,
                                      layerInput: layerInput)
         }

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -294,7 +294,7 @@ extension InputNodeRowObserver {
         }
         
         return inputs.filter {
-            $0.id.portType == self.id.portType
+            $0.rowDelegate?.id == self.id
         }
     }
 }
@@ -322,7 +322,7 @@ extension OutputNodeRowObserver {
         }
         
         return outputs.filter {
-            $0.id.portType == self.id.portType
+            $0.rowDelegate?.id == self.id
         }
     }
     
@@ -334,8 +334,9 @@ extension OutputNodeRowObserver {
             return .init()
         }
         
-        guard let downstreamConnections = graph.connections
-            .get(rowViewModel.id.coordinate) else {
+        guard let coordinate = rowViewModel.rowDelegate?.id,
+                let downstreamConnections = graph.connections
+            .get(coordinate) else {
             return .init()
         }
         
@@ -421,7 +422,7 @@ extension NodeRowViewModel {
         } // zip
         
         if let node = self.graphDelegate?.getNodeViewModel(self.id.nodeId),
-           let layerInputForThisRow = self.portType.keyPath {
+           let layerInputForThisRow = self.rowDelegate?.id.keyPath {
             node.blockOrUnlockFields(newValue: newValue,
                                      layerInput: layerInputForThisRow)
         }

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverCachedViewDataExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverCachedViewDataExtensions.swift
@@ -15,7 +15,7 @@ extension NodeRowViewModel {
     /// which save a differnt node ID.
     @MainActor
     var visibleNodeIds: Set<CanvasItemId> {
-        guard let nodeDelegate = self.rowDelegate?.nodeDelegate else {
+        guard let nodeDelegate = self.nodeDelegate else {
             return []
         }
         

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowViewModel.swift
@@ -369,8 +369,8 @@ extension Array where Element: NodeRowViewModel {
                 return entity
             } else {
                 let rowId = NodeRowViewModelId(graphItemType: .node,
-                                               // Important this is the node ID from row observer for group nodes
-                                               nodeId: newEntity.id.nodeId,
+                                               // Important this is the node ID from canvas for group nodes
+                                               nodeId: canvas.nodeDelegate?.id ?? newEntity.id.nodeId,
                                                portType: newEntity.id.portType)
                 
                 return Element(id: rowId,

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowViewModel.swift
@@ -34,11 +34,6 @@ extension NodeRowViewModelId {
     static let empty: Self = .init(graphItemType: .node,
                                    nodeId: .init(),
                                    portId: -1)
-    
-//    var coordinate: NodeIOCoordinate {
-//        .init(portType: self.portType,
-//              nodeId: self.nodeId)
-//    }
 }
 
 protocol NodeRowViewModel: AnyObject, Observable, Identifiable {
@@ -64,11 +59,6 @@ protocol NodeRowViewModel: AnyObject, Observable, Identifiable {
     var rowDelegate: RowObserver? { get set }
     
     var canvasItemDelegate: CanvasItemViewModel? { get set }
-    
-//    var portViewType: PortViewType { get }
-    
-    // Saves the port index if there's a node
-//    var nodeRowIndex: Int? { get set }
     
     static var nodeIO: NodeIO { get }
     

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowViewModel.swift
@@ -17,7 +17,7 @@ enum GraphItemType {
 struct NodeRowViewModelId: Hashable {
     var graphItemType: GraphItemType
     var nodeId: NodeId
-    var portType: NodeIOPortType
+    var portId: Int
 }
 
 extension NodeRowViewModelId {
@@ -33,12 +33,12 @@ extension NodeRowViewModelId {
     
     static let empty: Self = .init(graphItemType: .node,
                                    nodeId: .init(),
-                                   portType: .portIndex(-1))
+                                   portId: -1)
     
-    var coordinate: NodeIOCoordinate {
-        .init(portType: self.portType,
-              nodeId: self.nodeId)
-    }
+//    var coordinate: NodeIOCoordinate {
+//        .init(portType: self.portType,
+//              nodeId: self.nodeId)
+//    }
 }
 
 protocol NodeRowViewModel: AnyObject, Observable, Identifiable {
@@ -68,7 +68,7 @@ protocol NodeRowViewModel: AnyObject, Observable, Identifiable {
 //    var portViewType: PortViewType { get }
     
     // Saves the port index if there's a node
-    var nodeRowIndex: Int? { get set }
+//    var nodeRowIndex: Int? { get set }
     
     static var nodeIO: NodeIO { get }
     
@@ -85,23 +85,17 @@ protocol NodeRowViewModel: AnyObject, Observable, Identifiable {
     @MainActor
     init(id: NodeRowViewModelId,
          activeValue: PortValue,
-         nodeRowIndex: Int?,
          rowDelegate: RowObserver?,
          canvasItemDelegate: CanvasItemViewModel?)
 }
 
 extension NodeRowViewModel {
-    var portType: NodeIOPortType {
-        self.id.portType
-    }
-    
     var portViewData: PortViewType? {
-        guard let nodeRowIndex = self.nodeRowIndex,
-              let canvasId = self.canvasItemDelegate?.id else {
+        guard let canvasId = self.canvasItemDelegate?.id else {
             return nil
         }
         
-        return .init(portId: nodeRowIndex,
+        return .init(portId: self.id.portId,
                      canvasId: canvasId)
     }
     
@@ -189,7 +183,6 @@ final class InputNodeRowViewModel: NodeRowViewModel {
     var id: NodeRowViewModelId
     var activeValue: PortValue = .number(.zero)
     var fieldValueTypes = FieldGroupTypeViewModelList<InputFieldViewModel>()
-    var nodeRowIndex: Int?
     var anchorPoint: CGPoint?
     var connectedCanvasItems: Set<CanvasItemId> = .init()
     var portColor: PortColor = .noEdge
@@ -202,7 +195,6 @@ final class InputNodeRowViewModel: NodeRowViewModel {
     @MainActor
     init(id: NodeRowViewModelId,
          activeValue: PortValue,
-         nodeRowIndex: Int?,
          rowDelegate: InputNodeRowObserver?,
          canvasItemDelegate: CanvasItemViewModel?) {
         if !FeatureFlags.USE_LAYER_INSPECTOR && id.graphItemType == .layerInspector {
@@ -210,7 +202,6 @@ final class InputNodeRowViewModel: NodeRowViewModel {
         }
         
         self.id = id
-        self.nodeRowIndex = nodeRowIndex
         self.rowDelegate = rowDelegate
         self.canvasItemDelegate = canvasItemDelegate
         
@@ -265,7 +256,6 @@ final class OutputNodeRowViewModel: NodeRowViewModel {
     var id: NodeRowViewModelId
     var activeValue: PortValue = .number(.zero)
     var fieldValueTypes = FieldGroupTypeViewModelList<OutputFieldViewModel>()
-    var nodeRowIndex: Int?
     var anchorPoint: CGPoint?
     var connectedCanvasItems: Set<CanvasItemId> = .init()
     var portColor: PortColor = .noEdge
@@ -275,11 +265,9 @@ final class OutputNodeRowViewModel: NodeRowViewModel {
     @MainActor
     init(id: NodeRowViewModelId,
          activeValue: PortValue,
-         nodeRowIndex: Int?,
          rowDelegate: OutputNodeRowObserver?,
          canvasItemDelegate: CanvasItemViewModel?) {
         self.id = id
-        self.nodeRowIndex = nodeRowIndex
         self.rowDelegate = rowDelegate
         self.canvasItemDelegate = canvasItemDelegate
         
@@ -371,11 +359,10 @@ extension Array where Element: NodeRowViewModel {
                 let rowId = NodeRowViewModelId(graphItemType: .node,
                                                // Important this is the node ID from canvas for group nodes
                                                nodeId: canvas.nodeDelegate?.id ?? newEntity.id.nodeId,
-                                               portType: newEntity.id.portType)
+                                               portId: portIndex)
                 
                 return Element(id: rowId,
                                activeValue: newEntity.activeValue,
-                               nodeRowIndex: portIndex,
                                rowDelegate: newEntity,
                                canvasItemDelegate: canvas)
             }

--- a/Stitch/Graph/Node/View/NodesView.swift
+++ b/Stitch/Graph/Node/View/NodesView.swift
@@ -144,7 +144,7 @@ struct EdgeInputLabelsView: View {
                 let isVisible = isInputForNearbyNode && showLabels
                 
                 EdgeEditModeLabelsView(graph: graph,
-                                       portId: inputRowViewModel.portViewData?.portId ?? .zero)
+                                       portId: inputRowViewModel.nodeRowIndex ?? .zero)
                 .position(inputRowViewModel.anchorPoint ?? .zero)
                 .opacity(isVisible ? 1 : 0)
                 .animation(.linear(duration: .EDGE_EDIT_MODE_NODE_UI_ELEMENT_ANIMATION_LENGTH),

--- a/Stitch/Graph/Node/View/NodesView.swift
+++ b/Stitch/Graph/Node/View/NodesView.swift
@@ -144,7 +144,7 @@ struct EdgeInputLabelsView: View {
                 let isVisible = isInputForNearbyNode && showLabels
                 
                 EdgeEditModeLabelsView(graph: graph,
-                                       portId: inputRowViewModel.nodeRowIndex ?? .zero)
+                                       portId: inputRowViewModel.id.portId)
                 .position(inputRowViewModel.anchorPoint ?? .zero)
                 .opacity(isVisible ? 1 : 0)
                 .animation(.linear(duration: .EDGE_EDIT_MODE_NODE_UI_ELEMENT_ANIMATION_LENGTH),

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
@@ -360,9 +360,8 @@ extension NodeViewModel {
                               portType: NodeIOPortType) -> InputNodeRowViewModel? {
         self.getAllInputsObservers()
             .flatMap { $0.allRowViewModels }
-            .first { $0.id == .init(graphItemType: graphItemType,
-                                    nodeId: nodeId,
-                                    portType: portType) }
+            .first { $0.rowDelegate?.id == .init(portType: portType,
+                                                 nodeId: nodeId) }
     }
     
     @MainActor
@@ -687,9 +686,8 @@ extension NodeViewModel {
         
         let newInputViewModel = InputNodeRowViewModel(id: .init(graphItemType: .node,
                                                                 nodeId: newInputCoordinate.nodeId,
-                                                                portType: newInputCoordinate.portType),
+                                                                portId: allInputsObservers.count),
                                                       activeValue: newInputObserver.activeValue,
-                                                      nodeRowIndex: allInputsObservers.count,
                                                       rowDelegate: newInputObserver,
                                                       canvasItemDelegate: patchNode.canvasObserver)
         

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -563,7 +563,7 @@ extension GraphState {
     func getLayerInputOnGraph(_ id: LayerInputCoordinate) -> InputNodeRowViewModel? {
         self.getInputRowViewModel(for: .init(graphItemType: .node,
                                              nodeId: id.node,
-                                             portType: .keyPath(id.keyPath)),
+                                             portId: 0),
                                   nodeId: id.node)
     }
     
@@ -571,7 +571,7 @@ extension GraphState {
     func getLayerOutputOnGraph(_ id: LayerOutputCoordinate) -> OutputNodeRowViewModel? {
         self.getOutputRowViewModel(for: .init(graphItemType: .node,
                                               nodeId: id.node,
-                                              portType: .portIndex(id.portId)),
+                                              portId: 0),
                                    nodeId: id.node)
     }
     


### PR DESCRIPTION
Issues where a mismatch between the row view model ID and the row observer's. I removed the inconsistency by directly retrieving the row observer's ID directly from the row view model's delegate, and repurposing the view model's ID to be a non-optional port index.