### PR TITLE
Better handling of min and max with parent percentage with LayerGroups

### DIFF
--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonSizeModifier.swift
@@ -68,27 +68,60 @@ struct PreviewCommonSizeModifier: ViewModifier {
         height.isParentPercentage
     }
     
+    var finalMinWidth: CGFloat? {
+        minWidth?.asFrameDimension(parentSize.width)
+    }
+    
+    var finalMaxWidth: CGFloat? {
+        maxWidth?.asFrameDimension(parentSize.width)
+    }
+    
+    var finalMinHeight: CGFloat? {
+        minHeight?.asFrameDimension(parentSize.height)
+    }
+    
+    var finalMaxHeight: CGFloat? {
+        maxHeight?.asFrameDimension(parentSize.height)
+    }
+    
+    var finalWidth: CGFloat? {
+        if usesParentPercentForWidth && (finalMinWidth.isDefined || finalMaxWidth.isDefined) {
+            return nil
+        } else {
+            return width.asFrameDimension(parentSize.width)
+        }
+    }
+    
+    var finalHeight: CGFloat? {
+        if usesParentPercentForHeight && (finalMinHeight.isDefined || finalMaxHeight.isDefined) {
+            return nil
+        } else {
+            return height.asFrameDimension(parentSize.height)
+        }
+    }
+    
+    
     func body(content: Content) -> some View {
         if FeatureFlags.USE_LAYER_INSPECTOR {
             switch sizingScenario {
             case .auto:
-                logInView("case .auto")
+                // logInView("case .auto")
                 content
                     .modifier(LayerSizeModifier(
                         alignment: frameAlignment,
                         usesParentPercentForWidth: usesParentPercentForWidth,
                         usesParentPercentForHeight: usesParentPercentForHeight,
-                        width: width.asFrameDimension(parentSize.width),
-                        height: height.asFrameDimension(parentSize.height),
-                        minWidth: minWidth?.asFrameDimension(parentSize.width),
-                        maxWidth: maxWidth?.asFrameDimension(parentSize.width),
-                        minHeight: minHeight?.asFrameDimension(parentSize.height),
-                        maxHeight: maxHeight?.asFrameDimension(parentSize.height)
+                        width: finalWidth,
+                        height: finalHeight,
+                        minWidth: finalMinWidth,
+                        maxWidth: finalMaxWidth,
+                        minHeight: finalMinHeight,
+                        maxHeight: finalMaxHeight
                     ))
                     .modifier(LayerSizeReader(viewModel: viewModel))
                 
             case .constrainHeight:
-                logInView("case .constrainHeight")
+                // logInView("case .constrainHeight")
                 content
                 // apply `.aspectRatio` separately from `.frame(width:)` and `.frame(height:)`
                     .modifier(PreviewAspectRatioModifier(data: aspectRatio))
@@ -96,17 +129,17 @@ struct PreviewCommonSizeModifier: ViewModifier {
                         alignment: frameAlignment,
                         usesParentPercentForWidth: usesParentPercentForWidth,
                         usesParentPercentForHeight: usesParentPercentForHeight,
-                        width: width.asFrameDimension(parentSize.width),
+                        width: finalWidth,
                         height: nil,
-                        minWidth: minWidth?.asFrameDimension(parentSize.width),
-                        maxWidth: maxWidth?.asFrameDimension(parentSize.width),
+                        minWidth: finalMinWidth,
+                        maxWidth: finalMaxWidth,
                         minHeight: nil,
                         maxHeight: nil
                     ))
                     .modifier(LayerSizeReader(viewModel: viewModel))
                 
             case .constrainWidth:
-                logInView("case .constrainWidth")
+                // logInView("case .constrainWidth")
                 content
                 // apply `.aspectRatio` separately from `.frame(width:)` and `.frame(height:)`
                     .modifier(PreviewAspectRatioModifier(data: aspectRatio))
@@ -115,18 +148,18 @@ struct PreviewCommonSizeModifier: ViewModifier {
                         usesParentPercentForWidth: usesParentPercentForWidth,
                         usesParentPercentForHeight: usesParentPercentForHeight,
                         width: nil,
-                        height: height.asFrameDimension(parentSize.height),
+                        height: finalHeight,
                         minWidth: nil,
                         maxWidth: nil,
-                        minHeight: minHeight?.asFrameDimension(parentSize.height),
-                        maxHeight: maxHeight?.asFrameDimension(parentSize.height)
+                        minHeight: finalMinHeight,
+                        maxHeight: finalMaxHeight
                     ))
                     .modifier(LayerSizeReader(viewModel: viewModel))
             }
         } else {
             content
-                .frame(width: width.asFrameDimension(parentSize.width),
-                       height: height.asFrameDimension(parentSize.height),
+                .frame(width: finalWidth,
+                       height: finalHeight,
                        alignment: frameAlignment)
                 .modifier(LayerSizeReader(viewModel: viewModel))
         }

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
@@ -39,22 +39,38 @@ struct LayerSizeModifier: ViewModifier {
     let maxHeight: CGFloat?
     
     var someMinMaxDefined: Bool {
-        minWidth.isDefined || maxWidth.isDefined || minHeight.isDefined || maxHeight.isDefined
+        minOrMaxWidthIsDefined || minOrMaxHeightIsDefined
     }
-        
+    
+    var minOrMaxWidthIsDefined: Bool {
+        minWidth.isDefined || maxWidth.isDefined
+    }
+    
+    var minOrMaxHeightIsDefined: Bool {
+        minHeight.isDefined || maxHeight.isDefined
+    }
+    
+   
     func body(content: Content) -> some View {
-        // logInView("LayerSizeModifier: width: \(width)")
-        // logInView("LayerSizeModifier: height: \(height)")
-        // logInView("LayerSizeModifier: minWidth: \(minWidth)")
-        // logInView("LayerSizeModifier: maxWidth: \(maxWidth)")
-        // logInView("LayerSizeModifier: minHeight: \(minHeight)")
-        // logInView("LayerSizeModifier: maxHeight: \(maxHeight)")
+        //        logInView("LayerSizeModifier: alignment: \(alignment)")
+        //
+        //        logInView("LayerSizeModifier: usesParentPercentForWidth: \(usesParentPercentForWidth)")
+        //        logInView("LayerSizeModifier: usesParentPercentForHeight: \(usesParentPercentForHeight)")
+        //
+        //        logInView("LayerSizeModifier: width: \(width)")
+        //        logInView("LayerSizeModifier: height: \(height)")
+        //
+        //        logInView("LayerSizeModifier: minWidth: \(minWidth)")
+        //        logInView("LayerSizeModifier: maxWidth: \(maxWidth)")
+        //        logInView("LayerSizeModifier: minHeight: \(minHeight)")
+        //        logInView("LayerSizeModifier: maxHeight: \(maxHeight)")
+        //
                
         // TODO: the below conditionals can be simplified, but are currently evolving; will be cleaned up after final iterations on conditional input logic
         
         // Width is pt, but height is auto (so can use min/max height)
         if let width = width, !height.isDefined {
-            // logInView("LayerSizeModifier: defined width but not height")
+            //             logInView("LayerSizeModifier: defined width but not height")
             
             content
             // Note: parent-percentage supports min/max along a dimension
@@ -66,8 +82,8 @@ struct LayerSizeModifier: ViewModifier {
         
         // Height is pt, but width is auto (so can use min/max width)
         else if let height = height, !width.isDefined {
-            // logInView("LayerSizeModifier: defined height but not width")
-            
+            //             logInView("LayerSizeModifier: defined height but not width")
+                
             content
                 .frame(minHeight: usesParentPercentForHeight ? minHeight : nil)
                 .frame(maxHeight: usesParentPercentForHeight ? maxHeight : nil)
@@ -77,8 +93,7 @@ struct LayerSizeModifier: ViewModifier {
         
         // Both height and width are pt (so no min/max size at all)
         else if let width = width, let height = height {
-            // logInView("LayerSizeModifier: defined width and height")
-            
+            //             logInView("LayerSizeModifier: defined width and height")
             content
                 .frame(minWidth: usesParentPercentForWidth ? minWidth : nil)
                 .frame(maxWidth: usesParentPercentForWidth ? maxWidth : nil)
@@ -90,7 +105,7 @@ struct LayerSizeModifier: ViewModifier {
         
         // Both height and width are auto, so use min/max height and width
         else if someMinMaxDefined {
-            // logInView("LayerSizeModifier: defined min-max")
+            //             logInView("LayerSizeModifier: defined min-max")
             content.frame(minWidth: minWidth,
                           maxWidth: maxWidth,
                           minHeight: minHeight,


### PR DESCRIPTION
For a preview window that is 800x800.

So 50% width = 400 pts etc.
But we can constraint that via min and max width etc.

<img width="1020" alt="Screenshot 2024-07-29 at 6 40 52 PM" src="https://github.com/user-attachments/assets/d9b8caaf-feb8-4214-9e02-5ef6c48e7f63">
<img width="1024" alt="Screenshot 2024-07-29 at 6 39 49 PM" src="https://github.com/user-attachments/assets/38fc157c-f777-4904-881f-f91856d4e7bf">
