### PR TITLE
Group's Fill size uses 100% of parent

### DIFF
--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonSizeModifier.swift
@@ -9,10 +9,22 @@ import SwiftUI
 import StitchSchemaKit
  
 extension LayerDimension {
-    func asFrameDimension(_ parentLength: CGFloat) -> CGFloat? {
+    /*
+     Note: `nil` means setting no .frame along that dimension; but the result differs for a shape vs stack:
+     - a shape (e.g. `Ellipse`) without a .frame *grows* to take up as much space as possible inside its parent.
+     - a stack (e.g. `ZStack`) without a .frame *shrinks* to take up only as much space as required by the stack's contents.
+     */
+    func asFrameDimension(_ parentLength: CGFloat, isStack: Bool) -> CGFloat? {
            switch self {
-               // fill or hug = no set value along this dimension
-           case .fill, .hug,
+               
+           case .fill:
+               if isStack { // a stack like ZStack, VStack
+                   return parentLength // 100% of parent length
+               } else { // e.g. a shpe
+                   return nil
+               }
+            
+           case .hug,
                // auto on shapes = fill
                // auto on text, textfield = hug
                // auto on media = see either image or video display views
@@ -71,27 +83,31 @@ struct PreviewCommonSizeModifier: ViewModifier {
         height.isParentPercentage
     }
     
+    var isStack: Bool {
+        viewModel.layer == .group
+    }
+    
     var finalMinWidth: CGFloat? {
-        minWidth?.asFrameDimension(parentSize.width)
+        minWidth?.asFrameDimension(parentSize.width, isStack: isStack)
     }
     
     var finalMaxWidth: CGFloat? {
-        maxWidth?.asFrameDimension(parentSize.width)
+        maxWidth?.asFrameDimension(parentSize.width, isStack: isStack)
     }
     
     var finalMinHeight: CGFloat? {
-        minHeight?.asFrameDimension(parentSize.height)
+        minHeight?.asFrameDimension(parentSize.height, isStack: isStack)
     }
     
     var finalMaxHeight: CGFloat? {
-        maxHeight?.asFrameDimension(parentSize.height)
+        maxHeight?.asFrameDimension(parentSize.height, isStack: isStack)
     }
     
     var finalWidth: CGFloat? {
         if usesParentPercentForWidth && (finalMinWidth.isDefined || finalMaxWidth.isDefined) {
             return nil
         } else {
-            return width.asFrameDimension(parentSize.width)
+            return width.asFrameDimension(parentSize.width, isStack: isStack)
         }
     }
     
@@ -99,7 +115,7 @@ struct PreviewCommonSizeModifier: ViewModifier {
         if usesParentPercentForHeight && (finalMinHeight.isDefined || finalMaxHeight.isDefined) {
             return nil
         } else {
-            return height.asFrameDimension(parentSize.height)
+            return height.asFrameDimension(parentSize.height, isStack: isStack)
         }
     }
     


### PR DESCRIPTION
Demo projects:

[Group with hug.stitch.zip](https://github.com/user-attachments/files/16682983/Group.with.hug.stitch.zip)
[Group with fill.stitch.zip](https://github.com/user-attachments/files/16682984/Group.with.fill.stitch.zip)


### Group size = fill, so we use full space of parent (purple); but children do not use their .position modifiers, so they end up in the center

Group has its own anchoring of top left, but is same size as parent so that anchoring does nothing

<img width="1440" alt="Screenshot 2024-08-20 at 4 30 29 PM" src="https://github.com/user-attachments/assets/65bc3546-679a-4753-a908-24f0b2e56d05">

### Group size = hug: in a Group with orientation = VStack or HStack, the children do not use their .position modifiers, so the VStack/HStack does not inflate
<img width="1440" alt="Screenshot 2024-08-20 at 4 20 47 PM" src="https://github.com/user-attachments/assets/7969ca5b-138a-4067-909e-a9b21b9fbf8f">
<img width="1440" alt="Screenshot 2024-08-20 at 4 20 49 PM" src="https://github.com/user-attachments/assets/1c956467-b168-41d8-b4bf-3a1c1c546e33">

### Group size = hug: in a Group with orientation = none, the child still uses its .position modifier, so the ZStack's size is inflated (known SwiftUI behavior)
<img width="1440" alt="Screenshot 2024-08-20 at 4 20 52 PM" src="https://github.com/user-attachments/assets/f18f912c-c420-459c-8c23-691e3c932655">

