### PR TITLE
Fixed counter issue with press interaction node

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -5972,8 +5972,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StitchDesign/StitchEngine.git";
 			requirement = {
-				kind = exactVersion;
-				version = 1.0.0;
+				kind = revision;
+				revision = 1525512db7832fdd719b3bb12f5806e779ccf729;
 			};
 		};
 		B5FBE3C22C4195B3006DA0A7 /* XCRemoteSwiftPackageReference "DirectoryWatcher" */ = {

--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -5972,8 +5972,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StitchDesign/StitchEngine.git";
 			requirement = {
-				kind = revision;
-				revision = 1525512db7832fdd719b3bb12f5806e779ccf729;
+				kind = exactVersion;
+				version = 1.0.1;
 			};
 		};
 		B5FBE3C22C4195B3006DA0A7 /* XCRemoteSwiftPackageReference "DirectoryWatcher" */ = {

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
@@ -92,6 +92,10 @@ final class NodeViewModel: Sendable {
 }
 
 extension NodeViewModel: NodeCalculatable {
+    var requiresOutputValuesChange: Bool {
+        self.kind.getPatch == .pressInteraction
+    }
+    
     @MainActor func getAllInputsObservers() -> [InputNodeRowObserver] {        
         switch self.nodeType {
         case .patch(let patch):

--- a/stitch.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/stitch.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StitchDesign/StitchEngine.git",
       "state" : {
-        "revision" : "cf99144a2587e0078f80de5991e92918ae2228cb",
-        "version" : "1.0.0"
+        "revision" : "1525512db7832fdd719b3bb12f5806e779ccf729"
       }
     },
     {

--- a/stitch.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/stitch.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,7 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StitchDesign/StitchEngine.git",
       "state" : {
-        "revision" : "1525512db7832fdd719b3bb12f5806e779ccf729"
+        "revision" : "cf99144a2587e0078f80de5991e92918ae2228cb",
+        "version" : "1.0.0"
       }
     },
     {


### PR DESCRIPTION
Fixes issue where a downstream counter node would pulse on too many occasions when connected from a press interaction "down" output.

Changes are mostly in StitchEngine but have been isolated to only impact the press interaction node. Nodes can leverage this in the future with updates in the `requiresOutputValuesChange` computed getter.