### PR TITLE
Only show inspector section chevron on hover

### DIFF
--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -230,6 +230,7 @@ struct LayerInspectorInputsSectionView: View {
     let nodeId: NodeId
     
     @State private var expanded = true
+    @State private var isHovered = false
       
     var body: some View {
         Section(isExpanded: $expanded) {
@@ -259,8 +260,12 @@ struct LayerInspectorInputsSectionView: View {
                     .rotation3DEffect(Angle(degrees: rotationZ),
                                       axis: (x: 0, y: 0, z: rotationZ))
                     .animation(.linear(duration: 0.2), value: rotationZ)
+                    .opacity(self.isHovered ? 1 : 0)
                 
-                StitchTextView(string: sectionName.rawValue).textCase(nil)
+                StitchTextView(string: sectionName.rawValue,
+                               font: stitchFont(16))
+                    .textCase(nil)
+                    .bold()
             }
             // Note: list row insets appear to be the only way to control padding on a list's section headers
             .listRowInsets(EdgeInsets(top: 0,
@@ -268,6 +273,9 @@ struct LayerInspectorInputsSectionView: View {
                                       bottom: 0,
                                       trailing: 0))
             .contentShape(Rectangle())
+            .onHover {
+                self.isHovered = $0
+            }
             .onTapGesture {
                 withAnimation {
                     self.expanded.toggle()


### PR DESCRIPTION
Also: use larger font.

<img width="297" alt="PNG image" src="https://github.com/user-attachments/assets/bab36bff-ca57-4d38-b62e-4f733021ae10">
