### PR TITLE
Improved scroll perf on inspector sidebar

### DIFF
--- a/Stitch/Graph/LayerInspector/LayerInspectorState.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorState.swift
@@ -16,7 +16,8 @@ enum LayerInspectorRowId: Equatable, Hashable {
 
 typealias LayerInspectorRowIdSet = Set<LayerInspectorRowId>
 
-struct PropertySidebarState: Equatable {
+@Observable
+final class PropertySidebarObserver {
     var selectedProperty: LayerInspectorRowId?
     
     // Used for positioning flyouts; read and populated by every row,

--- a/Stitch/Graph/Node/Port/Util/Field/TabKeyPressActions.swift
+++ b/Stitch/Graph/Node/Port/Util/Field/TabKeyPressActions.swift
@@ -93,7 +93,7 @@ extension NodeRowViewModelId {
 extension NodeViewModel {
     @MainActor
     func nextInput(_ currentFocusedField: FieldCoordinate,
-                   propertySidebarState: PropertySidebarState) -> FieldCoordinate {
+                   propertySidebarState: PropertySidebarObserver) -> FieldCoordinate {
         
         let currentInputCoordinate: NodeRowViewModelId = currentFocusedField.rowId
                         
@@ -268,7 +268,7 @@ func getTabEligibleFields(layerNode: LayerNodeViewModel,
 extension NodeViewModel {
     @MainActor
     func previousInput(_ currentFocusedField: FieldCoordinate,
-                       propertySidebarState: PropertySidebarState) -> FieldCoordinate {
+                       propertySidebarState: PropertySidebarObserver) -> FieldCoordinate {
         
         let currentInputCoordinate = currentFocusedField.rowId
         

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -30,8 +30,8 @@ struct ActiveDragInteractionNodeVelocityData: Equatable, Hashable {
 
 @Observable
 final class GraphUIState {
-     
-    var propertySidebar = PropertySidebarState()
+
+    let propertySidebar = PropertySidebarObserver()
     
     var llmRecording = LLMRecordingState()
         


### PR DESCRIPTION
The fix was converting `PropertySidebarState` to an Observable class.

The issue is caused by too many data struct mutations of `PropertySidebarState` by the `LayerPropertyRowOriginReader` action, which is dispatched on all scroll events. Despite just one property being mutated, `PropertySidebarState` is a struct and will trigger a render cycle for any views which subscribe to its state.