### PR TITLE
Only allow inspector-row-selection on iOS

### DIFF
--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -182,6 +182,9 @@ extension GraphUIState {
         
         // Else select/de-select the property
         else {
+
+            // On Catalyst, use hover-only, never row-selection.
+            #if !targetEnvironment(macCatalyst)
             let alreadySelected = self.propertySidebar.selectedProperty == layerInspectorRowId
             
             withAnimation {
@@ -191,6 +194,7 @@ extension GraphUIState {
                     self.propertySidebar.selectedProperty = layerInspectorRowId
                 }
             }
+            #endif
         }
     }
 }

--- a/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
+++ b/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
@@ -200,7 +200,12 @@ struct CatalystTopBarGraphButtons: View {
 
 struct LayerInspectorToggled: GraphUIEvent {
     func handle(state: GraphUIState) {
+        
         state.showsLayerInspector.toggle()
+        
+        // reset selected inspector-row when inspector panel toggled
+        state.propertySidebar.selectedProperty = nil
+        
         state.closeFlyout()
     }
 }


### PR DESCRIPTION
Note: we currently do _not_ dismiss the row-selection-status when user scrolls etc.; only when user toggles inspector panel or selects another row

