### PR TITLE
Properly apply StitchPadding with SwiftUI .padding modifier

### DIFF
--- a/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
@@ -444,16 +444,7 @@ extension StitchPadding {
     
     static let demoPadding = Self.init(top: 8, right: 8, bottom: 8, left: 8)
 }
-
-extension Point4D {
-    var toStitchPadding: StitchPadding {
-        .init(top: self.x,
-              right: self.y,
-              bottom: self.z,
-              left: self.w)
-    }
-}
-                            
+                       
 struct PreviewGridData: Equatable {
     var horizontalSpacingBetweenColumns: StitchSpacing = .defaultStitchSpacing
     var verticalSpacingBetweenRows: StitchSpacing = .defaultStitchSpacing

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/LayerPaddingModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/LayerPaddingModifier.swift
@@ -17,7 +17,7 @@ struct LayerPaddingModifier: ViewModifier {
         content
             .padding(.init(top: padding.top,
                            leading: padding.left,
-                           bottom: padding.right,
-                           trailing: padding.bottom))
+                           bottom: padding.bottom,
+                           trailing: padding.right))
     }
 }


### PR DESCRIPTION
Had swapped bottom vs trailing padding.

<img width="1226" alt="Screenshot 2024-08-28 at 10 28 14 AM" src="https://github.com/user-attachments/assets/53f3a831-785e-4dbf-9432-32efde1933e3">

<img width="1440" alt="Screenshot 2024-08-28 at 10 20 46 AM" src="https://github.com/user-attachments/assets/1de1fa66-15d2-4ad6-84f8-164c32b10e4e">

