### PR TITLE
Do not crash when creating LayerGroup

### DIFF
--- a/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
@@ -319,6 +319,11 @@ extension NodeViewModel {
     }
     
     @MainActor
+    func getInputRowObserver(for layerInputType: LayerInputType) -> InputNodeRowObserver? {
+        self.getInputRowObserver(for: .keyPath(layerInputType))
+    }
+    
+    @MainActor
     func getOutputRowObserver(for portType: NodeIOPortType) -> OutputNodeRowObserver? {
         switch portType {
         case .keyPath:

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarGroupCreated.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarGroupCreated.swift
@@ -78,10 +78,8 @@ struct SidebarGroupCreated: GraphEventWithResponse {
         let assumedLayerGroupSize: LayerSize = groupFit.size
         
         // Update layer group's size input
-        newNode.getInputRowObserver(1)?.updateValues([.size(assumedLayerGroupSize)])
-        
-        
-        
+        newNode.getInputRowObserver(for: .size)?.updateValues([.size(assumedLayerGroupSize)])
+                
         return .persistenceResponse
     }
 }


### PR DESCRIPTION
Search for keyPath, not portId, when updating newly-created LayerGroup's size input