### PR TITLE
Use `auto x auto` size for newly created layer groups

### DIFF
--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarGroupCreated.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarGroupCreated.swift
@@ -74,8 +74,11 @@ struct SidebarGroupCreated: StitchDocumentEvent {
         let groupFit: LayerGroupFit = state.visibleGraph.getLayerGroupFit(
             primarilySelectedLayers,
             parentSize: state.visibleGraph.getParentSizeForSelectedNodes(selectedNodes: primarilySelectedLayers))
-        
-        let assumedLayerGroupSize: LayerSize = groupFit.size
+
+        // TODO: any reason to not use .auto x .auto for a nearly created group? ... perhaps for .background, which can become too big in a group whose children use .position modifiers?
+        // TODO: how important is the LayerGroupFit.adjustment/offset etc. ?
+//        let assumedLayerGroupSize: LayerSize = groupFit.size
+        let assumedLayerGroupSize: LayerSize = .init(width: .auto, height: .auto)
         
         // Update layer group's size input
         newNode.layerNode?.sizePort.updatePortValues([.size(assumedLayerGroupSize)])


### PR DESCRIPTION
`auto` handles loops etc. more easily.

Notes: 
- any reason to not use .auto x .auto for a nearly created group? ... perhaps for .background, which can become too big in a group whose children use .position modifiers?
- how important is the LayerGroupFit.adjustment/offset etc. ?



https://github.com/user-attachments/assets/248a778a-aa3a-432d-b189-7565c18f7763


