### PR TITLE
Fixed project deletion undo

### DIFF
--- a/Stitch/App/Serialization/DocumentLoading/StitchFileManager.swift
+++ b/Stitch/App/Serialization/DocumentLoading/StitchFileManager.swift
@@ -69,7 +69,7 @@ final class StitchFileManager: FileManager, MiddlewareService {
 
             // Remove any possibly existing file with same name
             let recentlyDeletedProjectUrl = StitchDocument.recentlyDeletedURL
-                .appendingStitchDocPath(projectId)
+                .appendingStitchProjectDataPath(projectId)
             
              log("StitchFileManager.removeStitchProject: recentlyDeletedProjectUrl: \(recentlyDeletedProjectUrl)")
             

--- a/Stitch/App/Serialization/Util/File/StitchDocumentURLUtils.swift
+++ b/Stitch/App/Serialization/Util/File/StitchDocumentURLUtils.swift
@@ -9,17 +9,13 @@ import Foundation
 import StitchSchemaKit
 
 extension URL {
-    func appendingStitchDocPath(_ document: StitchDocumentIdentifiable) -> URL {
-        self.appendingPathComponent(document.uniqueInternalDirectoryName, conformingTo: .stitchDocument)
-    }
-
     func appendingStitchProjectDataPath(_ document: StitchDocumentIdentifiable) -> URL {
         self.appendingPathComponent(document.uniqueInternalDirectoryName, conformingTo: .stitchProjectData)
     }
-
-    func appendingStitchDocPath(_ projectId: ProjectId) -> URL {
+    
+    func appendingStitchProjectDataPath(_ projectId: ProjectId) -> URL {
         self.appendingPathComponent(StitchDocument.getFileName(projectId: projectId),
-                                    conformingTo: .stitchDocument)
+                                    conformingTo: .stitchProjectData)
     }
 
     func appendingStitchMediaPath() -> URL {

--- a/Stitch/Home/Util/ProjectDestructiveActions.swift
+++ b/Stitch/Home/Util/ProjectDestructiveActions.swift
@@ -27,7 +27,6 @@ extension StitchStore {
 extension StitchStore {
     @MainActor
     func deleteProject(document: StitchDocument) {
-        let fileManager = self.environment.fileManager
         let projectId = document.projectId
 
         switch StitchFileManager.removeStitchProject(
@@ -80,7 +79,7 @@ extension StitchStore {
     func undoDeleteProject(projectId: ProjectId) {
         // Find URL from recently deleted
         let deletedProjectURL = StitchDocument.recentlyDeletedURL
-            .appendingStitchDocPath(projectId)
+            .appendingStitchProjectDataPath(projectId)
 
         // Reimports deleted project
         Task {

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -4,11 +4,12 @@ What’s new:
 
 New layer node inputs:
 - Padding + spacing
-- “Stroke” now available on on layers
+- “Stroke” now available on layers
 
 Bug fixes + other changes:
 - Fixed crash on first-run experience
 - Fixed various crashes caused by some input edits
+- Fixed project deletion undo
 - Graph edges use “curve” style by default
 - Node type options in dropdown list in alphabetical order
 - Re-enabled Cubic Bezier Animation patch node


### PR DESCRIPTION
The issue was caused by attempting to unzip a project from the recently deleted temp folder. Projects here aren't zipped.

Other changes:
* Tweaked logic to look at file extensions to determine if a file needs to be unzipped
* Matched the file extension in recently deleted files