### PR TITLE
Only tab through fields on canvas item, not inspector

### DIFF
--- a/Stitch/Graph/Node/Port/Util/Field/TabKeyPressActions.swift
+++ b/Stitch/Graph/Node/Port/Util/Field/TabKeyPressActions.swift
@@ -17,8 +17,11 @@ extension GraphState {
     @MainActor
     func tabPressed(focusedField: FieldCoordinate,
                     node: NodeViewModel) {
-                
+            
+        let layerInput = focusedField.rowId.portType.keyPath?.layerInput
+        
         let newFocusedField = node.nextInput(focusedField,
+                                             layerInput: layerInput,
                                              propertySidebarState: self.graphUI.propertySidebar)
 
         log("tabPressed: newFocusedField: \(newFocusedField)")
@@ -29,7 +32,10 @@ extension GraphState {
     func shiftTabPressed(focusedField: FieldCoordinate,
                          node: NodeViewModel) {
         
+        let layerInput = focusedField.rowId.portType.keyPath?.layerInput
+        
         let newFocusedField = node.previousInput(focusedField,
+                                                 layerInput: layerInput,
                                                  propertySidebarState: self.graphUI.propertySidebar)
         
         log("shiftTabPressed: newFocusedField: \(newFocusedField)")
@@ -93,6 +99,8 @@ extension NodeRowViewModelId {
 extension NodeViewModel {
     @MainActor
     func nextInput(_ currentFocusedField: FieldCoordinate,
+                   // non-nil = we're tabbing through this layer input on the canvas
+                   layerInput: LayerInputPort? = nil,
                    propertySidebarState: PropertySidebarObserver) -> FieldCoordinate {
         
         let currentInputCoordinate: NodeRowViewModelId = currentFocusedField.rowId
@@ -142,8 +150,11 @@ extension NodeViewModel {
                 return .fakeFieldCoordinate // should never happen
             }
             
+            // If we're editing a Position layer input on the canvas,
+            // then we should only have two eligible fields.
             let eligibleFields = getTabEligibleFields(
                 layerNode: layerNode,
+                layerInput: layerInput,
                 collapsedSections: propertySidebarState.collapsedSections)
             
             guard let currentEligibleField = eligibleFields.first(where: {
@@ -229,7 +240,17 @@ typealias LayerInputEligibleFields = OrderedSet<LayerInputEligibleField>
 
 @MainActor
 func getTabEligibleFields(layerNode: LayerNodeViewModel,
+                          layerInput: LayerInputPort? = nil,
                           collapsedSections: Set<LayerInspectorSectionName>) -> LayerInputEligibleFields {
+    
+    
+    if let layerInput = layerInput {
+        let fields = layerNode.getLayerInspectorInputFields(layerInput).map({ field in
+            LayerInputEligibleField(input: layerInput, fieldIndex: field.fieldIndex)
+        })
+        
+        return LayerInputEligibleFields(fields)
+    }
     
     let layer = layerNode.layer
     let inputsForThisLayer = layer.layerGraphNode.inputDefinitions
@@ -272,6 +293,8 @@ func getTabEligibleFields(layerNode: LayerNodeViewModel,
 extension NodeViewModel {
     @MainActor
     func previousInput(_ currentFocusedField: FieldCoordinate,
+                       // non-nil = we're tabbing through this layer input on the canvas
+                       layerInput: LayerInputPort? = nil,
                        propertySidebarState: PropertySidebarObserver) -> FieldCoordinate {
         
         let currentInputCoordinate = currentFocusedField.rowId
@@ -322,6 +345,7 @@ extension NodeViewModel {
 
             let eligibleFields = getTabEligibleFields(
                 layerNode: layerNode,
+                layerInput: layerInput,
                 collapsedSections: propertySidebarState.collapsedSections)
             
             guard let currentEligibleField = eligibleFields.first(where: {


### PR DESCRIPTION
Note: there are still intermittent issues where we will instead focus the project title text-field instead.