### PR TITLE
Use GameController EnvironmentObject to listen for Shift key

### DIFF
--- a/Stitch/App/StitchApp.swift
+++ b/Stitch/App/StitchApp.swift
@@ -11,6 +11,7 @@ import StitchSchemaKit
 @main @MainActor
 struct StitchApp: App {
     @State var store = StitchStore()
+    @StateObject var keyboardObserver = KeyboardObserver()
 
     // MARK: VERY important to pass the store StateObject into each view for perf
     var body: some Scene {
@@ -27,6 +28,7 @@ struct StitchApp: App {
             // Inject theme as environment variable
                 .environment(\.appTheme, self.store.appTheme)
                 .environment(\.edgeStyle, self.store.edgeStyle)
+                .environmentObject(self.keyboardObserver)
 
         }
 


### PR DESCRIPTION
Using a GameController observer EnvironmentObject seems more accurate for listening to the Shift key than UIHostingController key commands (we need to improve our responder chain issues?) and a GestureRecognizer's `shouldReceive: UIEvent` (does not work well with right-click).

Note: when GameController observer lived in the individual sidebar list item's view, the observer would not be re-initialized when we re-opened a project.