### PR TITLE
Reduce section spacing; never use caps in section headers

### DIFF
--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -138,6 +138,8 @@ struct LayerInspectorView: View {
                                                  layerNode: layerNode,
                                                  graph: graph)
             } // List
+            .listSectionSpacing(.compact) // reduce spacing between sections
+            
 //            .listStyle(.plain)
 //            .background(Color.SWIFTUI_LIST_BACKGROUND_COLOR)
                         
@@ -248,7 +250,7 @@ struct LayerInspectorInputsSectionView: View {
                                       axis: (x: 0, y: 0, z: rotationZ))
                     .animation(.linear(duration: 0.2), value: rotationZ)
                 
-                StitchTextView(string: sectionName.rawValue)
+                StitchTextView(string: sectionName.rawValue).textCase(nil)
             }
             // Note: list row insets appear to be the only way to control padding on a list's section headers
             // TODO: how much spacing do we want between first section and very top of inspector?
@@ -312,7 +314,7 @@ struct LayerInspectorOutputsSectionView: View {
                         .frame(width: LAYER_INSPECTOR_ROW_ICON_LENGTH,
                                height: LAYER_INSPECTOR_ROW_ICON_LENGTH)
 //                    
-                    StitchTextView(string: "Outputs")
+                    StitchTextView(string: "Outputs").textCase(nil)
                 }
                 .listRowInsets(EdgeInsets(top: 0,
                                           leading: 0,


### PR DESCRIPTION
Note: inspector background on iPad seems too dark?

### Catalyst 
<img width="363" alt="Screenshot 2024-08-23 at 9 53 25 AM" src="https://github.com/user-attachments/assets/8c74382c-51ee-4f1b-878d-8d57b10e8f2f">

### iPad

<img width="1194" alt="image" src="https://github.com/user-attachments/assets/6f76cc6d-4a4c-4717-ad5e-7212a1cc1913">
