### PR TITLE
Using container entities to wrap 3D Models

### DIFF
--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/AR/SIMDExtensions.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/AR/SIMDExtensions.swift
@@ -40,9 +40,8 @@ extension simd_float4x4 {
                                      Float(transform.scaleY),
                                      Float(transform.scaleZ)),
                   
-                  // MARK: swap x and y to mimic expected behavior
-                  rotationZYX: simd_float3(Float(transform.rotationY),
-                                           Float(transform.rotationX),
+                  rotationZYX: simd_float3(Float(transform.rotationX),
+                                           Float(transform.rotationY),
                                            Float(transform.rotationZ)))
     }
     
@@ -50,7 +49,7 @@ extension simd_float4x4 {
         return simd_float3x3(columns.0.xyz, columns.1.xyz, columns.2.xyz)
     }
     
-    // Create a 4x4 rotation matrix from Euler angles (in radians)
+    // Create a 4x4 rotation matrix from Euler angles (in radians) || TODO: This is fine, but, one layer beneath UI, convert from degrees to radians for a much smoother expereince 
     init(rotationZYX eulerAngles: SIMD3<Float>) {
         let cx = cos(eulerAngles.x), sx = sin(eulerAngles.x)
         let cy = cos(eulerAngles.y), sy = sin(eulerAngles.y)


### PR DESCRIPTION

https://github.com/user-attachments/assets/f0302819-6798-4968-a2dd-8a351f95b077


https://github.com/user-attachments/assets/939abf05-b353-4fe0-b5fb-83ccb23e9836

Notes:

So, in our current implementation on `main`, the entity held by the StitchEntity class was the loaded model entity, which might have a non-identity transform (https://en.wikipedia.org/wiki/Identity_matrix). So, subsequently, setting a transform on the StitchEntity could overwrite the model’s root transform, which might have a rotation to convert from Z-up to Y-up convention, or, a scale to convert from a format that uses centimeters instead of meters.

By injecting a container entity between the (optional) anchor and the model entity, any transform applied by the user is isolated from affecting the model’s root transform, and is instead composed with it correctly.

For example, with the previous implementation, if an imported model entity had a scale factor of 0.01 in its root transform, and the user wanted to double its size, they’d set the scale to 2, and the StitchEntity would set the model entity’s scale to 2, overwriting the corrective factor of 0.01. The correct behavior would be to set the effective scale to 0.02, which is what is achieved in the new implementation by setting the container’s scale to 2 and leaving the model entity’s scale at 0.01.

Think of it sort of as like, we're putting the 3D model inside of a glass box. Instead of manipulating the 3D model, we're manipulating the glass box. We don’t have to worry about whatever transforms or scaling factors are applied to the model at all; we just manipulate the glass box. 