### PR TITLE
Pinning: do not list a layer group's descendants in the layer group's pinTo dropdown

### DIFF
--- a/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
@@ -193,8 +193,8 @@ struct InputValueView: View {
                 value: .assignedLayer(layerId),
                 isForPinTo: false,
                 choices: graph.layerDropdownChoices(isForNode: rowObserverId.nodeId,
-                                                    isForPinTo: false)
-            )
+                                                    isForLayerGroup: false, // not relevant
+                                                    isForPinTo: false))
             
         case .pinTo(let pinToId):
             LayerNamesDropDownChoiceView(
@@ -203,6 +203,7 @@ struct InputValueView: View {
                            value: .pinTo(pinToId),
                            isForPinTo: true,
                            choices: graph.layerDropdownChoices(isForNode: rowObserverId.nodeId,
+                                                               isForLayerGroup: rowViewModel.nodeKind == .layer(.group),
                                                                isForPinTo: true))
 
         case .anchorPopover(let anchor):

--- a/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
@@ -136,13 +136,14 @@ struct OutputValueView: View {
                        alignment: .leading)
 
         case .layerDropdown(let layerId):
-                   //            // TODO: disable or use read-only view if this is an output ?
+            // TODO: use read-only view if this is an output ?
                    LayerNamesDropDownChoiceView(graph: graph,
                                                 id: coordinate,
                                                 value: .assignedLayer(layerId),
                                                 isForPinTo: false,
                                                 choices: graph.layerDropdownChoices(
                                                    isForNode: coordinate.nodeId,
+                                                   isForLayerGroup: false,
                                                    isForPinTo: false))
                    .disabled(true)
 
@@ -153,6 +154,7 @@ struct OutputValueView: View {
                                                 isForPinTo: true,
                                                 choices: graph.layerDropdownChoices(
                                                    isForNode: coordinate.nodeId,
+                                                   isForLayerGroup: false,
                                                    isForPinTo: true))
                    .disabled(true)
 

--- a/Stitch/Graph/Sidebar/Util/SidebarListItemGroupActions.swift
+++ b/Stitch/Graph/Sidebar/Util/SidebarListItemGroupActions.swift
@@ -35,8 +35,8 @@ extension GraphState {
         let closedParent = retrieveItem(closedParentId.asItemId,
                                         self.sidebarListState.masterList.items)
         
-        let descendants = getDescendants(closedParent,
-                                         self.sidebarListState.masterList.items)
+        let descendants = Stitch.getDescendants(closedParent,
+                                                self.sidebarListState.masterList.items)
         
         for childen in descendants {
             self.sidebarSelectionState.nonEditModeSelections.remove(childen.id.asLayerNodeId)


### PR DESCRIPTION
Part of a possible strategy for e.g. "not allowing a group to be pinned to one of its descendants"; we can explore how this feels; would need to be handled at input coercer level as well; plus various perf considerations.

![Screenshot 2024-08-16 at 1 55 06 PM](https://github.com/user-attachments/assets/30a1c009-9bb9-40dd-bebb-a8ac916417e4)
