### PR TITLE
Do not highlight the GhostView rendering of a pinned layer

### DIFF
--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonModifierWithoutFrame.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonModifierWithoutFrame.swift
@@ -91,6 +91,8 @@ struct PreviewCommonModifierWithoutFrame: ViewModifier {
         
         // should be BEFORE .scale, .position, .offset and .rotation, so that border can be affected by those changes; but AFTER layer-effects, so that e.g. masking or blur does
             .modifier(PreviewSidebarHighlightModifier(
+                viewModel: layerViewModel,
+                isPinnedViewRendering: isPinnedViewRendering,
                 nodeId: interactiveLayer.id.layerNodeId,
                 highlightedSidebarLayers: graph.graphUI.highlightedSidebarLayers,
                 scale: scale))

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewSidebarHighlightModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewSidebarHighlightModifier.swift
@@ -11,11 +11,25 @@ import StitchSchemaKit
 
 // Note: highlight border must be placed before `.position` .offset and
 struct PreviewSidebarHighlightModifier: ViewModifier {
+    @Bindable var viewModel: LayerViewModel
+    
+    let isPinnedViewRendering: Bool
+    
     let nodeId: LayerNodeId
     let highlightedSidebarLayers: LayerIdSet
     let scale: CGFloat
     
     static let baseBorderWidth = 2.0
+    
+    var isPinned: Bool {
+        viewModel.isPinned.getBool ?? false
+    }
+    
+    // ALSO: if this is View A and it is not being generated at the top level,
+    // then we should hide the view
+    var isGhostView: Bool {
+        isPinned && !isPinnedViewRendering
+    }
     
     var isHighlighted: Bool {
         highlightedSidebarLayers.contains(nodeId)
@@ -32,9 +46,13 @@ struct PreviewSidebarHighlightModifier: ViewModifier {
         }
     }
     
+    var borderOpacity: CGFloat {
+        (isHighlighted && !isGhostView) ? 1 : 0
+    }
+    
     func body(content: Content) -> some View {
         content
-            .border(.blue.opacity(isHighlighted ? 1 : 0),
+            .border(.blue.opacity(borderOpacity),
                     width: borderWidth)
     }
 }

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
@@ -131,6 +131,8 @@ struct PreviewGroupLayer: View {
         //        #endif
         
             .modifier(PreviewSidebarHighlightModifier(
+                viewModel: layerViewModel,
+                isPinnedViewRendering: isPinnedViewRendering,
                 nodeId: interactiveLayer.id.layerNodeId,
                 highlightedSidebarLayers: graph.graphUI.highlightedSidebarLayers,
                 scale: scale))

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewShapeLayer.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewShapeLayer.swift
@@ -74,6 +74,8 @@ struct PreviewShapeLayer: View {
             shape
                 .opacity(opacity)
                 .modifier(PreviewSidebarHighlightModifier(
+                    viewModel: layerViewModel,
+                    isPinnedViewRendering: isPinnedViewRendering,
                     nodeId: interactiveLayer.id.layerNodeId,
                     highlightedSidebarLayers: graph.graphUI.highlightedSidebarLayers,
                     scale: scale))


### PR DESCRIPTION
## before

<img width="1440" alt="Screenshot 2024-08-20 at 3 17 14 PM" src="https://github.com/user-attachments/assets/9aa61bb9-b033-4a08-a53c-185921e62e0f">

## after

<img width="1440" alt="Screenshot 2024-08-20 at 3 21 17 PM" src="https://github.com/user-attachments/assets/0f7696c8-f65d-4633-a65d-e63e5f15781d">
<img width="1440" alt="Screenshot 2024-08-20 at 3 21 15 PM" src="https://github.com/user-attachments/assets/371a2a82-0ddc-439c-a495-7987e5fb0b4d">
