### PR TITLE
Fixed crash caused by speaker node

### DIFF
--- a/Stitch/Graph/Node/Patch/Type/Media/SpeakerNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Media/SpeakerNode.swift
@@ -36,18 +36,16 @@ func speakerNode(id: NodeId,
 
 @MainActor
 func speakerEval(node: PatchNode) -> EvalResult {
-    let outputsValues = loopedEval(node: node) { values, loopIndex in
+    let _ = loopedEval(node: node) { values, loopIndex in
         guard let volume = values[safe: 1]?.getNumber,
               let speakerMedia = values.first?.asyncMedia?.mediaObject.soundFilePlayer else {
             log("speakerEval error: no engine or soundinput found.")
-            return [PortValue.number(0)]
+            return
         }
         
         // TODO: player volume should be displayed from this speaker node
         speakerMedia.updateVolume(volume)
-        return [PortValue.number(0)]
     }
-        .remapOutputs()
     
-    return EvalResult(outputsValues: outputsValues)
+    return .init(outputsValues: [])
 }

--- a/Stitch/Graph/Node/Port/Util/PulseActions.swift
+++ b/Stitch/Graph/Node/Port/Util/PulseActions.swift
@@ -86,14 +86,11 @@ struct ReversePulseCoercion: GraphEvent {
     func handle(state: GraphState) {
         // Cannot recalculate full node in some examples (like delay node)
         // so we just update downstream nodes
-        guard let downstreamNodeInputs = state.connections.get(pulsedOutput),
-              let node = state.getNodeViewModel(pulsedOutput.nodeId),
+        guard let node = state.getNodeViewModel(pulsedOutput.nodeId),
               let currentOutputs = node.getOutputRowObserver(for: pulsedOutput.portType)?.allLoopedValues else {
-                  log("ReversePulseCoercion error: data not found.")
+                  fatalErrorIfDebug("ReversePulseCoercion error: data not found.")
                   return
               }
-        
-        let downstreamNodeIds = downstreamNodeInputs.map { $0.nodeId }.toSet
         
         // Reverse the values in the downstream inputs
         let changedDownstreamNodeIds = state


### PR DESCRIPTION
Helpers expected output row observer when none was created for the speaker node, which doesn't contain any outputs.