### PR TITLE
Improve inspector flyouts (Figma spec)

### DIFF
--- a/Stitch/Graph/LayerInspector/FlyoutUtils.swift
+++ b/Stitch/Graph/LayerInspector/FlyoutUtils.swift
@@ -45,9 +45,9 @@ struct FlyoutClosed: GraphUIEvent {
 
 extension GraphUIState {
     func closeFlyout() {
-        withAnimation {
+//        withAnimation {
             self.propertySidebar.flyoutState = nil
-        }
+//        }
     }
 }
 

--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -102,17 +102,23 @@ struct LayerInspectorPortView<RowObserver, RowView>: View where RowObserver: Nod
     var isOnGraphAlready: Bool {
         canvasItemId.isDefined
     }
+    
+    var canBeAddedToCanvas: Bool {
+        switch layerProperty {
+        case .layerInput(let layerInputType):
+            return !layerInputType.usesFlyout
+        case .layerOutput(let int):
+            return true
+        }
+    }
         
     var body: some View {
         HStack(spacing: LAYER_INSPECTOR_ROW_SPACING) {
-            if let canvasItemId = canvasItemId {
-                JumpToLayerPropertyOnGraphButton(canvasItemId: canvasItemId)
-            } else {
-                AddLayerPropertyToGraphButton(
-                    propertyIsSelected: propertyRowIsSelected,
-                    coordinate: rowObserver.id)
-            }
-            
+            LayerInspectorRowButton(layerProperty: layerProperty,
+                                    coordinate: rowObserver.id,
+                                    canvasItemId: canvasItemId,
+                                    isRowSelected: propertyRowIsSelected)
+                        
             HStack {
                 rowView(propertyRowIsSelected)
                 Spacer()

--- a/Stitch/Graph/LayerInspector/PaddingFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/PaddingFlyoutView.swift
@@ -26,8 +26,12 @@ struct PaddingFlyoutView: View {
      
     var body: some View {
         
-        VStack(alignment: .leading) {
+        VStack(alignment: .leading,
+               spacing: INSPECTOR_LIST_ROW_TOP_AND_BOTTOM_INSET * 2) {
+            
+            // TODO: need better padding here; but confounding favtor is UIKitWrapper
             FlyoutHeader(flyoutTitle: "Padding")
+                .padding(.bottom, 8)
                         
             // TODO: better keypress listening situation; want to define a keypress press once in the view hierarchy, not multiple places etc.
             // Note: keypress listener needed for TAB, but UIKitWrapper messes up view's height if specific height not provided
@@ -55,6 +59,7 @@ struct PaddingFlyoutView: View {
         }
     }
     
+    // TODO: why not just use `NodeInputView` here ?
     @ViewBuilder @MainActor
     var inputOutputRow: some View {
         FieldsListView(graph: graph,
@@ -78,7 +83,7 @@ struct PaddingFlyoutView: View {
                                 propertyIsAlreadyOnGraph: false)
                 // Each row seems too tall? Probably from a set node row height somewhere?
                 // Uses padding to reduce size
-                .padding([.top, .bottom], 2)
+                .padding([.top, .bottom], 4)
                 .padding([.leading, .trailing], LAYER_INSPECTOR_ROW_SPACING)
 //                .frame(height: 32) // per Figma // Doesn't work while a single row is split across a VStack
                 .background {

--- a/Stitch/Graph/LayerInspector/PaddingFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/PaddingFlyoutView.swift
@@ -76,6 +76,15 @@ struct PaddingFlyoutView: View {
                                 forPropertySidebar: true,
                                 // TODO: fix
                                 propertyIsAlreadyOnGraph: false)
+                // Each row seems too tall? Probably from a set node row height somewhere?
+                // Uses padding to reduce size
+                .padding([.top, .bottom], 2)
+                .padding([.leading, .trailing], LAYER_INSPECTOR_ROW_SPACING)
+//                .frame(height: 32) // per Figma // Doesn't work while a single row is split across a VStack
+                .background {
+                    WHITE_IN_LIGHT_MODE_GRAY_IN_DARK_MODE
+                        .cornerRadius(6)
+                }
             } else {
                 Color.clear
                     .onAppear {

--- a/Stitch/Graph/LayerInspector/ShadowFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/ShadowFlyoutView.swift
@@ -43,6 +43,7 @@ struct ShadowFlyoutView: View {
         
         VStack(alignment: .leading) {
             FlyoutHeader(flyoutTitle: "Shadow")
+                .border(.teal)
             
             // TODO: why does UIKitWrapper mess up padding so badly?
 //            UIKitWrapper(ignoresKeyCommands: false,
@@ -74,7 +75,9 @@ struct ShadowFlyoutView: View {
     
     @MainActor
     var rows: some View {
-        VStack(alignment: .leading) {
+        VStack(alignment: .leading,
+               // TODO: why must we double this?
+               spacing: INSPECTOR_LIST_ROW_TOP_AND_BOTTOM_INSET * 2) {
             ForEach(LayerInspectorView.shadow) { shadowInput in
                 let layerInputData = layerNode[keyPath: shadowInput.layerNodeKeyPath]
                 NodeInputView(graph: graph,
@@ -84,11 +87,18 @@ struct ShadowFlyoutView: View {
                               propertyIsSelected: false, // NA
                               // TODO: applicable or not?
                               propertyIsAlreadyOnGraph: false ,
-                              isCanvasItemSelected: false)
+                              isCanvasItemSelected: false,
+                              forFlyout: true)
+                // Each row seems too tall? Probably from a set node row height somewhere?
+                // Uses padding to reduce size
+                .padding([.top, .bottom], -2)
+                .padding([.leading, .trailing], LAYER_INSPECTOR_ROW_SPACING)
+//                .frame(height: 32) // per Figma // Doesn't work while a single row is split across a VStack
+                .background {
+                    WHITE_IN_LIGHT_MODE_GRAY_IN_DARK_MODE
+                        .cornerRadius(6)
+                }
             }
         }
-//        .padding()
     }
-    
-    
 }

--- a/Stitch/Graph/LayerInspector/ShadowFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/ShadowFlyoutView.swift
@@ -43,7 +43,6 @@ struct ShadowFlyoutView: View {
         
         VStack(alignment: .leading) {
             FlyoutHeader(flyoutTitle: "Shadow")
-                .border(.teal)
             
             // TODO: why does UIKitWrapper mess up padding so badly?
 //            UIKitWrapper(ignoresKeyCommands: false,

--- a/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
+++ b/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
@@ -8,9 +8,34 @@
 import SwiftUI
 import StitchSchemaKit
 
+struct LayerInspectorRowButton: View {
+    
+    let layerProperty: LayerInspectorRowId
+    let coordinate: NodeIOCoordinate
+    let canvasItemId: CanvasItemId?
+    let isRowSelected: Bool
+    
+    var canBeAddedToCanvas: Bool {
+        switch layerProperty {
+        case .layerInput(let layerInputType):
+            return !layerInputType.usesFlyout
+        case .layerOutput(let int):
+            return true
+        }
+    }
+    
+    var body: some View {
+        if let canvasItemId = canvasItemId {
+            JumpToLayerPropertyOnGraphButton(canvasItemId: canvasItemId)
+        } else {
+            AddLayerPropertyToGraphButton(coordinate: coordinate)
+                .opacity((canBeAddedToCanvas && isRowSelected) ? 1.0 : 0.0)
+        }
+    }
+}
+
 // TODO: revisit this when we're able to add LayerNodes with outputs to the graph again
 struct AddLayerPropertyToGraphButton: View {
-    let propertyIsSelected: Bool
     let coordinate: NodeIOCoordinate
     
     var nodeId: NodeId {
@@ -32,7 +57,6 @@ struct AddLayerPropertyToGraphButton: View {
                                                      portId: portId))
                 }
             }
-            .opacity(propertyIsSelected ? 1 : 0)
     }
 }
 
@@ -123,6 +147,8 @@ struct NodeInputView: View {
     let propertyIsAlreadyOnGraph: Bool
     let isCanvasItemSelected: Bool
     
+    var forFlyout: Bool = false
+    
     @MainActor
     private var graphUI: GraphUIState {
         self.graph.graphUI
@@ -169,8 +195,6 @@ struct NodeInputView: View {
                 }
                 
                 let isPaddingLayerInputRow = rowData.rowDelegate?.id.keyPath == .padding
-                let hidePaddingFieldsOnPropertySidebar = isPaddingLayerInputRow && forPropertySidebar
-                
                 let isShadowLayerInputRow = rowData.rowDelegate?.id.keyPath == SHADOW_FLYOUT_LAYER_INPUT_PROXY
                 
                 if isPaddingLayerInputRow, forPropertySidebar {
@@ -178,12 +202,14 @@ struct NodeInputView: View {
                                         rowData: rowData,
                                         labelView: labelView)
                     
-                } else if isShadowLayerInputRow, forPropertySidebar {
+                } else if isShadowLayerInputRow, forPropertySidebar, !forFlyout {
                     HStack {
                         StitchTextView(string: "Shadow",
                                        fontColor: STITCH_FONT_GRAY_COLOR)
                         Spacer()
+                        
                     }
+                    .border(.green)
                     .overlay {
                         Color.white.opacity(0.001)
                             .onTapGesture {
@@ -204,7 +230,17 @@ struct NodeInputView: View {
                                    propertyIsAlreadyOnGraph: propertyIsAlreadyOnGraph,
                                    valueEntryView: valueEntryView)
                 }
-            }
+            } // HStack
+//            .border(.blue)
+//            .padding(forFlyout
+//                     ? LAYER_INSPECTOR_ROW_SPACING/4
+//                     : 0)
+//            .border(.orange)
+//            .background {
+//                WHITE_IN_LIGHT_MODE_GRAY_IN_DARK_MODE
+//                    .cornerRadius(6)
+//                    .opacity(forFlyout ? 1.0 : 0.0)
+//            }
         }
     }
     

--- a/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
+++ b/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
@@ -209,7 +209,6 @@ struct NodeInputView: View {
                         Spacer()
                         
                     }
-                    .border(.green)
                     .overlay {
                         Color.white.opacity(0.001)
                             .onTapGesture {

--- a/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
+++ b/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
@@ -230,16 +230,6 @@ struct NodeInputView: View {
                                    valueEntryView: valueEntryView)
                 }
             } // HStack
-//            .border(.blue)
-//            .padding(forFlyout
-//                     ? LAYER_INSPECTOR_ROW_SPACING/4
-//                     : 0)
-//            .border(.orange)
-//            .background {
-//                WHITE_IN_LIGHT_MODE_GRAY_IN_DARK_MODE
-//                    .cornerRadius(6)
-//                    .opacity(forFlyout ? 1.0 : 0.0)
-//            }
         }
     }
     


### PR DESCRIPTION
Need more love here but solves several UI issues. 

Fixes:
- issue where rapidly opening or closing a flyout could cause improper placement of the flyout
- updates flyouts' UI to be closer to Figma spec (white capsule etc.)
- remove double-listing of "Shadow" title in the Shadow flyout