### PR TITLE
Anchor popover arrow now appears next to icon, not at far away from it

### DIFF
--- a/Stitch/Graph/Node/Port/View/Field/InputView/AnchorPopoverView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/AnchorPopoverView.swift
@@ -29,7 +29,6 @@ struct AnchorPopoverView: View {
 
     var body: some View {
         AnchoringGridIconView(anchor: selection)
-            .scaleEffect(0.18) // seems best?
             .onTapGesture {
                 self.isOpen.toggle()
             }
@@ -37,6 +36,8 @@ struct AnchorPopoverView: View {
                 popover
                     .padding(ANCHOR_POPOVER_PADDING)
             }
+        // Important: place *after* .popover, so that popover's arrow is not so far away from the grid-icon-view
+            .scaleEffect(0.18)
     }
 
     @MainActor


### PR DESCRIPTION
Apply .scaleEffect *after* .popover

### before 

<img width="370" alt="Screenshot 2024-07-31 at 9 08 34 AM" src="https://github.com/user-attachments/assets/9c7103b7-13fa-42bc-955b-5fbc3baf425a">


### after 

<img width="279" alt="Screenshot 2024-07-31 at 9 14 48 AM" src="https://github.com/user-attachments/assets/bdc5c67a-1674-40cf-bcf7-90ccb6c1542f">
