### PR TITLE
Tap sidebar layer to jump to its node on the graph

### DIFF
--- a/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemView.swift
@@ -70,7 +70,11 @@ struct SidebarListItemView: View {
         // we need to place the SwiftUI TapGesture below the swipe menu.
         .gesture(TapGesture().onEnded({ _ in
             if !isBeingEdited {
-                dispatch(SidebarItemTapped(id: layerNodeId))
+                if FeatureFlags.USE_LAYER_INSPECTOR {
+                    dispatch(SidebarItemTapped(id: layerNodeId))
+                } else {
+                    dispatch(JumpToCanvasItem(id: .node(layerNodeId.id)))
+                }
             }
         }))
         


### PR DESCRIPTION
Fixes a regression by hiding layer-inspector-specific logic behind a feature flag. 

https://github.com/user-attachments/assets/69380788-57c1-447d-ae3e-a542ba926699

