### PR TITLE
Disable row-selection on inspector in Catalyst

### DIFF
--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -184,7 +184,7 @@ extension GraphUIState {
         else {
 
             // On Catalyst, use hover-only, never row-selection.
-//            #if !targetEnvironment(macCatalyst)
+            #if !targetEnvironment(macCatalyst)
             let alreadySelected = self.propertySidebar.selectedProperty == layerInspectorRowId
             
             withAnimation {
@@ -194,7 +194,7 @@ extension GraphUIState {
                     self.propertySidebar.selectedProperty = layerInspectorRowId
                 }
             }
-//            #endif
+            #endif
         }
     }
 }

--- a/Stitch/Graph/Sidebar/View/iPadProjectSidebarView.swift
+++ b/Stitch/Graph/Sidebar/View/iPadProjectSidebarView.swift
@@ -83,10 +83,6 @@ struct ProjectSidebarView: View {
         .toolbarBackground(.visible, for: .automatic)
         .toolbarBackground(Color.WHITE_IN_LIGHT_MODE_BLACK_IN_DARK_MODE, for: .automatic)
         
-//        .toolbarBackground(WHITE_IN_LIGHT_MODE_BLACK_IN_DARK_MODE, for: .automatic)
-        
-        // Change how navigation-title is dispalty
-//        .toolbarTitleDisplayMode(.inline)
 #endif
         .onChange(of: self.isEditing, initial: true) { _, newValue in
             dispatch(SidebarEditModeToggled(isEditing: newValue))


### PR DESCRIPTION
Fixing small regression from sidebar UI improvements.