### PR TITLE
Focused vs 'actively selected' layers in sidebar

### DIFF
--- a/Stitch/App/Shortcut/ProjectsHomeCommands.swift
+++ b/Stitch/App/Shortcut/ProjectsHomeCommands.swift
@@ -19,6 +19,13 @@ struct ProjectsHomeCommands: Commands {
     var activeProject: Bool {
         store.currentGraph.isDefined
     }
+    
+    var layersActivelySelected: Bool {
+        if let graph = store.currentGraph {
+            return !graph.sidebarSelectionState.inspectorFocusedLayers.activelySelected.isEmpty
+        }
+        return false
+    }
 
     var textFieldFocused: Bool {
         let k = activeReduxFocusedField.isDefined || focusedField.isDefined
@@ -47,29 +54,33 @@ struct ProjectsHomeCommands: Commands {
 
                 Divider()
 
-                SwiftUIShortcutView(title: "Insert Node",
+//                SwiftUIShortcutView(title: "Insert Node",
+                SwiftUIShortcutView(title: "Insert",
                                     key: .return) {
                     INSERT_NODE_ACTION()
                 }
 
-                SwiftUIShortcutView(title: "Duplicate Node(s)",
+//                SwiftUIShortcutView(title: "Duplicate Node(s)",
+                SwiftUIShortcutView(title: "Duplicate",
                                     key: DUPLICATE_SELECTED_NODES_SHORTCUT) {
                     // duplicates both selected nodes and selected comments
                     dispatch(SelectedGraphItemsDuplicated())
                 }
 
-                SwiftUIShortcutView(title: "Delete Node(s)",
+//                SwiftUIShortcutView(title: "Delete Node(s)",
+                SwiftUIShortcutView(title: "Delete",
                                     key: DELETE_SELECTED_NODES_SHORTCUT,
                                     // empty list = do not require CMD
                                     eventModifiers: DELETE_SELECTED_NODES_SHORTCUT_MODIFIERS) {
                     // deletes both selected nodes and selected comments
-                    dispatch(SelectedGraphItemsDeleted())
+                    dispatch(DeleteShortcutKeyPressed())
                 }
 
                 // Not shown in menu when no active project;
                 // Disabled when we have focused text input
                 //            if activeProject {
-                SwiftUIShortcutView(title: "Cut Node(s)",
+//                SwiftUIShortcutView(title: "Cut Node(s)",
+                SwiftUIShortcutView(title: "Cut",
                                     key: CUT_SELECTED_NODES_SHORTCUT,
                                     disabled: textFieldFocused) {
                     log("cut shortcut")
@@ -79,7 +90,8 @@ struct ProjectsHomeCommands: Commands {
                     dispatch(SelectedGraphItemsCut())
                 }
 
-                SwiftUIShortcutView(title: "Copy Node(s)",
+//                SwiftUIShortcutView(title: "Copy Node(s)",
+                SwiftUIShortcutView(title: "Copy",
                                     key: COPY_SELECTED_NODES_SHORTCUT,
                                     disabled: textFieldFocused) {
                     log("copy shortcut")
@@ -89,7 +101,8 @@ struct ProjectsHomeCommands: Commands {
                     dispatch(SelectedGraphItemsCopied())
                 }
                 
-                SwiftUIShortcutView(title: "Paste Node(s)",
+//                SwiftUIShortcutView(title: "Paste Node(s)",
+                SwiftUIShortcutView(title: "Paste",
                                     key: PASTE_SELECTED_NODES_SHORTCUT,
                                     disabled: textFieldFocused) {
                     log("paste shortcut")

--- a/Stitch/App/Shortcut/ProjectsHomeCommands.swift
+++ b/Stitch/App/Shortcut/ProjectsHomeCommands.swift
@@ -64,7 +64,7 @@ struct ProjectsHomeCommands: Commands {
                 SwiftUIShortcutView(title: "Duplicate",
                                     key: DUPLICATE_SELECTED_NODES_SHORTCUT) {
                     // duplicates both selected nodes and selected comments
-                    dispatch(SelectedGraphItemsDuplicated())
+                    dispatch(DuplicateShortcutKeyPressed())
                 }
 
 //                SwiftUIShortcutView(title: "Delete Node(s)",

--- a/Stitch/Graph/LayerInspector/FlyoutUtils.swift
+++ b/Stitch/Graph/LayerInspector/FlyoutUtils.swift
@@ -124,14 +124,6 @@ struct FlyoutToggled: GraphUIEvent {
     }
 }
 
-struct LeftSidebarToggled: GraphUIEvent {
-    
-    func handle(state: GraphUIState) {
-        // Reset flyout
-        state.closeFlyout()
-    }
-}
-
 struct LeftSidebarSet: GraphUIEvent {
     
     let open: Bool

--- a/Stitch/Graph/LayerInspector/LayerInspectorActions.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorActions.swift
@@ -14,7 +14,7 @@ extension GraphDelegate {
     // TODO: cache these for perf
     @MainActor
     var nonEditModeSelectedLayerInLayerSidebar: NodeId? {
-        self.sidebarSelectionState.inspectorFocusedLayers.first?.id
+        self.sidebarSelectionState.inspectorFocusedLayers.focused.first?.id
     }
     
     // TODO: cache these for perf

--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -395,20 +395,3 @@ extension GraphState {
         }
     }
 }
-
-
-
-
-//#Preview {
-//    let graph = GraphState(from: .init(), store: nil)
-//    let nodeTest = TextLayerNode.createViewModel(position: .zero,
-//                                                 zIndex: .zero,
-//                                                 activeIndex: .init(.zero),
-//                                                 graphDelegate: graph)
-//    nodeTest.isSelected = true
-//    
-//    graph.nodes.updateValue(nodeTest, forKey: nodeTest.id)
-//    
-//    return LayerInspectorView(graph: graph)
-//}
-

--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -348,7 +348,7 @@ extension GraphState {
             return nil
         }
 
-        var selectedLayers = self.sidebarSelectionState.inspectorFocusedLayers
+        var selectedLayers = self.sidebarSelectionState.inspectorFocusedLayers.focused
         
         #if DEV_DEBUG
         // For debug
@@ -379,7 +379,7 @@ extension GraphState {
         
         // else had 0 or 1 layers selected:
         else {
-            guard let inspectedLayerId = self.sidebarSelectionState.inspectorFocusedLayers.first?.id,
+            guard let inspectedLayerId = self.sidebarSelectionState.inspectorFocusedLayers.focused.first?.id,
                   let node = self.getNodeViewModel(inspectedLayerId),
                   let layerNode = node.layerNode else {
                 log("LayerInspectorView: No inspector-focused layers?:  \(self.sidebarSelectionState.inspectorFocusedLayers)")

--- a/Stitch/Graph/LayerInspector/LayerMultiselect.swift
+++ b/Stitch/Graph/LayerInspector/LayerMultiselect.swift
@@ -81,7 +81,7 @@ extension LayerInputPort {
                 
         let selectedLayers = graph.sidebarSelectionState.inspectorFocusedLayers
         
-        let observers: [LayerInputObserver] = selectedLayers.compactMap {
+        let observers: [LayerInputObserver] = selectedLayers.focused.compactMap {
             if let layerNode = graph.getNodeViewModel($0.id)?.layerNode {
                 let observer: LayerInputObserver = layerNode[keyPath: self.layerNodeKeyPath]
                 return observer

--- a/Stitch/Graph/Node/Util/NodeDeletedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeDeletedAction.swift
@@ -19,14 +19,6 @@ struct DeleteShortcutKeyPressed: GraphEventWithResponse {
         let activelySelectedLayers = state.sidebarSelectionState.inspectorFocusedLayers.activelySelected
         
         if !activelySelectedLayers.isEmpty {
-            
-//            // "Deleting actively selected layers" means we need to treat those layers as if they were deleted via the SidebarFooter "Delete" button in Sidebar Edit Mode.
-//            // So, add each actively-selected-layer as if it were an edit mode selection.
-//            activelySelectedLayers.forEach { activelySelectedLayer in
-//                state.sidebarItemSelectedViaEditMode(activelySelectedLayer)
-//            }
-            
-            // ... Then delete the layers.
             state.sidebarSelectedItemsDeletingViaEditMode()
         }
         

--- a/Stitch/Graph/Node/Util/NodeDeletedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeDeletedAction.swift
@@ -20,11 +20,11 @@ struct DeleteShortcutKeyPressed: GraphEventWithResponse {
         
         if !activelySelectedLayers.isEmpty {
             
-            // "Deleting actively selected layers" means we need to treat those layers as if they were deleted via the SidebarFooter "Delete" button in Sidebar Edit Mode.
-            // So, add each actively-selected-layer as if it were an edit mode selection.
-            activelySelectedLayers.forEach { activelySelectedLayer in
-                state.sidebarItemSelectedViaEditMode(activelySelectedLayer)
-            }
+//            // "Deleting actively selected layers" means we need to treat those layers as if they were deleted via the SidebarFooter "Delete" button in Sidebar Edit Mode.
+//            // So, add each actively-selected-layer as if it were an edit mode selection.
+//            activelySelectedLayers.forEach { activelySelectedLayer in
+//                state.sidebarItemSelectedViaEditMode(activelySelectedLayer)
+//            }
             
             // ... Then delete the layers.
             state.sidebarSelectedItemsDeletingViaEditMode()

--- a/Stitch/Graph/Node/Util/NodeDeletedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeDeletedAction.swift
@@ -10,16 +10,36 @@ import SwiftUI
 import StitchSchemaKit
 
 // Used for Delete key shortcut
-struct SelectedGraphItemsDeleted: GraphEventWithResponse {
+struct DeleteShortcutKeyPressed: GraphEventWithResponse {
     
     func handle(state: GraphState) -> GraphResponse {
 
-        // delete comment boxes
-        state.deleteSelectedCommentBoxes()
+        // Check which we have focused: layers or canvas items
+        
+        let activelySelectedLayers = state.sidebarSelectionState.inspectorFocusedLayers.activelySelected
+        
+        if !activelySelectedLayers.isEmpty {
+            
+            // "Deleting actively selected layers" means we need to treat those layers as if they were deleted via the SidebarFooter "Delete" button in Sidebar Edit Mode.
+            // So, add each actively-selected-layer as if it were an edit mode selection.
+            activelySelectedLayers.forEach { activelySelectedLayer in
+                state.sidebarItemSelectedViaEditMode(activelySelectedLayer)
+            }
+            
+            // ... Then delete the layers.
+            state.sidebarSelectedItemsDeletingViaEditMode()
+        }
+        
+        // If no layers actively selected, then assume canvas items may be selected
+        else {
+            
+            // delete comment boxes
+            state.deleteSelectedCommentBoxes()
 
-        // delete nodes
-        state.selectedGraphNodesDeleted(
-            selectedNodes: state.selectedNodeIds)
+            // delete nodes
+            state.selectedGraphNodesDeleted(
+                selectedNodes: state.selectedNodeIds)
+        }
                 
         return .shouldPersist
     }

--- a/Stitch/Graph/Node/Util/NodeDeletedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeDeletedAction.swift
@@ -20,6 +20,7 @@ struct DeleteShortcutKeyPressed: GraphEventWithResponse {
         
         if !activelySelectedLayers.isEmpty {
             state.sidebarSelectedItemsDeletingViaEditMode()
+            state.updateInspectorFocusedLayers()
         }
         
         // If no layers actively selected, then assume canvas items may be selected

--- a/Stitch/Graph/Node/View/NodeTag/TagMenuHelperViews.swift
+++ b/Stitch/Graph/Node/View/NodeTag/TagMenuHelperViews.swift
@@ -59,7 +59,7 @@ struct DuplicateNodesButton: View {
 
     var body: some View {
         TagMenuButtonView(label: label) {
-            dispatch(SelectedGraphItemsDuplicated())
+            dispatch(DuplicateShortcutKeyPressed())
         }
     }
 }

--- a/Stitch/Graph/Sidebar/Model/Gesture/SidebarSelectionState.swift
+++ b/Stitch/Graph/Sidebar/Model/Gesture/SidebarSelectionState.swift
@@ -13,13 +13,25 @@ typealias OrderedLayerNodeIdSet = OrderedSet<LayerNodeId>
 typealias SidebarSelections = LayerIdSet
 typealias NonEmptySidebarSelections = NonEmptyLayerIdSet
 
+/*
+ 
+ */
+struct InspectorFocusedLayers: Codable, Equatable, Hashable {
+    
+    // Focused = what we see focused in the inspector
+    var focused = LayerIdSet()
+    
+    // Actively Selected = what we see focused in inspector + what user has recently tapped on
+    var activelySelected = LayerIdSet()
+}
+
 // if a group is selected,
 struct SidebarSelectionState: Codable, Equatable, Hashable {
     
     var isEditMode: Bool = false
         
     // Layers focused in the inspector
-    var inspectorFocusedLayers = LayerIdSet()
+    var inspectorFocusedLayers = InspectorFocusedLayers() //LayerIdSet()
     
     // items selected because directly clicked
     var primary = SidebarSelections()

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
@@ -82,11 +82,13 @@ extension GraphState {
     @MainActor
     func updateInspectorFocusedLayers() {
         
+        #if !targetEnvironment(macCatalyst)
         // If left sidebar is in edit-mode, "primary selections" become inspector-focused
         if self.sidebarSelectionState.isEditMode {
             self.sidebarSelectionState.inspectorFocusedLayers.focused = self.sidebarSelectionState.primary
             self.sidebarSelectionState.inspectorFocusedLayers.activelySelected = self.sidebarSelectionState.primary
         }
+        #endif
         
         if self.sidebarSelectionState.inspectorFocusedLayers.focused.count > 1 {
             self.graphUI.propertySidebar.inputsCommonToSelectedLayers = self.multipleSidebarLayersSelected()

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
@@ -46,7 +46,7 @@ struct SidebarItemTapped: GraphEvent {
             } else {
                 state.sidebarSelectionState.inspectorFocusedLayers.focused.insert(id)
                 state.sidebarSelectionState.inspectorFocusedLayers.activelySelected.insert(id)
-                state.sidebarItemSelectedViaEditMode(id)
+                state.sidebarItemSelectedViaEditMode(id, isSidebarItemTapped: true)
                 state.deselectAllCanvasItems()
             }
             
@@ -61,7 +61,7 @@ struct SidebarItemTapped: GraphEvent {
             state.sidebarSelectionState.inspectorFocusedLayers.activelySelected = .init([id])
             
             
-            state.sidebarItemSelectedViaEditMode(id)
+            state.sidebarItemSelectedViaEditMode(id, isSidebarItemTapped: true)
             
             // But also need to deselect all other
             
@@ -156,8 +156,7 @@ struct SidebarItemSelected: GraphEvent {
     let id: LayerNodeId
     
     func handle(state: GraphState) {
-        state.sidebarItemSelectedViaEditMode(id,
-                                             isSidebarItemTapped: false)
+        state.sidebarItemSelectedViaEditMode(id, isSidebarItemTapped: false)
     }
 }
 
@@ -165,7 +164,7 @@ extension GraphState {
     
     @MainActor
     func sidebarItemSelectedViaEditMode(_ id: LayerNodeId,
-                                        isSidebarItemTapped: Bool = true) {
+                                        isSidebarItemTapped: Bool) {
         let sidebarGroups = self.getSidebarGroupsDict()
         
         // if we actively-selected (non-edit-mode-selected) an item that is already secondarily-selected, we don't need to change the

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
@@ -10,21 +10,6 @@ import StitchSchemaKit
 import SwiftUI
 import OrderedCollections
 
-//extension InspectorFocusedLayers {
-//    func layerActivelySelected(_ id: LayerNodeId) -> Self {
-//        var layerSet = self
-//        layerSet.focused.insert(id)
-//        layerSet.activelySelected.insert(id)
-//        return layerSet
-//    }
-//    
-//    func layerActivelyDeselected(_ id: LayerNodeId) -> Self {
-//        var layerSet = self
-//        layerSet.focused.remove(id)
-//        layerSet.activelySelected.remove(id)
-//        return layerSet
-//    }
-//}
 
 // Sidebar layer 'tapped' while not in
 struct SidebarItemTapped: GraphEvent {
@@ -51,21 +36,12 @@ struct SidebarItemTapped: GraphEvent {
             }
             
         } else {
-            
             state.sidebarSelectionState.resetEditModeSelections()
             
             // Note: Click will not deselect an already-selected layer
-            
-            
             state.sidebarSelectionState.inspectorFocusedLayers.focused = .init([id])
             state.sidebarSelectionState.inspectorFocusedLayers.activelySelected = .init([id])
-            
-            
             state.sidebarItemSelectedViaEditMode(id, isSidebarItemTapped: true)
-            
-            // But also need to deselect all other
-            
-            
             state.deselectAllCanvasItems()
         }
         
@@ -199,18 +175,8 @@ extension GraphState {
             // if the parent is currently selected,
             // then deselect the parent and all other children
             if self.sidebarSelectionState.isSelected(parent) {
-                
-//                if isSidebarItemTapped {
-//                    // Special case: if we're actively-selecting this layer,
-//                    // but the parent is already selected, then do not change
-//
-//                } else {
                     self.sidebarSelectionState.resetEditModeSelections()
                     self.sidebarSelectionState = addExclusivelyToPrimary(id, self.sidebarSelectionState)
-//                }
-                
-//                self.sidebarSelectionState.resetEditModeSelections()
-//                self.sidebarSelectionState = addExclusivelyToPrimary(id, self.sidebarSelectionState)
             }
 
             // ... otherwise, just primarily select the child

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarSelectedItemsDeleted.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarSelectedItemsDeleted.swift
@@ -14,22 +14,25 @@ import SwiftUI
 struct SidebarSelectedItemsDeleted: GraphEventWithResponse {
 
     func handle(state: GraphState) -> GraphResponse {
-        // Does deletion order matter?
-        let deletedIds = state.sidebarSelectionState.all.map(\.id)
+        state.sidebarSelectedItemsDeletingViaEditMode()
+        return .shouldPersist
+    }
+}
+
+extension GraphState {
+    func sidebarSelectedItemsDeletingViaEditMode() {
+        let deletedIds = self.sidebarSelectionState.all.map(\.id)
         
         deletedIds.forEach {
-            state.visibleNodesViewModel.nodes.removeValue(forKey: $0)
+            self.visibleNodesViewModel.nodes.removeValue(forKey: $0)
         }
-        
 
-        state.updateSidebarListStateAfterStateChange()
+        self.updateSidebarListStateAfterStateChange()
         
         // TODO: why is this necessary?
         _updateStateAfterListChange(
-            updatedList: state.sidebarListState,
-            expanded: state.getSidebarExpandedItems(),
-            graphState: state)
-
-        return .shouldPersist
+            updatedList: self.sidebarListState,
+            expanded: self.getSidebarExpandedItems(),
+            graphState: self)
     }
 }

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarSelectedItemsDuplicated.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarSelectedItemsDuplicated.swift
@@ -11,9 +11,14 @@ import Foundation
 struct SidebarSelectedItemsDuplicated: GraphEventWithResponse {
 
     func handle(state: GraphState) -> GraphResponse {
-        state.copyAndPasteSelectedNodes(selectedNodeIds: state.sidebarSelectionState.all.map(\.asNodeId).toSet)
+        state.sidebarSelectedItemsDeletingViaEditMode()
         return .persistenceResponse
     }
 }
 
-
+extension GraphState {
+    @MainActor
+    func sidebarSelectedItemsDuplicatedViaEditMode() {
+        self.copyAndPasteSelectedNodes(selectedNodeIds: self.sidebarSelectionState.all.map(\.asNodeId).toSet)
+    }
+}

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarSelectedItemsDuplicated.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarSelectedItemsDuplicated.swift
@@ -11,7 +11,7 @@ import Foundation
 struct SidebarSelectedItemsDuplicated: GraphEventWithResponse {
 
     func handle(state: GraphState) -> GraphResponse {
-        state.sidebarSelectedItemsDeletingViaEditMode()
+        state.sidebarSelectedItemsDuplicatedViaEditMode()
         return .persistenceResponse
     }
 }

--- a/Stitch/Graph/Sidebar/Util/SidebarListItemGroupActions.swift
+++ b/Stitch/Graph/Sidebar/Util/SidebarListItemGroupActions.swift
@@ -39,7 +39,8 @@ extension GraphState {
                                                 self.sidebarListState.masterList.items)
         
         for childen in descendants {
-            self.sidebarSelectionState.inspectorFocusedLayers.remove(childen.id.asLayerNodeId)
+            self.sidebarSelectionState.inspectorFocusedLayers.focused.remove(childen.id.asLayerNodeId)
+            self.sidebarSelectionState.inspectorFocusedLayers.activelySelected.remove(childen.id.asLayerNodeId)
         }
     }
 }

--- a/Stitch/Graph/Sidebar/View/SidebarFooterView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarFooterView.swift
@@ -59,6 +59,82 @@ struct SidebarFooterView: View {
     
     @MainActor
     var editModeFooter: some View {
+        
+        HStack(spacing: 10) {
+            Spacer()
+            SidebarFooterButtonsView(groups: groups,
+                                     selections: selections,
+                                     isBeingEdited: isBeingEdited,
+                                     layerNodes: layerNodes)
+        }
+        
+        
+        
+//        let allButtonsDisabled = selections.all.isEmpty
+//        
+//        let ungroupButtonEnabled = canUngroup(selections.primary,
+//                                              nodes: layerNodes)
+//
+//        let groupButtonEnabled = selections
+//            .nonEmptyPrimary
+//            .map { canBeGrouped($0, groups: groups) } ?? false
+//
+//        let duplicateButtonEnabled = canDuplicate(selections.primary)
+//
+//        return HStack(spacing: 10) {
+//            Spacer()
+//            StitchButton {
+//                dispatch(SidebarGroupUncreated())
+//            } label: {
+//                Text("Ungroup")
+//                    .modifier(DisabledButtonModifier(buttonEnabled: ungroupButtonEnabled))
+//            }.disabled(!ungroupButtonEnabled)
+//            
+//            StitchButton {
+//                dispatch(SidebarGroupCreated())
+//            } label: {
+//                Text("Group")
+//                    .modifier(DisabledButtonModifier(buttonEnabled: groupButtonEnabled))
+//            }
+//            .disabled(!groupButtonEnabled)
+//            
+//            StitchButton {
+//                log("SidebarFooterView duplicate tapped")
+//                dispatch(SidebarSelectedItemsDuplicated())
+//            } label: {
+//                Text("Duplicate")
+//                    .modifier(DisabledButtonModifier(buttonEnabled: duplicateButtonEnabled))
+//            }.disabled(!duplicateButtonEnabled)
+//            
+//            StitchButton {
+//                log("SidebarFooterView delete tapped")
+//                dispatch(SidebarSelectedItemsDeleted())
+//            } label: {
+//                Text("Delete")
+//                    .modifier(DisabledButtonModifier(buttonEnabled: !allButtonsDisabled))
+//            }.disabled(allButtonsDisabled)
+//        }
+    } // editModeFooter
+}
+
+// TODO: apply `.foregroundColor(Color(.titleFont))` in `StitchButton` messes with SwiftUI's native gray-out of disabled buttons?
+struct DisabledButtonModifier: ViewModifier {
+    let buttonEnabled: Bool
+    
+    func body(content: Content) -> some View {
+        content
+            .foregroundColor(buttonEnabled ? Color(.titleFont) : Color.gray.opacity(0.8))
+    }
+}
+
+struct SidebarFooterButtonsView: View {
+    
+    let groups: SidebarGroupsDict
+    let selections: SidebarSelectionState
+    let isBeingEdited: Bool
+    let layerNodes: LayerNodesForSidebarDict
+    
+    var body: some View {
         let allButtonsDisabled = selections.all.isEmpty
         
         let ungroupButtonEnabled = canUngroup(selections.primary,
@@ -70,8 +146,9 @@ struct SidebarFooterView: View {
 
         let duplicateButtonEnabled = canDuplicate(selections.primary)
 
-        return HStack(spacing: 10) {
-            Spacer()
+//        return HStack(spacing: 10) {
+        return Group {
+//            Spacer()
             StitchButton {
                 dispatch(SidebarGroupUncreated())
             } label: {
@@ -103,15 +180,5 @@ struct SidebarFooterView: View {
                     .modifier(DisabledButtonModifier(buttonEnabled: !allButtonsDisabled))
             }.disabled(allButtonsDisabled)
         }
-    } // editModeFooter
-}
-
-// TODO: apply `.foregroundColor(Color(.titleFont))` in `StitchButton` messes with SwiftUI's native gray-out of disabled buttons?
-struct DisabledButtonModifier: ViewModifier {
-    let buttonEnabled: Bool
-    
-    func body(content: Content) -> some View {
-        content
-            .foregroundColor(buttonEnabled ? Color(.titleFont) : Color.gray.opacity(0.8))
     }
 }

--- a/Stitch/Graph/Sidebar/View/SidebarFooterView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarFooterView.swift
@@ -59,7 +59,6 @@ struct SidebarFooterView: View {
     
     @MainActor
     var editModeFooter: some View {
-        
         HStack(spacing: 10) {
             Spacer()
             SidebarFooterButtonsView(groups: groups,
@@ -67,53 +66,6 @@ struct SidebarFooterView: View {
                                      isBeingEdited: isBeingEdited,
                                      layerNodes: layerNodes)
         }
-        
-        
-        
-//        let allButtonsDisabled = selections.all.isEmpty
-//        
-//        let ungroupButtonEnabled = canUngroup(selections.primary,
-//                                              nodes: layerNodes)
-//
-//        let groupButtonEnabled = selections
-//            .nonEmptyPrimary
-//            .map { canBeGrouped($0, groups: groups) } ?? false
-//
-//        let duplicateButtonEnabled = canDuplicate(selections.primary)
-//
-//        return HStack(spacing: 10) {
-//            Spacer()
-//            StitchButton {
-//                dispatch(SidebarGroupUncreated())
-//            } label: {
-//                Text("Ungroup")
-//                    .modifier(DisabledButtonModifier(buttonEnabled: ungroupButtonEnabled))
-//            }.disabled(!ungroupButtonEnabled)
-//            
-//            StitchButton {
-//                dispatch(SidebarGroupCreated())
-//            } label: {
-//                Text("Group")
-//                    .modifier(DisabledButtonModifier(buttonEnabled: groupButtonEnabled))
-//            }
-//            .disabled(!groupButtonEnabled)
-//            
-//            StitchButton {
-//                log("SidebarFooterView duplicate tapped")
-//                dispatch(SidebarSelectedItemsDuplicated())
-//            } label: {
-//                Text("Duplicate")
-//                    .modifier(DisabledButtonModifier(buttonEnabled: duplicateButtonEnabled))
-//            }.disabled(!duplicateButtonEnabled)
-//            
-//            StitchButton {
-//                log("SidebarFooterView delete tapped")
-//                dispatch(SidebarSelectedItemsDeleted())
-//            } label: {
-//                Text("Delete")
-//                    .modifier(DisabledButtonModifier(buttonEnabled: !allButtonsDisabled))
-//            }.disabled(allButtonsDisabled)
-//        }
     } // editModeFooter
 }
 

--- a/Stitch/Graph/Sidebar/View/SidebarFooterView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarFooterView.swift
@@ -20,9 +20,19 @@ struct SidebarFooterView: View {
     let syncStatus: iCloudSyncStatus
     let layerNodes: LayerNodesForSidebarDict
 
+    var showEditModeFooter: Bool {
+        #if targetEnvironment(macCatalyst)
+        // on Catalyst, show edit mode footer if we're in edit-mode or have at least one edit-mode-selection
+        return !selections.primary.isEmpty
+        #else
+        // on iPad, only show edit mode footer in edit-mode
+        return isBeingEdited
+        #endif
+    }
+    
     var body: some View {
         HStack {
-            if isBeingEdited {
+            if showEditModeFooter {
                 editModeFooter
                     .animation(.default, value: isBeingEdited)
             } else {
@@ -31,7 +41,7 @@ struct SidebarFooterView: View {
             }
         }
         .padding()
-        .animation(.default, value: isBeingEdited)
+        .animation(.default, value: showEditModeFooter)
         .animation(.default, value: selections)
         .animation(.default, value: groups)
         .animation(.default, value: layerNodes)

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemChevronView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemChevronView.swift
@@ -18,7 +18,7 @@ struct SidebarListItemChevronView: View {
     let parentId: LayerNodeId
     
     // white when layer is non-edit-mode selected; else determined by primary vs secondary selection status
-    let color: Color
+    let fontColor: Color
 
     let isHidden: Bool
     
@@ -43,7 +43,7 @@ struct SidebarListItemChevronView: View {
             .frame(width: SIDEBAR_LIST_ITEM_ICON_AND_TEXT_AREA_HEIGHT,
                    height: SIDEBAR_LIST_ITEM_ICON_AND_TEXT_AREA_HEIGHT)
         
-            .foregroundColor(color)
+            .foregroundColor(fontColor)
             .rotation3DEffect(Angle(degrees: rotationZ),
                               axis: (x: 0, y: 0, z: rotationZ))
                 

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemSelectionCircleView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemSelectionCircleView.swift
@@ -16,7 +16,7 @@ struct SidebarListItemSelectionCircleView: View {
     let id: LayerNodeId
     
     // white when layer is non-edit-mode selected; else determined by primary vs secondary selection status
-    let color: Color
+    let fontColor: Color
     
     let selection: SidebarListItemSelectionStatus
     let isHidden: Bool
@@ -41,7 +41,7 @@ struct SidebarListItemSelectionCircleView: View {
     @MainActor
     var selectionCircle: some View {
         Image(systemName: iconName)
-            .foregroundColor(color)
+            .foregroundColor(fontColor)
             .frame(width: SIDEBAR_ITEM_ICON_LENGTH,
                    height: SIDEBAR_ITEM_ICON_LENGTH)
             .padding(4)

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemView.swift
@@ -42,8 +42,17 @@ struct SidebarListItemView: View {
         item.id.asLayerNodeId
     }
     
+    var isNonEditModeFocused: Bool {
+        graph.sidebarSelectionState.inspectorFocusedLayers.focused.contains(layerNodeId)
+    }
+    
+    var isNonEditModeActivelySelected: Bool {
+        graph.sidebarSelectionState.inspectorFocusedLayers.activelySelected.contains(layerNodeId)
+    }
+    
+    // TODO: SEPT 18
     var isNonEditModeSelected: Bool {
-        graph.sidebarSelectionState.inspectorFocusedLayers.contains(layerNodeId)
+        isNonEditModeFocused || isNonEditModeActivelySelected
     }
         
     var body: some View {
@@ -76,7 +85,7 @@ struct SidebarListItemView: View {
         .frame(height: SIDEBAR_LIST_ITEM_ROW_COLORED_AREA_HEIGHT)
         .background {
             if isNonEditModeSelected || isBeingDragged {
-                theme.fontColor
+                theme.fontColor.opacity((isNonEditModeFocused && !isNonEditModeActivelySelected) ? 0.5 : 1)
             }
         }
         

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemView.swift
@@ -70,25 +70,30 @@ struct SidebarListItemView: View {
                 isClosed: isClosed)
             
 //            .padding(.leading)
-            
                 .offset(x: -swipeOffset)
             Spacer()
 
         }
+        
         .contentShape(Rectangle()) // for hit area
 
-        //        .background(Color.white.opacity(0.001)) // for hit area
         //        .background(.ultraThinMaterial.opacity(isBeingDragged ? 1 : 0))
         //        .background(.thinMaterial.opacity(isNonEditModeSelected ? 1 : 0))
                 
         .frame(height: SIDEBAR_LIST_ITEM_ROW_COLORED_AREA_HEIGHT)
-        .background {
-            if isNonEditModeSelected || isBeingDragged {
-                theme.fontColor.opacity((isNonEditModeFocused && !isNonEditModeActivelySelected) ? 0.5 : 1)
-            }
-        }
         
-        .cornerRadius(SWIPE_FULL_CORNER_RADIUS)
+        // To have color limited by indentation level etc.:
+        
+//        .background {
+//            if isNonEditModeSelected || isBeingDragged {
+//                theme.fontColor
+//                    .opacity((isNonEditModeFocused && !isNonEditModeActivelySelected) ? 0.5 : 1)
+////                    .frame(maxWidth: .infinity)
+////                    .border(.green, width: 4)
+//            }
+//        }
+        
+//        .cornerRadius(SWIPE_FULL_CORNER_RADIUS)
         
         // Note: given that we apparently must use the UIKitTappableWrapper on the swipe menu buttons,
         // we need to place the SwiftUI TapGesture below the swipe menu.

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemView.swift
@@ -50,7 +50,6 @@ struct SidebarListItemView: View {
         graph.sidebarSelectionState.inspectorFocusedLayers.activelySelected.contains(layerNodeId)
     }
     
-    // TODO: SEPT 18
     var isNonEditModeSelected: Bool {
         isNonEditModeFocused || isNonEditModeActivelySelected
     }
@@ -79,8 +78,8 @@ struct SidebarListItemView: View {
         .contentShape(Rectangle()) // for hit area
 
         //        .background(Color.white.opacity(0.001)) // for hit area
-//        .background(.ultraThinMaterial.opacity(isBeingDragged ? 1 : 0))
-//        .background(.thinMaterial.opacity(isNonEditModeSelected ? 1 : 0))
+        //        .background(.ultraThinMaterial.opacity(isBeingDragged ? 1 : 0))
+        //        .background(.thinMaterial.opacity(isNonEditModeSelected ? 1 : 0))
                 
         .frame(height: SIDEBAR_LIST_ITEM_ROW_COLORED_AREA_HEIGHT)
         .background {
@@ -108,10 +107,3 @@ struct SidebarListItemView: View {
         .animation(.default, value: isBeingDragged)
     }
 }
-
-// struct CustomListItemView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        //        CustomListItemView()
-//        TEST_CustomListItemBaseView()
-//    }
-// }

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemView.swift
@@ -22,7 +22,7 @@ struct SidebarListItemView: View {
     var isClosed: Bool
     
     // white when layer is non-edit-mode selected; else determined by primary vs secondary selection status
-    let color: Color
+    let fontColor: Color
     
     let selection: SidebarListItemSelectionStatus
     let isBeingEdited: Bool
@@ -63,7 +63,7 @@ struct SidebarListItemView: View {
                 name: name,
                 layer: layer,
                 nodeId: layerNodeId,
-                color: color,
+                fontColor: fontColor,
                 selection: selection,
                 isHidden: isHidden,
                 isBeingEdited: isBeingEdited,

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListLabelView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListLabelView.swift
@@ -17,7 +17,7 @@ struct SidebarListItemLeftLabelView: View {
     let nodeId: LayerNodeId // debug
     
     // white when layer is non-edit-mode selected; else determined by primary vs secondary selection status
-    let color: Color
+    let fontColor: Color
     
     let selection: SidebarListItemSelectionStatus
     let isHidden: Bool
@@ -83,7 +83,7 @@ struct SidebarListItemLeftLabelView: View {
                 #endif
                     .frame(width: SIDEBAR_LIST_ITEM_ICON_AND_TEXT_AREA_HEIGHT,
                            height: SIDEBAR_LIST_ITEM_ICON_AND_TEXT_AREA_HEIGHT)
-                    .foregroundColor(color)
+                    .foregroundColor(fontColor)
                     .opacity(masks ? 1 : 0)
                     .animation(.linear, value: masks)
                     // .border(.red)
@@ -92,7 +92,7 @@ struct SidebarListItemLeftLabelView: View {
 //            if isGroup {
                 SidebarListItemChevronView(isClosed: isClosed,
                                            parentId: nodeId,
-                                           color: color,
+                                           fontColor: fontColor,
                                            isHidden: isHidden)
                 .opacity(isGroup ? 1 : 0)
                 // .border(.green)
@@ -104,11 +104,11 @@ struct SidebarListItemLeftLabelView: View {
                 .padding(2)
                 .frame(width: SIDEBAR_LIST_ITEM_ICON_AND_TEXT_AREA_HEIGHT,
                        height: SIDEBAR_LIST_ITEM_ICON_AND_TEXT_AREA_HEIGHT)
-                .foregroundColor(color)
+                .foregroundColor(fontColor)
                 // .border(.yellow)
             
             label
-                .foregroundColor(color)
+                .foregroundColor(fontColor)
         }
         .padding(.leading, 4)
 //        .padding(.leading, isGroup ? 4 : 0)
@@ -120,7 +120,7 @@ struct SidebarListItemLeftLabelView: View {
             if isBeingEdited {
                 StitchTextView(string: _name,
                                font: SIDEBAR_LIST_ITEM_FONT,
-                               fontColor: color)
+                               fontColor: fontColor)
                 .truncationMode(.tail)
 #if targetEnvironment(macCatalyst)
                 .padding(.trailing, 44)
@@ -130,7 +130,7 @@ struct SidebarListItemLeftLabelView: View {
             } else {
                 StitchTextView(string: _name,
                                font: SIDEBAR_LIST_ITEM_FONT,
-                               fontColor: color)
+                               fontColor: fontColor)
             }
         }
         .lineLimit(1)
@@ -144,7 +144,7 @@ struct SidebarListItemRightLabelView: View {
     let isClosed: Bool
     
     // white when layer is non-edit-mode selected; else determined by primary vs secondary selection status
-    let color: Color
+    let fontColor: Color
     
     let selection: SidebarListItemSelectionStatus
     let isBeingEdited: Bool // is sidebar being edited?
@@ -161,7 +161,7 @@ struct SidebarListItemRightLabelView: View {
             if isBeingEditedAnimated {
                 HStack(spacing: .zero) {
                     SidebarListItemSelectionCircleView(id: id,
-                                                       color: color,
+                                                       fontColor: fontColor,
                                                        selection: selection,
                                                        isHidden: isHidden,
                                                        isBeingEdited: isBeingEdited)

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListLabelView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListLabelView.swift
@@ -69,25 +69,6 @@ struct SidebarListItemLeftLabelView: View {
     
     var body: some View {
         HStack(spacing: 4) {
-//        HStack(spacing: 0) {
-            
-            if masks {
-                Image(systemName: MASKS_LAYER_ABOVE_ICON_NAME)
-//                    .scaleEffect(1.2) // previously: 1.0 or 1.4
-                    .resizable()
-                    .scaledToFit()
-                #if targetEnvironment(macCatalyst)
-                    .padding(2)
-                #else
-                    .padding(4)
-                #endif
-                    .frame(width: SIDEBAR_LIST_ITEM_ICON_AND_TEXT_AREA_HEIGHT,
-                           height: SIDEBAR_LIST_ITEM_ICON_AND_TEXT_AREA_HEIGHT)
-                    .foregroundColor(fontColor)
-                    .opacity(masks ? 1 : 0)
-                    .animation(.linear, value: masks)
-                    // .border(.red)
-            }
             
 //            if isGroup {
                 SidebarListItemChevronView(isClosed: isClosed,
@@ -100,18 +81,34 @@ struct SidebarListItemLeftLabelView: View {
   
             Image(systemName: layer.sidebarLeftSideIcon)
                 .resizable()
-                .scaledToFit()
                 .padding(2)
                 .frame(width: SIDEBAR_LIST_ITEM_ICON_AND_TEXT_AREA_HEIGHT,
                        height: SIDEBAR_LIST_ITEM_ICON_AND_TEXT_AREA_HEIGHT)
                 .foregroundColor(fontColor)
-                // .border(.yellow)
+                .overlay(alignment: .bottomLeading) {
+                    ZStack {
+                        
+                        VisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
+                        
+                        Image(systemName: MASKS_LAYER_ABOVE_ICON_NAME)
+                            .resizable()
+                            .scaledToFit()
+                            .padding(2)
+                            .offset(x: -0.5)
+                            .foregroundColor(fontColor)
+                    }
+                    .frame(width: SIDEBAR_LIST_ITEM_ICON_AND_TEXT_AREA_HEIGHT/2,
+                           height: SIDEBAR_LIST_ITEM_ICON_AND_TEXT_AREA_HEIGHT/2)
+                    .foregroundColor(fontColor)
+                    .opacity(masks ? 1 : 0)
+                    .animation(.linear, value: masks)
+                    .cornerRadius(4)
+                }
             
             label
                 .foregroundColor(fontColor)
         }
         .padding(.leading, 4)
-//        .padding(.leading, isGroup ? 4 : 0)
         .frame(height: SIDEBAR_LIST_ITEM_ICON_AND_TEXT_AREA_HEIGHT)
     }
     

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeInnerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeInnerView.swift
@@ -37,7 +37,7 @@ struct SidebarListItemSwipeInnerView: View {
     }
 
     var isNonEditModeSelected: Bool {
-        graph.sidebarSelectionState.inspectorFocusedLayers.contains(item.id.asLayerNodeId)
+        graph.sidebarSelectionState.inspectorFocusedLayers.focused.contains(item.id.asLayerNodeId)
     }
     
     var color: Color {

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeInnerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeInnerView.swift
@@ -43,8 +43,13 @@ struct SidebarListItemSwipeInnerView: View {
         if isNonEditModeSelected {
             return .white
         }
-            
-        else if isBeingEdited {
+           
+        #if DEV_DEBUG
+        // Easier to see secondary selections for debug
+        return selection.color(isHidden)
+        #endif
+        
+        if isBeingEdited {
             return selection.color(isHidden)
         } else {
             return SIDE_BAR_OPTIONS_TITLE_FONT_COLOR

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeInnerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeInnerView.swift
@@ -11,6 +11,8 @@ import StitchSchemaKit
 
 struct SidebarListItemSwipeInnerView: View {
     
+    @Environment(\.appTheme) var theme
+    
     @Bindable var graph: GraphState
     
     var item: SidebarListItem
@@ -35,10 +37,6 @@ struct SidebarListItemSwipeInnerView: View {
     var isHidden: Bool {
         graph.getVisibilityStatus(for: item.id.asNodeId) != .visible
     }
-
-    var isNonEditModeSelected: Bool {
-        graph.sidebarSelectionState.inspectorFocusedLayers.focused.contains(item.id.asLayerNodeId)
-    }
     
     var fontColor: Color {
         // Any 'focused' (doesn't have to be 'actively selected') layer uses white text
@@ -52,6 +50,27 @@ struct SidebarListItemSwipeInnerView: View {
             return SIDE_BAR_OPTIONS_TITLE_FONT_COLOR
         }
     }
+    
+    var layerNodeId: LayerNodeId {
+        item.id.asLayerNodeId
+    }
+    
+    var isBeingDragged: Bool {
+        current.map { $0.current == item.id } ?? false
+    }
+    
+    var isNonEditModeFocused: Bool {
+        graph.sidebarSelectionState.inspectorFocusedLayers.focused.contains(layerNodeId)
+    }
+    
+    var isNonEditModeActivelySelected: Bool {
+        graph.sidebarSelectionState.inspectorFocusedLayers.activelySelected.contains(layerNodeId)
+    }
+    
+    var isNonEditModeSelected: Bool {
+        isNonEditModeFocused || isNonEditModeActivelySelected
+    }
+        
 
     var body: some View {
         HStack(spacing: .zero) {
@@ -70,8 +89,18 @@ struct SidebarListItemSwipeInnerView: View {
                                     isBeingEdited: isBeingEdited,
                                     isHidden: isHidden,
                                     swipeOffset: swipeX)
-                
+//                .background {
+//                    Color.yellow.opacity(0.5)
+//                }
                     .padding(.leading, itemIndent + 5)
+                    .background {
+                        if isNonEditModeSelected || isBeingDragged {
+                            theme.fontColor
+                                .opacity((isNonEditModeFocused && !isNonEditModeActivelySelected) ? 0.5 : 1)
+            //                    .frame(maxWidth: .infinity)
+            //                    .border(.green, width: 4)
+                        }
+                    }
 
                     // right-side label overlay comes AFTER x-placement of item,
                     // so as not to be affected by x-placement.

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeInnerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeInnerView.swift
@@ -40,12 +40,17 @@ struct SidebarListItemSwipeInnerView: View {
         graph.sidebarSelectionState.inspectorFocusedLayers.focused.contains(item.id.asLayerNodeId)
     }
     
-    var color: Color {
+    var fontColor: Color {
+        // Any 'focused' (doesn't have to be 'actively selected') layer uses white text
         if isNonEditModeSelected {
             return .white
         }
-        
-        return selection.color(isHidden)
+            
+        else if isBeingEdited {
+            return selection.color(isHidden)
+        } else {
+            return SIDE_BAR_OPTIONS_TITLE_FONT_COLOR
+        }
     }
 
     var body: some View {
@@ -60,7 +65,7 @@ struct SidebarListItemSwipeInnerView: View {
                                     current: current,
                                     proposedGroup: proposedGroup,
                                     isClosed: isClosed,
-                                    color: color,
+                                    fontColor: fontColor,
                                     selection: selection,
                                     isBeingEdited: isBeingEdited,
                                     isHidden: isHidden,
@@ -75,7 +80,7 @@ struct SidebarListItemSwipeInnerView: View {
                             item: item,
                             isGroup: item.isGroup,
                             isClosed: isClosed,
-                            color: color,
+                            fontColor: fontColor,
                             selection: selection,
                             isBeingEdited: isBeingEdited,
                             isHidden: isHidden)

--- a/Stitch/Graph/Sidebar/View/SidebarListView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarListView.swift
@@ -125,6 +125,7 @@ struct SidebarListView: View {
                         isBeingEdited: isBeingEditedAnimated,
                         activeGesture: $activeGesture,
                         activeSwipeId: $activeSwipeId)
+                    
 #if targetEnvironment(macCatalyst)
                     .modifier(SidebarListItemContextMenuModifier(layerNodeId: item.id.asLayerNodeId,
                                                                  groups: groups,
@@ -132,6 +133,7 @@ struct SidebarListView: View {
                                                                  isBeingEdited: isBeingEdited,
                                                                  layerNodes: layerNodesForSidebarDict))
 #endif
+                    
                     .zIndex(item.zIndex)
                     .transition(.move(edge: .top).combined(with: .opacity))
                 } // ForEach

--- a/Stitch/Graph/Sidebar/View/SidebarListView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarListView.swift
@@ -108,6 +108,11 @@ struct SidebarListView: View {
                 }
                 
                 ForEach(masterList.items, id: \.id.value) { (item: SidebarListItem) in
+                    
+                    let selection = getSelectionStatus(
+                        item.id.asLayerNodeId,
+                        selections)
+                    
                     SidebarListItemSwipeView(
                         graph: $graph,
                         item: item,
@@ -116,19 +121,24 @@ struct SidebarListView: View {
                         current: current,
                         proposedGroup: sidebarListState.proposedGroup,
                         isClosed: masterList.collapsedGroups.contains(item.id),
-                        selection: getSelectionStatus(
-                            item.id.asLayerNodeId,
-                            selections),
+                        selection: selection,
                         isBeingEdited: isBeingEditedAnimated,
                         activeGesture: $activeGesture,
                         activeSwipeId: $activeSwipeId)
                     // Would `primaryAction` help with right click?: https://developer.apple.com/documentation/swiftui/view/contextmenu(forselectiontype:menu:primaryaction:)#Add-a-primary-action
+                    // TODO: enable on iPad?
+                    #if targetEnvironment(macCatalyst)
                     .contextMenu(ContextMenu(menuItems: {
-                        SidebarFooterButtonsView(groups: groups,
-                                                 selections: selections,
-                                                 isBeingEdited: isBeingEdited,
-                                                 layerNodes: layerNodesForSidebarDict)
+                        // TODO: select the layer on right click; cannot use `NSViewRepresentable` and `primaryAction` is fired on double-click, not right click
+                        if selection.isSelected {
+                            SidebarFooterButtonsView(groups: groups,
+                                                     selections: selections,
+                                                     isBeingEdited: isBeingEdited,
+                                                     layerNodes: layerNodesForSidebarDict)
+                        }
                     }))
+                    #endif
+                    
                     .zIndex(item.zIndex)
                     .transition(.move(edge: .top).combined(with: .opacity))
                 } // ForEach

--- a/Stitch/Graph/Sidebar/View/SidebarListView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarListView.swift
@@ -44,12 +44,16 @@ struct SidebarListView: View {
         graph.sidebarListState
     }
     
+    var groups: SidebarGroupsDict {
+        graph.getSidebarGroupsDict()
+    }
+        
     var sidebarDeps: SidebarDeps {
         SidebarDeps(
             layerNodes: .fromLayerNodesDict(
                 nodes: graph.layerNodes,
                 orderedSidebarItems: graph.orderedSidebarLayers),
-            groups: graph.getSidebarGroupsDict(),
+            groups: groups,
             expandedItems: graph.getSidebarExpandedItems())
     }
 
@@ -118,6 +122,13 @@ struct SidebarListView: View {
                         isBeingEdited: isBeingEditedAnimated,
                         activeGesture: $activeGesture,
                         activeSwipeId: $activeSwipeId)
+                    // Would `primaryAction` help with right click?: https://developer.apple.com/documentation/swiftui/view/contextmenu(forselectiontype:menu:primaryaction:)#Add-a-primary-action
+                    .contextMenu(ContextMenu(menuItems: {
+                        SidebarFooterButtonsView(groups: groups,
+                                                 selections: selections,
+                                                 isBeingEdited: isBeingEdited,
+                                                 layerNodes: layerNodesForSidebarDict)
+                    }))
                     .zIndex(item.zIndex)
                     .transition(.move(edge: .top).combined(with: .opacity))
                 } // ForEach

--- a/Stitch/Graph/Sidebar/View/iPadProjectSidebarView.swift
+++ b/Stitch/Graph/Sidebar/View/iPadProjectSidebarView.swift
@@ -34,7 +34,8 @@ struct ProjectSidebarView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: .zero) {
-            
+         
+            // TODO: REMOVE ONCE OTHER BEHAVIOR COMPARISONS ETC. ARE FINSHED
             // Catalyst only
 #if targetEnvironment(macCatalyst)
             VStack {
@@ -103,7 +104,7 @@ struct SidebarEditModeToggled: GraphEvent {
     func handle(state: GraphState) {
         // Reset selection-state, but preserve inspector's focused layers
         let inspectorFocusedLayers = state.sidebarSelectionState.inspectorFocusedLayers
-        state.sidebarSelectionState = .init()
+        state.sidebarSelectionState.resetEditModeSelections()
         state.sidebarSelectionState.inspectorFocusedLayers = inspectorFocusedLayers
         
         // Do not set until the end; otherwise selection-state resets loses the change.

--- a/Stitch/Graph/Sidebar/View/iPadProjectSidebarView.swift
+++ b/Stitch/Graph/Sidebar/View/iPadProjectSidebarView.swift
@@ -34,27 +34,6 @@ struct ProjectSidebarView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: .zero) {
-         
-//            // TODO: REMOVE ONCE OTHER BEHAVIOR COMPARISONS ETC. ARE FINSHED
-//            // Catalyst only
-//#if targetEnvironment(macCatalyst)
-//            VStack {
-//                HStack(spacing: .zero) {
-//                    // Padding HStack
-//                    HStack {
-//                        titleView
-//                        Spacer()
-//                        SidebarEditButtonView(isEditing: $isEditing)
-//                    }
-//                    .padding([.top, .horizontal])
-//                }
-//            }
-//            //            .padding(.bottom)
-////            .background(SIDEBAR_BODY_COLOR.ignoresSafeArea())
-//            // Higher z-index here for scroll view
-////            .background(WHITE_IN_LIGHT_MODE_GRAY_IN_DARK_MODE)
-//            .zIndex(2)
-//#endif
             
             SidebarListView(graph: graph,
                             isBeingEdited: isEditing,
@@ -70,7 +49,6 @@ struct ProjectSidebarView: View {
         .edgesIgnoringSafeArea(.bottom)
         
         // iPad only
-        // TODO: why is .navigationTitle ignored on Catalyst?
 #if !targetEnvironment(macCatalyst)
         .navigationTitle("Stitch")
         .toolbar {
@@ -83,18 +61,11 @@ struct ProjectSidebarView: View {
         // We can change the color of the sidebar's top-most section
         .toolbarBackground(.visible, for: .automatic)
         .toolbarBackground(Color.WHITE_IN_LIGHT_MODE_BLACK_IN_DARK_MODE, for: .automatic)
-        
 #endif
+        
         .onChange(of: self.isEditing, initial: true) { _, newValue in
             dispatch(SidebarEditModeToggled(isEditing: newValue))
         }
-    }
-
-    var titleView: some View {
-        Text("Stitch")
-            .font(.largeTitle)
-            .bold()
-
     }
 }
 

--- a/Stitch/Graph/Sidebar/View/iPadProjectSidebarView.swift
+++ b/Stitch/Graph/Sidebar/View/iPadProjectSidebarView.swift
@@ -75,7 +75,10 @@ struct SidebarEditModeToggled: GraphEvent {
     func handle(state: GraphState) {
         // Reset selection-state, but preserve inspector's focused layers
         let inspectorFocusedLayers = state.sidebarSelectionState.inspectorFocusedLayers
-        state.sidebarSelectionState.resetEditModeSelections()
+        
+        // Don't actually reset these?
+//        state.sidebarSelectionState.resetEditModeSelections()
+        
         state.sidebarSelectionState.inspectorFocusedLayers = inspectorFocusedLayers
         
         // Do not set until the end; otherwise selection-state resets loses the change.

--- a/Stitch/Graph/Sidebar/View/iPadProjectSidebarView.swift
+++ b/Stitch/Graph/Sidebar/View/iPadProjectSidebarView.swift
@@ -35,26 +35,26 @@ struct ProjectSidebarView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: .zero) {
          
-            // TODO: REMOVE ONCE OTHER BEHAVIOR COMPARISONS ETC. ARE FINSHED
-            // Catalyst only
-#if targetEnvironment(macCatalyst)
-            VStack {
-                HStack(spacing: .zero) {
-                    // Padding HStack
-                    HStack {
-                        titleView
-                        Spacer()
-                        SidebarEditButtonView(isEditing: $isEditing)
-                    }
-                    .padding([.top, .horizontal])
-                }
-            }
-            //            .padding(.bottom)
-//            .background(SIDEBAR_BODY_COLOR.ignoresSafeArea())
-            // Higher z-index here for scroll view
-//            .background(WHITE_IN_LIGHT_MODE_GRAY_IN_DARK_MODE)
-            .zIndex(2)
-#endif
+//            // TODO: REMOVE ONCE OTHER BEHAVIOR COMPARISONS ETC. ARE FINSHED
+//            // Catalyst only
+//#if targetEnvironment(macCatalyst)
+//            VStack {
+//                HStack(spacing: .zero) {
+//                    // Padding HStack
+//                    HStack {
+//                        titleView
+//                        Spacer()
+//                        SidebarEditButtonView(isEditing: $isEditing)
+//                    }
+//                    .padding([.top, .horizontal])
+//                }
+//            }
+//            //            .padding(.bottom)
+////            .background(SIDEBAR_BODY_COLOR.ignoresSafeArea())
+//            // Higher z-index here for scroll view
+////            .background(WHITE_IN_LIGHT_MODE_GRAY_IN_DARK_MODE)
+//            .zIndex(2)
+//#endif
             
             SidebarListView(graph: graph,
                             isBeingEdited: isEditing,

--- a/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
+++ b/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
@@ -135,6 +135,8 @@ extension GraphState {
                     let id = nodeEntity.id.asLayerNodeId
                     self.sidebarSelectionState.inspectorFocusedLayers.focused.insert(id)
                     self.sidebarSelectionState.inspectorFocusedLayers.activelySelected.insert(id)
+                    
+                    // This doesn't quite work to go through
                     self.sidebarItemSelectedViaEditMode(id)
                     
                     layerNode.layer.layerGraphNode.inputDefinitions.forEach { inputType in

--- a/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
+++ b/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
@@ -135,9 +135,13 @@ extension GraphState {
                     let id = nodeEntity.id.asLayerNodeId
                     self.sidebarSelectionState.inspectorFocusedLayers.focused.insert(id)
                     self.sidebarSelectionState.inspectorFocusedLayers.activelySelected.insert(id)
+                                        
+                    self.sidebarItemSelectedViaEditMode(
+                        id,
+                        // Can treat as always true?
+                        isSidebarItemTapped: true)
                     
-                    // This doesn't quite work to go through
-                    self.sidebarItemSelectedViaEditMode(id)
+                    self.updateInspectorFocusedLayers()
                     
                     layerNode.layer.layerGraphNode.inputDefinitions.forEach { inputType in
                         

--- a/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
+++ b/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
@@ -20,11 +20,18 @@ struct SelectedGraphItemsDuplicated: StitchDocumentEvent {
             return
         }
         
-        let copiedComponentResult = state.visibleGraph.createCopiedComponent(
-            groupNodeFocused: state.graphUI.groupNodeFocused?.asNodeId,
-            selectedNodeIds: state.visibleGraph.selectedNodeIds.compactMap(\.nodeCase).toSet)
+        // TODO: `graph` vs `visibleGraph` ?
+        let activelySelectedLayers = state.visibleGraph.sidebarSelectionState.inspectorFocusedLayers.activelySelected
         
-        state.visibleGraph.insertNewComponent(copiedComponentResult)
+        if !activelySelectedLayers.isEmpty {
+            state.visibleGraph.sidebarSelectedItemsDuplicatedViaEditMode()
+        } else {
+            let copiedComponentResult = state.visibleGraph.createCopiedComponent(
+                groupNodeFocused: state.graphUI.groupNodeFocused?.asNodeId,
+                selectedNodeIds: state.visibleGraph.selectedNodeIds.compactMap(\.nodeCase).toSet)
+            
+            state.visibleGraph.insertNewComponent(copiedComponentResult)
+        }
         
         state.graph.encodeProjectInBackground()
     }

--- a/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
+++ b/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 import StitchSchemaKit
 
-struct SelectedGraphItemsDuplicated: StitchDocumentEvent {
+struct DuplicateShortcutKeyPressed: StitchDocumentEvent {
     
     // Duplicates BOTH nodes AND comments
     @MainActor
@@ -119,14 +119,30 @@ extension GraphState {
         // Reset selected nodes
         self.resetSelectedCanvasItems()
 
+        // Reset edit mode selections + inspector focus and actively-selected
+        self.sidebarSelectionState.resetEditModeSelections()
+        self.sidebarSelectionState.inspectorFocusedLayers.focused = .init()
+        self.sidebarSelectionState.inspectorFocusedLayers.activelySelected = .init()
+        
+        // NOTE: we can either duplicate layers OR patch nodes; but NEVER both
         // Update selected nodes
         newNodes
             .forEach { nodeEntity in
                 switch nodeEntity.nodeTypeEntity {
                 case .layer(let layerNode):
+                    
+                    // Actively-select the new layer node
+                    let id = nodeEntity.id.asLayerNodeId
+                    self.sidebarSelectionState.inspectorFocusedLayers.focused.insert(id)
+                    self.sidebarSelectionState.inspectorFocusedLayers.activelySelected.insert(id)
+                    self.sidebarItemSelectedViaEditMode(id)
+                    
                     layerNode.layer.layerGraphNode.inputDefinitions.forEach { inputType in
+                        
                         let portData = layerNode[keyPath: inputType.schemaPortKeyPath]
+                        
                         let isPacked = portData.mode == .packed
+                        
                         portData.allInputData.enumerated().forEach { portId, inputData in
                             let unpackedId = UnpackedPortType(rawValue: portId)
                             
@@ -142,7 +158,6 @@ extension GraphState {
                                 canvasItem.select()
                             }
                         }
-                        
                     }
                     
                 case .patch, .group:
@@ -161,9 +176,6 @@ extension GraphState {
             updatedList: self.sidebarListState,
             expanded: self.getSidebarExpandedItems(),
             graphState: self)
-        
-        // Also wipe sidebar selection state
-        self.sidebarSelectionState = .init()
         
         self.calculateFullGraph() // not needed?
         self.updateOrderedPreviewLayers()

--- a/Stitch/Graph/ViewModel/GraphDelegate.swift
+++ b/Stitch/Graph/ViewModel/GraphDelegate.swift
@@ -54,7 +54,7 @@ protocol GraphDelegate: AnyObject, Sendable, StitchDocumentIdentifiable {
     @MainActor var multiselectInputs: LayerInputTypeSet? { get }
     
     @MainActor
-    var sidebarSelectionState: SidebarSelectionState { get }
+    var sidebarSelectionState: SidebarSelectionState { get set }
     
     @MainActor
     var orderedSidebarLayers: OrderedSidebarLayers { get }

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -378,11 +378,16 @@ extension GraphState {
     }
     
     @MainActor
+    func deselectAllCanvasItems() {
+        self.graphUI.selection = GraphUISelectionState()
+        self.resetSelectedCanvasItems()
+    }
+    
+    @MainActor
     func selectSingleCanvasItem(_ canvasItem: CanvasItemViewModel) {
         // ie expansionBox, isSelecting, selected-comments etc.
         // get reset when we select a single canvasItem.
-        self.graphUI.selection = GraphUISelectionState()
-        self.resetSelectedCanvasItems()
+        self.deselectAllCanvasItems()
         canvasItem.select()
     }
     
@@ -401,6 +406,11 @@ extension CanvasItemViewModel {
     @MainActor
     func select() {
         self.isSelected = true
+        
+        // Anytime we select a canvas item,
+        // we "de-actively-select" any sidebar layers,
+        // but do not touch the "focused" layers.
+        self.graphDelegate?.sidebarSelectionState.inspectorFocusedLayers.activelySelected = .init()
     }
     
     @MainActor

--- a/StitchTests/nodeUIGroupingTests.swift
+++ b/StitchTests/nodeUIGroupingTests.swift
@@ -93,7 +93,7 @@ class GroupNodeTests: XCTestCase {
         XCTAssertEqual(graphState.selectedNodeIds.count, 1)
         XCTAssertEqual(graphState.selectedNodeIds.first!, canvasItem.id)
         
-        let _ = SelectedGraphItemsDuplicated().handle(state: graphState)
+        let _ = DuplicateShortcutKeyPressed().handle(state: graphState)
         
         XCTAssertEqual(graphState.groupNodes.keys.count, 2)
         


### PR DESCRIPTION
## selecting canvas items vs sidebar layers; sidebar layers staying focused 
https://github.com/user-attachments/assets/d132110c-2b80-4a2c-84a5-3fa26280eb74

## duplicating, deleting, ungrouping, grouping
https://github.com/user-attachments/assets/ed2bc071-76ea-46d3-a3e4-5bbbaf548f73

## and via contextMenu
https://github.com/user-attachments/assets/dfa06af1-f54a-43ba-8337-92690197cb85

## new masking icon
https://github.com/user-attachments/assets/726a55e9-ab05-4554-8bad-e8d4d1c8e6c4

