### PR TITLE
Fixed drag interaction output reset on each drag

### DIFF
--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -11,6 +11,7 @@ Media improvements:
 
 Other bugs:
 - Fixed issue where “/“ characters in project titles would break project sharing
+- Fixed issue where Drag Interaction position output woud reset on each drag
 
 Other improvements:
 - CMD + . toggles visibility of both sidebars


### PR DESCRIPTION
This fixes an issue where the Drag Interaction patch would reset its position output value after each drag. This misses parity with Origami which updates position locally in the patch node, without reacting to actual position values from the layer.