### PR TITLE
Pinning support for nested pins and orientation groups

### DIFF
--- a/Stitch/Graph/Node/Layer/Type/GroupLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/GroupLayerNode.swift
@@ -32,6 +32,14 @@ extension StitchOrientation: PortValueEnum {
         }
     }
 
+    var isOrientated: Bool {
+        switch self {
+        case .horizontal, .vertical, .grid:
+            return true
+        case .none:
+            return false
+        }
+    }
 }
 
 // Defaults to iPhone 11 preview window size

--- a/Stitch/Graph/Node/Layer/Type/HitAreaLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/HitAreaLayerNode.swift
@@ -29,7 +29,8 @@ struct HitAreaLayerNode: LayerNodeDefinition {
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,
                         parentSize: CGSize,
-                        layersInGroup: LayerDataList, isPinnedViewRendering: Bool,
+                        layersInGroup: LayerDataList,
+                        isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool) -> some View {
         PreviewHitAreaLayer(
             graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/ProgressIndicatorLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/ProgressIndicatorLayerNode.swift
@@ -35,7 +35,8 @@ struct ProgressIndicatorLayerNode: LayerNodeDefinition {
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,
                         parentSize: CGSize,
-                        layersInGroup: LayerDataList, isPinnedViewRendering: Bool,
+                        layersInGroup: LayerDataList,
+                        isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool) -> some View {
         PreviewProgressIndicatorLayer(
             graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/RadialGradientNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/RadialGradientNode.swift
@@ -34,7 +34,8 @@ struct RadialGradientLayerNode: LayerNodeDefinition {
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,
                         parentSize: CGSize,
-                        layersInGroup: LayerDataList, isPinnedViewRendering: Bool,
+                        layersInGroup: LayerDataList, 
+                        isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool) -> some View {
         PreviewRadialGradientLayer(
             graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/RealityView/RealityNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/RealityView/RealityNode.swift
@@ -44,7 +44,8 @@ struct RealityViewLayerNode: LayerNodeDefinition {
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,
                         parentSize: CGSize,
-                        layersInGroup: LayerDataList, isPinnedViewRendering: Bool,
+                        layersInGroup: LayerDataList,
+                        isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool) -> some View {
         PreviewRealityLayer(graph: graph,
                             viewModel: viewModel,

--- a/Stitch/Graph/Node/Layer/Type/SFSymbolLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/SFSymbolLayerNode.swift
@@ -44,7 +44,8 @@ struct SFSymbolLayerNode: LayerNodeDefinition {
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,
                         parentSize: CGSize,
-                        layersInGroup: LayerDataList, isPinnedViewRendering: Bool,
+                        layersInGroup: LayerDataList,
+                        isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool) -> some View {
         
         let stroke = viewModel.getLayerStrokeData()

--- a/Stitch/Graph/Node/Layer/Type/SwitchLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/SwitchLayerNode.swift
@@ -44,7 +44,8 @@ struct SwitchLayerNode: LayerNodeDefinition {
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,
                         parentSize: CGSize,
-                        layersInGroup: LayerDataList, isPinnedViewRendering: Bool,
+                        layersInGroup: LayerDataList,
+                        isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool) -> some View {
         PreviewSwitchLayer(
             graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/TextFieldLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/TextFieldLayerNode.swift
@@ -58,7 +58,8 @@ struct TextFieldLayerNode: LayerNodeDefinition {
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,
                         parentSize: CGSize,
-                        layersInGroup: LayerDataList, isPinnedViewRendering: Bool,
+                        layersInGroup: LayerDataList, 
+                        isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool) -> some View {
         PreviewTextFieldLayer(
             graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/TextLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/TextLayerNode.swift
@@ -71,7 +71,8 @@ struct TextLayerNode: LayerNodeDefinition {
     static func content(graph: GraphState,
                         viewModel: LayerViewModel,
                         parentSize: CGSize,
-                        layersInGroup: LayerDataList, isPinnedViewRendering: Bool,
+                        layersInGroup: LayerDataList, 
+                        isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool) -> some View {
         PreviewTextLayer(
             graph: graph,

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Shapes/ShapeUtils.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Shapes/ShapeUtils.swift
@@ -31,7 +31,7 @@ struct ApplyStroke: ViewModifier {
     
     @ViewBuilder
     func body(content: Content) -> some View {
-        
+        // TODO: stroke logic
         if isGhostView {
             content
         } else {

--- a/Stitch/Graph/Node/Port/View/Field/InputView/LayerNamesDropDownChoiceView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/LayerNamesDropDownChoiceView.swift
@@ -58,7 +58,7 @@ extension GraphState {
                               // specific use case of pinToId dropdown
                               isForPinTo: Bool) -> LayerDropdownChoices {
         
-        let pinMap = self.graphUI.pinMap
+        let pinMap = self.visibleNodesViewModel.flattenedPinMap
         let viewsPinnedToThisLayerId = pinMap.get(isForNode.asLayerNodeId) ?? .init()
         
         // includes self?

--- a/Stitch/Graph/Node/Port/View/Field/Media/VideoDisplayView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/Media/VideoDisplayView.swift
@@ -63,7 +63,7 @@ struct VideoDisplayView: View {
         .modifier(PreviewCommonSizeModifier(
             viewModel: layerViewModel,
             isPinnedViewRendering: isPinnedViewRendering,
-            pinMap: graph.graphUI.pinMap,
+            pinMap: graph.visibleNodesViewModel.pinMap,
             aspectRatio: layerViewModel.getAspectRatioData(),
             size: size,
             minWidth: layerViewModel.getMinWidth,

--- a/Stitch/Graph/PrototypePreview/Frame/View/PreviewContent.swift
+++ b/Stitch/Graph/PrototypePreview/Frame/View/PreviewContent.swift
@@ -13,6 +13,8 @@ extension Color {
 }
 
 struct PreviewContent: View {
+    static let prototypeCoordinateSpace = "STITCH_PROTOTYPE_COORDINATE"
+    
     @Bindable var graph: GraphState
     let isFullScreen: Bool
     
@@ -57,6 +59,7 @@ struct PreviewContent: View {
         UIKitWrapper(ignoresKeyCommands: false, name: "PreviewContent") {
             generatedPreview
                 .frame(finalSize)
+                .coordinateSpace(name: Self.prototypeCoordinateSpace)
                 .background(graph.previewWindowBackgroundColor)
                 .contentShape(Rectangle())
                 // Keeps layers rendered within preview window

--- a/Stitch/Graph/PrototypePreview/Layer/Model/LayerData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/LayerData.swift
@@ -15,8 +15,8 @@ typealias LayerDataList = [LayerData]
 
 /// Data type used for getting sorted data.
 indirect enum LayerType: Equatable, Hashable {
-    case nongroup(LayerNonGroupData)
-    case group(LayerGroupData)
+    case nongroup(LayerNonGroupData, Bool)
+    case group(LayerGroupData, Bool)
     
     // TODO: theoretically could just use `[LayerType]` but need to update recursion logic
     // TODO: should be also NonEmpty, i.e. guaranteed to have at least one masked view and one masker view
@@ -25,8 +25,8 @@ indirect enum LayerType: Equatable, Hashable {
 
 /// Data type used for getting sorted data in views.
 indirect enum LayerData {
-    case nongroup(LayerViewModel, isPinnedView: Bool)
-    case group(LayerViewModel, LayerDataList, isPinnedView: Bool)
+    case nongroup(LayerViewModel, Bool)
+    case group(LayerViewModel, LayerDataList, Bool)
     case mask(masked: LayerDataList, masker: LayerDataList)
 }
 
@@ -35,7 +35,6 @@ struct LayerNonGroupData: Equatable, Hashable {
     let zIndex: CGFloat
     let sidebarIndex: Int
     let layer: Layer // debug
-    let pinnedViewType: PinnedViewType?
 }
 
 struct LayerGroupData: Equatable, Hashable {
@@ -44,27 +43,26 @@ struct LayerGroupData: Equatable, Hashable {
     let sidebarIndex: Int
     let childrenSidebarLayers: SidebarLayerList
     let layer: Layer // debug
-    let pinnedViewType: PinnedViewType?
 }
 
 // "A is pinned to B" = A is a pinned view;
 // but a given pinned view is rendered TWICE in the preview window:
 // 1. `PinnedViewA` is the view that user sees, is pinned to some anchor of B, is rendered at same hierarchy level as B etc.
 // 2. `GhostViewA` is the view the user DOES NOT see, is rendered at A's normal hierarchy level and is used simply to read how A's parents may have affected A's size etc. (e.g. A's parent layer group is scaled 2x etc.)
-enum PinnedViewType {
-    // visible to user, seen in pin-anchor; lives at same hierarchy level as B etc.
-    case pinnedView
-    
-    // inivislbe to user but still rendered in preview window; used to read how A's size is modified by parent
-    case ghostView
-}
+//enum PinnedViewType {
+//    // visible to user, seen in pin-anchor; lives at same hierarchy level as B etc.
+//    case pinnedView
+//
+//    // inivislbe to user but still rendered in preview window; used to read how A's size is modified by parent
+//    case ghostView
+//}
 
 extension LayerType {
     var id: PreviewCoordinate {
         switch self {
-        case .nongroup(let data):
+        case .nongroup(let data, _):
             return data.id
-        case .group(let data):
+        case .group(let data, _):
             return data.id
         case .mask(masked: let masked, masker: _):
             // TODO: what is the the layer-node-id of a LayerType in a masking situation? Really, it's nil, there's no single LayerNode
@@ -76,9 +74,9 @@ extension LayerType {
     // DEBUG ONLY?
     var layer: Layer {
         switch self {
-        case .nongroup(let data):
+        case .nongroup(let data, _):
             return data.layer
-        case .group(let data):
+        case .group(let data, _):
             return data.layer
         case .mask(masked: let masked, masker: _):
             // TODO: what is the the layer-node-id of a LayerType in a masking situation? Really, it's nil, there's no single LayerNode
@@ -96,24 +94,24 @@ extension LayerType {
         }
     }
     
-    var pinnedViewType: PinnedViewType? {
+    var isPinnedView: Bool {
         switch self {
-        case .nongroup(let x):
-            return x.pinnedViewType
-        case .group(let x):
+        case .nongroup(_, let isPinned):
+            return isPinned
+        case .group(_, let isPinned):
             // "Is group layer itself pinned?"
-            return x.pinnedViewType
+            return isPinned
         case .mask(masked: let x, masker: _):
             // "Is first masked view pinned?" (is this correct?)
-            return x.first?.pinnedViewType
+            return x.first?.isPinnedView ?? false
         }
     }
     
     var sidebarIndex: Int {
         switch self {
-        case .nongroup(let nongroup):
+        case .nongroup(let nongroup, _):
             return nongroup.sidebarIndex
-        case .group(let group):
+        case .group(let group, _):
             return group.sidebarIndex
         case .mask(masked: let masked, masker: _):
 #if DEV_DEBUG || DEBUG
@@ -126,9 +124,9 @@ extension LayerType {
 
     var zIndex: CGFloat {
         switch self {
-        case .nongroup(let nongroup):
+        case .nongroup(let nongroup, _):
             return nongroup.zIndex
-        case .group(let group):
+        case .group(let group, _):
             return group.zIndex
         case .mask(masked: let maskedLayerTypes, masker: _):
 //            return masked.zIndex
@@ -143,10 +141,9 @@ extension LayerType {
 
 // If pinned, the same layer view model is rendered in PreviewLayers twice (GhostView, PinnedView),
 // so we need an id that distinguishes
-struct LayerDataId: Equatable, Hashable, Codable {
-    let coordinate: PreviewCoordinate
-    let isPinned: Bool
-}
+//struct LayerDataId: Equatable, Hashable, Codable {
+//    let coordinate: PreviewCoordinate
+//}
 
 extension LayerData: Identifiable {
     var id: PreviewCoordinate {
@@ -154,10 +151,9 @@ extension LayerData: Identifiable {
     }
 
     // Perf cost?
-    var layerDataId: LayerDataId {
-        LayerDataId(coordinate: self.layer.id,
-                    isPinned: self.isPinned)
-    }
+//    var layerDataId: LayerDataId {
+//        LayerDataId(coordinate: self.layer.id)
+//    }
 
     var groupDataList: LayerDataList? {
         switch self {

--- a/Stitch/Graph/PrototypePreview/Layer/Model/LayerData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/LayerData.swift
@@ -45,18 +45,6 @@ struct LayerGroupData: Equatable, Hashable {
     let layer: Layer // debug
 }
 
-// "A is pinned to B" = A is a pinned view;
-// but a given pinned view is rendered TWICE in the preview window:
-// 1. `PinnedViewA` is the view that user sees, is pinned to some anchor of B, is rendered at same hierarchy level as B etc.
-// 2. `GhostViewA` is the view the user DOES NOT see, is rendered at A's normal hierarchy level and is used simply to read how A's parents may have affected A's size etc. (e.g. A's parent layer group is scaled 2x etc.)
-//enum PinnedViewType {
-//    // visible to user, seen in pin-anchor; lives at same hierarchy level as B etc.
-//    case pinnedView
-//
-//    // inivislbe to user but still rendered in preview window; used to read how A's size is modified by parent
-//    case ghostView
-//}
-
 extension LayerType {
     var id: PreviewCoordinate {
         switch self {
@@ -139,21 +127,10 @@ extension LayerType {
     }
 }
 
-// If pinned, the same layer view model is rendered in PreviewLayers twice (GhostView, PinnedView),
-// so we need an id that distinguishes
-//struct LayerDataId: Equatable, Hashable, Codable {
-//    let coordinate: PreviewCoordinate
-//}
-
 extension LayerData: Identifiable {
     var id: PreviewCoordinate {
         self.layer.id
     }
-
-    // Perf cost?
-//    var layerDataId: LayerDataId {
-//        LayerDataId(coordinate: self.layer.id)
-//    }
 
     var groupDataList: LayerDataList? {
         switch self {

--- a/Stitch/Graph/PrototypePreview/Layer/Util/LayerNodesSorting.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Util/LayerNodesSorting.swift
@@ -19,24 +19,27 @@ extension VisibleNodesViewModel {
                                 isInGroupOrientation: Bool = false) -> LayerDataList {
         
         let isRoot = sidebarLayersAtHierarchy == nil
-        var sidebarLayersAtHierarchy = sidebarLayersAtHierarchy ?? sidebarLayersGlobal
+        let sidebarLayersAtHierarchy = sidebarLayersAtHierarchy ?? sidebarLayersGlobal
         let pinnedLayerIds = pinMap.allPinnedLayerIds.map { $0.id }
         var layerTypesAtThisLevel = LayerTypeSet()
         var handled = LayerIdSet()
         
         // Filter out pinned views for visible layers, they'll be re-inserted in handleRawSidebarLayer
-        sidebarLayersAtHierarchy = sidebarLayersAtHierarchy.filter {
+        let filteredSidebarLayersAtHierarchy = sidebarLayersAtHierarchy.filter {
             !pinnedLayerIds.contains($0.id)
         }
         
-        sidebarLayersAtHierarchy.enumerated().forEach {
+        filteredSidebarLayersAtHierarchy.forEach { sidebarItem in
+            let sidebarIndex = sidebarLayersAtHierarchy.firstIndex { $0.id == sidebarItem.id }
+            assertInDebug(sidebarIndex.isDefined)
+            
             let (newLayerTypesAtThisLevel,
                  newLayersUsedAsMaskers) = handleRawSidebarLayer(
-                    sidebarIndex: $0.offset,
-                    layerData: $0.element,
+                    sidebarIndex: sidebarIndex ?? .zero,
+                    layerData: sidebarItem,
                     layerTypesAtThisLevel: layerTypesAtThisLevel,
                     handled: handled,
-                    sidebarLayersAtHierarchy: sidebarLayersAtHierarchy,
+                    sidebarLayersAtHierarchy: filteredSidebarLayersAtHierarchy,
                     sidebarLayersGlobal: sidebarLayersGlobal,
                     layerNodes: self.layerNodes,
                     pinMap: pinMap)

--- a/Stitch/Graph/PrototypePreview/Layer/Util/LayerNodesSorting.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Util/LayerNodesSorting.swift
@@ -13,23 +13,31 @@ extension VisibleNodesViewModel {
     
     /// Recursively creates a sorted list of layers.
     @MainActor
-    func recursivePreviewLayers(sidebarLayers: SidebarLayerList,
-                                isRoot: Bool) -> (LayerDataList, PinMap) {
+    func recursivePreviewLayers(sidebarLayersAtHierarchy: SidebarLayerList? = nil,
+                                sidebarLayersGlobal: SidebarLayerList,
+                                pinMap: RootPinMap,
+                                isInGroupOrientation: Bool = false) -> LayerDataList {
         
-        let pinMap: PinMap = self.getPinMap()
-        
+        let isRoot = sidebarLayersAtHierarchy == nil
+        var sidebarLayersAtHierarchy = sidebarLayersAtHierarchy ?? sidebarLayersGlobal
+        let pinnedLayerIds = pinMap.allPinnedLayerIds.map { $0.id }
         var layerTypesAtThisLevel = LayerTypeSet()
         var handled = LayerIdSet()
         
-        sidebarLayers.enumerated().forEach {
-            
+        // Filter out pinned views for visible layers, they'll be re-inserted in handleRawSidebarLayer
+        sidebarLayersAtHierarchy = sidebarLayersAtHierarchy.filter {
+            !pinnedLayerIds.contains($0.id)
+        }
+        
+        sidebarLayersAtHierarchy.enumerated().forEach {
             let (newLayerTypesAtThisLevel,
                  newLayersUsedAsMaskers) = handleRawSidebarLayer(
                     sidebarIndex: $0.offset,
                     layerData: $0.element,
                     layerTypesAtThisLevel: layerTypesAtThisLevel,
                     handled: handled,
-                    sidebarLayers: sidebarLayers,
+                    sidebarLayersAtHierarchy: sidebarLayersAtHierarchy,
+                    sidebarLayersGlobal: sidebarLayersGlobal,
                     layerNodes: self.layerNodes,
                     pinMap: pinMap)
             
@@ -39,11 +47,11 @@ extension VisibleNodesViewModel {
         
         // If we're at the root level, we need to also add the LayerTypes for views with `isPinned = true` and `pinToId = .root`, since those views' PinnedViews will not be handled by
         if isRoot,
-           let rootPinnedViews = pinMap.get(nil) {
+           let pinnedData = pinMap.get(nil) {
             
             let layerTypesFromRootPinnedViews = getLayerTypesForPinnedViews(
-                pinnedViews: rootPinnedViews,
-                sidebarLayers: sidebarLayers,
+                pinnedData: pinnedData,
+                sidebarLayers: sidebarLayersGlobal,
                 layerNodes: self.layerNodes,
                 layerTypesAtThisLevel: layerTypesAtThisLevel)
             
@@ -53,53 +61,83 @@ extension VisibleNodesViewModel {
         
         // log("recursivePreviewLayers: DONE GETTING ALL LAYER TYPES: \(layerTypesAtThisLevel)")
         
-        // Sorting comparator
-        let comparator = { (lhs: LayerType, rhs: LayerType) in
-            // Variables for sorting
-            let lhsZIndex = lhs.zIndex
-            let rhsZIndex = rhs.zIndex
-            let lhsSidebarIndex = lhs.sidebarIndex
-            let rhsSidebarIndex = rhs.sidebarIndex
-            
-            // Sorting tiebreaker:
-            // 1. Z-index input
-            // 2. Sidebar order
-            
-            guard lhsZIndex != rhsZIndex else {
-                /*
-                 Larger sidebar indices should be higher in stack
-                 
-                 ... actually, depends on stack-type:
-                 - ZStack: smallest index = bottom of stack, largest index = top of stack
-                 - VStack: smallest index = top of column, largest index = bottom of column
-                 - HStack: smallest index = far left of row, largest index = far right of row
-                 */
-                return lhsSidebarIndex > rhsSidebarIndex
-            }
-            
-            return lhsZIndex < rhsZIndex
+        var sortedLayerTypes = layerTypesAtThisLevel.sorted(by: { lhs, rhs in
+            Self.layerSortingComparator(lhs: lhs,
+                                        rhs: rhs,
+                                        pinMap: pinMap)
+        })
+        
+        if isInGroupOrientation {
+            sortedLayerTypes = sortedLayerTypes.reversed()
         }
         
-        let sortedLayerTypes = layerTypesAtThisLevel.sorted(by: comparator)
-        
         let sortedLayerDataList: LayerDataList = sortedLayerTypes.compactMap { (layerType: LayerType) -> LayerData? in
-            self.getLayerDataFromLayerType(layerType, layerNodes: self.layerNodes)
+            self.getLayerDataFromLayerType(layerType,
+                                           pinMap: pinMap,
+                                           sidebarLayersGlobal: sidebarLayersGlobal,
+                                           layerNodes: self.layerNodes)
         }
         
         log("recursivePreviewLayers: sortedLayerDataList: \(sortedLayerDataList)")
         
-        return (sortedLayerDataList, pinMap)
+        return sortedLayerDataList
+    }
+    
+    /// Sorting comparator for layer data, which drives z-index order.
+    static func layerSortingComparator(lhs: LayerType, 
+                                       rhs: LayerType,
+                                       pinMap: RootPinMap) -> Bool {
+        // Variables for sorting
+        let lhsZIndex = lhs.zIndex
+        let rhsZIndex = rhs.zIndex
+        let lhsSidebarIndex = lhs.sidebarIndex
+        let rhsSidebarIndex = rhs.sidebarIndex
+        
+        // Determines if a view is pinned and if so, how nested that pin is (higher value = more nesting)
+        let lhsPinNestedCount = pinMap.getPinnedNestedLayerCount(id: lhs.id.layerNodeId)
+        let rhsPinNestedCount = pinMap.getPinnedNestedLayerCount(id: rhs.id.layerNodeId)
+        
+        // Sorting tiebreaker:
+        // 1. Pinning
+        // 2. Z-index input
+        // 3. Sidebar order
+        
+        if lhsPinNestedCount != rhsPinNestedCount {
+            return rhsPinNestedCount > lhsPinNestedCount
+        }
+        
+        if lhsZIndex != rhsZIndex {
+            return lhsZIndex < rhsZIndex
+        }
+        
+        /*
+         Larger sidebar indices should be higher in stack
+         
+         ... actually, depends on stack-type:
+         - ZStack: smallest index = bottom of stack, largest index = top of stack
+         - VStack: smallest index = top of column, largest index = bottom of column
+         - HStack: smallest index = far left of row, largest index = far right of row
+         */
+        return lhsSidebarIndex > rhsSidebarIndex
     }
     
     @MainActor
     func getLayerDataFromLayerType(_ layerType: LayerType,
+                                   pinMap: RootPinMap,
+                                   sidebarLayersGlobal: SidebarLayerList,
                                    layerNodes: NodesViewModelDict) -> LayerData? {
         
         switch layerType {
             
         case .mask(masked: let masked, masker: let masker):
-            let maskedLayerData = masked.compactMap { getLayerDataFromLayerType($0, layerNodes: layerNodes) }
-            let maskerLayerData = masker.compactMap { getLayerDataFromLayerType($0, layerNodes: layerNodes) }
+            let maskedLayerData = masked.compactMap { getLayerDataFromLayerType($0,
+                                                                                pinMap: pinMap, 
+                                                                                sidebarLayersGlobal: sidebarLayersGlobal,
+                                                                                layerNodes: layerNodes) }
+            let maskerLayerData = masker.compactMap { getLayerDataFromLayerType($0,
+                                                                                pinMap: pinMap,
+                                                                                sidebarLayersGlobal: sidebarLayersGlobal,
+                                                                                layerNodes: layerNodes) }
             
             guard !maskedLayerData.isEmpty,
                   !maskerLayerData.isEmpty else {
@@ -109,7 +147,7 @@ extension VisibleNodesViewModel {
             return .mask(masked: maskedLayerData,
                          masker: maskerLayerData)
             
-        case .nongroup(let data): // LayerData
+        case .nongroup(let data, let isPinned): // LayerData
             guard let previewLayer: LayerViewModel = layerNodes
                 .get(data.id.layerNodeId.id)?
                 .layerNode?
@@ -118,10 +156,9 @@ extension VisibleNodesViewModel {
                 return nil
             }
             
-            return .nongroup(previewLayer,
-                             isPinnedView: layerType.pinnedViewType == .pinnedView)
+            return .nongroup(previewLayer, isPinned)
             
-        case .group(let layerGroupData): // LayerGroupData
+        case .group(let layerGroupData, let isPinned): // LayerGroupData
             guard let previewLayer: LayerViewModel = layerNodes
                 .get(layerGroupData.id.layerNodeId.asNodeId)?
                 .layerNode?
@@ -130,18 +167,22 @@ extension VisibleNodesViewModel {
                 return nil
             }
             
+            let isInGroupOrientation = previewLayer.orientation.getOrientation?.isOrientated ?? false
+            
             // Pass the pinned-view-type from the LayerType to the LayerViewModel
             //            previewLayer.pinnedViewType = layerType.pinnedViewType
             
             // Recursively call on group data
             // TODO: we start the recursion all over again here? do we need to pass on the same pinMap?
-            let (childrenData, _) = self.recursivePreviewLayers(
-                sidebarLayers: layerGroupData.childrenSidebarLayers,
-                isRoot: false)
+            let childrenData = self.recursivePreviewLayers(
+                sidebarLayersAtHierarchy: layerGroupData.childrenSidebarLayers,
+                sidebarLayersGlobal: sidebarLayersGlobal,
+                pinMap: pinMap,
+                isInGroupOrientation: isInGroupOrientation)
             
             return .group(previewLayer,
                           childrenData,
-                          isPinnedView: layerType.pinnedViewType == .pinnedView)
+                          isPinned)
         }
     }
 }
@@ -166,8 +207,8 @@ func getLayerTypesFromSidebarLayerData(_ layerData: SidebarLayerData,
                                  zIndex: layerViewModel.zIndex.getNumber ?? .zero,
                                  sidebarIndex: sidebarIndex,
                                  childrenSidebarLayers: children,
-                                 layer: layerNode.layer,
-                                 pinnedViewType: isPinnedView ? .pinnedView : nil))
+                                 layer: layerNode.layer),
+                           isPinnedView)
             }
             .toOrderedSet
         
@@ -182,8 +223,8 @@ func getLayerTypesFromSidebarLayerData(_ layerData: SidebarLayerData,
                     .nongroup(.init(id: layerViewModel.id,
                                     zIndex: layerViewModel.zIndex.getNumber ?? .zero,
                                     sidebarIndex: sidebarIndex,
-                                    layer: layerNode.layer,
-                                    pinnedViewType: isPinnedView ? .pinnedView : nil))
+                                    layer: layerNode.layer),
+                              isPinnedView)
             }
             .toOrderedSet
         
@@ -198,9 +239,10 @@ func handleRawSidebarLayer(sidebarIndex: Int,
                            layerData: SidebarLayerData,
                            layerTypesAtThisLevel: LayerTypeSet, // i.e. acc
                            handled: LayerIdSet, // i.e. acc2
-                           sidebarLayers: SidebarLayerList, // raw sidebar layers
+                           sidebarLayersAtHierarchy: SidebarLayerList, // raw sidebar layers
+                           sidebarLayersGlobal: SidebarLayerList, // all sidebar layers, needed for pinning
                            layerNodes: NodesViewModelDict,
-                           pinMap: PinMap) -> (LayerTypeSet,
+                           pinMap: RootPinMap) -> (LayerTypeSet,
                                                // layers used as masks
                                                // TODO: not needed anymore?
                                                LayerIdSet) {
@@ -215,7 +257,7 @@ func handleRawSidebarLayer(sidebarIndex: Int,
     
     // if this sidebar layer has a masker, the masker's index will be *immediately* below
     let maskerSidebarIndex = sidebarIndex + 1
-    let maskerLayerData: SidebarLayerData? = sidebarLayers[safe: maskerSidebarIndex]
+    let maskerLayerData: SidebarLayerData? = sidebarLayersAtHierarchy[safe: maskerSidebarIndex]
     
     /*
      TODO: need to iterate through each preview layer view model on layer node and check, *at that particular index*, whether the `mask input = true`; rather than checking just at top level.
@@ -255,7 +297,8 @@ func handleRawSidebarLayer(sidebarIndex: Int,
             layerData: maskerLayerData,
             layerTypesAtThisLevel: .init(), // each mask-recur-level has own layer types
             handled: handled, // ... but a given layer can only appear at a single mask-recur-level
-            sidebarLayers: sidebarLayers,
+            sidebarLayersAtHierarchy: sidebarLayersAtHierarchy,
+            sidebarLayersGlobal: sidebarLayersGlobal,
             layerNodes: layerNodes,
             pinMap: pinMap)
         
@@ -294,10 +337,9 @@ func handleRawSidebarLayer(sidebarIndex: Int,
             // "Does this layer have other views pinned to it?"
             // i.e. "Is this layer the B to some A and C?"
             if let pinnedViews = pinMap.get(layerData.id.asLayerNodeId) {
-                
                 let layerTypesFromPinnedViews = getLayerTypesForPinnedViews(
-                    pinnedViews: pinnedViews, 
-                    sidebarLayers: sidebarLayers,
+                    pinnedData: pinnedViews,
+                    sidebarLayers: sidebarLayersGlobal,
                     layerNodes: layerNodes,
                     layerTypesAtThisLevel: layerTypesAtThisLevel)
                 
@@ -309,14 +351,54 @@ func handleRawSidebarLayer(sidebarIndex: Int,
     return (layerTypesAtThisLevel, handled)
 }
 
-func getLayerTypesForPinnedViews(pinnedViews: LayerIdSet, // views pinned to this layer
+/*
+ Tricky -- sidebar index is for comparing z-ordering, but pinned views could live at different hierarchy levels:
+ 
+ Group 1
+ - B
+ Group 2
+ - C
+ - Q
+ A
+ 
+ Supposed A and Q are both pinned to B. Is Q's sidebar-index higher?
+ 
+ 
+ 
+ Another tricky case:
+ 
+ Group
+ - Blue
+ - Red
+ 
+ Blue is pinned to Group; but, if we just go by list-item-index in each layer's respective hierarchy level (without any pinning changes),
+ *both* Blue and Group have the same index: 0
+ And so our comparator logic is indeterminate.
+ 
+ 
+ A possible solution?: flatten the hierarchy so that each layer has unique index; e.g.:
+ 
+ Group 1
+ - Blue
+ - Red
+ - Group 2
+    - Yellow
+ 
+ ... becomes: [Group 1, Blue, Red, Group 2, Yellow]
+ */
+func getLayerTypesForPinnedViews(pinnedData: LayerPinData, // views pinned to this layer
                                  sidebarLayers: SidebarLayerList,
                                  layerNodes: NodesViewModelDict,
                                  layerTypesAtThisLevel: LayerTypeSet) -> LayerTypeSet {
     
     var layerTypesAtThisLevel = layerTypesAtThisLevel
     
-    pinnedViews.forEach { (pinnedView: LayerNodeId) in
+    pinnedData
+        .pins?
+        .flatMap { $0.getAllPins() }
+        .toSet
+        .compactMap { $0 }
+        .forEach { (pinnedView: LayerNodeId) in
         
         // Note: we do NOT add the pinned-view A to `handled`; another copy/version of A must be handled separately and 'normally' so that its ghost view can live at its proper hierarchy level to be affected by parent scale etc.
         
@@ -326,47 +408,9 @@ func getLayerTypesForPinnedViews(pinnedViews: LayerIdSet, // views pinned to thi
             
             // the pinned view A could have a loop, so we get back multiple `LayerType`s, not just one.
             let layerTypesFromThisPinnedView = getLayerTypesFromSidebarLayerData(
-                
                 // use the layer data for the pinned view A, not the pin-receiving view B
                 layerDataForPinnedView,
-                
-                /*
-                 Tricky -- sidebar index is for comparing z-ordering, but pinned views could live at different hierarchy levels:
-                 
-                 Group 1
-                 - B
-                 Group 2
-                 - C
-                 - Q
-                 A
-                 
-                 Supposed A and Q are both pinned to B. Is Q's sidebar-index higher?
-                 
-                 
-                 
-                 Another tricky case:
-                 
-                 Group
-                 - Blue
-                 - Red
-                 
-                 Blue is pinned to Group; but, if we just go by list-item-index in each layer's respective hierarchy level (without any pinning changes),
-                 *both* Blue and Group have the same index: 0
-                 And so our comparator logic is indeterminate.
-                 
-                 
-                 A possible solution?: flatten the hierarchy so that each layer has unique index; e.g.:
-                 
-                 Group 1
-                 - Blue
-                 - Red
-                 - Group 2
-                    - Yellow
-                 
-                 ... becomes: [Group 1, Blue, Red, Group 2, Yellow]
-                 */
                 sidebarIndex: sidebarIndexOfPinnedView,
-                
                 layerNodes: layerNodes,
                 isPinnedView: true)
             

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/LayerSizeReader.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/LayerSizeReader.swift
@@ -10,14 +10,32 @@ import SwiftUI
 struct LayerSizeReader: ViewModifier {
     @Bindable var viewModel: LayerViewModel
     
+    // Represents the origin view of a pinned layer, needed to relay positional data
+    // for calculating the offset of its pinned layer equivalent
+    let isPinnedViewRendering: Bool
+    
+    /// Important to only report data from ghost view
+    
+    func getFrame(geometry: GeometryProxy) -> CGRect {
+        !isPinnedViewRendering ? geometry.frame(in: .named(PreviewContent.prototypeCoordinateSpace)) : .zero
+    }
+    
     func body(content: Content) -> some View {
         content.background {
             GeometryReader { proxy in
+                let frameData = self.getFrame(geometry: proxy)
+                
                 Color.clear
-                    .onChange(of: proxy.frame(in: .local).size, initial: true) { _, newSize in
+                    .onChange(of: frameData.size, initial: !isPinnedViewRendering) { _, newSize in
                         // log("LayerSizeReader: \(viewModel.layer), new size: \(newSize)")
                         if viewModel.readSize != newSize {
                             viewModel.readSize = newSize
+                        }
+                    }
+                    .onChange(of: frameData.mid, initial: !isPinnedViewRendering) { _, newPosition in
+                        // log("LayerSizeReader: \(viewModel.layer), new pos: \(newPosition)")
+                        if viewModel.readMidPosition != newPosition {
+                            viewModel.readMidPosition = newPosition
                         }
                     }
             }

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PinningUtils.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PinningUtils.swift
@@ -23,29 +23,118 @@ import SwiftUI
      C: { A, D },
  ]
  */
+
 typealias PinMap = [LayerNodeId?: LayerIdSet]
 
-extension VisibleNodesViewModel {
+/// Key: root hierarchy group layer ID
+/// Value: all possibled nested key-value pairs of pinning views
+/// Problem to solve: we need to find chain of connected layers say if there's a pinning relationship like A -> B -> C,
+/// at which point we need to pin views at the group context of C.
+typealias RootPinMap = [LayerNodeId?: LayerPinData]
+
+struct LayerPinData {
+    let id: LayerNodeId?
+    var pins: [Self]?
+}
+
+extension LayerPinData {
+    func getAllPins() -> Set<LayerNodeId?> {
+        var set = Set<LayerNodeId?>([self.id])
+        
+        self.pins?.forEach { pin in
+            set = set.union(pin.getAllPins())
+        }
+        
+        return set
+    }
     
+    func recursiveContains(id: LayerNodeId) -> Bool {
+        if self.id == id {
+            return true
+        }
+        
+        guard let pins = self.pins else {
+            return false
+        }
+        
+        return pins.contains { $0.recursiveContains(id: id) }
+    }
+    
+    /// Calculates nested level of some pin given its ID. A value of 0 means no match was found.
+    func getPinnedNestedLayerCount(id: LayerNodeId) -> Int {
+        if self.id == id {
+            return 1
+        }
+        
+        guard let pins = self.pins else {
+            return 0
+        }
+        
+        let maxCountInChildren = pins.getMaxPinnedNestedLayerCount(id: id)
+        
+        return 1 + maxCountInChildren
+    }
+}
+
+extension RootPinMap {
+    /// Getter which ignores layers receiving pins.
+    var allPinnedLayerIds: Set<LayerNodeId> {
+        let pinDataList: [LayerPinData] = self.values.flatMap { $0.pins ?? [] }
+        
+        return pinDataList.flatMap {
+            $0.getAllPins()
+        }
+        .compactMap { $0 }
+        .toSet
+    }
+    
+    /// Recursively checks most upstream parent ID for pinning data.
+    func findRootPinReceiver(from id: LayerNodeId) -> LayerNodeId? {
+        for pinData in self.values {
+            if pinData.recursiveContains(id: id) {
+                return pinData.id
+            }
+        }
+        
+        // No match
+        return nil
+    }
+    
+    func getPinnedNestedLayerCount(id: LayerNodeId) -> Int {
+        Array(self.values).getMaxPinnedNestedLayerCount(id: id)
+    }
+}
+
+extension [LayerPinData] {
+    func getMaxPinnedNestedLayerCount(id: LayerNodeId) -> Int {
+        self.reduce(0) { currentMaxCount, pin in
+            let pinNestedCount = pin.getPinnedNestedLayerCount(id: id)
+            return Swift.max(pinNestedCount, currentMaxCount)
+        }
+    }
+}
+
+extension VisibleNodesViewModel {
     // Note: PinMap is only for views with a PinToId that corresponds to some layer node; so e.g. `PinToId.root` needs to be handled separately
     @MainActor
-    func getPinMap() -> PinMap {
-        
-        var pinMap = PinMap()
-        
+    func getFlattenedPinMap() -> PinMap {
         // Iterate through all layer nodes, checking each layer node's pinTo input loop; turn that loop into entries in the PinMap
-        self.layerNodes.forEach { (nodeId: NodeId, node: NodeViewModel) in
+        self.nodes.values.reduce(into: PinMap()) { pinMap, node in
+            guard let layerNode = node.layerNode else {
+                return
+            }
+            
+            let nodeId = node.id
             
             // Iterate th
-            node.layerNode?.previewLayerViewModels.forEach({ (viewModel: LayerViewModel) in
-                                
+            layerNode.previewLayerViewModels.forEach({ (viewModel: LayerViewModel) in
                 // have to check whether the viewModel is actually pinned as well
                 if (viewModel.isPinned.getBool ?? false),
                    var pinToId = viewModel.pinTo.getPinToId {
                     
                     // `PinToId.root` case does not have a corresponding layer node,
                     //
-                   let pinReceivingLayer = pinToId.asLayerNodeId(viewModel.id.layerNodeId, from: self)
+                    let pinReceivingLayer = pinToId.asLayerNodeId(viewModel.id.layerNodeId, from: self)
                     
                     if pinReceivingLayer == nil && pinToId != .root {
                         log("getPinMap: had nil pin-receiving-layer but PinToId was not 'root'; will default to 'root'")
@@ -66,15 +155,64 @@ extension VisibleNodesViewModel {
                     
                     pinMap.updateValue(current, forKey: pinReceivingLayer)
                     log("getPinMap: pinMap is now: \(pinMap)")
-            
+                    
                 }
             })
         } // self.layerNodes.forEach
+    }
+    
+    func getRootPinMap(pinMap: PinMap) -> RootPinMap {
+        // 1. Identify root pairs
+        // 2. For each pin via root, check list for chains
+        // 3. Assert keys count == root pairs count from 1
         
-        return pinMap
+        let allValues = pinMap.values.flatMap { $0 }
+        let rootNodes = pinMap.keys
+            .filter { key in
+                guard let key = key else {
+                    // nil = root, which counts
+                    return true
+                }
+                
+                return !allValues.contains(key)
+            }
+        
+        let rootPinMap = rootNodes.reduce(into: RootPinMap()) { result, rootNode in
+            let pinData = pinMap.getRecursiveData(from: rootNode)
+            result.updateValue(pinData, forKey: rootNode)
+        }
+        
+        return rootPinMap
     }
 }
 
+extension PinMap {
+    func getRecursiveData(from layerNodeId: LayerNodeId?,
+                          visitedSet: Set<LayerNodeId?> = .init()) -> LayerPinData {
+        var pinData = LayerPinData(id: layerNodeId)
+        
+        guard let values = self.get(layerNodeId) else {
+            return pinData
+        }
+        
+        // Prevents cycle
+        if let layerNodeId = layerNodeId,
+           visitedSet.contains(layerNodeId) {
+            log("PinMap.getRecursive pairs: cycle detected for \(layerNodeId)")
+            return pinData
+        }
+        
+        var visitedSet = visitedSet
+        visitedSet.insert(layerNodeId)
+        
+        pinData.pins = values.map { layerNodePinId in
+            self.getRecursiveData(from: layerNodePinId,
+                                  visitedSet: visitedSet)
+        }
+        
+        return pinData
+    }
+}
 
 // MARK: POSITIONING
 
@@ -97,7 +235,7 @@ extension GraphState {
 func getPinReceiverData(for pinnedLayerViewModel: LayerViewModel,
                         from graph: GraphState) -> PinReceiverData? {
 
-    log("getPinReceiverData: pinned layer \(pinnedLayerViewModel.layer) had pinTo of \(pinnedLayerViewModel.pinTo)")
+//    log("getPinReceiverData: pinned layer \(pinnedLayerViewModel.layer) had pinTo of \(pinnedLayerViewModel.pinTo)")
                 
     guard let pinnedTo: PinToId = pinnedLayerViewModel.pinTo.getPinToId else {
         log("getPinReceiverData: no pinnedTo for layer \(pinnedLayerViewModel.layer)")
@@ -152,7 +290,8 @@ func getPinReceiverData(pinReceiverId: LayerNodeId,
                         for pinnedLayerViewModel: LayerViewModel,
                         from graph: GraphState) -> PinReceiverData? {
     
-    guard let pinReceiver = graph.layerNodes.get(pinReceiverId.id) else {
+    guard let rootPinReceiverId = graph.visibleNodesViewModel.pinMap.findRootPinReceiver(from: pinReceiverId),
+          let pinReceiver = graph.layerNodes.get(rootPinReceiverId.id) else {
         log("getPinReceiverData: no pinReceiver for layer \(pinnedLayerViewModel.layer)")
         return graph.rootPinReceiverData
     }
@@ -192,12 +331,13 @@ func getPinReceiverData(pinReceiverId: LayerNodeId,
 
 
 func getPinnedViewPosition(pinnedLayerViewModel: LayerViewModel,
-                           pinReceiverData: PinReceiverData) -> StitchPosition {
+                           pinReceiverData: PinReceiverData) -> CGPoint {
     
     adjustPosition(size: pinnedLayerViewModel.pinnedSize ?? .zero,
                    position: pinReceiverData.origin.toCGSize,
                    anchor: pinnedLayerViewModel.pinAnchor.getAnchoring ?? .topLeft,
                    parentSize: pinReceiverData.size)
+    .toCGPoint
 }
 
 

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PinningUtils.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PinningUtils.swift
@@ -103,6 +103,21 @@ extension RootPinMap {
     func getPinnedNestedLayerCount(id: LayerNodeId) -> Int {
         Array(self.values).getMaxPinnedNestedLayerCount(id: id)
     }
+    
+    /// Given some layer ID set, checks if each member of the set is located in the same pinning linked list.
+    func areLayersInSamePinFamily(idSet: LayerIdSet) -> Bool {
+        for pinData in self.values {
+            let allPins = pinData.getAllPins()
+            
+            if allPins.intersection(idSet) == idSet {
+                // If pins contains each member in ID set, exit and return true
+                return true
+            }
+        }
+        
+        // No matches
+        return false
+    }
 }
 
 extension [LayerPinData] {

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommon.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommon.swift
@@ -64,7 +64,7 @@ struct PreviewCommonModifier: ViewModifier {
             .modifier(PreviewCommonSizeModifier(
                 viewModel: layerViewModel, 
                 isPinnedViewRendering: isPinnedViewRendering,
-                pinMap: graph.graphUI.pinMap,
+                pinMap: graph.visibleNodesViewModel.pinMap,
                 aspectRatio: layerViewModel.getAspectRatioData(),
                 size: size,
                 minWidth: layerViewModel.getMinWidth,

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonMisc.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonMisc.swift
@@ -57,7 +57,7 @@ struct PreviewLayerRotationModifier: ViewModifier {
     
     @MainActor
     var receivesPin: Bool {
-        !(self.graph.graphUI.pinMap.get(viewModel.id.layerNodeId) ?? []).isEmpty
+        self.graph.visibleNodesViewModel.pinMap.get(viewModel.id.layerNodeId).isDefined
     }
     
     @MainActor

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonModifierWithoutFrame.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonModifierWithoutFrame.swift
@@ -104,7 +104,7 @@ struct PreviewCommonModifierWithoutFrame: ViewModifier {
                 nodeId: interactiveLayer.id.layerNodeId,
                 highlightedSidebarLayers: graph.graphUI.highlightedSidebarLayers,
                 scale: scale))
-
+        
             .modifier(PreviewLayerRotationModifier(
                 graph: graph,
                 viewModel: layerViewModel,

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonPositionModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonPositionModifier.swift
@@ -35,17 +35,13 @@ struct PreviewCommonPositionModifier: ViewModifier {
     // NOTE: for a pinned view, `pos` will be something adjusted to the pinReceiver's anchoring, size and position
     
     var pos: StitchPosition
-      
-    var isPinned: Bool {
-        viewModel.isPinned.getBool ?? false
-    }
     
     var isGhostView: Bool {
-        isPinned && !isPinnedViewRendering
+        viewModel.isPinnedView && !isPinnedViewRendering
     }
     
     var isPinnedView: Bool {
-        isPinned && isPinnedViewRendering
+        viewModel.isPinnedView && isPinnedViewRendering
     }
 
     func body(content: Content) -> some View {
@@ -59,31 +55,41 @@ struct PreviewCommonPositionModifier: ViewModifier {
             let pinPos = getPinnedViewPosition(pinnedLayerViewModel: viewModel,
                                                pinReceiverData: pinReceiverData)
             
+            // Ghost view equivalent of pin view passes position info for calculating
+            // final position location
+            let ghostViewPosition = self.viewModel.readMidPosition
+            let pinPositionOffset = pinPos - ghostViewPosition
+            
+            // Input value of pin offset
             let pinOffset: CGSize = viewModel.pinOffset.getSize?.asCGSize ?? .zero
             
              // logInView("PreviewCommonPositionModifier: pinPos: \(pinPos)")
              // logInView("PreviewCommonPositionModifier: pinOffset: \(pinOffset)")
             
-            content
-                .position(x: pinPos.width, y: pinPos.height)
+            positioningView(content)
+                .offset(x: pinPositionOffset.x, y: pinPositionOffset.y)
                 .offset(x: pinOffset.width, y: pinOffset.height)
             
         } else {
-            // logInView("PreviewCommonPositionModifier: regular: \(viewModel.layer)")
-            
-            // A non-PinnedView rendering of a layer uses .position unless:
-            // 1. the layer is a child inside a group that uses a VStack or HStack, or
-            // 2. it is a GhostView rendering
-            if isGhostView {
-                content
-            } else if parentDisablesPosition {
-                content
-                    .offset(x: viewModel.offsetInGroup.width,
-                            y: viewModel.offsetInGroup.height)
-            } else {
-                content
-                    .position(x: pos.width, y: pos.height)
-            }
+            positioningView(content)
+        }
+    }
+    
+    @ViewBuilder func positioningView(_ content: Content) -> some View {
+        // logInView("PreviewCommonPositionModifier: regular: \(viewModel.layer)")
+        
+        // A non-PinnedView rendering of a layer uses .position unless:
+        // 1. the layer is a child inside a group that uses a VStack or HStack, or
+        // 2. it is a GhostView rendering
+//            if isGhostView {
+//                content
+        if parentDisablesPosition {
+            content
+                .offset(x: viewModel.offsetInGroup.width,
+                        y: viewModel.offsetInGroup.height)
+        } else {
+            content
+                .position(x: pos.width, y: pos.height)
         }
     }
 }

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonPositionModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonPositionModifier.swift
@@ -78,11 +78,6 @@ struct PreviewCommonPositionModifier: ViewModifier {
     @ViewBuilder func positioningView(_ content: Content) -> some View {
         // logInView("PreviewCommonPositionModifier: regular: \(viewModel.layer)")
         
-        // A non-PinnedView rendering of a layer uses .position unless:
-        // 1. the layer is a child inside a group that uses a VStack or HStack, or
-        // 2. it is a GhostView rendering
-//            if isGhostView {
-//                content
         if parentDisablesPosition {
             content
                 .offset(x: viewModel.offsetInGroup.width,

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonSizeModifier.swift
@@ -47,7 +47,7 @@ struct PreviewCommonSizeModifier: ViewModifier {
     @Bindable var viewModel: LayerViewModel
     let isPinnedViewRendering: Bool
     
-    let pinMap: PinMap
+    let pinMap: RootPinMap
     
     let aspectRatio: AspectRatioData
     let size: LayerSize
@@ -141,7 +141,8 @@ struct PreviewCommonSizeModifier: ViewModifier {
                     minHeight: finalMinHeight,
                     maxHeight: finalMaxHeight
                 ))
-                .modifier(LayerSizeReader(viewModel: viewModel))
+                .modifier(LayerSizeReader(viewModel: viewModel,
+                                          isPinnedViewRendering: isPinnedViewRendering))
             
             // Note: the pinned view ("View A"), the ghost view AND the pin-receiver ("View B") need to read their preview-window-relative size and/or center
             // Does it matter whether this is applied before or after the other GR in LayerSizeReader?
@@ -170,7 +171,8 @@ struct PreviewCommonSizeModifier: ViewModifier {
                     minHeight: nil,
                     maxHeight: nil
                 ))
-                .modifier(LayerSizeReader(viewModel: viewModel))
+                .modifier(LayerSizeReader(viewModel: viewModel,
+                                          isPinnedViewRendering: isPinnedViewRendering))
                 .modifier(PreviewWindowCoordinateSpaceReader(
                     viewModel: viewModel,
                     isPinnedViewRendering: isPinnedViewRendering,
@@ -196,7 +198,8 @@ struct PreviewCommonSizeModifier: ViewModifier {
                     minHeight: finalMinHeight,
                     maxHeight: finalMaxHeight
                 ))
-                .modifier(LayerSizeReader(viewModel: viewModel))
+                .modifier(LayerSizeReader(viewModel: viewModel,
+                                          isPinnedViewRendering: isPinnedViewRendering))
                 .modifier(PreviewWindowCoordinateSpaceReader(
                     viewModel: viewModel,
                     isPinnedViewRendering: isPinnedViewRendering,

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
@@ -112,7 +112,7 @@ struct PreviewGroupLayer: View {
             .modifier(PreviewCommonSizeModifier(
                 viewModel: layerViewModel,
                 isPinnedViewRendering: isPinnedViewRendering,
-                pinMap: graph.graphUI.pinMap,
+                pinMap: graph.visibleNodesViewModel.pinMap,
                 aspectRatio: layerViewModel.getAspectRatioData(),
                 size: size,
                 minWidth: layerViewModel.getMinWidth,
@@ -192,7 +192,8 @@ struct PreviewGroupLayer: View {
                           parentCornerRadius: cornerRadius,
                           // i.e. if this view (a LayerGroup) uses .hug, then its children will not use their own .position values.
                           parentUsesHug: usesHug,
-                          parentGridData: gridData)
+                          parentGridData: gridData,
+                          isGhostView: !isPinnedViewRendering)
     }
 }
 

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewImage.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewImage.swift
@@ -278,11 +278,12 @@ struct PreviewImageLayer: View {
                          opacity: opacity,
                          fitStyle: fitStyle,
                          isClipped: isClipped)
-        .modifier(LayerSizeReader(viewModel: layerViewModel))
+        .modifier(LayerSizeReader(viewModel: layerViewModel,
+                                 isPinnedViewRendering: isPinnedViewRendering))
         .modifier(PreviewWindowCoordinateSpaceReader(
             viewModel: layerViewModel,
             isPinnedViewRendering: isPinnedViewRendering,
-            pinMap: graph.graphUI.pinMap))
+            pinMap: graph.visibleNodesViewModel.pinMap))
         .modifier(PreviewCommonModifierWithoutFrame(
             graph: graph,
             layerViewModel: layerViewModel,

--- a/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
@@ -70,6 +70,7 @@ final class LayerViewModel {
     // Size of the layer as read by layer's background GeometryReader,
     // see `LayerSizeReader`.
     var readSize: CGSize = .zero
+    var readMidPosition: CGPoint = .zero
 
     // Ports
     var position: PortValue
@@ -333,6 +334,10 @@ extension LayerViewModel: InteractiveLayerDelegate {
 }
 
 extension LayerViewModel {
+    var isPinnedView: Bool {
+        isPinned.getBool ?? false
+    }
+    
     @MainActor
     func updatePreviewLayer(from lengthenedValuesList: PortValuesList,
                             changedPortId: Int) {

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -265,11 +265,17 @@ extension GraphState: SchemaObserver {
     func updateOrderedPreviewLayers() {
         // Cannot use Equality check here since LayerData does not conform to Equatable;
         // so instead we should be smart about only calling this when layer nodes actually change.
-        let (previewLayers, pinMap) = self.visibleNodesViewModel
-            .recursivePreviewLayers(sidebarLayers: self.orderedSidebarLayers,
-                                    isRoot: true)
+        
+        let flattenedPinMap = self.visibleNodesViewModel.getFlattenedPinMap()
+        let rootPinMap = self.visibleNodesViewModel.getRootPinMap(pinMap: flattenedPinMap)
+        
+        let previewLayers = self.visibleNodesViewModel
+            .recursivePreviewLayers(sidebarLayersGlobal: self.orderedSidebarLayers,
+                                    pinMap: rootPinMap)
+        
         self.cachedOrderedPreviewLayers = previewLayers
-        self.graphUI.pinMap = pinMap
+        self.visibleNodesViewModel.flattenedPinMap = flattenedPinMap
+        self.visibleNodesViewModel.pinMap = rootPinMap
     }
 
     func createSchema() -> StitchDocument {

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -30,10 +30,6 @@ struct ActiveDragInteractionNodeVelocityData: Equatable, Hashable {
 
 @Observable
 final class GraphUIState {
-    
-    /// Used in rotation modifier to know whether view receives a pin;
-    /// updated whenever preview layers cache is updated.
-    var pinMap = PinMap()
 
     let propertySidebar = PropertySidebarObserver()
     

--- a/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
+++ b/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
@@ -11,12 +11,17 @@ import StitchSchemaKit
 typealias NodeEntityDict = [NodeId: NodeEntity]
 
 @Observable
-class VisibleNodesViewModel {
+final class VisibleNodesViewModel {
     // Storage for view models
     var nodes = NodesViewModelDict()
 
     // Saves location and zoom-specific data for groups
     var nodesByPage: NodesPagingDict = [.root: .init(zoomData: .init())]
+    
+    /// Used in rotation modifier to know whether view receives a pin;
+    /// updated whenever preview layers cache is updated.
+    var pinMap = RootPinMap()
+    var flattenedPinMap = PinMap()
 }
 
 extension VisibleNodesViewModel {


### PR DESCRIPTION
Big changes:
1. Pinning data is now saved in a nested data structure so we can better determine a linked list of pins. This allows us to better determine all the views to render at a specific hierarchy so that nesting is supported.
2. Revamped ghosting logic to better support orientation groups. We now render a duplicate prototype view that is totally invisible. Doing this allows us to more easily handle offset changes necessary to render a pinned view in the correct location.
3. To better support orientation groups, pinned views are rendered outside the `VStack`, `HStack` etc. This assumes shrinkage in an orientation group and can be modified in the future given priority.