### PR TITLE
Hide aspect ratio and min/max size inputs if layer inspector disabled

### DIFF
--- a/Stitch/Graph/Node/Layer/Type/ShapeLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/ShapeLayerNode.swift
@@ -43,18 +43,18 @@ extension LayerInputTypeSet {
     ]
     
     @MainActor
-    static let aspectRatio: LayerInputTypeSet = [
+    static let aspectRatio: LayerInputTypeSet = FeatureFlags.USE_LAYER_INSPECTOR ? [
         .widthAxis,
         .heightAxis,
         .contentMode
-    ]
+    ] : []
     
     @MainActor
-    static let sizing: LayerInputTypeSet = [
+    static let sizing: LayerInputTypeSet = FeatureFlags.USE_LAYER_INSPECTOR ? [
         .minSize,
         .maxSize,
         .sizingScenario
-    ]
+    ] : []
     
     // LayerGroup only?
     @MainActor


### PR DESCRIPTION
Hide the inputs that represent features not available when the layer inspector FeatureFlag is turned off.

<img width="1224" alt="Screenshot 2024-07-25 at 10 53 36 AM" src="https://github.com/user-attachments/assets/4d90a4ef-c567-4251-9a8d-41b22871a1d3">
