### PR TITLE
Property sidebar: padding, margin and offset-in-group inputs

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -6040,8 +6040,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StitchDesign/StitchSchemaKit";
 			requirement = {
-				kind = exactVersion;
-				version = 23.1.0;
+				branch = "releases/v24.0.0-introduce-padding-margin-and-childOffset-inputs";
+				kind = branch;
 			};
 		};
 		EC1137362719F9B400ADCA72 /* XCRemoteSwiftPackageReference "swift-collections" */ = {

--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -6040,8 +6040,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StitchDesign/StitchSchemaKit";
 			requirement = {
-				branch = "releases/v24.0.0-introduce-padding-margin-and-childOffset-inputs";
-				kind = branch;
+				kind = revision;
+				revision = 2e43778ca86f550618ae1d91bb6837b80f5f0c4c;
 			};
 		};
 		EC1137362719F9B400ADCA72 /* XCRemoteSwiftPackageReference "swift-collections" */ = {

--- a/Stitch/Graph/LayerInspector/LayerInspectorState.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorState.swift
@@ -82,7 +82,7 @@ extension LayerInspectorView {
             .init(.positioning, Self.positioning),
             .init(.common, Self.common),
             .init(.group, layer.supportsGroupInputs ? Self.groupLayer : []),
-            .init(.pinning, layer.supportsPinningInputs ? Self.pinning : []),
+            .init(.pinning, Self.pinning),
             .init(.typography, layer.supportsTypographyInputs ? Self.text : []),
             .init(.stroke, layer.supportsStrokeInputs ? Self.stroke : []),
             .init(.rotation, layer.supportsRotationInputs ? Self.rotation : []),
@@ -101,7 +101,7 @@ extension LayerInspectorView {
         .position,
         .anchoring,
         .zIndex,
-        // .offset // TO BE ADED
+        .offsetInGroup
     ]
     
     @MainActor
@@ -199,7 +199,11 @@ extension LayerInspectorView {
         .allAnchors,
         .cameraDirection,
         .isCameraEnabled,
-        .isShadowsEnabled
+        .isShadowsEnabled,
+        
+        // Layer padding, margin
+        .layerMargin,
+        .layerPadding
     ]
     
     @MainActor
@@ -281,13 +285,7 @@ extension Layer {
         let layerInputs = self.layerGraphNode.inputDefinitions
         return !layerInputs.intersection(LayerInspectorView.groupLayer).isEmpty
     }
-    
-    @MainActor
-    var supportsPinningInputs: Bool {
-        let layerInputs = self.layerGraphNode.inputDefinitions
-        return !layerInputs.intersection(LayerInputTypeSet.pinning).isEmpty
-    }
-    
+        
     @MainActor
     var supportsTypographyInputs: Bool {
         let layerInputs = self.layerGraphNode.inputDefinitions
@@ -300,18 +298,21 @@ extension Layer {
         return !layerInputs.intersection(LayerInspectorView.stroke).isEmpty
     }
 
+    // TODO: don't *all* layers support x-y-z rotation?
     @MainActor
     var supportsRotationInputs: Bool {
         let layerInputs = self.layerGraphNode.inputDefinitions
         return !layerInputs.intersection(LayerInspectorView.rotation).isEmpty
     }
     
+    // TODO: don't *all* layers support shadows?
     @MainActor
     var supportsShadowInputs: Bool {
         let layerInputs = self.layerGraphNode.inputDefinitions
         return !layerInputs.intersection(LayerInspectorView.shadow).isEmpty
     }
     
+    // TODO: don't *all* layers support layer-effects? (Not HitArea ?)
     @MainActor
     var supportsLayerEffectInputs: Bool {
         let layerInputs = self.layerGraphNode.inputDefinitions

--- a/Stitch/Graph/Node/Layer/Type/3DModelLayerNode/Model3DLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/3DModelLayerNode/Model3DLayerNode.swift
@@ -55,7 +55,7 @@ struct Model3DLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning)
+        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
 
         static func createEphemeralObserver() -> NodeEphemeralObservable? {
         MediaEvalOpObserver()

--- a/Stitch/Graph/Node/Layer/Type/AngularGradientNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/AngularGradientNode.swift
@@ -29,7 +29,7 @@ struct AngularGradientLayerNode: LayerNodeDefinition {
     ])
         .union(.layerEffects)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning)
+        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/CanvasSketchLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/CanvasSketchLayerNode.swift
@@ -47,7 +47,7 @@ struct CanvasSketchLayerNode: LayerNodeDefinition {
         .union(.strokeInputs)
         .union(.layerEffects)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning)
+        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
 
         static func createEphemeralObserver() -> NodeEphemeralObservable? {
         MediaEvalOpObserver()

--- a/Stitch/Graph/Node/Layer/Type/ColorFillLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/ColorFillLayerNode.swift
@@ -25,7 +25,7 @@ struct ColorFillLayerNode: LayerNodeDefinition {
     ])
         .union(.layerEffects)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning)
+        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/GroupLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/GroupLayerNode.swift
@@ -77,7 +77,7 @@ struct GroupLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning)
+        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
         .union(.paddingAndSpacing)
     
     static func content(graph: GraphState,

--- a/Stitch/Graph/Node/Layer/Type/HitAreaLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/HitAreaLayerNode.swift
@@ -24,7 +24,7 @@ struct HitAreaLayerNode: LayerNodeDefinition {
         .setupMode
     ])
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning)
+        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/LinearGradientNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/LinearGradientNode.swift
@@ -30,7 +30,7 @@ struct LinearGradientLayerNode: LayerNodeDefinition {
     ])
         .union(.layerEffects)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning)
+        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
     
     
     static func content(graph: GraphState,

--- a/Stitch/Graph/Node/Layer/Type/MapLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/MapLayerNode.swift
@@ -43,7 +43,7 @@ struct MapLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning)
+        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/OvalLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/OvalLayerNode.swift
@@ -52,7 +52,7 @@ struct OvalLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning)
+        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
     
     
     static func content(graph: GraphState,

--- a/Stitch/Graph/Node/Layer/Type/ProgressIndicatorLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/ProgressIndicatorLayerNode.swift
@@ -30,7 +30,7 @@ struct ProgressIndicatorLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning)
+        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/RadialGradientNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/RadialGradientNode.swift
@@ -29,7 +29,7 @@ struct RadialGradientLayerNode: LayerNodeDefinition {
     ])
         .union(.layerEffects)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning)
+        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/RealityView/RealityNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/RealityView/RealityNode.swift
@@ -35,7 +35,7 @@ struct RealityViewLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning)
+        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
 
         static func createEphemeralObserver() -> NodeEphemeralObservable? {
         MediaEvalOpObserver()

--- a/Stitch/Graph/Node/Layer/Type/RectangleLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/RectangleLayerNode.swift
@@ -65,7 +65,7 @@ struct RectangleLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning)
+        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/SFSymbolLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/SFSymbolLayerNode.swift
@@ -39,7 +39,7 @@ struct SFSymbolLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning)
+        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/ShapeLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/ShapeLayerNode.swift
@@ -70,6 +70,17 @@ extension LayerInputTypeSet {
         .pinAnchor,
         .pinOffset
     ]
+    
+    @MainActor
+    static let layerPaddingAndMargin: LayerInputTypeSet = [
+        .layerPadding,
+        .layerMargin
+    ]
+    
+    @MainActor
+    static let offsetInGroup: LayerInputTypeSet = [
+        .offsetInGroup // belongs with "positioning" section
+    ]
 }
 
 extension StrokeLineCap: PortValueEnum {
@@ -183,7 +194,7 @@ struct ShapeLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning)
+        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/SwitchLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/SwitchLayerNode.swift
@@ -39,7 +39,7 @@ struct SwitchLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning)
+        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/TextFieldLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/TextFieldLayerNode.swift
@@ -53,7 +53,7 @@ struct TextFieldLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning)
+        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/TextLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/TextLayerNode.swift
@@ -64,7 +64,7 @@ struct TextLayerNode: LayerNodeDefinition {
     .union(.strokeInputs)
     .union(.typography)
     .union(.aspectRatio)
-    .union(.sizing).union(.pinning)
+    .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
     
     
     

--- a/Stitch/Graph/Node/Layer/Type/VideoLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/VideoLayerNode.swift
@@ -33,7 +33,7 @@ struct VideoLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning)
+        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/VideoStreamingLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/VideoStreamingLayerNode.swift
@@ -38,7 +38,7 @@ struct VideoStreamingLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning)
+        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Type/VisualMedia.swift
+++ b/Stitch/Graph/Node/Layer/Type/VisualMedia.swift
@@ -34,7 +34,7 @@ struct ImageLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning)
+        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
     
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,

--- a/Stitch/Graph/Node/Layer/Util/LayerNodeEntityUtils.swift
+++ b/Stitch/Graph/Node/Layer/Util/LayerNodeEntityUtils.swift
@@ -111,6 +111,9 @@ extension LayerNodeEntity {
          pinToPort: LayerInputEntity = .empty,
          pinAnchorPort: LayerInputEntity = .empty,
          pinOffsetPort: LayerInputEntity = .empty,
+         layerMarginPort: LayerInputEntity = .empty,
+         layerPaddingPort: LayerInputEntity = .empty,
+         offsetInGroupPort: LayerInputEntity = .empty,
          hasSidebarVisibility: Bool,
          layerGroupId: NodeId?,
          isExpandedInSidebar: Bool?) {
@@ -226,6 +229,10 @@ extension LayerNodeEntity {
             pinToPort: pinToPort,
             pinAnchorPort: pinAnchorPort,
             pinOffsetPort: pinOffsetPort,
+            
+            layerPaddingPort: layerPaddingPort, 
+            layerMarginPort: layerMarginPort,
+            offsetInGroupPort: offsetInGroupPort,
             
             hasSidebarVisibility: hasSidebarVisibility,
             layerGroupId: layerGroupId,

--- a/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
+++ b/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
@@ -133,6 +133,10 @@ final class LayerNodeViewModel {
     @MainActor var pinAnchorPort: LayerInputObserver
     @MainActor var pinOffsetPort: LayerInputObserver
     
+    @MainActor var layerMarginPort: LayerInputObserver
+    @MainActor var layerPaddingPort: LayerInputObserver
+    @MainActor var offsetInGroupPort: LayerInputObserver
+    
     weak var nodeDelegate: NodeDelegate?
 
     // Sidebar visibility setting
@@ -278,6 +282,10 @@ final class LayerNodeViewModel {
         self.pinToPort = .init(from: schema, port: .pinTo)
         self.pinAnchorPort = .init(from: schema, port: .pinAnchor)
         self.pinOffsetPort = .init(from: schema, port: .pinOffset)
+        
+        self.layerPaddingPort = .init(from: schema, port: .layerPadding)
+        self.layerMarginPort = .init(from: schema, port: .layerMargin)
+        self.offsetInGroupPort = .init(from: schema, port: .offsetInGroup)
         
         // Initialize each NodeRowObserver for each expected layer input
         for layerInputPort in graphNode.inputDefinitions {

--- a/Stitch/Graph/Node/Model/RowData/LayerInputType.swift
+++ b/Stitch/Graph/Node/Model/RowData/LayerInputType.swift
@@ -256,6 +256,12 @@ extension LayerInputPort {
             return .anchoring(.defaultAnchoring)
         case .pinOffset:
             return .size(.zero)
+        case .layerPadding:
+            return .padding(.zero)
+        case .layerMargin:
+            return .padding(.zero)
+        case .offsetInGroup:
+            return .size(.zero)
         }
     }
     
@@ -462,6 +468,12 @@ extension LayerInputPort {
             return \.pinAnchorPort
         case .pinOffset:
             return \.pinOffsetPort
+        case .layerPadding:
+            return \.layerPaddingPort
+        case .layerMargin:
+            return \.layerMarginPort
+        case .offsetInGroup:
+            return \.offsetInGroupPort
         }
     }
     
@@ -701,6 +713,12 @@ extension LayerViewModel {
             return self.pinAnchor
         case .pinOffset:
             return self.pinOffset
+        case .layerPadding:
+            return self.layerPadding
+        case .layerMargin:
+            return self.layerMargin
+        case .offsetInGroup:
+            return self.offsetInGroup
         }
     }
     
@@ -903,6 +921,12 @@ extension LayerViewModel {
             self.pinAnchor = value
         case .pinOffset:
             self.pinOffset = value
+        case .layerPadding:
+            self.layerPadding = value
+        case .layerMargin:
+            self.layerMargin = value
+        case .offsetInGroup:
+            self.offsetInGroup = value
         }
     }
 }
@@ -1099,6 +1123,12 @@ extension LayerInputPort {
             return \.pinAnchorPort
         case .pinOffset:
             return \.pinOffsetPort
+        case .layerPadding:
+            return \.layerPaddingPort
+        case .layerMargin:
+            return \.layerMarginPort
+        case .offsetInGroup:
+            return \.offsetInGroupPort
         }
     }
     
@@ -1390,8 +1420,14 @@ extension LayerInputPort {
         case .pinTo:
             return "Pin To"
         case .pinAnchor:
-            return "Anchor"
+            return "Pin Anchor"
         case .pinOffset:
+            return "Pin Offset"
+        case .layerPadding:
+            return "Layer Padding"
+        case .layerMargin:
+            return "Layer Margin"
+        case .offsetInGroup:
             return "Offset"
         }
     }

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonModifierWithoutFrame.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonModifierWithoutFrame.swift
@@ -73,7 +73,7 @@ struct PreviewCommonModifierWithoutFrame: ViewModifier {
         
         // Margin input comes *after* `.frame`
         // Should be applied before layer-effects, rotation etc.?
-            .modifier(LayerPaddingModifier(padding: layerViewModel.layerMargin))
+            .modifier(LayerPaddingModifier(padding: layerViewModel.layerMargin.getPadding ?? .defaultPadding))
         
         // TODO: How do layer-padding and layer-margin inputs affect stroke ?
             .modifier(ApplyStroke(
@@ -120,7 +120,8 @@ struct PreviewCommonModifierWithoutFrame: ViewModifier {
                 graph: graph,
                 viewModel: layerViewModel, 
                 isPinnedViewRendering: isPinnedViewRendering,
-                parentDisablesPosition: parentDisablesPosition,
+                parentDisablesPosition: parentDisablesPosition, 
+                parentSize: parentSize,
                 pos: pos))
                 
         //  SwiftUI gestures must come AFTER the .position modifier

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonPositionModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonPositionModifier.swift
@@ -29,6 +29,8 @@ struct PreviewCommonPositionModifier: ViewModifier {
     // Is this view a child of a group that uses HStack, VStack or Grid? If so, we ignore this view's position.
     // TODO: use .offset instead of .position when layer is a child
     let parentDisablesPosition: Bool
+    
+    let parentSize: CGSize
 
     // Position already adjusted by anchoring
     
@@ -77,9 +79,9 @@ struct PreviewCommonPositionModifier: ViewModifier {
             if isGhostView {
                 content
             } else if parentDisablesPosition {
+                let offset = viewModel.offsetInGroup.getSize?.asCGSize(parentSize) ?? .zero
                 content
-                    .offset(x: viewModel.offsetInGroup.width,
-                            y: viewModel.offsetInGroup.height)
+                    .offset(x: offset.width, y: offset.height)
             } else {
                 content
                     .position(x: pos.width, y: pos.height)

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonSizeModifier.swift
@@ -126,7 +126,7 @@ struct PreviewCommonSizeModifier: ViewModifier {
             // logInView("case .auto")
             content
                 // padding input must be applied *before* .frame
-                .modifier(LayerPaddingModifier(padding: viewModel.layerPadding))
+                .modifier(LayerPaddingModifier(padding: viewModel.layerPadding.getPadding ?? .defaultPadding))
             
                 .modifier(LayerSizeModifier(
                     viewModel: viewModel,
@@ -154,7 +154,7 @@ struct PreviewCommonSizeModifier: ViewModifier {
             // logInView("case .constrainHeight")
             content
             // padding input must be applied *before* .frame
-            .modifier(LayerPaddingModifier(padding: viewModel.layerPadding))
+                .modifier(LayerPaddingModifier(padding: viewModel.layerPadding.getPadding ?? .defaultPadding))
             // apply `.aspectRatio` separately from `.frame(width:)` and `.frame(height:)`
                 .modifier(PreviewAspectRatioModifier(data: aspectRatio))
                 .modifier(LayerSizeModifier(
@@ -180,7 +180,7 @@ struct PreviewCommonSizeModifier: ViewModifier {
             // logInView("case .constrainWidth")
             content
             // padding input must be applied *before* .frame
-            .modifier(LayerPaddingModifier(padding: viewModel.layerPadding))
+                .modifier(LayerPaddingModifier(padding: viewModel.layerPadding.getPadding ?? .defaultPadding))
             // apply `.aspectRatio` separately from `.frame(width:)` and `.frame(height:)`
                 .modifier(PreviewAspectRatioModifier(data: aspectRatio))
                 .modifier(LayerSizeModifier(

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
@@ -164,7 +164,8 @@ struct PreviewGroupLayer: View {
                 graph: graph,
                 viewModel: layerViewModel,
                 isPinnedViewRendering: isPinnedViewRendering,
-                parentDisablesPosition: parentDisablesPosition,
+                parentDisablesPosition: parentDisablesPosition, 
+                parentSize: parentSize,
                 pos: pos))
         
         // SwiftUI gestures must be applied after .position modifier

--- a/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
@@ -181,9 +181,13 @@ final class LayerViewModel {
     var pinOffset: PortValue
     
     // TODO: source these from LayerNodeViewModel after SSK update
-    var layerPadding: StitchPadding = .zero // .demoPadding // PortValue
-    var layerMargin: StitchPadding = .zero // .demoPadding // PortValue
-    var offsetInGroup: CGSize = .zero // .init(width: 50, height: 100)
+//    var layerPadding: StitchPadding = .zero // .demoPadding // PortValue
+//    var layerMargin: StitchPadding = .zero // .demoPadding // PortValue
+//    var offsetInGroup: CGSize = .zero // .init(width: 50, height: 100)
+    
+    var layerPadding: PortValue
+    var layerMargin: PortValue
+    var offsetInGroup: PortValue
     
     // Ephemeral state on the layer view model
     
@@ -310,6 +314,9 @@ final class LayerViewModel {
         self.pinTo = LayerInputPort.pinTo.getDefaultValue(for: layer)
         self.pinAnchor = LayerInputPort.pinAnchor.getDefaultValue(for: layer)
         self.pinOffset = LayerInputPort.pinOffset.getDefaultValue(for: layer)
+        self.layerPadding = LayerInputPort.layerPadding.getDefaultValue(for: layer)
+        self.layerMargin = LayerInputPort.layerMargin.getDefaultValue(for: layer)
+        self.offsetInGroup = LayerInputPort.offsetInGroup.getDefaultValue(for: layer)
         
         self.nodeDelegate = nodeDelegate
         self.interactiveLayer.delegate = self

--- a/stitch.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/stitch.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -67,8 +67,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StitchDesign/StitchSchemaKit",
       "state" : {
-        "branch" : "releases/v24.0.0-introduce-padding-margin-and-childOffset-inputs",
-        "revision" : "7518124ba067c3e359882bd087298acca3f65cae"
+        "revision" : "2e43778ca86f550618ae1d91bb6837b80f5f0c4c"
       }
     },
     {

--- a/stitch.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/stitch.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -67,8 +67,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StitchDesign/StitchSchemaKit",
       "state" : {
-        "revision" : "80c59373a31f125c34b45058719bc600914fb412",
-        "version" : "23.1.0"
+        "branch" : "releases/v24.0.0-introduce-padding-margin-and-childOffset-inputs",
+        "revision" : "7518124ba067c3e359882bd087298acca3f65cae"
       }
     },
     {


### PR DESCRIPTION
Uses StitchSchemaKit update for proper, editable inputs. 

Todo:
- [ ] UI: each padding input
- [ ] block position, unblock offset-in-group when layer in group; vice-versa when layer moved outside a group

<img width="1440" alt="Screenshot 2024-08-23 at 5 49 50 PM" src="https://github.com/user-attachments/assets/9a8ab27c-45de-496e-b033-207f1ec1e79d">
