### PR TITLE
ApplyStroke modifier ignores a pinned layer's GhostView

### DIFF
--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Shapes/ShapeUtils.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Shapes/ShapeUtils.swift
@@ -13,19 +13,37 @@ import StitchSchemaKit
 // Intended for strokes on non-Shape layers.
 struct ApplyStroke: ViewModifier {
     
+    @Bindable var viewModel: LayerViewModel
+    
+    let isPinnedViewRendering: Bool
+    
     let stroke: LayerStrokeData
+    
+    var isPinned: Bool {
+        viewModel.isPinned.getBool ?? false
+    }
+    
+    // ALSO: if this is View A and it is not being generated at the top level,
+    // then we should hide the view
+    var isGhostView: Bool {
+        isPinned && !isPinnedViewRendering
+    }
     
     @ViewBuilder
     func body(content: Content) -> some View {
         
-        switch stroke.stroke {
-                        
-        case .none:
+        if isGhostView {
             content
-            
-        case .inside, .outside:
-            content.overlay {
-                Rectangle().stitchStroke(stroke)
+        } else {
+            switch stroke.stroke {
+                            
+            case .none:
+                content
+                
+            case .inside, .outside:
+                content.overlay {
+                    Rectangle().stitchStroke(stroke)
+                }
             }
         }
     }

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonModifierWithoutFrame.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonModifierWithoutFrame.swift
@@ -71,7 +71,10 @@ struct PreviewCommonModifierWithoutFrame: ViewModifier {
 
         return content
 
-            .modifier(ApplyStroke(stroke: stroke))
+            .modifier(ApplyStroke(
+                viewModel: layerViewModel,
+                isPinnedViewRendering: isPinnedViewRendering,
+                stroke: stroke))
         
             .modifier(PreviewLayerEffectsModifier(
                 blurRadius: blurRadius,

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
@@ -151,7 +151,9 @@ struct PreviewGroupLayer: View {
                                      cornerRadius: cornerRadius))
         
         // Stroke needs to come AFTER the .clipped modifier, so that .outsideStroke is not cut off.
-            .modifier(ApplyStroke(stroke: stroke))
+            .modifier(ApplyStroke(viewModel: layerViewModel,
+                                  isPinnedViewRendering: isPinnedViewRendering,
+                                  stroke: stroke))
 
             .opacity(opacity) // opacity on group and all its contents
         


### PR DESCRIPTION
<img width="1426" alt="Screenshot 2024-08-21 at 4 11 02 PM" src="https://github.com/user-attachments/assets/a579d066-7e3f-4c8e-914d-e7e4dfa6af97">
