### PR TITLE
Select a right-clicked layer (if not already selected) when opening context menu

### DIFF
--- a/Stitch/Graph/Sidebar/Model/Gesture/SidebarSelectionState.swift
+++ b/Stitch/Graph/Sidebar/Model/Gesture/SidebarSelectionState.swift
@@ -25,6 +25,16 @@ struct InspectorFocusedLayers: Codable, Equatable, Hashable {
     var activelySelected = LayerIdSet()
 }
 
+extension SidebarSelections {
+    var nonEmptyPrimary: NonEmptySidebarSelections? {
+        if self.isEmpty {
+            return nil
+        } else {
+            return NES(self)!
+        }
+    }
+}
+
 // if a group is selected,
 struct SidebarSelectionState: Codable, Equatable, Hashable {
     
@@ -44,11 +54,7 @@ struct SidebarSelectionState: Codable, Equatable, Hashable {
     }
 
     var nonEmptyPrimary: NonEmptySidebarSelections? {
-        if primary.isEmpty {
-            return nil
-        } else {
-            return NES(primary)!
-        }
+        self.primary.nonEmptyPrimary
     }
 
     func isSelected(_ id: LayerNodeId) -> Bool {

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
@@ -17,43 +17,48 @@ struct SidebarItemTapped: GraphEvent {
     let id: LayerNodeId
     
     func handle(state: GraphState) {
-        let alreadySelected = state.sidebarSelectionState.inspectorFocusedLayers.activelySelected.contains(id)
-        
-        // TODO: why does shift-key seem to be interrupted so often?
-//        if state.keypressState.isCommandPressed ||  state.keypressState.isShiftPressed {
-        if state.keypressState.isCommandPressed {
-            
-            // Note: Cmd + Click will select a currently-unselected layer or deselect an already-selected layer
-            if alreadySelected {
-                state.sidebarSelectionState.inspectorFocusedLayers.focused.remove(id)
-                state.sidebarSelectionState.inspectorFocusedLayers.activelySelected.remove(id)
-                state.sidebarItemDeselectedViaEditMode(id)
-            } else {
-                state.sidebarSelectionState.inspectorFocusedLayers.focused.insert(id)
-                state.sidebarSelectionState.inspectorFocusedLayers.activelySelected.insert(id)
-                state.sidebarItemSelectedViaEditMode(id, isSidebarItemTapped: true)
-                state.deselectAllCanvasItems()
-            }
-            
-        } else {
-            state.sidebarSelectionState.resetEditModeSelections()
-            
-            // Note: Click will not deselect an already-selected layer
-            state.sidebarSelectionState.inspectorFocusedLayers.focused = .init([id])
-            state.sidebarSelectionState.inspectorFocusedLayers.activelySelected = .init([id])
-            state.sidebarItemSelectedViaEditMode(id, isSidebarItemTapped: true)
-            state.deselectAllCanvasItems()
-        }
-        
-        state.updateInspectorFocusedLayers()
-                
-        // Reset selected row in property sidebar when focused-layers changes
-        state.graphUI.propertySidebar.selectedProperty = nil
+        state.sidebarItemTapped(id: id)
     }
 }
 
 
 extension GraphState {
+    
+    @MainActor
+    func sidebarItemTapped(id: LayerNodeId) {
+        let alreadySelected = self.sidebarSelectionState.inspectorFocusedLayers.activelySelected.contains(id)
+        
+        // TODO: why does shift-key seem to be interrupted so often?
+//        if self.keypressState.isCommandPressed ||  self.keypressState.isShiftPressed {
+        if self.keypressState.isCommandPressed {
+            
+            // Note: Cmd + Click will select a currently-unselected layer or deselect an already-selected layer
+            if alreadySelected {
+                self.sidebarSelectionState.inspectorFocusedLayers.focused.remove(id)
+                self.sidebarSelectionState.inspectorFocusedLayers.activelySelected.remove(id)
+                self.sidebarItemDeselectedViaEditMode(id)
+            } else {
+                self.sidebarSelectionState.inspectorFocusedLayers.focused.insert(id)
+                self.sidebarSelectionState.inspectorFocusedLayers.activelySelected.insert(id)
+                self.sidebarItemSelectedViaEditMode(id, isSidebarItemTapped: true)
+                self.deselectAllCanvasItems()
+            }
+            
+        } else {
+            self.sidebarSelectionState.resetEditModeSelections()
+            
+            // Note: Click will not deselect an already-selected layer
+            self.sidebarSelectionState.inspectorFocusedLayers.focused = .init([id])
+            self.sidebarSelectionState.inspectorFocusedLayers.activelySelected = .init([id])
+            self.sidebarItemSelectedViaEditMode(id, isSidebarItemTapped: true)
+            self.deselectAllCanvasItems()
+        }
+        
+        self.updateInspectorFocusedLayers()
+                
+        // Reset selected row in property sidebar when focused-layers changes
+        self.graphUI.propertySidebar.selectedProperty = nil
+    }
     
     @MainActor
     func updateInspectorFocusedLayers() {

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
@@ -224,8 +224,12 @@ extension SidebarListGestureRecognizer: UIContextMenuInteractionDelegate {
         log("UIContextMenuInteractionDelegate: contextMenuInteraction")
         
         // Do the selection action in here
-        self.graph.sidebarItemTapped(id: self.layerNodeId)
         
+        // Only select the layer if not already actively-selected; otherwise just open the menu
+        if !self.graph.sidebarSelectionState.inspectorFocusedLayers.activelySelected.contains(self.layerNodeId) {
+            self.graph.sidebarItemTapped(id: self.layerNodeId)
+        }
+                
         let selections = self.graph.sidebarSelectionState
         let groups = self.graph.getSidebarGroupsDict()
         let sidebarDeps =  SidebarDeps(layerNodes: .fromLayerNodesDict( nodes: self.graph.layerNodes, orderedSidebarItems: self.graph.orderedSidebarLayers),

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
@@ -29,6 +29,9 @@ struct SidebarListItemGestureRecognizerView<T: View>: UIViewControllerRepresenta
     @ObservedObject var gestureViewModel: SidebarItemGestureViewModel
 
     var instantDrag: Bool = false
+    
+    var graph: GraphState
+    var layerNodeId: LayerNodeId
 
     func makeUIViewController(context: Context) -> GestureHostingController<T> {
         let vc = GestureHostingController(
@@ -60,6 +63,13 @@ struct SidebarListItemGestureRecognizerView<T: View>: UIViewControllerRepresenta
         trackpadPanGesture.delegate = delegate
         vc.view.addGestureRecognizer(trackpadPanGesture)
 
+        // Use a UIKit UIContextMenuInteraction so that we can detect when contextMenu opens
+        #if targetEnvironment(macCatalyst)
+        // We define the
+        let interaction = UIContextMenuInteraction(delegate: delegate)
+        vc.view.addInteraction(interaction)
+        #endif
+        
         vc.delegate = delegate
         return vc
     }
@@ -69,12 +79,17 @@ struct SidebarListItemGestureRecognizerView<T: View>: UIViewControllerRepresenta
         uiViewController.rootView = view
 
         delegate.instantDrag = instantDrag
+        
+        delegate.graph = graph
+        delegate.layerNodeId = layerNodeId
     }
 
     func makeCoordinator() -> SidebarListGestureRecognizer {
         SidebarListGestureRecognizer(
             gestureViewModel: gestureViewModel,
-            instantDrag: instantDrag)
+            instantDrag: instantDrag,
+            graph: graph,
+            layerNodeId: layerNodeId)
     }
 }
 
@@ -91,11 +106,20 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
     let gestureViewModel: SidebarItemGestureViewModel
 
     var instantDrag: Bool
+    
+    var graph: GraphState
+    var layerNodeId: LayerNodeId
 
     init(gestureViewModel: SidebarItemGestureViewModel,
-         instantDrag: Bool) {
+         instantDrag: Bool,
+         graph: GraphState,
+         layerNodeId: LayerNodeId) {
+        
         self.gestureViewModel = gestureViewModel
         self.instantDrag = instantDrag
+        
+        self.graph = graph
+        self.layerNodeId = layerNodeId
     }
 
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
@@ -184,4 +208,65 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
             }
         }
     } // trackpadGestureHandler
+}
+
+
+
+extension SidebarListGestureRecognizer: UIContextMenuInteractionDelegate {
+        
+    // // Not needed, since the required `contextMenuInteraction` delegate method is called every time the menu appears?
+    //    func contextMenuInteraction(_ interaction: UIContextMenuInteraction, willDisplayMenuFor configuration: UIContextMenuConfiguration, animator: (any UIContextMenuInteractionAnimating)?) {
+    //        log("UIContextMenuInteractionDelegate: contextMenuInteraction: WILL DISPLAY MENU")
+    //    }
+    
+    func contextMenuInteraction(_ interaction: UIContextMenuInteraction, 
+                                configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
+        log("UIContextMenuInteractionDelegate: contextMenuInteraction")
+        
+        // Do the selection action in here
+        self.graph.sidebarItemTapped(id: self.layerNodeId)
+        
+        let selections = self.graph.sidebarSelectionState
+        let groups = self.graph.getSidebarGroupsDict()
+        let sidebarDeps =  SidebarDeps(layerNodes: .fromLayerNodesDict( nodes: self.graph.layerNodes, orderedSidebarItems: self.graph.orderedSidebarLayers),
+                                       groups: groups,
+                                       expandedItems: self.graph.getSidebarExpandedItems())
+        let layerNodes = sidebarDeps.layerNodes
+        
+        let primary = selections.primary
+        
+        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { _ in
+        
+            var buttons: [UIMenuElement] = []
+            
+            if canUngroup(primary, nodes: layerNodes) {
+                buttons.append(UIAction(title: "Ungroup", image: nil) { action in
+                    // Handle action here
+                    dispatch(SidebarGroupUncreated())
+                })
+            }
+            
+            let canGroup = primary.nonEmptyPrimary.map { canBeGrouped($0, groups: groups) } ?? false
+            if canGroup {
+                buttons.append(UIAction(title: "Group", image: nil) { action in
+                    dispatch(SidebarGroupCreated())
+                })
+            }
+            
+            if canDuplicate(primary) {
+                let groupButton = UIAction(title: "Duplicate", image: nil) { action in
+                    dispatch(SidebarSelectedItemsDuplicated())
+                }
+                buttons.append(groupButton)
+            }
+            
+            if !selections.all.isEmpty {
+                buttons.append(UIAction(title: "Delete", image: nil) { action in
+                    dispatch(SidebarSelectedItemsDeleted())
+                })
+            }
+                        
+            return UIMenu(title: "", children: buttons)
+        }
+    }
 }

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeView.swift
@@ -60,7 +60,9 @@ struct SidebarListItemSwipeView: View {
         // TODO: why does drag gesture on Catalyst break if we remove this?
         SidebarListItemGestureRecognizerView(
             view: customSwipeItem,
-            gestureViewModel: gestureViewModel)
+            gestureViewModel: gestureViewModel,
+            graph: graph,
+            layerNodeId: item.id.asLayerNodeId)
         .height(CGFloat(CUSTOM_LIST_ITEM_VIEW_HEIGHT))
         .padding(.horizontal, 4)
         .offset(y: item.location.y)

--- a/Stitch/Graph/Sidebar/View/SidebarListView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarListView.swift
@@ -47,7 +47,7 @@ struct SidebarListView: View {
     var groups: SidebarGroupsDict {
         graph.getSidebarGroupsDict()
     }
-        
+    
     var sidebarDeps: SidebarDeps {
         SidebarDeps(
             layerNodes: .fromLayerNodesDict(
@@ -125,15 +125,6 @@ struct SidebarListView: View {
                         isBeingEdited: isBeingEditedAnimated,
                         activeGesture: $activeGesture,
                         activeSwipeId: $activeSwipeId)
-                    
-#if targetEnvironment(macCatalyst)
-                    .modifier(SidebarListItemContextMenuModifier(layerNodeId: item.id.asLayerNodeId,
-                                                                 groups: groups,
-                                                                 selections: selections,
-                                                                 isBeingEdited: isBeingEdited,
-                                                                 layerNodes: layerNodesForSidebarDict))
-#endif
-                    
                     .zIndex(item.zIndex)
                     .transition(.move(edge: .top).combined(with: .opacity))
                 } // ForEach
@@ -198,40 +189,5 @@ struct SidebarListView: View {
             activeGesture: $activeGesture,
             activeSwipeId: $activeSwipeId)
             .opacity(0)
-    }
-}
-
-struct SidebarListItemContextMenuModifier: ViewModifier {
-    
-    let layerNodeId: LayerNodeId
-    let groups: SidebarGroupsDict
-    let selections: SidebarSelectionState
-    let isBeingEdited: Bool
-    let layerNodes: LayerNodesForSidebarDict
-    
-    var canShowContextMenu: Bool {
-#if targetEnvironment(macCatalyst)
-        return getSelectionStatus(layerNodeId, selections).isSelected
-#else
-        return false
-#endif
-    }
-    
-    func body(content: Content) -> some View {
-        if canShowContextMenu {
-            content
-            // TODO: enable on iPad?
-#if targetEnvironment(macCatalyst)
-                .contextMenu(ContextMenu(menuItems: {
-                    // TODO: select the layer on right click; cannot use `NSViewRepresentable` and `primaryAction` is fired on double-click, not right click
-                    SidebarFooterButtonsView(groups: groups,
-                                             selections: selections,
-                                             isBeingEdited: isBeingEdited,
-                                             layerNodes: layerNodes)
-                }))
-#endif
-        } else {
-            content
-        }
     }
 }


### PR DESCRIPTION
Note: Catalyst-only. ContextMenu's iOS LongPress gesture would clash with iPad's "long press + drag to move layer around in the sidebar."

Implementation details: we had to switch to UIKit's context menu to use delegate methods that tell us when context menu is opening.