### PR TITLE
Bring inspector row closer to Figma spec; inspected layer now has sticky header

### DIFF
--- a/Stitch/App/Resources/Assets.xcassets/Colors/LayerInspectorRowCapsuleColor.colorset/Contents.json
+++ b/Stitch/App/Resources/Assets.xcassets/Colors/LayerInspectorRowCapsuleColor.colorset/Contents.json
@@ -1,0 +1,68 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "255",
+          "green" : "255",
+          "red" : "255"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "255",
+          "green" : "255",
+          "red" : "255"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "255",
+          "green" : "255",
+          "red" : "255"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "55",
+          "green" : "55",
+          "red" : "55"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -24,47 +24,13 @@ struct LayerInspectorInputPortView: View {
                                node: node,
                                layerNode: layerNode,
                                graph: graph) { propertyRowIsSelected, isOnGraphAlready in
-            
-            HStack {
-                
-                if layerInput == .opacity {
-                    logInView("on opacity")
-                }
-                
-                if isOnGraphAlready,
-                   let canvasItemId = rowViewModel.canvasItemDelegate?.id {
-                    JumpToLayerPropertyOnGraphButton(canvasItemId: canvasItemId)
-                        .border(.purple)
-                } else {
-                    AddLayerPropertyToGraphButton(
-                        propertyIsSelected: propertyRowIsSelected,
-                        coordinate: rowObserver.id)
-                    .border(.orange)
-                }
-                
-                HStack {
-                    NodeInputView(graph: graph,
-                                  rowObserver: rowObserver,
-                                  rowData: rowViewModel,
-                                  forPropertySidebar: true,
-                                  propertyIsSelected: propertyRowIsSelected,
-                                  propertyIsAlreadyOnGraph: isOnGraphAlready,
-                                  isCanvasItemSelected: false)
-                    Spacer()
-                }
-//                .padding(8)
-                .padding(.leading, 8)
-                .background {
-                    //
-//                    Color.green
-//                        .opacity(0.5)
-                    WHITE_IN_LIGHT_MODE_GRAY_IN_DARK_MODE
-                        .cornerRadius(6)
-                }
-
-            }
-//            .border(.blue)
-            
+            NodeInputView(graph: graph,
+                          rowObserver: rowObserver,
+                          rowData: rowViewModel,
+                          forPropertySidebar: true,
+                          propertyIsSelected: propertyRowIsSelected,
+                          propertyIsAlreadyOnGraph: isOnGraphAlready,
+                          isCanvasItemSelected: false)
         }
     }
 }
@@ -86,12 +52,12 @@ struct LayerInspectorOutputPortView: View {
                                layerNode: layerNode,
                                graph: graph) { propertyRowIsSelected, isOnGraphAlready in
             NodeOutputView(graph: graph,
-                          rowObserver: rowObserver,
-                          rowData: rowViewModel,
-                          forPropertySidebar: true,
-                          propertyIsSelected: propertyRowIsSelected,
-                          propertyIsAlreadyOnGraph: isOnGraphAlready,
-                          isCanvasItemSelected: false)
+                           rowObserver: rowObserver,
+                           rowData: rowViewModel,
+                           forPropertySidebar: true,
+                           propertyIsSelected: propertyRowIsSelected,
+                           propertyIsAlreadyOnGraph: isOnGraphAlready,
+                           isCanvasItemSelected: false)
         }
     }
 }
@@ -122,44 +88,50 @@ struct LayerInspectorPortView<RowObserver, RowView>: View where RowObserver: Nod
         }
         return rowViewModel.canvasItemDelegate.isDefined
     }
-
+    
     var body: some View {
         
-//        let listBackgroundColor: Color = isOnGraphAlready
-//            ? Color.black.opacity(0.3)
-//            : (self.propertyRowIsSelected
-//               ? STITCH_PURPLE.opacity(0.4) : .clear)
         
-        // See if layer node uses this input
-        rowView(propertyRowIsSelected, isOnGraphAlready)
-            .listRowBackground(Color.clear)
-        
-//        .background {
-//            // Extending the hit area of the NodeInputOutputView view
-////            Color.white.opacity(0.001)
-//            Color.white.opacity(0.1)
-//                .padding(-12)
-//                .padding(.trailing, -LayerInspectorView.LAYER_INSPECTOR_WIDTH)
-//                .cornerRadius(6)
-//                .border(.red)
-//            
-//            // TODO: this avoids accidentally selecting the row when using a dropdown, but then the row's overall-label and field-labels are no longer covered; so just add this .gesture to the overall-label and field-label views?
-////                .gesture(
-////                    TapGesture().onEnded({ _ in
-////                        log("LayerInspectorPortView tapped")
-////                        if isOnGraphAlready,
-////                           let canvasItemId = rowViewModel.canvasItemDelegate?.id {
-////                            dispatch(JumpToCanvasItem(id: canvasItemId))
-////                        } else {
-////                            withAnimation {
-////                                graph.graphUI.layerPropertyTapped(layerProperty)
-////                            }
-////                        }
-////                    })
-////                ) // .gesture
-//        }
-//        .listRowBackground(listBackgroundColor)
-        //            .listRowSpacing(12)
+        HStack(spacing: 8) {
+            if isOnGraphAlready,
+               let canvasItemId = rowViewModel.canvasItemDelegate?.id {
+                JumpToLayerPropertyOnGraphButton(canvasItemId: canvasItemId)
+            } else {
+                AddLayerPropertyToGraphButton(
+                    propertyIsSelected: propertyRowIsSelected,
+                    coordinate: rowObserver.id)
+            }
+            
+            HStack {
+                rowView(propertyRowIsSelected, isOnGraphAlready)
+                Spacer()
+            }
+            .padding(.leading, 8)
+            .background {
+                WHITE_IN_LIGHT_MODE_GRAY_IN_DARK_MODE
+                    .cornerRadius(6)
+                // Note: applying the gesture to the background instead of the HStack avoids accidentally selecting the row when using a dropdown, but then the row's overall-label and field-labels are no longer covered; so just add this .gesture to the overall-label and field-label views?
+                //                    .gesture(
+                //                        TapGesture().onEnded({ _ in
+                //                            log("LayerInspectorPortView tapped")
+                //                            if isOnGraphAlready,
+                //                               let canvasItemId = rowViewModel.canvasItemDelegate?.id {
+                //                                dispatch(JumpToCanvasItem(id: canvasItemId))
+                //                            } else {
+                //                                withAnimation {
+                //                                    graph.graphUI.layerPropertyTapped(layerProperty)
+                //                                }
+                //                            }
+                //                        })
+                //                    ) // .gesture
+            }
+        }
+        .listRowBackground(Color.clear)
+        .listRowSeparator(.hidden)
+        .listRowInsets(EdgeInsets(top: INSPECTOR_LIST_ROW_TOP_AND_BOTTOM_INSET,
+                                  leading: 0,
+                                  bottom: INSPECTOR_LIST_ROW_TOP_AND_BOTTOM_INSET,
+                                  trailing: 0))
         .gesture(
             TapGesture().onEnded({ _ in
                 // log("LayerInspectorPortView tapped")

--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -24,13 +24,47 @@ struct LayerInspectorInputPortView: View {
                                node: node,
                                layerNode: layerNode,
                                graph: graph) { propertyRowIsSelected, isOnGraphAlready in
-            NodeInputView(graph: graph,
-                          rowObserver: rowObserver,
-                          rowData: rowViewModel,
-                          forPropertySidebar: true,
-                          propertyIsSelected: propertyRowIsSelected,
-                          propertyIsAlreadyOnGraph: isOnGraphAlready,
-                          isCanvasItemSelected: false)
+            
+            HStack {
+                
+                if layerInput == .opacity {
+                    logInView("on opacity")
+                }
+                
+                if isOnGraphAlready,
+                   let canvasItemId = rowViewModel.canvasItemDelegate?.id {
+                    JumpToLayerPropertyOnGraphButton(canvasItemId: canvasItemId)
+                        .border(.purple)
+                } else {
+                    AddLayerPropertyToGraphButton(
+                        propertyIsSelected: propertyRowIsSelected,
+                        coordinate: rowObserver.id)
+                    .border(.orange)
+                }
+                
+                HStack {
+                    NodeInputView(graph: graph,
+                                  rowObserver: rowObserver,
+                                  rowData: rowViewModel,
+                                  forPropertySidebar: true,
+                                  propertyIsSelected: propertyRowIsSelected,
+                                  propertyIsAlreadyOnGraph: isOnGraphAlready,
+                                  isCanvasItemSelected: false)
+                    Spacer()
+                }
+//                .padding(8)
+                .padding(.leading, 8)
+                .background {
+                    //
+//                    Color.green
+//                        .opacity(0.5)
+                    WHITE_IN_LIGHT_MODE_GRAY_IN_DARK_MODE
+                        .cornerRadius(6)
+                }
+
+            }
+//            .border(.blue)
+            
         }
     }
 }
@@ -83,40 +117,48 @@ struct LayerInspectorPortView<RowObserver, RowView>: View where RowObserver: Nod
     }
     
     var isOnGraphAlready: Bool {
-        rowViewModel.canvasItemDelegate.isDefined
+        if layerProperty == .layerInput(.opacity) {
+            log("rowViewModel.canvasItemDelegate.isDefined: \(rowViewModel.canvasItemDelegate.isDefined)")
+        }
+        return rowViewModel.canvasItemDelegate.isDefined
     }
 
     var body: some View {
         
-        let listBackgroundColor: Color = isOnGraphAlready
-            ? Color.black.opacity(0.3)
-            : (self.propertyRowIsSelected
-               ? STITCH_PURPLE.opacity(0.4) : .clear)
+//        let listBackgroundColor: Color = isOnGraphAlready
+//            ? Color.black.opacity(0.3)
+//            : (self.propertyRowIsSelected
+//               ? STITCH_PURPLE.opacity(0.4) : .clear)
         
         // See if layer node uses this input
         rowView(propertyRowIsSelected, isOnGraphAlready)
-        .background {
-            // Extending the hit area of the NodeInputOutputView view
-            Color.white.opacity(0.001)
-                .padding(-12)
-                .padding(.trailing, -LayerInspectorView.LAYER_INSPECTOR_WIDTH)
-            
-            // TODO: this avoids accidentally selecting the row when using a dropdown, but then the row's overall-label and field-labels are no longer covered; so just add this .gesture to the overall-label and field-label views?
-//                .gesture(
-//                    TapGesture().onEnded({ _ in
-//                        log("LayerInspectorPortView tapped")
-//                        if isOnGraphAlready,
-//                           let canvasItemId = rowViewModel.canvasItemDelegate?.id {
-//                            dispatch(JumpToCanvasItem(id: canvasItemId))
-//                        } else {
-//                            withAnimation {
-//                                graph.graphUI.layerPropertyTapped(layerProperty)
-//                            }
-//                        }
-//                    })
-//                ) // .gesture
-        }
-        .listRowBackground(listBackgroundColor)
+            .listRowBackground(Color.clear)
+        
+//        .background {
+//            // Extending the hit area of the NodeInputOutputView view
+////            Color.white.opacity(0.001)
+//            Color.white.opacity(0.1)
+//                .padding(-12)
+//                .padding(.trailing, -LayerInspectorView.LAYER_INSPECTOR_WIDTH)
+//                .cornerRadius(6)
+//                .border(.red)
+//            
+//            // TODO: this avoids accidentally selecting the row when using a dropdown, but then the row's overall-label and field-labels are no longer covered; so just add this .gesture to the overall-label and field-label views?
+////                .gesture(
+////                    TapGesture().onEnded({ _ in
+////                        log("LayerInspectorPortView tapped")
+////                        if isOnGraphAlready,
+////                           let canvasItemId = rowViewModel.canvasItemDelegate?.id {
+////                            dispatch(JumpToCanvasItem(id: canvasItemId))
+////                        } else {
+////                            withAnimation {
+////                                graph.graphUI.layerPropertyTapped(layerProperty)
+////                            }
+////                        }
+////                    })
+////                ) // .gesture
+//        }
+//        .listRowBackground(listBackgroundColor)
         //            .listRowSpacing(12)
         .gesture(
             TapGesture().onEnded({ _ in

--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -83,10 +83,7 @@ struct LayerInspectorPortView<RowObserver, RowView>: View where RowObserver: Nod
     }
     
     var isOnGraphAlready: Bool {
-        if layerProperty == .layerInput(.opacity) {
-            log("rowViewModel.canvasItemDelegate.isDefined: \(rowViewModel.canvasItemDelegate.isDefined)")
-        }
-        return rowViewModel.canvasItemDelegate.isDefined
+        rowViewModel.canvasItemDelegate.isDefined
     }
     
     var body: some View {

--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -58,30 +58,20 @@ struct LayerInspectorView: View {
             @Bindable var node = node
             @Bindable var layerNode = layerNode
             
-            UIKitWrapper(ignoresKeyCommands: false,
-                         name: "LayerInspectorView") {
+//            UIKitWrapper(ignoresKeyCommands: false,
+//                         name: "LayerInspectorView") {
                 selectedLayerView(node, layerNode)
-            }
+//            }
 
             // TODO: need UIKitWrapper to detect keypresses; alternatively, place UIKitWrapper on the sections themselves?
             // Takes care of the mysterious white top padding UIKitWrapper introduces
-            #if targetEnvironment(macCatalyst)
-                         .padding(.top, INSPECTOR_LIST_TOP_PADDING)
-            #else
-                         .padding(.top, INSPECTOR_LIST_TOP_PADDING)
-                         .padding(.bottom, -20)
-            #endif
-            
-                         .onAppear {
-                             //#if DEV_DEBUG
-                             //                             // TODO: write a test; make sure we handle all layer input types at least in some cases?
-                             //                             let listedLayers = Self.allInputs
-                             //                             let allLayers = LayerInputType.allCases.toSet
-                             //                             let diff = allLayers.subtracting(listedLayers)
-                             //                             log("diff: \(diff)")
-                             //                             assert(diff.count == 0)
-                             //#endif
-                         }
+//            #if targetEnvironment(macCatalyst)
+//                         .padding(.top, INSPECTOR_LIST_TOP_PADDING)
+//            #else
+//                         .padding(.top, INSPECTOR_LIST_TOP_PADDING)
+//                         .padding(.bottom, -20)
+//            #endif
+//            
         } else {
             // Empty List, so have same background
             List { }
@@ -92,7 +82,13 @@ struct LayerInspectorView: View {
     func selectedLayerView(_ node: NodeViewModel,
                            _ layerNode: LayerNodeViewModel) -> some View {
 
-        VStack(alignment: .leading) {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text(node.displayTitle).font(.title2)
+                Spacer()
+            }
+                .padding()
+                .background(Color.SWIFTUI_LIST_BACKGROUND_COLOR)
             
             //            // TODO: remove? make editable TextField for renaming etc.?
             //            // TODO: want something that
@@ -108,7 +104,7 @@ struct LayerInspectorView: View {
             
             List {
                 // TODO: remove?
-                Text(node.displayTitle).font(.title2)
+//                Text(node.displayTitle).font(.title2)
                 
                 ForEach(Self.layerInspectorRowsInOrder(layerNode.layer), id: \.name) { sectionNameAndInputs in
                     
@@ -152,6 +148,9 @@ struct LayerInspectorView: View {
                                                  layerNode: layerNode,
                                                  graph: graph)
             } // List
+        
+        // Note: gives us sticky headers, but we lose background color?
+//            .listStyle(.plain)
             
         } // VStack
     }
@@ -245,14 +244,17 @@ struct LayerInspectorInputsSectionView: View {
             }
             .transition(.slideInAndOut(edge: .top))
         } header: {
-            HStack  {
-                StitchTextView(string: sectionName.rawValue)
-                Spacer()
+            
+            // TODO: use a button instead?
+            
+            HStack { // spacing of 8 ?
                 let rotationZ: CGFloat = expanded ? 90 : 0
                 Image(systemName: CHEVRON_GROUP_TOGGLE_ICON)
                     .rotation3DEffect(Angle(degrees: rotationZ),
                                       axis: (x: 0, y: 0, z: rotationZ))
                     .animation(.linear(duration: 0.2), value: rotationZ)
+                StitchTextView(string: sectionName.rawValue)
+                
             }
             .padding(4)
             .contentShape(Rectangle())

--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -18,6 +18,13 @@ extension LayerInputType: Identifiable {
 }
 
 #if targetEnvironment(macCatalyst)
+let INSPECTOR_LIST_ROW_TOP_AND_BOTTOM_INSET = 2.0
+#else
+let INSPECTOR_LIST_ROW_TOP_AND_BOTTOM_INSET = 4.0
+#endif
+
+
+#if targetEnvironment(macCatalyst)
 let INSPECTOR_LIST_TOP_PADDING = -40.0
 #else
 let INSPECTOR_LIST_TOP_PADDING = -60.0
@@ -58,20 +65,20 @@ struct LayerInspectorView: View {
             @Bindable var node = node
             @Bindable var layerNode = layerNode
             
-//            UIKitWrapper(ignoresKeyCommands: false,
-//                         name: "LayerInspectorView") {
+            UIKitWrapper(ignoresKeyCommands: false,
+                         name: "LayerInspectorView") {
                 selectedLayerView(node, layerNode)
-//            }
+            }
 
             // TODO: need UIKitWrapper to detect keypresses; alternatively, place UIKitWrapper on the sections themselves?
             // Takes care of the mysterious white top padding UIKitWrapper introduces
-//            #if targetEnvironment(macCatalyst)
-//                         .padding(.top, INSPECTOR_LIST_TOP_PADDING)
-//            #else
-//                         .padding(.top, INSPECTOR_LIST_TOP_PADDING)
-//                         .padding(.bottom, -20)
-//            #endif
-//            
+#if targetEnvironment(macCatalyst)
+                         .padding(.top, INSPECTOR_LIST_TOP_PADDING)
+#else
+                         .padding(.top, INSPECTOR_LIST_TOP_PADDING)
+                         .padding(.bottom, -20)
+#endif
+            
         } else {
             // Empty List, so have same background
             List { }
@@ -84,28 +91,14 @@ struct LayerInspectorView: View {
 
         VStack(alignment: .leading, spacing: 0) {
             HStack {
+                // TODO: should be editable, to rename the layer?
                 Text(node.displayTitle).font(.title2)
                 Spacer()
             }
                 .padding()
                 .background(Color.SWIFTUI_LIST_BACKGROUND_COLOR)
-            
-            //            // TODO: remove? make editable TextField for renaming etc.?
-            //            // TODO: want something that
-            //            Text(node.displayTitle).font(.title2)
-            //                            .padding()
-            //#if targetEnvironment(macCatalyst)
-            //                .padding(.top, 12)
-            //#else
-            //                .padding(.top, 12)
-            //#endif
-            ////                         .background(.clear)
-            //
-            
+                        
             List {
-                // TODO: remove?
-//                Text(node.displayTitle).font(.title2)
-                
                 ForEach(Self.layerInspectorRowsInOrder(layerNode.layer), id: \.name) { sectionNameAndInputs in
                     
                     let sectionName = sectionNameAndInputs.name
@@ -151,10 +144,17 @@ struct LayerInspectorView: View {
         
         // Note: gives us sticky headers, but we lose background color?
 //            .listStyle(.plain)
+//            .background(Color.SWIFTUI_LIST_BACKGROUND_COLOR)
             
+            // Note: hard to be exact here
+            // The default ListStyle adds padding (visible if we do not use Color.clear as list row background), but using e.g. ListStyle.plain introduces sticky header sections that we do not want.
+            .padding([.leading], -6)
+            .padding([.trailing], -4)
         } // VStack
     }
 }
+
+
 
 struct LayerPropertyRowOriginReader: ViewModifier {
     

--- a/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
@@ -98,12 +98,12 @@ struct OutputValueView: View {
     // - input or,
     // - field within a multifield output
     var outputAlignment: Alignment {
-        isMultiField ? .leading : .trailing
+        if forPropertySidebar {
+            return .leading
+        } else {
+            return isMultiField ? .leading : .trailing
+        }
     }
-
-//    var isInput: Bool {
-//        self.nodeIO == .input
-//    }
 
     var body: some View {
         switch fieldValue {
@@ -113,9 +113,7 @@ struct OutputValueView: View {
                                alignment: outputAlignment,
                                fontColor: STITCH_FONT_GRAY_COLOR)
 
-        case .number, .layerDimension,
-            //
-                .spacing:
+        case .number, .layerDimension, .spacing:
             ReadOnlyValueEntry(value: fieldValue.stringValue,
                                alignment: outputAlignment,
                                fontColor: STITCH_FONT_GRAY_COLOR)

--- a/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
+++ b/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
@@ -20,7 +20,7 @@ struct AddLayerPropertyToGraphButton: View {
     var body: some View {
         Image(systemName: "plus.circle")
             .resizable()
-            .frame(width: 15, height: 15)
+            .frame(width: 16, height: 16) // per Figma
             .onTapGesture {
                 if let layerInput = coordinate.keyPath {
                     dispatch(LayerInputAddedToGraph(
@@ -32,6 +32,20 @@ struct AddLayerPropertyToGraphButton: View {
                 }
             }
             .opacity(propertyIsSelected ? 1 : 0)
+    }
+}
+
+struct JumpToLayerPropertyOnGraphButton: View {
+    let canvasItemId: CanvasItemId
+        
+    var body: some View {
+        // TODO: use a button ?
+        Image(systemName: "scope")
+            .resizable()
+            .frame(width: 16, height: 16)
+            .onTapGesture {
+                dispatch(JumpToCanvasItem(id: canvasItemId))
+            }
     }
 }
 
@@ -64,19 +78,11 @@ struct NodeInputOutputView<NodeRowObserverType: NodeRowObserver,
     
     var isGroupNode: Bool {
         self.rowData.nodeDelegate?.kind.isGroup ?? false
-    }
+    } 
     
     var body: some View {
-        HStack(spacing: NODE_COMMON_SPACING) {
-            if forPropertySidebar {
-                AddLayerPropertyToGraphButton(propertyIsSelected: propertyIsSelected,
-                                              coordinate: self.rowObserver.id)
-            }
-            
             // Fields and port ordering depending on input/output
             self.fieldsView(rowData, labelView)
-        }
-        //        .frame(height: NODE_ROW_HEIGHT)
         
         // Don't specify height for layer inspector property row, so that multifields can be shown vertically
         .frame(height: forPropertySidebar ? nil : NODE_ROW_HEIGHT)

--- a/Stitch/Graph/Util/Font/FontConstants.swift
+++ b/Stitch/Graph/Util/Font/FontConstants.swift
@@ -29,6 +29,10 @@ let VALUE_FIELD_BODY_COLOR: Color = Color(.valueFieldBody)
 
 let INSERT_NODE_MENU_SEARCH_TEXT: Color = Color(.insertNodeMenuTitle)
 
+// white in light mode, gray in dark mode
+let INSERT_NODE_MENU_SEARCH_PREVIEW_WINDOW: Color = Color(.insertNodePreviewWindow)
+let WHITE_IN_LIGHT_MODE_GRAY_IN_DARK_MODE = INSERT_NODE_MENU_SEARCH_PREVIEW_WINDOW
+
 let SIDE_BAR_OPTIONS_TITLE_FONT_COLOR: Color = Color(.sideBarOptionsTitleFont)
 
 let CATALYST_TOP_BAR_ICON_SIZE = CGSize(width: 17, height: 17)

--- a/Stitch/Graph/Util/Font/FontConstants.swift
+++ b/Stitch/Graph/Util/Font/FontConstants.swift
@@ -30,8 +30,8 @@ let VALUE_FIELD_BODY_COLOR: Color = Color(.valueFieldBody)
 let INSERT_NODE_MENU_SEARCH_TEXT: Color = Color(.insertNodeMenuTitle)
 
 // white in light mode, gray in dark mode
-let INSERT_NODE_MENU_SEARCH_PREVIEW_WINDOW: Color = Color(.insertNodePreviewWindow)
-let WHITE_IN_LIGHT_MODE_GRAY_IN_DARK_MODE = INSERT_NODE_MENU_SEARCH_PREVIEW_WINDOW
+let LAYER_INSPECTOR_ROW_CAPSULE_COLOR: Color = Color(.layerInspectorRowCapsule)
+let WHITE_IN_LIGHT_MODE_GRAY_IN_DARK_MODE = LAYER_INSPECTOR_ROW_CAPSULE_COLOR
 
 let SIDE_BAR_OPTIONS_TITLE_FONT_COLOR: Color = Color(.sideBarOptionsTitleFont)
 

--- a/stitch.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/stitch.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -68,7 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StitchDesign/StitchSchemaKit.git",
       "state" : {
-        "revision" : "e7d39d45a2487960930f123556b739517b08f4ce"
+        "revision" : "b3e7b2379c6996fed07ee335ae0e8ecd39e7dc4d",
+        "version" : "21.1.0"
       }
     },
     {

--- a/stitch.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/stitch.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -68,8 +68,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StitchDesign/StitchSchemaKit.git",
       "state" : {
-        "revision" : "b3e7b2379c6996fed07ee335ae0e8ecd39e7dc4d",
-        "version" : "21.1.0"
+        "revision" : "e7d39d45a2487960930f123556b739517b08f4ce"
       }
     },
     {


### PR DESCRIPTION
Brings inspector row UI closer to Figma spec and uses a "sticky header" for the specific layer we're inspecting.

Note:
- no blue tinting yet
- some aspects of dark mode are still being refined


https://github.com/user-attachments/assets/0ea5ce00-f619-47b4-8b98-85b8c004d14c


https://github.com/user-attachments/assets/4b569567-75fb-4425-adfd-1ee8cddb8cb1

