### PR TITLE
Fixed splitter type changes for group node ports

### DIFF
--- a/Stitch/Graph/Node/Port/Util/TypeChange/NodeTypeChangedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/TypeChange/NodeTypeChangedActions.swift
@@ -78,9 +78,7 @@ extension GraphState {
                     graphTime: TimeInterval) -> NodeIdSet {
 
         guard let patchNode = node.patchNode else {
-            #if DEBUG
-            fatalError()
-            #endif
+            fatalErrorIfDebug()
             return .init()
         }
 

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
@@ -57,10 +57,15 @@ extension NodeRowObserver {
             guard let canvas = rowViewModel.canvasItemDelegate else {
                 return rowViewModel
             }
+            
+            // view model is rendering at this group context
+            let isVisibleInCurrentGroup = canvas.isVisibleInFrame &&
+            canvas.parentGroupNodeId == self.nodeDelegate?.graphDelegate?.groupNodeFocused
+            
+            // always update group node, whose row view models don't otherwise update
+            let isGroupNode = canvas.nodeDelegate?.nodeType.groupNode.isDefined ?? false
                
-            if canvas.isVisibleInFrame &&
-               // view model is rendering at this group context
-               canvas.parentGroupNodeId == self.nodeDelegate?.graphDelegate?.groupNodeFocused {
+            if isVisibleInCurrentGroup || isGroupNode {
                 return rowViewModel
             }
             


### PR DESCRIPTION
Fixes an issue where group node view models wouldn't update unless the user open+closes project.