### PR TITLE
Introduce .offset modifier when a child's position has been disabled due to being in an HStack, VStack or Grid

### DIFF
--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonPositionModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonPositionModifier.swift
@@ -74,8 +74,12 @@ struct PreviewCommonPositionModifier: ViewModifier {
             // A non-PinnedView rendering of a layer uses .position unless:
             // 1. the layer is a child inside a group that uses a VStack or HStack, or
             // 2. it is a GhostView rendering
-            if parentDisablesPosition || isGhostView {
+            if isGhostView {
                 content
+            } else if parentDisablesPosition {
+                content
+                    .offset(x: viewModel.offsetInGroup.width,
+                            y: viewModel.offsetInGroup.height)
             } else {
                 content
                     .position(x: pos.width, y: pos.height)

--- a/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
@@ -183,6 +183,7 @@ final class LayerViewModel {
     // TODO: source these from LayerNodeViewModel after SSK update
     var layerPadding: StitchPadding = .zero // .demoPadding // PortValue
     var layerMargin: StitchPadding = .zero // .demoPadding // PortValue
+    var offsetInGroup: CGSize = .zero // .init(width: 50, height: 100)
     
     // Ephemeral state on the layer view model
     


### PR DESCRIPTION
Example: VStack, unclipped, where each child was hardcoded to use modifier to have offset of w=50, h=100

Todo:
- [ ] introduce proper ports via SSK update

<img width="1433" alt="Screenshot 2024-08-23 at 12 48 27 PM" src="https://github.com/user-attachments/assets/6dc4347e-0294-4a45-a62c-5f80e3a4dbd5">
