### PR TITLE
Fixed transform updates for 3D Model layer node

### DIFF
--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -8,6 +8,7 @@ New layer node inputs:
 
 Bug fixes + other changes:
 - Fixed crash on first-run experience
+- Fixed issue where 3D Model layer node wouldn't update transform
 - Fixed various crashes caused by some input edits
 - Fixed project deletion undo
 - Graph edges use “curve” style by default


### PR DESCRIPTION
Model entities in a 3D model layer use a different tech stack than the reality node, and therefore need to be updated differently. The fix required converting StitchEntity into an Observable, allowing it to publish changes to the view representable. When these updates happen we can trigger matrix transform updates in the update view method.