### PR TITLE
Pinning now works with Image and ToggleSwitch layers

### DIFF
--- a/Stitch/Graph/Node/Layer/Type/SwitchLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/SwitchLayerNode.swift
@@ -114,35 +114,36 @@ struct PreviewSwitchLayer: View {
             .toggleStyle(.switch)
             .labelsHidden()
 
-        return view.modifier(PreviewCommonModifierWithoutFrame(
-            graph: graph,
-            layerViewModel: viewModel,
-            isPinnedViewRendering: isPinnedViewRendering,
-            interactiveLayer: interactiveLayer,
-            position: position,
-            rotationX: rotationX,
-            rotationY: rotationY,
-            rotationZ: rotationZ,
-//            size: Self.ASSUMED_SWIFTUI_TOGGLE_SWITCH_SIZE, 
-            size: .init(Self.ASSUMED_SWIFTUI_TOGGLE_SWITCH_SIZE),
-            minimumDragDistance: SWITCH_NODE_MINIMUM_DRAG_DISTANCE,
-            scale: 1, // Always 1, since "no real size"
-            anchoring: anchoring,
-            blurRadius: blurRadius,
-            blendMode: blendMode,
-            brightness: brightness,
-            colorInvert: colorInvert,
-            contrast: contrast,
-            hueRotation: hueRotation,
-            saturation: saturation, 
-            pivot: .defaultPivot,
-            shadowColor: .defaultShadowColor,
-            shadowOpacity: .defaultShadowOpacity,
-            shadowRadius: .defaultShadowRadius,
-            shadowOffset: .defaultShadowOffset,
-            parentSize: parentSize,
-            parentDisablesPosition: parentDisablesPosition
-        ))
+        return view
+            .modifier(PreviewCommonModifier(
+                graph: graph,
+                layerViewModel: viewModel,
+                isPinnedViewRendering: isPinnedViewRendering,
+                interactiveLayer: interactiveLayer,
+                position: position,
+                rotationX: rotationX,
+                rotationY: rotationY,
+                rotationZ: rotationZ,
+                //            size: Self.ASSUMED_SWIFTUI_TOGGLE_SWITCH_SIZE,
+                size: .init(Self.ASSUMED_SWIFTUI_TOGGLE_SWITCH_SIZE),
+                minimumDragDistance: SWITCH_NODE_MINIMUM_DRAG_DISTANCE,
+                scale: 1, // Always 1, since "no real size"
+                anchoring: anchoring,
+                blurRadius: blurRadius,
+                blendMode: blendMode,
+                brightness: brightness,
+                colorInvert: colorInvert,
+                contrast: contrast,
+                hueRotation: hueRotation,
+                saturation: saturation,
+                pivot: .defaultPivot,
+                shadowColor: .defaultShadowColor,
+                shadowOpacity: .defaultShadowOpacity,
+                shadowRadius: .defaultShadowRadius,
+                shadowOffset: .defaultShadowOffset,
+                parentSize: parentSize,
+                parentDisablesPosition: parentDisablesPosition
+            ))
         .onChange(of: self.viewModel.isUIToggled) {
             dispatch(SwitchLayerToggled(id: id))
         }

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommon.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommon.swift
@@ -25,7 +25,10 @@ struct PreviewCommonModifier: ViewModifier {
     
     // should receive LayerSize, so can use `nil` for a .frame dimension when we have LayerDimension.fill/grow
     let size: LayerSize
-        
+    
+    // Overidden in a handful of cases, e.g. the PreviewSwitchLayer
+    var minimumDragDistance: Double = DEFAULT_MINIMUM_DRAG_DISTANCE
+    
     let scale: Double
     let anchoring: Anchoring
     let blurRadius: CGFloat
@@ -89,7 +92,7 @@ struct PreviewCommonModifier: ViewModifier {
                 rotationZ: rotationZ,
                 // actual calculated size at which we're displaying the image
                 size: size,
-                minimumDragDistance: DEFAULT_MINIMUM_DRAG_DISTANCE,
+                minimumDragDistance: minimumDragDistance,
                 scale: scale,
                 anchoring: anchoring,
                 blurRadius: blurRadius,

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewImage.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewImage.swift
@@ -279,6 +279,10 @@ struct PreviewImageLayer: View {
                          fitStyle: fitStyle,
                          isClipped: isClipped)
         .modifier(LayerSizeReader(viewModel: layerViewModel))
+        .modifier(PreviewWindowCoordinateSpaceReader(
+            viewModel: layerViewModel,
+            isPinnedViewRendering: isPinnedViewRendering,
+            pinMap: graph.graphUI.pinMap))
         .modifier(PreviewCommonModifierWithoutFrame(
             graph: graph,
             layerViewModel: layerViewModel,


### PR DESCRIPTION
Use preview coordinate space reader with PreviewImage and ToggleSwitch

![Screenshot 2024-08-16 at 2 33 42 PM](https://github.com/user-attachments/assets/e01b9e5f-b955-4aa0-8c12-bb8370b972b5)
