### PR TITLE
Show edge-edit-mode input labels according to CanvasItemId, not NodeId

### DIFF
--- a/Stitch/Graph/Edge/Model/EdgeEditingState.swift
+++ b/Stitch/Graph/Edge/Model/EdgeEditingState.swift
@@ -35,7 +35,7 @@ struct EdgeEditingState {
     var originOutput: OutputPortViewData
 
     // the node that is east of, and the shortest distance from, the origin node
-    var nearbyNode: CanvasItemId
+    var nearbyCanvasItem: CanvasItemId
 
     var possibleEdges: PossibleEdgeSet
 

--- a/Stitch/Graph/Edge/Util/EdgeEditingActions.swift
+++ b/Stitch/Graph/Edge/Util/EdgeEditingActions.swift
@@ -84,7 +84,7 @@ extension GraphState {
 
         self.graphUI.edgeEditingState = .init(
             originOutput: outputCoordinate,
-            nearbyNode: nearbyNodeId,
+            nearbyCanvasItem: nearbyNodeId,
             possibleEdges: possibleEdges,
             shownIds: alreadyShownEdges)
     }
@@ -232,8 +232,8 @@ extension GraphState {
             return
         }
         
-        guard let nearbyNode = self.getCanvasItem(edgeEditingState.nearbyNode) else {
-            log("keyCharPressedDuringEdgeEditingMode: could not retrieve \(edgeEditingState.nearbyNode)")
+        guard let nearbyNode = self.getCanvasItem(edgeEditingState.nearbyCanvasItem) else {
+            log("keyCharPressedDuringEdgeEditingMode: could not retrieve \(edgeEditingState.nearbyCanvasItem)")
             return
         }
         

--- a/Stitch/Graph/Node/View/NodesView.swift
+++ b/Stitch/Graph/Node/View/NodesView.swift
@@ -70,6 +70,7 @@ struct NodesView: View {
                     .overlay {
                         edgeDrawingView(inputs: inputs, 
                                         graph: self.graph)
+                        
                         EdgeInputLabelsView(inputs: inputs,
                                             graph: graph,
                                             graphUI: graph.graphUI)
@@ -137,11 +138,16 @@ struct EdgeInputLabelsView: View {
     var body: some View {
         let showLabels = graph.graphUI.edgeEditingState?.labelsShown ?? false
         
-        if let nearbyNodeId = graph.graphUI.edgeEditingState?.nearbyNode {
+        if let nearbyCanvasItem: CanvasItemId = graph.graphUI.edgeEditingState?.nearbyCanvasItem {
             ForEach(inputs) { inputRowViewModel in
+                
+                
+                // Doesn't seem to be needed? Checking the canvasItemDelegate seems to work well
                 // visibleNodeId property checks for group splitter inputs
-                let isInputForNearbyNode = inputRowViewModel.visibleNodeIds.contains(nearbyNodeId)
-                let isVisible = isInputForNearbyNode && showLabels
+//                let isInputForNearbyNode = inputRowViewModel.visibleNodeIds.contains(nearbyCanvasItem)
+                
+                let isInputOnNearbyCanvasItem = inputRowViewModel.canvasItemDelegate?.id == nearbyCanvasItem
+                let isVisible = isInputOnNearbyCanvasItem && showLabels
                 
                 EdgeEditModeLabelsView(graph: graph,
                                        portId: inputRowViewModel.id.portId)


### PR DESCRIPTION

https://github.com/user-attachments/assets/9e9ffd82-b8b0-42fb-a84a-57771451c398

