### PR TITLE
Use Color.clear instead of 3D Model View when generating project thumbnail

### DIFF
--- a/Stitch/Graph/Node/Layer/Type/3DModelLayerNode/PreviewModel3DLayer.swift
+++ b/Stitch/Graph/Node/Layer/Type/3DModelLayerNode/PreviewModel3DLayer.swift
@@ -53,7 +53,9 @@ struct Preview3DModelLayer: View {
 
     var body: some View {
         Group {
-            if let entity = entity {
+            if graph.isGeneratingProjectThumbnail {
+                Color.clear
+            } else if let entity = entity {
                 Model3DView(entity: entity,
                             sceneSize: size.asCGSize!,
                             modelOpacity: opacity)


### PR DESCRIPTION
Looks like I missed this case in original PR a while back.

## before 
<img width="228" alt="Screenshot 2024-09-10 at 1 11 10 PM" src="https://github.com/user-attachments/assets/ae2ec0eb-0fea-4a97-973c-908d9e3b2df7">

## after
<img width="234" alt="Screenshot 2024-09-10 at 1 11 13 PM" src="https://github.com/user-attachments/assets/6dc1e863-b100-4e8d-a1b7-29115a7ef0c2">
