### PR TITLE
Change preview layers when pinTo changes; avoid some pinning scenarios where a LayerGroup unexpectedly expanded

### DIFF
--- a/Stitch/Graph/Node/Model/RowData/LayerInputType.swift
+++ b/Stitch/Graph/Node/Model/RowData/LayerInputType.swift
@@ -1398,7 +1398,7 @@ extension LayerInputPort {
 
     var shouldResetGraphPreviews: Bool {
         switch self {
-        case .zIndex, .masks, .isPinned:
+        case .zIndex, .masks, .isPinned, .pinTo:
             return true
         default:
             return false

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonModifierWithoutFrame.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonModifierWithoutFrame.swift
@@ -108,7 +108,8 @@ struct PreviewCommonModifierWithoutFrame: ViewModifier {
                 
             .modifier(PreviewCommonPositionModifier(
                 graph: graph,
-                viewModel: layerViewModel,
+                viewModel: layerViewModel, 
+                isPinnedViewRendering: isPinnedViewRendering,
                 parentDisablesPosition: parentDisablesPosition,
                 pos: pos))
                 

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
@@ -159,6 +159,7 @@ struct PreviewGroupLayer: View {
             .modifier(PreviewCommonPositionModifier(
                 graph: graph,
                 viewModel: layerViewModel,
+                isPinnedViewRendering: isPinnedViewRendering,
                 parentDisablesPosition: parentDisablesPosition,
                 pos: pos))
         


### PR DESCRIPTION
Two parts:
1. we now update preview when pinTo changes; fixes bugs where pinTo changes would not take effect until project was reopened (due to not triggering a preview-cache update)
2. do not use .position modifier with GhostView rendering of a layer; fixes bugs where using a .position modifier causes the parent stack (HStack, VStack or ZStack) to expand (underlying SwiftUI issue remains but we now avoid it more gracefully)

### For 2, the Blue rectangle being pinned or not is now the same, doesn't affect the size of the Group:

<img width="1383" alt="Screenshot 2024-08-20 at 2 37 37 PM" src="https://github.com/user-attachments/assets/38645036-4449-4df8-a13d-17b06cbfd9b6">

<img width="1384" alt="Screenshot 2024-08-20 at 2 37 32 PM" src="https://github.com/user-attachments/assets/c5634f18-dc67-4dd8-9c22-b4846257cbf8">

