### PR TITLE
Fix for multiple input edges in layer inspector node

### DIFF
--- a/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
+++ b/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
@@ -28,8 +28,17 @@ final class InputLayerNodeRowData {
          canvasObserver: CanvasItemViewModel? = nil) {
         self.rowObserver = rowObserver
         self.canvasObserver = canvasObserver
+        var itemType: GraphItemType
         
-        let itemType: GraphItemType = FeatureFlags.USE_LAYER_INSPECTOR ? .layerInspector : .node
+        if FeatureFlags.USE_LAYER_INSPECTOR {
+            itemType = .layerInspector
+        } else if let canvasObserver = canvasObserver {
+            itemType = .node(canvasObserver.id)
+        } else {
+            fatalErrorIfDebug()
+            itemType = .layerInspector
+        }
+        
         self.inspectorRowViewModel = .init(id: .init(graphItemType: itemType,
                                                      nodeId: rowObserver.id.nodeId,
                                                      portId: 0),
@@ -52,8 +61,17 @@ final class OutputLayerNodeRowData {
          canvasObserver: CanvasItemViewModel? = nil) {
         self.rowObserver = rowObserver
         self.canvasObserver = canvasObserver
+        var itemType: GraphItemType
         
-        let itemType: GraphItemType = FeatureFlags.USE_LAYER_INSPECTOR ? .layerInspector : .node
+        if FeatureFlags.USE_LAYER_INSPECTOR {
+            itemType = .layerInspector
+        } else if let canvasObserver = canvasObserver {
+            itemType = .node(canvasObserver.id)
+        } else {
+            fatalErrorIfDebug()
+            itemType = .layerInspector
+        }
+        
         self.inspectorRowViewModel = .init(id: .init(graphItemType: itemType,
                                                      nodeId: rowObserver.id.nodeId,
                                                      portId: 0),

--- a/Stitch/Graph/Node/Port/Model/Field/FieldCoordinate.swift
+++ b/Stitch/Graph/Node/Port/Model/Field/FieldCoordinate.swift
@@ -18,7 +18,7 @@ struct FieldCoordinate: Hashable {
 
     static var fakeFieldCoordinate: Self {
         .init(
-            rowId: .init(graphItemType: .node, 
+            rowId: .init(graphItemType: .node(.node(.init())),
                          nodeId: .init(),
                          portId: 0),
             fieldIndex: 0)

--- a/Stitch/Graph/Node/Port/Util/Field/TabKeyPressActions.swift
+++ b/Stitch/Graph/Node/Port/Util/Field/TabKeyPressActions.swift
@@ -188,7 +188,7 @@ extension NodeViewModel {
             // TODO: not yet supported. Need to move ordering logic from inspector view so that it can be leveraged here.
             fatalErrorIfDebug()
             return currentInput.fieldValueTypes.first!.id
-        case .node:
+        case .node(let canvasId):
             let portId = currentInputCoordinate.portId
             
             // Input Indices, for only those ports on a patch node which are eligible for Tab or Shift+Tab.
@@ -208,7 +208,7 @@ extension NodeViewModel {
             if currentEligibleInput == firstEligibleInput,
                let maxFieldIndex = allInputs[safe: lastEligibleInput.originalIndex]?.maxFieldIndex {
                 return FieldCoordinate(
-                    rowId: .init(graphItemType: .node,
+                    rowId: .init(graphItemType: .node(canvasId),
                                  nodeId: nodeId,
                                  portId: lastEligibleInput.originalIndex),
                     fieldIndex: maxFieldIndex)
@@ -218,7 +218,7 @@ extension NodeViewModel {
             else if let previousEligibleInput = eligibleInputs.before(currentEligibleInput),
                     let maxFieldIndex = allInputs[safe: previousEligibleInput.originalIndex]?.maxFieldIndex{
                 
-                return FieldCoordinate(rowId: .init(graphItemType: .node,
+                return FieldCoordinate(rowId: .init(graphItemType: .node(canvasId),
                                                     nodeId: nodeId,
                                                     portId: previousEligibleInput.originalIndex),
                                        fieldIndex: maxFieldIndex)

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowViewModel.swift
@@ -9,8 +9,8 @@ import Foundation
 import SwiftUI
 import StitchSchemaKit
 
-enum GraphItemType {
-    case node
+enum GraphItemType: Hashable {
+    case node(CanvasItemId)
     case layerInspector
 }
 
@@ -31,7 +31,7 @@ extension NodeRowViewModelId {
         }
     }
     
-    static let empty: Self = .init(graphItemType: .node,
+    static let empty: Self = .init(graphItemType: .node(.node(.init())),
                                    nodeId: .init(),
                                    portId: -1)
 }
@@ -347,7 +347,7 @@ extension Array where Element: NodeRowViewModel {
             if let entity = currentEntitiesMap.get(newEntity.id) {
                 return entity
             } else {
-                let rowId = NodeRowViewModelId(graphItemType: .node,
+                let rowId = NodeRowViewModelId(graphItemType: .node(canvas.id),
                                                // Important this is the node ID from canvas for group nodes
                                                nodeId: canvas.nodeDelegate?.id ?? newEntity.id.nodeId,
                                                portId: portIndex)

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
@@ -659,7 +659,7 @@ extension NodeViewModel {
                                                     upstreamOutputCoordinate: nil,
                                                     nodeDelegate: lastRowObserver.nodeDelegate)
         
-        let newInputViewModel = InputNodeRowViewModel(id: .init(graphItemType: .node,
+        let newInputViewModel = InputNodeRowViewModel(id: .init(graphItemType: .node(patchNode.canvasObserver.id),
                                                                 nodeId: newInputCoordinate.nodeId,
                                                                 portId: allInputsObservers.count),
                                                       activeValue: newInputObserver.activeValue,

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -553,18 +553,26 @@ extension GraphState {
     // TODO: will look slightly different once inputs live on PatchNodeViewModel and LayerNodeViewModel instead of just NodeViewModel
     @MainActor
     func getLayerInputOnGraph(_ id: LayerInputCoordinate) -> InputNodeRowViewModel? {
-        self.getInputRowViewModel(for: .init(graphItemType: .node,
-                                             nodeId: id.node,
-                                             portId: 0),
-                                  nodeId: id.node)
+        guard let canvasItem = self.getNodeViewModel(id.node)?.layerNode?[keyPath: id.keyPath.layerNodeKeyPath].canvasObserver else {
+            return nil
+        }
+        
+        return self.getInputRowViewModel(for: .init(graphItemType: .node(canvasItem.id),
+                                                    nodeId: id.node,
+                                                    portId: 0),
+                                         nodeId: id.node)
     }
     
     @MainActor
     func getLayerOutputOnGraph(_ id: LayerOutputCoordinate) -> OutputNodeRowViewModel? {
-        self.getOutputRowViewModel(for: .init(graphItemType: .node,
-                                              nodeId: id.node,
-                                              portId: 0),
-                                   nodeId: id.node)
+        guard let canvasItem = self.getNodeViewModel(id.node)?.layerNode?.outputPorts[safe: id.portId]?.canvasObserver else {
+            return nil
+        }
+        
+        return self.getOutputRowViewModel(for: .init(graphItemType: .node(canvasItem.id),
+                                                     nodeId: id.node,
+                                                     portId: 0),
+                                          nodeId: id.node)
     }
     
     func getNodeViewModel(_ id: NodeId) -> NodeViewModel? {


### PR DESCRIPTION
Issue was `NodeRowViewModelId` needed a more specific identifier. There were multiple equal IDs with the prior system which screwed up view builders.