### PR TITLE
Fixed issue where layer input values incorrectly changed on delete

### DIFF
--- a/Stitch/Graph/Node/Util/NodeDeletedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeDeletedAction.swift
@@ -93,10 +93,19 @@ extension GraphState {
                 return
             }
 
+            let inputPort = layerNode[keyPath: x.keyPath.layerInput.layerNodeKeyPath]
+            let prevPackMode = inputPort.mode
+            
             layerNode[keyPath: x.keyPath.layerNodeKeyPath].canvasObserver = nil
             
             // Remove conection
             layerNode[keyPath: x.keyPath.layerNodeKeyPath].rowObserver.upstreamOutputCoordinate = nil
+            
+            // Check if packed mode changed
+            let newPackMode = inputPort.mode
+            if prevPackMode != newPackMode {
+                inputPort.wasPackModeToggled()
+            }
             
         case .layerOutput(let x):
             // Set the canvas-ui-data on the layer node's input = nil


### PR DESCRIPTION
Issue was caused by pack mode changes not getting triggered due to over-reliance on the view handling this logic.