### PR TITLE
Fixed broken Reality layer node

### DIFF
--- a/Stitch/Graph/Node/Eval/MediaEvalOpObservable.swift
+++ b/Stitch/Graph/Node/Eval/MediaEvalOpObservable.swift
@@ -126,7 +126,8 @@ extension MediaEvalOpObservable {
         // A bit of a hack to get fields to update with loaded media
         if let mediaPortRow = self.nodeDelegate?.getInputRowObserver(0) {
             guard mediaPortRow.allLoopedValues.count > loopIndex else {
-                fatalErrorIfDebug()
+                // Hit on loops with anchors, likely not a big deal
+//                fatalErrorIfDebug()
                 return
             }
             

--- a/Stitch/Graph/Node/Layer/Type/RealityView/PreviewRealityLayer.swift
+++ b/Stitch/Graph/Node/Layer/Type/RealityView/PreviewRealityLayer.swift
@@ -131,7 +131,8 @@ struct RealityLayerView: View {
     
     var body: some View {
         Group {
-            if let arView = cameraFeedManager.arView,
+            if isPinnedViewRendering, // Can't run multiple reality views
+               let arView = cameraFeedManager.arView,
                !graph.isGeneratingProjectThumbnail {
                 RealityView(arView: arView,
                             size: layerSize,
@@ -146,7 +147,7 @@ struct RealityLayerView: View {
                     arView.updateAnchors(mediaList: mediaList)
                 }
             } else {
-                EmptyView()
+                Color.clear
             }
         }
         .modifier(PreviewCommonModifier(

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -1,5 +1,6 @@
 - Layer inputs now support node creation and connections into specific fields
 - Layer inspector flyout popover dismisses on scroll, tap, or pinch
+- Fixed broken Reality layer node
 - Fixed Length node to use improved counting logic for numbers and strings
 - Improved project thumbnails in home screen to remove error display from 3D model layers
 - Added placeholder default text for Soulver node


### PR DESCRIPTION
Cause by pinning implementation which created a duplicate RealityView, causing AR to no longer work.