### PR TITLE
When parent's group-orientation is updated, block or unblock position and offset fields on children

### DIFF
--- a/Stitch/Graph/ViewModel/GraphDelegate.swift
+++ b/Stitch/Graph/ViewModel/GraphDelegate.swift
@@ -58,6 +58,18 @@ protocol GraphDelegate: AnyObject, Sendable, StitchDocumentIdentifiable {
     
     @MainActor
     var orderedSidebarLayers: OrderedSidebarLayers { get }
+    
+    @MainActor
+    func children(of parent: NodeId) -> NodeViewModels
+}
+
+extension GraphState {
+    @MainActor
+    func children(of parent: NodeId) -> NodeViewModels {
+        self.layerNodes.values.filter { layerNode in
+            layerNode.layerNode?.layerGroupId == parent
+        }
+    }
 }
 
 extension GraphDelegate {

--- a/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
+++ b/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
@@ -126,7 +126,8 @@ extension VisibleNodesViewModel {
                                   forKey: newNode.id)
             }
         }
-
+        
+        
         // Build weak references to connected nodes
         nodesDict.values.forEach { nodeEntity in
             self.buildUpstreamReferences(nodeEntity: nodeEntity)
@@ -155,6 +156,21 @@ extension VisibleNodesViewModel {
                 
             default:
                 return
+            }
+        }
+        
+        
+        // Special case: we must re-initialize the group orientation input, since its first initialization happens before we have constructed the layer view models that can tell us all the parents
+        // TODO: a better way to handle this?
+        self.nodes.forEach { (key: NodeId, value: NodeViewModel) in
+            if let layerNode = value.layerNode,
+               layerNode.layer == .group,
+                let groupOrientationInputObserver: InputNodeRowObserver = value.getInputRowObserver(for: .keyPath(.init(
+                    layerInput: .orientation,
+                    // Group Orientation is always packed
+                    portType: .packed))) {
+                value.blockOrUnblockFields(newValue: groupOrientationInputObserver.activeValue,
+                                           layerInput: .orientation)
             }
         }
     }


### PR DESCRIPTION
<img width="1440" alt="Screenshot 2024-09-30 at 7 35 47 PM" src="https://github.com/user-attachments/assets/6ebf7496-978c-46c2-9d69-bf81d8b0a463">
<img width="1440" alt="Screenshot 2024-09-30 at 7 35 55 PM" src="https://github.com/user-attachments/assets/90d92eee-b7e6-4bab-99bc-ad17b20bf466">
