### PR TITLE
Fixed broken interactions when nodes aren't visible

### DIFF
--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
@@ -26,11 +26,18 @@ extension NodeRowObserver {
         }
         
         // Update cached view-specific data: "viewValue" i.e. activeValue
-        self.getVisibleRowViewModels().forEach { rowViewModel in
-            rowViewModel.didPortValuesUpdate(values: newValues)
-        }
+        self.updatePortViewModels(values: newValues)
         
         self.postProcessing(oldValues: oldValues, newValues: newValues)
+    }
+    
+    @MainActor
+    /// Updates port view models when the backend port observer has been updated.
+    /// Also invoked when nodes enter the viewframe incase they need to be udpated.
+    func updatePortViewModels(values: PortValues) {
+        self.getVisibleRowViewModels().forEach { rowViewModel in
+            rowViewModel.didPortValuesUpdate(values: values)
+        }
     }
     
     @MainActor

--- a/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
@@ -202,8 +202,8 @@ extension CanvasItemViewModel {
 
             // Refresh values if node back in frame
             if newValue {
-                self.nodeDelegate?.updateInputsObservers(activeIndex: activeIndex)
-                self.nodeDelegate?.updateOutputsObservers(activeIndex: activeIndex)
+                self.nodeDelegate?.updateInputPortViewModels(activeIndex: activeIndex)
+                self.nodeDelegate?.updateOutputPortViewModels(activeIndex: activeIndex)
             }
         }
     }

--- a/Stitch/Graph/Node/ViewModel/NodeDelegate.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeDelegate.swift
@@ -67,9 +67,9 @@ protocol NodeDelegate: AnyObject {
     
     @MainActor func getAllOutputsObservers() -> [OutputNodeRowObserver]
     
-    @MainActor func updateInputsObservers(activeIndex: ActiveIndex)
+    @MainActor func updateInputPortViewModels(activeIndex: ActiveIndex)
     
-    @MainActor func updateOutputsObservers(activeIndex: ActiveIndex)
+    @MainActor func updateOutputPortViewModels(activeIndex: ActiveIndex)
     
     @MainActor func updateOutputsObservers(newOutputsValues: PortValuesList,
                                            activeIndex: ActiveIndex)


### PR DESCRIPTION
Main issue here is graph delegate not getting assigned in time.

Other changes include simplifications around row view model updates to involve the backend observer less if there's just a visibility change.