### PR TITLE
Fixed crashes caused by disconnected layer nodes

### DIFF
--- a/Stitch/Graph/Node/Util/NodeDeletedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeDeletedAction.swift
@@ -95,6 +95,9 @@ extension GraphState {
 
             layerNode[keyPath: x.keyPath.layerNodeKeyPath].canvasObserver = nil
             
+            // Remove conection
+            layerNode[keyPath: x.keyPath.layerNodeKeyPath].rowObserver.upstreamOutputCoordinate = nil
+            
         case .layerOutput(let x):
             // Set the canvas-ui-data on the layer node's input = nil
             guard let layerNode = self.getNodeViewModel(x.node)?.layerNode,

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewSidebarHighlightModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewSidebarHighlightModifier.swift
@@ -32,7 +32,10 @@ struct PreviewSidebarHighlightModifier: ViewModifier {
     }
     
     var isHighlighted: Bool {
-        highlightedSidebarLayers.contains(nodeId)
+        // TODO: reads here cause a crash nodes once connected to layer inputs nodes
+        /// https://github.com/StitchDesign/Stitch/issues/264
+//        highlightedSidebarLayers.contains(nodeId)
+        false
     }
     
     // Subtract out scale, so that line is always same width


### PR DESCRIPTION
Fixes two crashes:
1. Reads of `highlightedSidebarLayers` can cause a crash, tracked in #264 
2. Connections to deleted layer nodes would cause the same unsafe memory access crash when editing an input