### PR TITLE
Select multiple sidebar layers via Shift

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -295,6 +295,7 @@
 		EC0B8A7F2953C4C500AA01B6 /* RoundedRectanglePatchNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0B8A7E2953C4C500AA01B6 /* RoundedRectanglePatchNode.swift */; };
 		EC0B8A812953C5FE00AA01B6 /* OvalPatchNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0B8A802953C5FE00AA01B6 /* OvalPatchNode.swift */; };
 		EC0B8A832953C63A00AA01B6 /* CirclePatchNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0B8A822953C63A00AA01B6 /* CirclePatchNode.swift */; };
+		EC0CDC322C9E25B400678661 /* SidebarListItemSelectionHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0CDC312C9E25B400678661 /* SidebarListItemSelectionHelpers.swift */; };
 		EC0DE03E2973A57D0026A39C /* PreviewElementTrackpadPanView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0DE03D2973A57D0026A39C /* PreviewElementTrackpadPanView.swift */; };
 		EC0E392D29F9C6100076FE4B /* JSONSampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0E392C29F9C6100076FE4B /* JSONSampleData.swift */; };
 		EC0E656426F3E7D1000E8997 /* ReframeEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0E656326F3E7D1000E8997 /* ReframeEvent.swift */; };
@@ -1214,6 +1215,7 @@
 		EC0B8A7E2953C4C500AA01B6 /* RoundedRectanglePatchNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedRectanglePatchNode.swift; sourceTree = "<group>"; };
 		EC0B8A802953C5FE00AA01B6 /* OvalPatchNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OvalPatchNode.swift; sourceTree = "<group>"; };
 		EC0B8A822953C63A00AA01B6 /* CirclePatchNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CirclePatchNode.swift; sourceTree = "<group>"; };
+		EC0CDC312C9E25B400678661 /* SidebarListItemSelectionHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarListItemSelectionHelpers.swift; sourceTree = "<group>"; };
 		EC0DE03D2973A57D0026A39C /* PreviewElementTrackpadPanView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewElementTrackpadPanView.swift; sourceTree = "<group>"; };
 		EC0E392C29F9C6100076FE4B /* JSONSampleData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONSampleData.swift; sourceTree = "<group>"; };
 		EC0E656326F3E7D1000E8997 /* ReframeEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReframeEvent.swift; sourceTree = "<group>"; };
@@ -2440,6 +2442,7 @@
 				EC2942402BA13E0800D14CD1 /* SidebarSelectedItemsDeleted.swift */,
 				EC2942422BA13E4000D14CD1 /* SidebarSelectedItemsDuplicated.swift */,
 				EC2942442BA13E6100D14CD1 /* SidebarItemSelectionActions.swift */,
+				EC0CDC312C9E25B400678661 /* SidebarListItemSelectionHelpers.swift */,
 			);
 			path = ListModification;
 			sourceTree = "<group>";
@@ -4767,6 +4770,7 @@
 				ECD7FA8B29D73C010073ACAC /* InsertNodeMenuOption.swift in Sources */,
 				E4F7AC242974AF5300B7F55A /* RealityNode.swift in Sources */,
 				ECADA8B428FB5B5D0007748F /* UIImageExtensionUtils.swift in Sources */,
+				EC0CDC322C9E25B400678661 /* SidebarListItemSelectionHelpers.swift in Sources */,
 				B5CB82F4283D987F00FE29A6 /* StitchStore.swift in Sources */,
 				ECF6AEF6263CB7C70011C679 /* TransitionNode.swift in Sources */,
 				EC363D56294282FD0093C473 /* Triangle.swift in Sources */,

--- a/Stitch/Graph/Sidebar/Model/Gesture/SidebarSelectionState.swift
+++ b/Stitch/Graph/Sidebar/Model/Gesture/SidebarSelectionState.swift
@@ -23,6 +23,9 @@ struct InspectorFocusedLayers: Codable, Equatable, Hashable {
     
     // Actively Selected = what we see focused in inspector + what user has recently tapped on
     var activelySelected = LayerIdSet()
+    
+    // TODO: use an ordered set and do .last ?
+    var lastActivelySelectedLayer: LayerNodeId? = nil
 }
 
 extension SidebarSelections {

--- a/Stitch/Graph/Sidebar/Model/Gesture/SidebarSelectionState.swift
+++ b/Stitch/Graph/Sidebar/Model/Gesture/SidebarSelectionState.swift
@@ -13,9 +13,6 @@ typealias OrderedLayerNodeIdSet = OrderedSet<LayerNodeId>
 typealias SidebarSelections = LayerIdSet
 typealias NonEmptySidebarSelections = NonEmptyLayerIdSet
 
-/*
- 
- */
 struct InspectorFocusedLayers: Codable, Equatable, Hashable {
     
     // Focused = what we see focused in the inspector
@@ -25,7 +22,7 @@ struct InspectorFocusedLayers: Codable, Equatable, Hashable {
     var activelySelected = LayerIdSet()
     
     // TODO: use an ordered set and do .last ?
-    var lastActivelySelectedLayer: LayerNodeId? = nil
+    var lastFocusedLayer: LayerNodeId? = nil
 }
 
 extension SidebarSelections {

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
@@ -26,23 +26,6 @@ struct SidebarItemTapped: GraphEvent {
     }
 }
 
-extension Array where Element: StitchNestedListElement {
-    public func _get(_ id: Element.ID) -> Element? {
-        for item in self {
-            if id == item.id {
-                return item
-            }
-            
-            // Recursively check children
-            return item.children?._get(id)
-        }
-        
-        return nil
-    }
-}
-
-
-
 extension GraphState {
     
     @MainActor
@@ -50,28 +33,26 @@ extension GraphState {
         log("sidebarItemTapped: id: \(id)")
         log("sidebarItemTapped: shiftHeld: \(shiftHeld)")
         
-        
         let originalSelections = self.sidebarSelectionState.inspectorFocusedLayers.focused
         
         if shiftHeld,
            // We must have at least one layer already selected / focused
-           !originalSelections.isEmpty {
-           // god damnit, this is has that same bug as before -- we didn't update the framework yet
-//            guard let clickedItem = self.orderedSidebarLayers._get(id.id) else {
+           !originalSelections.isEmpty,
+           let lastClickedItemId = self.sidebarSelectionState.inspectorFocusedLayers.lastFocusedLayer {
             
-            guard let clickedItem: SidebarLayerData = self.orderedSidebarLayers.getSidebarLayerData(id.id) else {
-                
-//            guard let clickedItem = self.orderedSidebarLayers.first(where: { $0.id == id.id
-//            }) else {
+            log("sidebarItemTapped: shift select")
+            
+            guard let clickedItem: SidebarLayerData = self.orderedSidebarLayers.getSidebarLayerData(id.id),
+                  let lastClickedItem: SidebarLayerData = self.orderedSidebarLayers.getSidebarLayerData(lastClickedItemId.id) else {
                 log("sidebarItemTapped: could not get clicked data")
                 fatalErrorIfDebug()
-                return 
+                return
             }
-            
             
             if let (itemsBetween, clickedEarlierThanStart) = itemsBetweenClosestSelectedStart(
                 in: self.orderedSidebarLayers,
                 clickedItem: clickedItem,
+                lastClickedItem: lastClickedItem,
                 // Look at focused layers
                 selections: originalSelections) {
                 
@@ -84,31 +65,35 @@ extension GraphState {
                     log("sidebarItemTapped: clickedEarlierThanStart")
                     self.sidebarSelectionState.inspectorFocusedLayers.focused = itemsBetweenSet
                     self.sidebarSelectionState.inspectorFocusedLayers.activelySelected = itemsBetweenSet
-                    self.sidebarSelectionState.inspectorFocusedLayers.lastActivelySelectedLayer = id
+                    self.sidebarSelectionState.inspectorFocusedLayers.lastFocusedLayer = id
+                    self.deselectAllCanvasItems()
+                    
+                    // TODO: should not need to return early?
                     return
                 } else {
                     log("sidebarItemTapped: had NOT clickedEarlierThanStart")
                     self.sidebarSelectionState.inspectorFocusedLayers.focused =
                     self.sidebarSelectionState.inspectorFocusedLayers.focused.union(itemsBetweenSet)
                     self.sidebarSelectionState.inspectorFocusedLayers.activelySelected = self.sidebarSelectionState.inspectorFocusedLayers.focused.union(itemsBetweenSet)
-                    self.sidebarSelectionState.inspectorFocusedLayers.lastActivelySelectedLayer = id
+                    self.sidebarSelectionState.inspectorFocusedLayers.lastFocusedLayer = id
+                    self.deselectAllCanvasItems()
+                    // TODO: should not need to return early?
                     return
                 }
-                
                 
             } else {
                 log("sidebarItemTapped: did not have itemsBetween")
             }
-        } else {
-            log("sidebarItemTapped: either shift not held or focused layers were empty")
-        }
-        
-        
-        let alreadySelected = self.sidebarSelectionState.inspectorFocusedLayers.activelySelected.contains(id)
-        
-        // TODO: why does shift-key seem to be interrupted so often?
-//        if self.keypressState.isCommandPressed ||  self.keypressState.isShiftPressed {
-        if self.keypressState.isCommandPressed {
+        } 
+//        else {
+//            log("sidebarItemTapped: either shift not held or focused layers were empty")
+//        }
+                
+        else if self.keypressState.isCommandPressed {
+            
+            log("sidebarItemTapped: command select")
+            
+            let alreadySelected = self.sidebarSelectionState.inspectorFocusedLayers.activelySelected.contains(id)
             
             // Note: Cmd + Click will select a currently-unselected layer or deselect an already-selected layer
             if alreadySelected {
@@ -117,23 +102,25 @@ extension GraphState {
                 self.sidebarItemDeselectedViaEditMode(id)
                 
                 // Don't set nil, but rather use `orderedSet.dropLast.last` ?
-                self.sidebarSelectionState.inspectorFocusedLayers.lastActivelySelectedLayer = nil
+                self.sidebarSelectionState.inspectorFocusedLayers.lastFocusedLayer = nil
             } else {
                 self.sidebarSelectionState.inspectorFocusedLayers.focused.insert(id)
                 self.sidebarSelectionState.inspectorFocusedLayers.activelySelected.insert(id)
                 self.sidebarItemSelectedViaEditMode(id, isSidebarItemTapped: true)
-                self.sidebarSelectionState.inspectorFocusedLayers.lastActivelySelectedLayer = id
+                self.sidebarSelectionState.inspectorFocusedLayers.lastFocusedLayer = id
                 self.deselectAllCanvasItems()
             }
             
         } else {
+            log("sidebarItemTapped: normal select")
+            
             self.sidebarSelectionState.resetEditModeSelections()
             
             // Note: Click will not deselect an already-selected layer
             self.sidebarSelectionState.inspectorFocusedLayers.focused = .init([id])
             self.sidebarSelectionState.inspectorFocusedLayers.activelySelected = .init([id])
             self.sidebarItemSelectedViaEditMode(id, isSidebarItemTapped: true)
-            self.sidebarSelectionState.inspectorFocusedLayers.lastActivelySelectedLayer = id
+            self.sidebarSelectionState.inspectorFocusedLayers.lastFocusedLayer = id
             self.deselectAllCanvasItems()
         }
         

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
@@ -70,17 +70,19 @@ extension GraphState {
 //                    
 //                    // TODO: should not need to return early?
 //                    return
-//                } else {
+                //                } else {
+                log("sidebarItemTapped: had NOT clickedEarlierThanStart")
+                self.sidebarSelectionState.inspectorFocusedLayers.focused =
+                self.sidebarSelectionState.inspectorFocusedLayers.focused.union(itemsBetweenSet)
+                self.sidebarSelectionState.inspectorFocusedLayers.activelySelected = self.sidebarSelectionState.inspectorFocusedLayers.focused.union(itemsBetweenSet)
+                self.sidebarSelectionState.inspectorFocusedLayers.lastFocusedLayer = id
                 
-                    log("sidebarItemTapped: had NOT clickedEarlierThanStart")
-                    self.sidebarSelectionState.inspectorFocusedLayers.focused =
-                    self.sidebarSelectionState.inspectorFocusedLayers.focused.union(itemsBetweenSet)
-                    self.sidebarSelectionState.inspectorFocusedLayers.activelySelected = self.sidebarSelectionState.inspectorFocusedLayers.focused.union(itemsBetweenSet)
-                    self.sidebarSelectionState.inspectorFocusedLayers.lastFocusedLayer = id
-                    self.deselectAllCanvasItems()
-                    // TODO: should not need to return early?
-                    return
-//                }
+                self.editModeSelectTappedItems(tappedItems: self.sidebarSelectionState.inspectorFocusedLayers.focused)
+                
+                self.deselectAllCanvasItems()
+                // TODO: should not need to return early?
+                //                    return
+                //                }
                 
             } else {
                 log("sidebarItemTapped: did not have itemsBetween")

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
@@ -61,16 +61,17 @@ extension GraphState {
                 log("sidebarItemTapped: itemsBetweenSet: \(itemsBetweenSet)")
                 
                 // TODO: do you really need this distinction ?
-                if clickedEarlierThanStart {
-                    log("sidebarItemTapped: clickedEarlierThanStart")
-                    self.sidebarSelectionState.inspectorFocusedLayers.focused = itemsBetweenSet
-                    self.sidebarSelectionState.inspectorFocusedLayers.activelySelected = itemsBetweenSet
-                    self.sidebarSelectionState.inspectorFocusedLayers.lastFocusedLayer = id
-                    self.deselectAllCanvasItems()
-                    
-                    // TODO: should not need to return early?
-                    return
-                } else {
+//                if clickedEarlierThanStart {
+//                    log("sidebarItemTapped: clickedEarlierThanStart")
+//                    self.sidebarSelectionState.inspectorFocusedLayers.focused = itemsBetweenSet
+//                    self.sidebarSelectionState.inspectorFocusedLayers.activelySelected = itemsBetweenSet
+//                    self.sidebarSelectionState.inspectorFocusedLayers.lastFocusedLayer = id
+//                    self.deselectAllCanvasItems()
+//                    
+//                    // TODO: should not need to return early?
+//                    return
+//                } else {
+                
                     log("sidebarItemTapped: had NOT clickedEarlierThanStart")
                     self.sidebarSelectionState.inspectorFocusedLayers.focused =
                     self.sidebarSelectionState.inspectorFocusedLayers.focused.union(itemsBetweenSet)
@@ -79,7 +80,7 @@ extension GraphState {
                     self.deselectAllCanvasItems()
                     // TODO: should not need to return early?
                     return
-                }
+//                }
                 
             } else {
                 log("sidebarItemTapped: did not have itemsBetween")

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
@@ -54,8 +54,11 @@ extension GraphState {
         if shiftHeld {
            // god damnit, this is has that same bug as before -- we didn't update the framework yet
 //            guard let clickedItem = self.orderedSidebarLayers._get(id.id) else {
-            guard let clickedItem = self.orderedSidebarLayers.first(where: { $0.id == id.id
-            }) else {
+            
+            guard let clickedItem: SidebarLayerData = self.orderedSidebarLayers.getSidebarLayerData(id.id) else {
+                
+//            guard let clickedItem = self.orderedSidebarLayers.first(where: { $0.id == id.id
+//            }) else {
                 log("sidebarItemTapped: could not get clicked data")
                 fatalErrorIfDebug()
                 return 
@@ -83,7 +86,7 @@ extension GraphState {
                     self.sidebarSelectionState.inspectorFocusedLayers.focused =
                     self.sidebarSelectionState.inspectorFocusedLayers.focused.union(itemsBetweenSet)
                     self.sidebarSelectionState.inspectorFocusedLayers.activelySelected = self.sidebarSelectionState.inspectorFocusedLayers.focused.union(itemsBetweenSet)
-                    return 
+                    return
                 }
                 
                 

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
@@ -23,7 +23,7 @@ struct SidebarItemTapped: GraphEvent {
 }
 
 extension GraphState {
-    
+        
     @MainActor
     func sidebarItemTapped(id: LayerNodeId, shiftHeld: Bool) {
         log("sidebarItemTapped: id: \(id)")
@@ -64,20 +64,19 @@ extension GraphState {
 //                    self.sidebarSelectionState.inspectorFocusedLayers.lastFocusedLayer = id
 //                    self.deselectAllCanvasItems()
 //                    
-//                    // TODO: should not need to return early?
-//                    return
                 //                } else {
                 log("sidebarItemTapped: had NOT clickedEarlierThanStart")
+                
                 self.sidebarSelectionState.inspectorFocusedLayers.focused =
                 self.sidebarSelectionState.inspectorFocusedLayers.focused.union(itemsBetweenSet)
+                
                 self.sidebarSelectionState.inspectorFocusedLayers.activelySelected = self.sidebarSelectionState.inspectorFocusedLayers.focused.union(itemsBetweenSet)
+                
                 self.sidebarSelectionState.inspectorFocusedLayers.lastFocusedLayer = id
                 
                 self.editModeSelectTappedItems(tappedItems: self.sidebarSelectionState.inspectorFocusedLayers.focused)
                 
                 self.deselectAllCanvasItems()
-                // TODO: should not need to return early?
-                //                    return
                 //                }
                 
             } else {

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
@@ -10,9 +10,6 @@ import StitchSchemaKit
 import SwiftUI
 import OrderedCollections
 
-import StitchViewKit
-
-
 // Sidebar layer 'tapped' while not in
 struct SidebarItemTapped: GraphEvent {
     
@@ -20,7 +17,6 @@ struct SidebarItemTapped: GraphEvent {
     let shiftHeld: Bool
     
     func handle(state: GraphState) {
-                
         state.sidebarItemTapped(id: id,
                                 shiftHeld: shiftHeld)
     }

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarListItemSelectionHelpers.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarListItemSelectionHelpers.swift
@@ -54,28 +54,35 @@ func findClosestSelectedStart(in flatList: [ListItem],
 //func itemsBetweenClosestSelectedStart(in nestedList: [[ListItem]],
 func itemsBetweenClosestSelectedStart(in nestedList: [ListItem],
                                       clickedItem: ListItem,
+                                      lastClickedItem: ListItem,
                                       selections: LayerIdSet) -> (newSelections: [ListItem],
                                                                   clickedEarlierThanStart: Bool)? {
-    // Flatten the nested list
-//    let flatList = nestedList.flatMap { $0 }
-    
-    //
+    // Flatten the nested list: the item + its children
     let flatList: [ListItem] = nestedList.flatMap { [$0] + ($0.children ?? []) }
-    
-    // WORKS
 //    let flatList: [ListItem] = nestedList
     
-//    log("itemsBetweenClosestSelectedStart: flatList: \(flatList)")
     log("itemsBetweenClosestSelectedStart: flatList map ids: \(flatList.map(\.id))")
     
+    
+    // TODO: shift+select
     // Find the closest selected start item
-    guard let start = findClosestSelectedStart(in: flatList,
-                                               to: clickedItem,
-                                               selections: selections),
-          let startIndex = flatList.firstIndex(of: start),
+//    guard let start = findClosestSelectedStart(in: flatList,
+//                                               from: lastClickedItem,
+//                                               to: clickedItem,
+//                                               selections: selections),
+//          let startIndex = flatList.firstIndex(of: start),
+//          let clickedItemIndex = flatList.firstIndex(of: clickedItem) else {
+//        log("itemsBetweenClosestSelectedStart: no start")
+//        return nil // Return nil if start or end not found
+//    }
+//    
+    
+    let start = lastClickedItem
+    
+    guard let startIndex = flatList.firstIndex(of: start),
           let clickedItemIndex = flatList.firstIndex(of: clickedItem) else {
-        log("itemsBetweenClosestSelectedStart: no start")
-        return nil // Return nil if start or end not found
+        log("itemsBetweenClosestSelectedStart: could not get index of start item and/or clicked item")
+        return nil
     }
     
     // Ensure that start and end are not the same

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarListItemSelectionHelpers.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarListItemSelectionHelpers.swift
@@ -1,0 +1,93 @@
+//
+//  SidebarListItemSelectionHelpers.swift
+//  Stitch
+//
+//  Created by Christian J Clampitt on 9/20/24.
+//
+
+import StitchSchemaKit
+import Foundation
+import SwiftUI
+
+typealias ListItem = SidebarLayerData
+
+// Function to find the closest selected item (start point) relative to an end item, excluding the end itself
+//func findClosestSelectedStart(in nestedList: [[ListItem]],
+func findClosestSelectedStart(in flatList: [ListItem],
+                              to clickedItem: ListItem,
+                              selections: LayerIdSet) -> ListItem? {
+    // Flatten the nested list
+//    let flatList = nestedList.flatMap { $0 }
+    
+    // Find the index of the end item
+    guard let clickedItemIndex = flatList.firstIndex(of: clickedItem) else {
+        log("findClosestSelectedStart: could not find clickedItemIndex")
+        return nil // Return nil if the end item is not found
+    }
+    
+    // Initialize a variable to store the closest selected item
+    var closestSelected: ListItem? = nil
+    var closestDistance = Int.max
+        
+    // Search for the closest selected item (before and after the end index)
+    for i in 0..<flatList.count {
+        let item = flatList[i]
+        
+        let isSelected = selections.contains(item.id.asLayerNodeId)
+        
+        if isSelected && item != clickedItem {  // Ensure the selected item is not the same as the end
+            
+            let distance = abs(i - clickedItemIndex)
+            if distance < closestDistance {
+                log("findClosestSelectedStart: found closest \(item)")
+                closestSelected = item
+                closestDistance = distance
+            }
+        }
+    }
+    
+    log("findClosestSelectedStart: returning closestSelected \(closestSelected)")
+    return closestSelected
+}
+
+// Function to return all items between the closest selected start and end, ensuring start != end
+//func itemsBetweenClosestSelectedStart(in nestedList: [[ListItem]],
+func itemsBetweenClosestSelectedStart(in nestedList: [ListItem],
+                                      clickedItem: ListItem,
+                                      selections: LayerIdSet) -> (newSelections: [ListItem],
+                                                                  clickedEarlierThanStart: Bool)? {
+    // Flatten the nested list
+//    let flatList = nestedList.flatMap { $0 }
+//    let flatList: [ListItem] = nestedList.flatMap { $0.children ?? [] }
+    let flatList: [ListItem] = nestedList
+//    log("itemsBetweenClosestSelectedStart: flatList: \(flatList)")
+    log("itemsBetweenClosestSelectedStart: flatList map ids: \(flatList.map(\.id))")
+    
+    // Find the closest selected start item
+    guard let start = findClosestSelectedStart(in: flatList,
+                                               to: clickedItem,
+                                               selections: selections),
+          let startIndex = flatList.firstIndex(of: start),
+          let clickedItemIndex = flatList.firstIndex(of: clickedItem) else {
+        log("itemsBetweenClosestSelectedStart: no start")
+        return nil // Return nil if start or end not found
+    }
+    
+    // Ensure that start and end are not the same
+    guard start != clickedItem else {
+        log("itemsBetweenClosestSelectedStart: start same as clicked item")
+        return nil // If start and end are the same, return nil or handle as needed
+    }
+    
+    let startEarlierThanClickedItem = startIndex < clickedItemIndex
+    let clickedEarlierThanStart = clickedItemIndex < startIndex
+    
+    // Determine the range and ensure it includes items regardless of their order
+    let range = startEarlierThanClickedItem ? startIndex...clickedItemIndex : clickedItemIndex...startIndex
+//    let range = startIndex < clickedItemIndex ? startIndex...clickedItemIndex : clickedItemIndex...startIndex
+    
+    // Return the items between start and end (inclusive)
+    return (newSelections: Array(flatList[range]),
+            clickedEarlierThanStart: clickedEarlierThanStart)
+}
+

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarListItemSelectionHelpers.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarListItemSelectionHelpers.swift
@@ -58,8 +58,13 @@ func itemsBetweenClosestSelectedStart(in nestedList: [ListItem],
                                                                   clickedEarlierThanStart: Bool)? {
     // Flatten the nested list
 //    let flatList = nestedList.flatMap { $0 }
-//    let flatList: [ListItem] = nestedList.flatMap { $0.children ?? [] }
-    let flatList: [ListItem] = nestedList
+    
+    //
+    let flatList: [ListItem] = nestedList.flatMap { [$0] + ($0.children ?? []) }
+    
+    // WORKS
+//    let flatList: [ListItem] = nestedList
+    
 //    log("itemsBetweenClosestSelectedStart: flatList: \(flatList)")
     log("itemsBetweenClosestSelectedStart: flatList map ids: \(flatList.map(\.id))")
     

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarListItemSelectionHelpers.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarListItemSelectionHelpers.swift
@@ -103,3 +103,37 @@ func itemsBetweenClosestSelectedStart(in nestedList: [ListItem],
             clickedEarlierThanStart: clickedEarlierThanStart)
 }
 
+
+extension GraphState {
+    
+    /*
+     Given an unordered set of tapped items,
+     Start at top level of the ordered sidebar layers.
+     If a group is tapped, then edit-mode-select it and all its descendants.
+     If a non-group is tapped, only edit-mode-select it if we do not already do so via some parent’s descendants.
+
+     Iterating through the ordered sidebar layers provides the order and guarantees you don’t hit a child before its parent.
+
+     */
+    @MainActor
+    func editModeSelectTappedItems(tappedItems: LayerIdSet) {
+        
+        // Wipe existing edit mode selections
+        self.sidebarSelectionState.resetEditModeSelections()
+        
+        let orderedSidebarLayers: SidebarLayerList = self.orderedSidebarLayers
+        
+        orderedSidebarLayers.forEach { (sidebarLayer: SidebarLayerData) in
+            
+            let layerId = sidebarLayer.id.asLayerNodeId
+            let wasTapped = tappedItems.contains(layerId)
+            
+            // Only interested in items that were tapped
+            if wasTapped {
+                self.sidebarItemSelectedViaEditMode(layerId,
+                                                    isSidebarItemTapped: true)
+            } // if wasTapped
+        } // forEach
+    }
+}
+

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarListItemSelectionHelpers.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarListItemSelectionHelpers.swift
@@ -68,8 +68,7 @@ func itemsBetweenClosestSelectedStart(in nestedList: [ListItem],
 //        log("itemsBetweenClosestSelectedStart: no start")
 //        return nil // Return nil if start or end not found
 //    }
-//    
-    
+      
     let start = lastClickedItem
     
     guard let startIndex = flatList.firstIndex(of: start),

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarListItemSelectionHelpers.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarListItemSelectionHelpers.swift
@@ -12,12 +12,9 @@ import SwiftUI
 typealias ListItem = SidebarLayerData
 
 // Function to find the closest selected item (start point) relative to an end item, excluding the end itself
-//func findClosestSelectedStart(in nestedList: [[ListItem]],
 func findClosestSelectedStart(in flatList: [ListItem],
                               to clickedItem: ListItem,
                               selections: LayerIdSet) -> ListItem? {
-    // Flatten the nested list
-//    let flatList = nestedList.flatMap { $0 }
     
     // Find the index of the end item
     guard let clickedItemIndex = flatList.firstIndex(of: clickedItem) else {
@@ -50,8 +47,7 @@ func findClosestSelectedStart(in flatList: [ListItem],
     return closestSelected
 }
 
-// Function to return all items between the closest selected start and end, ensuring start != end
-//func itemsBetweenClosestSelectedStart(in nestedList: [[ListItem]],
+// TODO: finalize this logic; it's not as simple as "the range between last-clicked and just-clicked" nor is it "the range between just-clicked and least-distant-currently-selected"
 func itemsBetweenClosestSelectedStart(in nestedList: [ListItem],
                                       clickedItem: ListItem,
                                       lastClickedItem: ListItem,
@@ -59,12 +55,9 @@ func itemsBetweenClosestSelectedStart(in nestedList: [ListItem],
                                                                   clickedEarlierThanStart: Bool)? {
     // Flatten the nested list: the item + its children
     let flatList: [ListItem] = nestedList.flatMap { [$0] + ($0.children ?? []) }
-//    let flatList: [ListItem] = nestedList
     
     log("itemsBetweenClosestSelectedStart: flatList map ids: \(flatList.map(\.id))")
     
-    
-    // TODO: shift+select
     // Find the closest selected start item
 //    guard let start = findClosestSelectedStart(in: flatList,
 //                                               from: lastClickedItem,
@@ -113,7 +106,6 @@ extension GraphState {
      If a non-group is tapped, only edit-mode-select it if we do not already do so via some parent’s descendants.
 
      Iterating through the ordered sidebar layers provides the order and guarantees you don’t hit a child before its parent.
-
      */
     @MainActor
     func editModeSelectTappedItems(tappedItems: LayerIdSet) {
@@ -121,9 +113,7 @@ extension GraphState {
         // Wipe existing edit mode selections
         self.sidebarSelectionState.resetEditModeSelections()
         
-        let orderedSidebarLayers: SidebarLayerList = self.orderedSidebarLayers
-        
-        orderedSidebarLayers.forEach { (sidebarLayer: SidebarLayerData) in
+        self.orderedSidebarLayers.forEach { (sidebarLayer: SidebarLayerData) in
             
             let layerId = sidebarLayer.id.asLayerNodeId
             let wasTapped = tappedItems.contains(layerId)

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemView.swift
@@ -10,7 +10,6 @@ import StitchSchemaKit
 
 struct SidebarListItemView: View {
 
-    
     // Move this ... elsewhere? Globally?
     @State var keyboardObserver: KeyboardObserver = .init()
     
@@ -114,7 +113,8 @@ struct SidebarListItemView: View {
                 
                 log("shiftIsPressed: \(shiftIsPressed)")
                 
-                dispatch(SidebarItemTapped(id: layerNodeId))
+                dispatch(SidebarItemTapped(id: layerNodeId,
+                                           shiftHeld: shiftIsPressed))
             }
         }))
         

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemView.swift
@@ -98,25 +98,44 @@ struct SidebarListItemView: View {
         
 //        .cornerRadius(SWIPE_FULL_CORNER_RADIUS)
         
-        // Note: given that we apparently must use the UIKitTappableWrapper on the swipe menu buttons,
-        // we need to place the SwiftUI TapGesture below the swipe menu.
-        .gesture(TapGesture().onEnded({ _ in
-            if !isBeingEdited {
-                
-                let keyboardInput = keyboardObserver.keyboard?.keyboardInput
         
-                let shiftIsPressed = keyboardInput?.button(
-                    forKeyCode: .leftShift
-                )?.isPressed ?? false || keyboardInput?.button(
-                    forKeyCode: .rightShift
-                )?.isPressed ?? false
-                
-                log("shiftIsPressed: \(shiftIsPressed)")
-                
-                dispatch(SidebarItemTapped(id: layerNodeId,
-                                           shiftHeld: shiftIsPressed))
-            }
-        }))
+//        // REMOVED
+//
+//        // Note: given that we apparently must use the UIKitTappableWrapper on the swipe menu buttons,
+//        // we need to place the SwiftUI TapGesture below the swipe menu.
+//        .gesture(TapGesture().onEnded({ _ in
+//            if !isBeingEdited {
+//                
+//                let keyboardInput = keyboardObserver.keyboard?.keyboardInput
+//        
+//                log("KeyboardObserver: keyboardInput: \(keyboardInput)")
+//                
+////                let shiftIsPressed = keyboardInput?.button(
+////                    forKeyCode: .leftShift
+////                )?.isPressed ?? false || keyboardInput?.button(
+////                    forKeyCode: .rightShift
+////                )?.isPressed ?? false
+//                
+//                let leftShift = keyboardInput?.button(
+//                    forKeyCode: .leftShift
+//                )?.isPressed ?? false
+//                
+//                
+//                let rightShift = keyboardInput?.button(
+//                    forKeyCode: .rightShift
+//                )?.isPressed ?? false
+//                
+//                log("KeyboardObserver: leftShift: \(leftShift)")
+//                log("KeyboardObserver: rightShift: \(rightShift)")
+//                
+//                let shiftIsPressed = leftShift || rightShift
+//                
+//                log("KeyboardObserver: shiftIsPressed: \(shiftIsPressed)")
+//                
+//                dispatch(SidebarItemTapped(id: layerNodeId,
+//                                           shiftHeld: shiftIsPressed))
+//            }
+//        }))
         
         .overlay {
             RoundedRectangle(cornerRadius: SWIPE_FULL_CORNER_RADIUS)
@@ -133,15 +152,36 @@ import GameController
 class KeyboardObserver: ObservableObject {
     @Published var keyboard: GCKeyboard?
     
-    var observer: Any? = nil
+//    var observer: Any? = nil
+    @Published var observer: Any? = nil
+//    @Published var observer: Any
     
     init() {
+        log("KeyboardObserver: init")
+        
         observer = NotificationCenter.default.addObserver(
             forName: .GCKeyboardDidConnect,
             object: nil,
             queue: .main
         ) { [weak self] notification in
-            self?.keyboard = notification.object as? GCKeyboard
+            
+            log("KeyboardObserver: observer: init")
+            
+            let notificationObject = notification.object as? GCKeyboard
+            
+            
+            // these are never nil ? yet
+            
+            if self == nil {
+                log("KeyboardObserver: observer: init: did not have self")
+            }
+            
+            if notificationObject == nil {
+                log("KeyboardObserver: observer: init: did not have GCKeyboard")
+            }
+            
+            
+            self?.keyboard = notificationObject
         }
     }
 }

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemView.swift
@@ -10,9 +10,6 @@ import StitchSchemaKit
 
 struct SidebarListItemView: View {
 
-    // Move this ... elsewhere? Globally?
-    @State var keyboardObserver: KeyboardObserver = .init()
-    
     @Environment(\.appTheme) var theme
     
     @Bindable var graph: GraphState
@@ -85,7 +82,7 @@ struct SidebarListItemView: View {
                 
         .frame(height: SIDEBAR_LIST_ITEM_ROW_COLORED_AREA_HEIGHT)
         
-        // To have color limited by indentation level etc.:
+        // Note: to have color limited by indentation level etc.:
         
 //        .background {
 //            if isNonEditModeSelected || isBeingDragged {
@@ -98,44 +95,7 @@ struct SidebarListItemView: View {
         
 //        .cornerRadius(SWIPE_FULL_CORNER_RADIUS)
         
-        
-//        // REMOVED
-//
-//        // Note: given that we apparently must use the UIKitTappableWrapper on the swipe menu buttons,
-//        // we need to place the SwiftUI TapGesture below the swipe menu.
-//        .gesture(TapGesture().onEnded({ _ in
-//            if !isBeingEdited {
-//                
-//                let keyboardInput = keyboardObserver.keyboard?.keyboardInput
-//        
-//                log("KeyboardObserver: keyboardInput: \(keyboardInput)")
-//                
-////                let shiftIsPressed = keyboardInput?.button(
-////                    forKeyCode: .leftShift
-////                )?.isPressed ?? false || keyboardInput?.button(
-////                    forKeyCode: .rightShift
-////                )?.isPressed ?? false
-//                
-//                let leftShift = keyboardInput?.button(
-//                    forKeyCode: .leftShift
-//                )?.isPressed ?? false
-//                
-//                
-//                let rightShift = keyboardInput?.button(
-//                    forKeyCode: .rightShift
-//                )?.isPressed ?? false
-//                
-//                log("KeyboardObserver: leftShift: \(leftShift)")
-//                log("KeyboardObserver: rightShift: \(rightShift)")
-//                
-//                let shiftIsPressed = leftShift || rightShift
-//                
-//                log("KeyboardObserver: shiftIsPressed: \(shiftIsPressed)")
-//                
-//                dispatch(SidebarItemTapped(id: layerNodeId,
-//                                           shiftHeld: shiftIsPressed))
-//            }
-//        }))
+        // Note: we used to apply our SwiftUI .tapGesture here, but now we use a UITapGestureRecognizer in `SidebarListGestureRecognizer`
         
         .overlay {
             RoundedRectangle(cornerRadius: SWIPE_FULL_CORNER_RADIUS)
@@ -144,44 +104,5 @@ struct SidebarListItemView: View {
         }
         .animation(.default, value: isProposedGroup)
         .animation(.default, value: isBeingDragged)
-    }
-}
-
-import GameController
-
-class KeyboardObserver: ObservableObject {
-    @Published var keyboard: GCKeyboard?
-    
-//    var observer: Any? = nil
-    @Published var observer: Any? = nil
-//    @Published var observer: Any
-    
-    init() {
-        log("KeyboardObserver: init")
-        
-        observer = NotificationCenter.default.addObserver(
-            forName: .GCKeyboardDidConnect,
-            object: nil,
-            queue: .main
-        ) { [weak self] notification in
-            
-            log("KeyboardObserver: observer: init")
-            
-            let notificationObject = notification.object as? GCKeyboard
-            
-            
-            // these are never nil ? yet
-            
-            if self == nil {
-                log("KeyboardObserver: observer: init: did not have self")
-            }
-            
-            if notificationObject == nil {
-                log("KeyboardObserver: observer: init: did not have GCKeyboard")
-            }
-            
-            
-            self?.keyboard = notificationObject
-        }
     }
 }

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListItemView.swift
@@ -10,6 +10,10 @@ import StitchSchemaKit
 
 struct SidebarListItemView: View {
 
+    
+    // Move this ... elsewhere? Globally?
+    @State var keyboardObserver: KeyboardObserver = .init()
+    
     @Environment(\.appTheme) var theme
     
     @Bindable var graph: GraphState
@@ -99,6 +103,17 @@ struct SidebarListItemView: View {
         // we need to place the SwiftUI TapGesture below the swipe menu.
         .gesture(TapGesture().onEnded({ _ in
             if !isBeingEdited {
+                
+                let keyboardInput = keyboardObserver.keyboard?.keyboardInput
+        
+                let shiftIsPressed = keyboardInput?.button(
+                    forKeyCode: .leftShift
+                )?.isPressed ?? false || keyboardInput?.button(
+                    forKeyCode: .rightShift
+                )?.isPressed ?? false
+                
+                log("shiftIsPressed: \(shiftIsPressed)")
+                
                 dispatch(SidebarItemTapped(id: layerNodeId))
             }
         }))
@@ -110,5 +125,23 @@ struct SidebarListItemView: View {
         }
         .animation(.default, value: isProposedGroup)
         .animation(.default, value: isBeingDragged)
+    }
+}
+
+import GameController
+
+class KeyboardObserver: ObservableObject {
+    @Published var keyboard: GCKeyboard?
+    
+    var observer: Any? = nil
+    
+    init() {
+        observer = NotificationCenter.default.addObserver(
+            forName: .GCKeyboardDidConnect,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            self?.keyboard = notification.object as? GCKeyboard
+        }
     }
 }

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListLabelView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListLabelView.swift
@@ -58,13 +58,13 @@ struct SidebarListItemLeftLabelView: View {
     
     
     var _name: String {
-        return name
+//        return name
         
-//#if DEV_DEBUG
-//        name + " \(nodeId.id.debugFriendlyId)"
-//#else
-//        name
-//#endif
+#if DEV_DEBUG
+        name + " \(nodeId.id.debugFriendlyId)"
+#else
+        name
+#endif
     }
     
     var body: some View {

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
@@ -92,6 +92,23 @@ struct SidebarListItemGestureRecognizerView<T: View>: UIViewControllerRepresenta
             layerNodeId: layerNodeId)
     }
 }
+//
+//
+//// THIS IS NOT FOR A RIGHT CLICK VIA TRACKPAD
+////class RightClickGestureRecognizer: UIGestureRecognizer {
+//extension UIGestureRecognizer {
+//    func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
+//        log("UIGestureRecognizer: touchesBegan CALLED")
+//        if let touch = touches.first,
+//            touch.type == .indirectPointer {
+//            // Handle right-click or secondary click here
+//            if touch.tapCount == 1 && touch.phase == .began {
+//                print("Right click detected!")
+//            }
+//        }
+//    }
+//}
+
 
 final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate {
     // Handles:
@@ -126,6 +143,8 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
                            shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         true
     }
+    
+//    func touchesBegan
 
     // finger on screen
     @objc func screenGestureHandler(_ gestureRecognizer: UIPanGestureRecognizer) {
@@ -172,7 +191,7 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
         //        }
 
     } // screenGestureHandler
-
+    
     @objc func trackpadGestureHandler(_ gestureRecognizer: UIPanGestureRecognizer) {
 
         //        log("CustomListItemGestureRecognizerVC: trackpadGestureHandler: gestureRecognizer.numberOfTouches:  \(gestureRecognizer.numberOfTouches)")
@@ -184,6 +203,8 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
 
         // `touches == 0` = running our fingers on trackpad, but no click
         if gestureRecognizer.numberOfTouches == 0 {
+            
+                        
             switch gestureRecognizer.state {
             case .changed:
                 gestureViewModel.onItemSwipeChanged(translation.x)

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
@@ -164,10 +164,16 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
     @objc func tapInView(_ gestureRecognizer: UIPanGestureRecognizer) {
         print("tapInView")
         
-        if !graph.sidebarSelectionState.isEditMode {
-            dispatch(SidebarItemTapped(id: layerNodeId,
-                                       shiftHeld: shiftHeldDown))
+        let isEditMode = graph.sidebarSelectionState.isEditMode
+        let swipeMenuOpen = gestureViewModel.swipeSetting != .closed
+        
+        // Do not 'tap' a layer if we're in edit mode or the swipe menu is open
+        if isEditMode || swipeMenuOpen {
+            return
         }
+        
+        dispatch(SidebarItemTapped(id: layerNodeId,
+                                   shiftHeld: shiftHeldDown))
     }
 
     // finger on screen

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
@@ -247,14 +247,14 @@ extension SidebarListGestureRecognizer: UIContextMenuInteractionDelegate {
         // Do the selection action in here
         
         // Only select the layer if not already actively-selected; otherwise just open the menu
-        if !self.graph.sidebarSelectionState.inspectorFocusedLayers.activelySelected.contains(self.layerNodeId) {
-            
-            self.graph.sidebarItemTapped(
-                id: self.layerNodeId,
-                // TODO: SEPT 20: PASS THIS DOWN
-                shiftHeld: false)
-        }
-                
+//        if !self.graph.sidebarSelectionState.inspectorFocusedLayers.activelySelected.contains(self.layerNodeId) {
+//            
+//            self.graph.sidebarItemTapped(
+//                id: self.layerNodeId,
+//                // TODO: SEPT 20: PASS THIS DOWN
+//                shiftHeld: false)
+//        }
+//                
         let selections = self.graph.sidebarSelectionState
         let groups = self.graph.getSidebarGroupsDict()
         let sidebarDeps =  SidebarDeps(layerNodes: .fromLayerNodesDict( nodes: self.graph.layerNodes, orderedSidebarItems: self.graph.orderedSidebarLayers),

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
@@ -248,7 +248,11 @@ extension SidebarListGestureRecognizer: UIContextMenuInteractionDelegate {
         
         // Only select the layer if not already actively-selected; otherwise just open the menu
         if !self.graph.sidebarSelectionState.inspectorFocusedLayers.activelySelected.contains(self.layerNodeId) {
-            self.graph.sidebarItemTapped(id: self.layerNodeId)
+            
+            self.graph.sidebarItemTapped(
+                id: self.layerNodeId,
+                // TODO: SEPT 20: PASS THIS DOWN
+                shiftHeld: false)
         }
                 
         let selections = self.graph.sidebarSelectionState

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
@@ -262,8 +262,6 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
     } // trackpadGestureHandler
 }
 
-
-
 extension SidebarListGestureRecognizer: UIContextMenuInteractionDelegate {
         
     // // NOTE: Not needed, since the required `contextMenuInteraction` delegate method is called every time the menu appears?
@@ -274,16 +272,14 @@ extension SidebarListGestureRecognizer: UIContextMenuInteractionDelegate {
     func contextMenuInteraction(_ interaction: UIContextMenuInteraction, 
                                 configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
         log("UIContextMenuInteractionDelegate: contextMenuInteraction")
-        
-        // Do the selection action in here
-        
+                
         // Only select the layer if not already actively-selected; otherwise just open the menu
         if !self.graph.sidebarSelectionState.inspectorFocusedLayers.activelySelected.contains(self.layerNodeId) {
             
+            // Note: we do the selection logic in here so that
             self.graph.sidebarItemTapped(
                 id: self.layerNodeId,
-                // TODO: SEPT 20: PASS THIS DOWN
-                shiftHeld: false)
+                shiftHeld: self.shiftHeldDown)
         }
                 
         let selections = self.graph.sidebarSelectionState

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
@@ -138,15 +138,18 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, 
                            shouldReceive event: UIEvent) -> Bool {
         log("event.modifierFlags: \(event.modifierFlags)")
-        if event.modifierFlags.contains(.control) {
-            log("had .control")
-        }
-        if event.modifierFlags.contains(.alternate) {
-            log("had .alternate")
-        }
-        if event.modifierFlags.contains(.command) {
-            log("had .command")
-        }
+        
+//        if event.modifierFlags.contains(.control) {
+//            log("had .control")
+//        }
+//        if event.modifierFlags.contains(.alternate) {
+//            log("had .alternate")
+//        }
+//        if event.modifierFlags.contains(.command) {
+//            log("had .command")
+//        }
+        
+        // TODO: could also update global state from here? (but no point?)
         if event.modifierFlags.contains(.shift) {
             log("had .shift")
             self.shiftHeldDown = true
@@ -160,8 +163,11 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
     
     @objc func tapInView(_ gestureRecognizer: UIPanGestureRecognizer) {
         print("tapInView")
-        dispatch(SidebarItemTapped(id: layerNodeId,
-                                   shiftHeld: shiftHeldDown))
+        
+        if !graph.sidebarSelectionState.isEditMode {
+            dispatch(SidebarItemTapped(id: layerNodeId,
+                                       shiftHeld: shiftHeldDown))
+        }
     }
 
     // finger on screen

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
@@ -108,7 +108,7 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
     // Handled elsewhere:
     // - one finger long-press-drag item-dragging: see `SwiftUI .simultaneousGesture`
     // - two fingers on trackpad list scrolling
-
+    
     let gestureViewModel: SidebarItemGestureViewModel
 
     var instantDrag: Bool
@@ -138,24 +138,24 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, 
                            shouldReceive event: UIEvent) -> Bool {
         
-        log("event.modifierFlags: \(event.modifierFlags)")
+        // log("event.modifierFlags: \(event.modifierFlags)")
         
-//        if event.modifierFlags.contains(.control) {
-//            log("had .control")
-//        }
-//        if event.modifierFlags.contains(.alternate) {
-//            log("had .alternate")
-//        }
-//        if event.modifierFlags.contains(.command) {
-//            log("had .command")
-//        }
+        //        if event.modifierFlags.contains(.control) {
+        //            log("had .control")
+        //        }
+        //        if event.modifierFlags.contains(.alternate) {
+        //            log("had .alternate")
+        //        }
+        //        if event.modifierFlags.contains(.command) {
+        //            log("had .command")
+        //        }
         
         // TODO: could also update global state from here? (but no point?)
         if event.modifierFlags.contains(.shift) {
-            log("had .shift")
+            // log("had .shift")
             self.shiftHeldDown = true
         } else {
-            log("did NOT have .shift")
+            // log("did NOT have .shift")
             self.shiftHeldDown = false
         }
         
@@ -197,7 +197,7 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
                 if instantDrag {
                     gestureViewModel.onItemDragChanged(translation.toCGSize)
                 }
-                let velocity = gestureRecognizer.velocity(in: gestureRecognizer.view)
+                // let velocity = gestureRecognizer.velocity(in: gestureRecognizer.view)
                 gestureViewModel.onItemSwipeChanged(translation.x)
             default:
                 break // do nothing
@@ -234,7 +234,6 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
 
         // `touches == 0` = running our fingers on trackpad, but no click
         if gestureRecognizer.numberOfTouches == 0 {
-            
                         
             switch gestureRecognizer.state {
             case .changed:
@@ -271,7 +270,8 @@ extension SidebarListGestureRecognizer: UIContextMenuInteractionDelegate {
     
     func contextMenuInteraction(_ interaction: UIContextMenuInteraction, 
                                 configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
-        log("UIContextMenuInteractionDelegate: contextMenuInteraction")
+        
+        // log("UIContextMenuInteractionDelegate: contextMenuInteraction")
                 
         // Only select the layer if not already actively-selected; otherwise just open the menu
         if !self.graph.sidebarSelectionState.inspectorFocusedLayers.activelySelected.contains(self.layerNodeId) {

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
@@ -137,6 +137,7 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
     
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, 
                            shouldReceive event: UIEvent) -> Bool {
+        
         log("event.modifierFlags: \(event.modifierFlags)")
         
 //        if event.modifierFlags.contains(.control) {
@@ -162,7 +163,7 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
     }
     
     @objc func tapInView(_ gestureRecognizer: UIPanGestureRecognizer) {
-        print("tapInView")
+        log("tapInView")
         
         let isEditMode = graph.sidebarSelectionState.isEditMode
         let swipeMenuOpen = gestureViewModel.swipeSetting != .closed
@@ -265,7 +266,7 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
 
 extension SidebarListGestureRecognizer: UIContextMenuInteractionDelegate {
         
-    // // Not needed, since the required `contextMenuInteraction` delegate method is called every time the menu appears?
+    // // NOTE: Not needed, since the required `contextMenuInteraction` delegate method is called every time the menu appears?
     //    func contextMenuInteraction(_ interaction: UIContextMenuInteraction, willDisplayMenuFor configuration: UIContextMenuConfiguration, animator: (any UIContextMenuInteractionAnimating)?) {
     //        log("UIContextMenuInteractionDelegate: contextMenuInteraction: WILL DISPLAY MENU")
     //    }

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
@@ -134,8 +134,8 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
                            shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         true
     }
-    
-    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, 
+        
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
                            shouldReceive event: UIEvent) -> Bool {
         
         // log("event.modifierFlags: \(event.modifierFlags)")
@@ -151,11 +151,12 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
         //        }
         
         // TODO: could also update global state from here? (but no point?)
+        // TODO: this is not fired when we right-click?
         if event.modifierFlags.contains(.shift) {
-            // log("had .shift")
+             log("had .shift")
             self.shiftHeldDown = true
         } else {
-            // log("did NOT have .shift")
+             log("did NOT have .shift")
             self.shiftHeldDown = false
         }
         

--- a/Stitch/Graph/Sidebar/View/iPadProjectSidebarView.swift
+++ b/Stitch/Graph/Sidebar/View/iPadProjectSidebarView.swift
@@ -13,7 +13,6 @@ let SIDEBAR_HEADER_COLOR: Color = Color(.sideBarHeader)
 
 struct StitchSidebarView: View {
     @Environment(StitchStore.self) var store
-//    @State var keyboardObserver: KeyboardObserver = .init()
 
     let syncStatus: iCloudSyncStatus
 

--- a/Stitch/Graph/Sidebar/View/iPadProjectSidebarView.swift
+++ b/Stitch/Graph/Sidebar/View/iPadProjectSidebarView.swift
@@ -13,6 +13,7 @@ let SIDEBAR_HEADER_COLOR: Color = Color(.sideBarHeader)
 
 struct StitchSidebarView: View {
     @Environment(StitchStore.self) var store
+//    @State var keyboardObserver: KeyboardObserver = .init()
 
     let syncStatus: iCloudSyncStatus
 


### PR DESCRIPTION
Note: some remaining work:
- selection logic needs finalization; is not quite as simple as "range between just-selected and last-selected" nor "range between just-selected and closest-already-selected"
- shift needs to be made more reliable; our common key listening logic does not work well with shift (responder chain gets interrupted?); an observer on GameController is not recreated when project re-opened and a listener on UITapGesture seems fickle with right-click to open context menu
- https://github.com/StitchDesign/Stitch--Old/issues/6451