### PR TITLE
Layer nodes now start with proper fields blocked or unblocked

### DIFF
--- a/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
@@ -65,7 +65,8 @@ struct GenericFlyoutView: View {
             graph: graph,
             fieldValueTypes: fieldValueTypes,
             nodeId: nodeId,
-            forPropertySidebar: true) { inputFieldViewModel, isMultifield in
+            forPropertySidebar: true,
+            blockedFields: layerInputObserver.blockedFields) { inputFieldViewModel, isMultifield in
                 GenericFlyoutRowView(
                     graph: graph,
                     viewModel: inputFieldViewModel,

--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -234,12 +234,24 @@ struct LayerInspectorInputsSectionView: View {
       
     var body: some View {
         Section(isExpanded: $expanded) {
-            ForEach(layerInputs, id: \.layerInput) { (layerInput) in
+            ForEach(layerInputs, id: \.layerInput) { layerInput in
                 let layerPort: LayerInputObserver = layerInput.portObserver
                 
                 
                 // TODO: only using packed data here
-                let allFieldsBlockedOut = layerPort._packedData.inspectorRowViewModel .fieldValueTypes.first?.fieldObservers.allSatisfy(\.isBlockedOut) ?? false
+//                let allFieldsBlockedOut = layerPort._packedData.inspectorRowViewModel .fieldValueTypes.first?.fieldObservers.allSatisfy(\.isBlockedOut) ?? false
+                
+//                let allFieldsBlockedOut = layerPort._packedData.inspectorRowViewModel .fieldValueTypes.first?.fieldObservers.allSatisfy(\.isBlockedOut) ?? false
+                
+                // TODO: OCT 1
+//                let allFieldsBlockedOut = layerInput.portObserver.blockedFields.contains(.init(layerInput: layerInput.layerInput, portType: .packed))
+                
+                let allFieldsBlockedOut = layerInput.portObserver.blockedFields.contains(.packed)
+                
+                if layerInput.layerInput == .pinAnchor || layerInput.layerInput == .pinOffset || layerInput.layerInput == .pinTo {
+                    logInView("LayerInspectorInputsSectionView: for node \(nodeId) and layer input: \(layerInput.layerInput): blockedFields: \(layerInput.portObserver.blockedFields)")
+                }
+                
                 
                 if !allFieldsBlockedOut {
                     LayerInspectorInputPortView(layerInputObserver: layerPort,

--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -237,20 +237,6 @@ struct LayerInspectorInputsSectionView: View {
             ForEach(layerInputs, id: \.layerInput) { layerInput in
                 let layerInputObserver: LayerInputObserver = layerInput.portObserver
                 
-                
-                // TODO: only using packed data here
-//                let allFieldsBlockedOut = layerInputObserver._packedData.inspectorRowViewModel .fieldValueTypes.first?.fieldObservers.allSatisfy(\.isBlockedOut) ?? false
-                
-//                let allFieldsBlockedOut = layerInputObserver._packedData.inspectorRowViewModel .fieldValueTypes.first?.fieldObservers.allSatisfy(\.isBlockedOut) ?? false
-                
-                // TODO: OCT 1
-//                let allFieldsBlockedOut = layerInput.portObserver.blockedFields.contains(.init(layerInput: layerInput.layerInput, portType: .packed))
-                
-//                let allFieldsBlockedOut = layerInput.portObserver.blockedFields.contains(.packed)
-//                let allFieldsBlockedOut = layerInput.portObserver.blockedFields.blocks(layerInput.portType)
-//                layerInput.layerInput.id
-                
-
                 let blockedFields = layerInputObserver.blockedFields
                 
                 let allFieldsBlockedOut = layerInputObserver

--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -235,18 +235,28 @@ struct LayerInspectorInputsSectionView: View {
     var body: some View {
         Section(isExpanded: $expanded) {
             ForEach(layerInputs, id: \.layerInput) { layerInput in
-                let layerPort: LayerInputObserver = layerInput.portObserver
+                let layerInputObserver: LayerInputObserver = layerInput.portObserver
                 
                 
                 // TODO: only using packed data here
-//                let allFieldsBlockedOut = layerPort._packedData.inspectorRowViewModel .fieldValueTypes.first?.fieldObservers.allSatisfy(\.isBlockedOut) ?? false
+//                let allFieldsBlockedOut = layerInputObserver._packedData.inspectorRowViewModel .fieldValueTypes.first?.fieldObservers.allSatisfy(\.isBlockedOut) ?? false
                 
-//                let allFieldsBlockedOut = layerPort._packedData.inspectorRowViewModel .fieldValueTypes.first?.fieldObservers.allSatisfy(\.isBlockedOut) ?? false
+//                let allFieldsBlockedOut = layerInputObserver._packedData.inspectorRowViewModel .fieldValueTypes.first?.fieldObservers.allSatisfy(\.isBlockedOut) ?? false
                 
                 // TODO: OCT 1
 //                let allFieldsBlockedOut = layerInput.portObserver.blockedFields.contains(.init(layerInput: layerInput.layerInput, portType: .packed))
                 
-                let allFieldsBlockedOut = layerInput.portObserver.blockedFields.contains(.packed)
+//                let allFieldsBlockedOut = layerInput.portObserver.blockedFields.contains(.packed)
+//                let allFieldsBlockedOut = layerInput.portObserver.blockedFields.blocks(layerInput.portType)
+//                layerInput.layerInput.id
+                
+
+                let blockedFields = layerInputObserver.blockedFields
+                
+                let allFieldsBlockedOut = layerInputObserver
+                    .fieldValueTypes.first?
+                    .fieldObservers.allSatisfy({ $0.isBlocked(blockedFields)})
+                ?? false
                 
                 if layerInput.layerInput == .pinAnchor || layerInput.layerInput == .pinOffset || layerInput.layerInput == .pinTo {
                     logInView("LayerInspectorInputsSectionView: for node \(nodeId) and layer input: \(layerInput.layerInput): blockedFields: \(layerInput.portObserver.blockedFields)")
@@ -254,7 +264,7 @@ struct LayerInspectorInputsSectionView: View {
                 
                 
                 if !allFieldsBlockedOut {
-                    LayerInspectorInputPortView(layerInputObserver: layerPort,
+                    LayerInspectorInputPortView(layerInputObserver: layerInputObserver,
                                                 graph: graph,
                                                 nodeId: nodeId)
                     .modifier(LayerPropertyRowOriginReader(graph: graph,

--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -244,11 +244,6 @@ struct LayerInspectorInputsSectionView: View {
                     .fieldObservers.allSatisfy({ $0.isBlocked(blockedFields)})
                 ?? false
                 
-                if layerInput.layerInput == .pinAnchor || layerInput.layerInput == .pinOffset || layerInput.layerInput == .pinTo {
-                    logInView("LayerInspectorInputsSectionView: for node \(nodeId) and layer input: \(layerInput.layerInput): blockedFields: \(layerInput.portObserver.blockedFields)")
-                }
-                
-                
                 if !allFieldsBlockedOut {
                     LayerInspectorInputPortView(layerInputObserver: layerInputObserver,
                                                 graph: graph,

--- a/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
+++ b/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
@@ -457,7 +457,6 @@ extension LayerNodeViewModel {
                                           layer: self.layer)
         }
         
-        // TODO: OCT 1
         // Set blocked fields after all fields have been initialized
         self.forEachInput { layerInput in
             self.blockOrUnblockFields(

--- a/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
+++ b/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
@@ -27,6 +27,21 @@ final class LayerNodeViewModel {
     // View models for layers in prototype window
     var previewLayerViewModels: [LayerViewModel] = []
     
+    /*
+     Only fields on a layer input (not a patch input or layer output) can be blocked,
+     and a field is blocked regardless of an input's packed vs unpacked status.
+     
+     Example use:
+     
+     // the entire minSize input blocked:
+     blockedFields.contains(.init(layerInput: .minSize, portType: .packed))
+     
+     // just the width field on the minSize input blocked:
+     blockedFields.contains(.init(layerInput: .minSize, portType: .unpacked(.port0)))
+     */
+//    var blockedFields: Set<LayerInputType> = .init()
+    
+    
     // Some layer nodes contain outputs
     @MainActor var outputPorts: [OutputLayerNodeRowData] = []
     
@@ -164,6 +179,8 @@ final class LayerNodeViewModel {
 
     @MainActor
     init(from schema: LayerNodeEntity) {
+        log("LayerNodeViewModel: init called for \(schema.id)")
+        
         let graphNode = schema.layer.layerGraphNode
         
         // Create initial inputs and outputs using default data
@@ -440,10 +457,17 @@ extension LayerNodeViewModel {
                                           layer: self.layer)
         }
         
+        // TODO: OCT 1
         // Set blocked fields after all fields have been initialized
         self.forEachInput { layerInput in
-            node.blockOrUnblockFields(newValue: layerInput.activeValue,
-                                      layerInput: layerInput.port)
+//            node.blockOrUnblockFields(newValue: layerInput.activeValue,
+//            self.blockOrUnblockFields(newValue: layerInput.activeValue,
+//                                      layerInput: layerInput.port)
+            
+//            layerInput.blockOrUnblockFields(newValue: layerInput.activeValue)
+            self.blockOrUnblockFields(
+                newValue: layerInput.activeValue,
+                layerInput: layerInput.port)
         }
     }
     

--- a/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
+++ b/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
@@ -26,22 +26,7 @@ final class LayerNodeViewModel {
 
     // View models for layers in prototype window
     var previewLayerViewModels: [LayerViewModel] = []
-    
-    /*
-     Only fields on a layer input (not a patch input or layer output) can be blocked,
-     and a field is blocked regardless of an input's packed vs unpacked status.
-     
-     Example use:
-     
-     // the entire minSize input blocked:
-     blockedFields.contains(.init(layerInput: .minSize, portType: .packed))
-     
-     // just the width field on the minSize input blocked:
-     blockedFields.contains(.init(layerInput: .minSize, portType: .unpacked(.port0)))
-     */
-//    var blockedFields: Set<LayerInputType> = .init()
-    
-    
+ 
     // Some layer nodes contain outputs
     @MainActor var outputPorts: [OutputLayerNodeRowData] = []
     
@@ -179,7 +164,6 @@ final class LayerNodeViewModel {
 
     @MainActor
     init(from schema: LayerNodeEntity) {
-        log("LayerNodeViewModel: init called for \(schema.id)")
         
         let graphNode = schema.layer.layerGraphNode
         

--- a/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
+++ b/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
@@ -460,11 +460,6 @@ extension LayerNodeViewModel {
         // TODO: OCT 1
         // Set blocked fields after all fields have been initialized
         self.forEachInput { layerInput in
-//            node.blockOrUnblockFields(newValue: layerInput.activeValue,
-//            self.blockOrUnblockFields(newValue: layerInput.activeValue,
-//                                      layerInput: layerInput.port)
-            
-//            layerInput.blockOrUnblockFields(newValue: layerInput.activeValue)
             self.blockOrUnblockFields(
                 newValue: layerInput.activeValue,
                 layerInput: layerInput.port)

--- a/Stitch/Graph/Node/Port/Util/Field/TabKeyPressActions.swift
+++ b/Stitch/Graph/Node/Port/Util/Field/TabKeyPressActions.swift
@@ -283,12 +283,9 @@ func getTabEligibleFields(layerNode: LayerNodeViewModel,
     // Turn each non-blocked field on a layeri input into a LayerInputEligibleField
         .reduce(into: LayerInputEligibleFields(), { partialResult, layerInput in
             (layerNode.getLayerInspectorInputFields(layerInput)).forEach { field in
-                // TODO: OCT 1
                 let blockedFields = layerNode.getLayerInputObserver(layerInput).blockedFields
                 
-                let isBlocked = field.isBlocked(blockedFields)
-                
-                if !isBlocked {
+                if !field.isBlocked(blockedFields) {
                     partialResult.append(.init(input: layerInput,
                                                fieldIndex: field.fieldIndex))
                 }

--- a/Stitch/Graph/Node/Port/Util/Field/TabKeyPressActions.swift
+++ b/Stitch/Graph/Node/Port/Util/Field/TabKeyPressActions.swift
@@ -284,10 +284,14 @@ func getTabEligibleFields(layerNode: LayerNodeViewModel,
         .reduce(into: LayerInputEligibleFields(), { partialResult, layerInput in
             (layerNode.getLayerInspectorInputFields(layerInput)).forEach { field in
                 // TODO: OCT 1
-//                if !field.isBlockedOut {
+                let blockedFields = layerNode.getLayerInputObserver(layerInput).blockedFields
+                
+                let isBlocked = field.isBlocked(blockedFields)
+                
+                if !isBlocked {
                     partialResult.append(.init(input: layerInput,
                                                fieldIndex: field.fieldIndex))
-//                }
+                }
             }
         })
 

--- a/Stitch/Graph/Node/Port/Util/Field/TabKeyPressActions.swift
+++ b/Stitch/Graph/Node/Port/Util/Field/TabKeyPressActions.swift
@@ -283,10 +283,11 @@ func getTabEligibleFields(layerNode: LayerNodeViewModel,
     // Turn each non-blocked field on a layeri input into a LayerInputEligibleField
         .reduce(into: LayerInputEligibleFields(), { partialResult, layerInput in
             (layerNode.getLayerInspectorInputFields(layerInput)).forEach { field in
-                if !field.isBlockedOut {
+                // TODO: OCT 1
+//                if !field.isBlockedOut {
                     partialResult.append(.init(input: layerInput,
                                                fieldIndex: field.fieldIndex))
-                }
+//                }
             }
         })
 

--- a/Stitch/Graph/Node/Port/Util/InputEdit/InputCommittedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/InputEdit/InputCommittedActions.swift
@@ -143,26 +143,8 @@ extension GraphState {
         // TODO: OCT 1
         if let layerInputType: LayerInputType = input.id.keyPath,
            let layerNode: LayerNodeViewModel = nodeViewModel.layerNode {
-            
-//            layerNode.getLayerInspectorInputFields(<#T##LayerInputPort#>)
-//            let port: LayerInputObserver = layerNode[keyPath: layerInputType.layerNodeKeyPath]
-//            let port = layerNode[keyPath: layerInputType.layerNodeKeyPath]
-            
-//            let port: LayerInputObserver = layerNode[keyPath: layerInputType.layerInput.layerNodeKeyPath]
-//            port.blockOrUnblockFields(newValue: value)
-            
-            layerNode
-//                .getLayerInputObserver(layerInputType.layerInput)
-                .blockOrUnblockFields(newValue: value,
-                                      layerInput: layerInputType.layerInput)
-            
-            
-//            let k = layerNode[keyPath: layerInputType]
-            
-            
-//            nodeViewModel.blockOrUnblockFields(
-//                newValue: value,
-//                layerInput: layerInputType.layerInput)
+            layerNode.blockOrUnblockFields(newValue: value,
+                                           layerInput: layerInputType.layerInput)
         }
         
         let newCommandType = value.shapeCommandType

--- a/Stitch/Graph/Node/Port/Util/InputEdit/InputCommittedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/InputEdit/InputCommittedActions.swift
@@ -134,10 +134,35 @@ extension GraphState {
                                          activeIndex: self.activeIndex)
         
         // Block or unblock certain layer inputs
-        if let layerInputType = input.id.keyPath {
-            nodeViewModel.blockOrUnblockFields(
-                newValue: value,
-                layerInput: layerInputType.layerInput)
+//        if let layerInputType = input.id.keyPath {
+//            nodeViewModel.blockOrUnblockFields(
+//                newValue: value,
+//                layerInput: layerInputType.layerInput)
+//        }
+        
+        // TODO: OCT 1
+        if let layerInputType: LayerInputType = input.id.keyPath,
+           let layerNode: LayerNodeViewModel = nodeViewModel.layerNode {
+            
+//            layerNode.getLayerInspectorInputFields(<#T##LayerInputPort#>)
+//            let port: LayerInputObserver = layerNode[keyPath: layerInputType.layerNodeKeyPath]
+//            let port = layerNode[keyPath: layerInputType.layerNodeKeyPath]
+            
+//            let port: LayerInputObserver = layerNode[keyPath: layerInputType.layerInput.layerNodeKeyPath]
+//            port.blockOrUnblockFields(newValue: value)
+            
+            layerNode
+//                .getLayerInputObserver(layerInputType.layerInput)
+                .blockOrUnblockFields(newValue: value,
+                                      layerInput: layerInputType.layerInput)
+            
+            
+//            let k = layerNode[keyPath: layerInputType]
+            
+            
+//            nodeViewModel.blockOrUnblockFields(
+//                newValue: value,
+//                layerInput: layerInputType.layerInput)
         }
         
         let newCommandType = value.shapeCommandType

--- a/Stitch/Graph/Node/Port/Util/InputEdit/InputCommittedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/InputEdit/InputCommittedActions.swift
@@ -134,13 +134,6 @@ extension GraphState {
                                          activeIndex: self.activeIndex)
         
         // Block or unblock certain layer inputs
-//        if let layerInputType = input.id.keyPath {
-//            nodeViewModel.blockOrUnblockFields(
-//                newValue: value,
-//                layerInput: layerInputType.layerInput)
-//        }
-        
-        // TODO: OCT 1
         if let layerInputType: LayerInputType = input.id.keyPath,
            let layerNode: LayerNodeViewModel = nodeViewModel.layerNode {
             layerNode.blockOrUnblockFields(newValue: value,

--- a/Stitch/Graph/Node/Port/Util/InputEdit/InputEditedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/InputEdit/InputEditedActions.swift
@@ -73,8 +73,10 @@ extension InputNodeRowObserver {
         // If we edited a field on a layer-size input, we may need to block or unblock certain other fields.
         if let newSize = newValue.getSize,
            // Only look at size (not min/max size) changes
-           self.id.keyPath?.layerInput == .size {
-            node.layerSizeUpdated(newValue: newSize)
+           self.id.keyPath?.layerInput == .size,
+           let layerNode = node.layerNode {
+            
+            layerNode.layerSizeUpdated(newValue: newSize)
         }
 
         node.calculate()

--- a/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
@@ -73,11 +73,8 @@ struct NodeFieldsView<FieldType, ValueEntryView>: View where FieldType: FieldVie
 //                        Color.clear
 //                    }
 //                }
-            
-//            fieldViewModel.rowViewModelDelegate?.inputUsesTextField
-                                    
-//            let isBlocked = self.blockedFields?.blocks(.unpacked(fieldViewModel.fieldLabelIndex.asUnpackedPortType)) ?? false
-            let isBlocked = self.blockedFields?.blocks(.unpacked(fieldViewModel.fieldIndex.asUnpackedPortType)) ?? false
+                                                
+            let isBlocked = self.blockedFields?.blocks(.unpacked(fieldViewModel.fieldLabelIndex.asUnpackedPortType)) ?? false
                         
             if !isBlocked {
                 self.valueEntryView(fieldViewModel, isMultiField)

--- a/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
@@ -8,13 +8,6 @@
 import SwiftUI
 import StitchSchemaKit
 
-//extension Set<LayerInputKeyPathType> {
-//    func asIndicesOfBlockedFields() -> Set<Int> {
-//        self.map {
-//            
-//        }
-//    }
-//}
 
 typealias LayerPortTypeSet = Set<LayerInputKeyPathType>
 
@@ -30,18 +23,6 @@ struct NodeFieldsView<FieldType, ValueEntryView>: View where FieldType: FieldVie
     let forPropertySidebar: Bool
     
     let blockedFields: Set<LayerInputKeyPathType>?
-    
-//////    // TODO: OCT 1: pass down from layer input observer
-//    var blockedFields: Set<LayerInputKeyPathType> {
-//        
-//        // Normally only populated for specific inputs; but this would be for ALL
-//        .init([
-//            .unpacked(.port1) // only height blocked
-////            .unpacked(.port0) // only width blocked
-////            .packed // both blocked
-//        ])
-//    }
-    
     
     @ViewBuilder var valueEntryView: (FieldType, Bool) -> ValueEntryView
         
@@ -95,13 +76,9 @@ struct NodeFieldsView<FieldType, ValueEntryView>: View where FieldType: FieldVie
             
 //            fieldViewModel.rowViewModelDelegate?.inputUsesTextField
                                     
-            let isBlocked = self.blockedFields?.blocks(.unpacked(fieldViewModel.fieldLabelIndex.asUnpackedPortType)) ?? false
-            
-            logInView("NodeFieldsView: self.blockedFields: \(self.blockedFields)")
-            logInView("NodeFieldsView: fieldViewModel.fieldLabel: \(fieldViewModel.fieldLabel)")
-            logInView("NodeFieldsView: fieldViewModel.fieldIndex: \(fieldViewModel.fieldIndex)")
-            logInView("NodeFieldsView: isBlocked: \(isBlocked)")
-            
+//            let isBlocked = self.blockedFields?.blocks(.unpacked(fieldViewModel.fieldLabelIndex.asUnpackedPortType)) ?? false
+            let isBlocked = self.blockedFields?.blocks(.unpacked(fieldViewModel.fieldIndex.asUnpackedPortType)) ?? false
+                        
             if !isBlocked {
                 self.valueEntryView(fieldViewModel, isMultiField)
             }
@@ -135,12 +112,5 @@ extension Set<LayerInputKeyPathType> {
         
         // Else, field must be specifically blocked
         return self.contains(portKeypath)
-        
-//        // A field is blocked if its field is specifically blocked,
-//        // or its entire input is blocked:
-//        let specificFieldBlocked = self.contains(portKeypath)
-//        let wholeInputBlocked = self.contains(.packed)
-//        
-//        return specificFieldBlocked || wholeInputBlocked
     }
 }

--- a/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
@@ -50,7 +50,6 @@ struct NodeFieldsView<FieldType, ValueEntryView>: View where FieldType: FieldVie
     }
     
     var allFieldsBlockedOut: Bool {
-//        fieldGroupViewModel.fieldObservers.allSatisfy(\.isBlockedOut)
         if let blockedFields = blockedFields {
             return fieldGroupViewModel.fieldObservers.allSatisfy {
                 $0.isBlocked(blockedFields)
@@ -85,14 +84,7 @@ struct NodeFieldsView<FieldType, ValueEntryView>: View where FieldType: FieldVie
 
 extension FieldViewModel {
     
-    // How often will this run?
-    // and how expensive is the type casting?
-    // Can you instead pass down this information from the top level,
-    // as info that would rarely or hardly change?
-    
-    // ... could instrument this...
-    
-    // Mostly
+    // TODO: instrument perf here?
     func isBlocked(_ blockedFields: Set<LayerInputKeyPathType>) -> Bool {
         blockedFields.blocks(.unpacked(self.fieldLabelIndex.asUnpackedPortType))
     }

--- a/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
@@ -8,27 +8,45 @@
 import SwiftUI
 import StitchSchemaKit
 
+//extension Set<LayerInputKeyPathType> {
+//    func asIndicesOfBlockedFields() -> Set<Int> {
+//        self.map {
+//            
+//        }
+//    }
+//}
+
+typealias LayerPortTypeSet = Set<LayerInputKeyPathType>
+
 struct NodeFieldsView<FieldType, ValueEntryView>: View where FieldType: FieldViewModel,
                                                              ValueEntryView: View {
     @Bindable var graph: GraphState
     
     // just becomes a list of field models
     @Bindable var fieldGroupViewModel: FieldGroupTypeViewModel<FieldType>
-    
-
-//    let blockedFields: Set<LayerInputType>
-    
+        
     let nodeId: NodeId
     let isMultiField: Bool
     let forPropertySidebar: Bool
+    
+    let blockedFields: Set<LayerInputKeyPathType>?
+    
+//////    // TODO: OCT 1: pass down from layer input observer
+//    var blockedFields: Set<LayerInputKeyPathType> {
+//        
+//        // Normally only populated for specific inputs; but this would be for ALL
+//        .init([
+//            .unpacked(.port1) // only height blocked
+////            .unpacked(.port0) // only width blocked
+////            .packed // both blocked
+//        ])
+//    }
     
     
     @ViewBuilder var valueEntryView: (FieldType, Bool) -> ValueEntryView
         
     var body: some View {
-//        if allFieldsBlockedOut {
-        // TODO: OCT 1
-        if false {
+        if allFieldsBlockedOut {
             EmptyView()
         } else {
             
@@ -50,10 +68,16 @@ struct NodeFieldsView<FieldType, ValueEntryView>: View where FieldType: FieldVie
         }
     }
     
-    // TODO: OCT 1
-//    var allFieldsBlockedOut: Bool {
+    var allFieldsBlockedOut: Bool {
 //        fieldGroupViewModel.fieldObservers.allSatisfy(\.isBlockedOut)
-//    }
+        if let blockedFields = blockedFields {
+            return fieldGroupViewModel.fieldObservers.allSatisfy {
+                $0.isBlocked(blockedFields)
+            }
+        }
+        
+        return false
+    }
         
     // fieldObservers / field view models remain our bread-and-butter
     var fields: some View {
@@ -69,10 +93,54 @@ struct NodeFieldsView<FieldType, ValueEntryView>: View where FieldType: FieldVie
 //                    }
 //                }
             
-            // TODO: OCT 1
-//            if !fieldViewModel.isBlockedOut {
+//            fieldViewModel.rowViewModelDelegate?.inputUsesTextField
+                                    
+            let isBlocked = self.blockedFields?.blocks(.unpacked(fieldViewModel.fieldLabelIndex.asUnpackedPortType)) ?? false
+            
+            logInView("NodeFieldsView: self.blockedFields: \(self.blockedFields)")
+            logInView("NodeFieldsView: fieldViewModel.fieldLabel: \(fieldViewModel.fieldLabel)")
+            logInView("NodeFieldsView: fieldViewModel.fieldIndex: \(fieldViewModel.fieldIndex)")
+            logInView("NodeFieldsView: isBlocked: \(isBlocked)")
+            
+            if !isBlocked {
                 self.valueEntryView(fieldViewModel, isMultiField)
-//            }
+            }
         }
+    }
+}
+
+extension FieldViewModel {
+    
+    // How often will this run?
+    // and how expensive is the type casting?
+    // Can you instead pass down this information from the top level,
+    // as info that would rarely or hardly change?
+    
+    // ... could instrument this...
+    
+    // Mostly
+    func isBlocked(_ blockedFields: Set<LayerInputKeyPathType>) -> Bool {
+        blockedFields.blocks(.unpacked(self.fieldLabelIndex.asUnpackedPortType))
+    }
+}
+
+extension Set<LayerInputKeyPathType> {
+    func blocks(_ portKeypath: LayerInputKeyPathType) -> Bool {
+        
+        // If the entire input is blocked,
+        // then every field is blocked:
+        if self.contains(.packed) {
+            return true
+        }
+        
+        // Else, field must be specifically blocked
+        return self.contains(portKeypath)
+        
+//        // A field is blocked if its field is specifically blocked,
+//        // or its entire input is blocked:
+//        let specificFieldBlocked = self.contains(portKeypath)
+//        let wholeInputBlocked = self.contains(.packed)
+//        
+//        return specificFieldBlocked || wholeInputBlocked
     }
 }

--- a/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
@@ -15,13 +15,20 @@ struct NodeFieldsView<FieldType, ValueEntryView>: View where FieldType: FieldVie
     // just becomes a list of field models
     @Bindable var fieldGroupViewModel: FieldGroupTypeViewModel<FieldType>
     
+
+//    let blockedFields: Set<LayerInputType>
+    
     let nodeId: NodeId
     let isMultiField: Bool
     let forPropertySidebar: Bool
+    
+    
     @ViewBuilder var valueEntryView: (FieldType, Bool) -> ValueEntryView
         
     var body: some View {
-        if allFieldsBlockedOut {
+//        if allFieldsBlockedOut {
+        // TODO: OCT 1
+        if false {
             EmptyView()
         } else {
             
@@ -43,9 +50,10 @@ struct NodeFieldsView<FieldType, ValueEntryView>: View where FieldType: FieldVie
         }
     }
     
-    var allFieldsBlockedOut: Bool {
-        fieldGroupViewModel.fieldObservers.allSatisfy(\.isBlockedOut)
-    }
+    // TODO: OCT 1
+//    var allFieldsBlockedOut: Bool {
+//        fieldGroupViewModel.fieldObservers.allSatisfy(\.isBlockedOut)
+//    }
         
     // fieldObservers / field view models remain our bread-and-butter
     var fields: some View {
@@ -61,9 +69,10 @@ struct NodeFieldsView<FieldType, ValueEntryView>: View where FieldType: FieldVie
 //                    }
 //                }
             
-            if !fieldViewModel.isBlockedOut {
+            // TODO: OCT 1
+//            if !fieldViewModel.isBlockedOut {
                 self.valueEntryView(fieldViewModel, isMultiField)
-            }
+//            }
         }
     }
 }

--- a/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
+++ b/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
@@ -136,7 +136,7 @@ struct NodeInputView: View {
         
     // ONLY for port-view, which is only on canvas items
     let rowObserver: InputNodeRowObserver?
-    let rowViewModel: InputNodeRowObserver.RowViewModelType?
+    let rowViewModel: InputNodeRowViewModel? // InputNodeRowObserver.RowViewModelType?
         
     let fieldValueTypes: [FieldGroupTypeViewModel<InputNodeRowViewModel.FieldType>]
     
@@ -206,6 +206,7 @@ struct NodeInputView: View {
                     fieldValueTypes: fieldValueTypes,
                     nodeId: nodeId,
                     forPropertySidebar: forPropertySidebar,
+                    blockedFields: layerInputObserver?.blockedFields,
                     valueEntryView: valueEntryView)
             }
         } // HStack
@@ -311,6 +312,7 @@ struct NodeOutputView: View {
                     fieldValueTypes: rowViewModel.fieldValueTypes,
                     nodeId: nodeId,
                     forPropertySidebar: forPropertySidebar,
+                    blockedFields: nil, // Always nil for output fields
                     valueEntryView: valueEntryView)
             }
             
@@ -345,6 +347,7 @@ struct FieldsListView<PortType, ValueEntryView>: View where PortType: NodeRowVie
     var fieldValueTypes: [FieldGroupTypeViewModel<PortType.FieldType>]
     let nodeId: NodeId
     let forPropertySidebar: Bool
+    let blockedFields: LayerPortTypeSet?
 
     @ViewBuilder var valueEntryView: (PortType.FieldType, Bool) -> ValueEntryView
     
@@ -364,6 +367,7 @@ struct FieldsListView<PortType, ValueEntryView>: View where PortType: NodeRowVie
                            nodeId: nodeId,
                            isMultiField: isMultiField,
                            forPropertySidebar: forPropertySidebar,
+                           blockedFields: blockedFields,
                            valueEntryView: valueEntryView)
         }
     }

--- a/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
+++ b/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
@@ -136,7 +136,7 @@ struct NodeInputView: View {
         
     // ONLY for port-view, which is only on canvas items
     let rowObserver: InputNodeRowObserver?
-    let rowViewModel: InputNodeRowViewModel? // InputNodeRowObserver.RowViewModelType?
+    let rowViewModel: InputNodeRowObserver.RowViewModelType? // i.e. `InputNodeRowViewModel?`
         
     let fieldValueTypes: [FieldGroupTypeViewModel<InputNodeRowViewModel.FieldType>]
     

--- a/Stitch/Graph/Node/Port/ViewModel/FieldViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/FieldViewModel.swift
@@ -25,7 +25,7 @@ protocol FieldViewModel: AnyObject, Observable, Identifiable {
 
     // e.g. Layer's size-scenario is "Constrain Height",
     // so we "block out" the Height fields on the Layer: size.height, minSize.height, maxSize.height
-    var isBlockedOut: Bool { get set }
+//    var isBlockedOut: Bool { get set }
     
     var rowViewModelDelegate: NodeRowType? { get set }
     
@@ -40,7 +40,7 @@ final class InputFieldViewModel: FieldViewModel {
     var fieldValue: FieldValue
     var fieldIndex: Int
     var fieldLabel: String
-    var isBlockedOut: Bool = false
+//    var isBlockedOut: Bool = false
 
     weak var rowViewModelDelegate: InputNodeRowViewModel?
     
@@ -60,7 +60,7 @@ final class OutputFieldViewModel: FieldViewModel {
     var fieldValue: FieldValue
     var fieldIndex: Int
     var fieldLabel: String
-    var isBlockedOut: Bool = false
+//    var isBlockedOut: Bool = false
     
     weak var rowViewModelDelegate: OutputNodeRowViewModel?
     

--- a/Stitch/Graph/Node/Port/ViewModel/FieldViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/FieldViewModel.swift
@@ -22,10 +22,6 @@ protocol FieldViewModel: AnyObject, Observable, Identifiable {
     // eg "X" vs "Y" vs "Z" for .point3D parent-value
     // eg "X" vs "Y" for .position parent-value
     var fieldLabel: String { get set }
-
-    // e.g. Layer's size-scenario is "Constrain Height",
-    // so we "block out" the Height fields on the Layer: size.height, minSize.height, maxSize.height
-//    var isBlockedOut: Bool { get set }
     
     var rowViewModelDelegate: NodeRowType? { get set }
     
@@ -35,43 +31,44 @@ protocol FieldViewModel: AnyObject, Observable, Identifiable {
          rowViewModelDelegate: NodeRowType?)
 }
 
-extension FieldViewModel {
-    
-    // a field index that ignores packed vs. unpacked mode
-    var fieldLabelIndex: Int {
-        guard let rowViewModelDelegate = rowViewModelDelegate else {
-            fatalErrorIfDebug()
-            return fieldIndex
-        }
+// NOTE: not needed, since fieldIndex was updated to be pack vs unpack indifferent
 
-        switch rowViewModelDelegate.id.portType {
-
-        case .portIndex:
-            // leverage patch node definition to get label
-            return fieldIndex
-
-        case .keyPath(let layerInputType):
-
-            switch layerInputType.portType {
-            case .packed:
-                // if it is packed, then field index is correct,
-                // so can use proper label list etc.
-                return fieldIndex
-
-            case .unpacked(let unpackedPortType):
-                let index = unpackedPortType.rawValue
-                return index
-            }
-        }
-    }
-}
+//extension FieldViewModel {
+//    
+//    // a field index that ignores packed vs. unpacked mode
+//    var fieldLabelIndex: Int {
+//        guard let rowViewModelDelegate = rowViewModelDelegate else {
+//            fatalErrorIfDebug()
+//            return fieldIndex
+//        }
+//
+//        switch rowViewModelDelegate.id.portType {
+//
+//        case .portIndex:
+//            // leverage patch node definition to get label
+//            return fieldIndex
+//
+//        case .keyPath(let layerInputType):
+//
+//            switch layerInputType.portType {
+//            case .packed:
+//                // if it is packed, then field index is correct,
+//                // so can use proper label list etc.
+//                return fieldIndex
+//
+//            case .unpacked(let unpackedPortType):
+//                let index = unpackedPortType.rawValue
+//                return index
+//            }
+//        }
+//    }
+//}
 
 @Observable
 final class InputFieldViewModel: FieldViewModel {
     var fieldValue: FieldValue
     var fieldIndex: Int
     var fieldLabel: String
-//    var isBlockedOut: Bool = false
 
     weak var rowViewModelDelegate: InputNodeRowViewModel?
     
@@ -91,7 +88,6 @@ final class OutputFieldViewModel: FieldViewModel {
     var fieldValue: FieldValue
     var fieldIndex: Int
     var fieldLabel: String
-//    var isBlockedOut: Bool = false
     
     weak var rowViewModelDelegate: OutputNodeRowViewModel?
     

--- a/Stitch/Graph/Node/Port/ViewModel/FieldViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/FieldViewModel.swift
@@ -35,6 +35,37 @@ protocol FieldViewModel: AnyObject, Observable, Identifiable {
          rowViewModelDelegate: NodeRowType?)
 }
 
+extension FieldViewModel {
+    
+    // a field index that ignores packed vs. unpacked mode
+    var fieldLabelIndex: Int {
+        guard let rowViewModelDelegate = rowViewModelDelegate else {
+            fatalErrorIfDebug()
+            return fieldIndex
+        }
+
+        switch rowViewModelDelegate.id.portType {
+
+        case .portIndex:
+            // leverage patch node definition to get label
+            return fieldIndex
+
+        case .keyPath(let layerInputType):
+
+            switch layerInputType.portType {
+            case .packed:
+                // if it is packed, then field index is correct,
+                // so can use proper label list etc.
+                return fieldIndex
+
+            case .unpacked(let unpackedPortType):
+                let index = unpackedPortType.rawValue
+                return index
+            }
+        }
+    }
+}
+
 @Observable
 final class InputFieldViewModel: FieldViewModel {
     var fieldValue: FieldValue

--- a/Stitch/Graph/Node/Port/ViewModel/FieldViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/FieldViewModel.swift
@@ -31,38 +31,37 @@ protocol FieldViewModel: AnyObject, Observable, Identifiable {
          rowViewModelDelegate: NodeRowType?)
 }
 
-// NOTE: not needed, since fieldIndex was updated to be pack vs unpack indifferent
+extension FieldViewModel {
+    
+    // a field index that ignores packed vs. unpacked mode
+    // so e.g. a field view model for a height field of a size input will have a fieldLabelIndex of 1, not 0
+    var fieldLabelIndex: Int {
+        guard let rowViewModelDelegate = rowViewModelDelegate else {
+            fatalErrorIfDebug()
+            return fieldIndex
+        }
 
-//extension FieldViewModel {
-//    
-//    // a field index that ignores packed vs. unpacked mode
-//    var fieldLabelIndex: Int {
-//        guard let rowViewModelDelegate = rowViewModelDelegate else {
-//            fatalErrorIfDebug()
-//            return fieldIndex
-//        }
-//
-//        switch rowViewModelDelegate.id.portType {
-//
-//        case .portIndex:
-//            // leverage patch node definition to get label
-//            return fieldIndex
-//
-//        case .keyPath(let layerInputType):
-//
-//            switch layerInputType.portType {
-//            case .packed:
-//                // if it is packed, then field index is correct,
-//                // so can use proper label list etc.
-//                return fieldIndex
-//
-//            case .unpacked(let unpackedPortType):
-//                let index = unpackedPortType.rawValue
-//                return index
-//            }
-//        }
-//    }
-//}
+        switch rowViewModelDelegate.id.portType {
+
+        case .portIndex:
+            // leverage patch node definition to get label
+            return fieldIndex
+
+        case .keyPath(let layerInputType):
+
+            switch layerInputType.portType {
+            case .packed:
+                // if it is packed, then field index is correct,
+                // so can use proper label list etc.
+                return fieldIndex
+
+            case .unpacked(let unpackedPortType):
+                let index = unpackedPortType.rawValue
+                return index
+            }
+        }
+    }
+}
 
 @Observable
 final class InputFieldViewModel: FieldViewModel {

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
@@ -38,10 +38,6 @@ final class LayerInputObserver {
     @MainActor
     init(from schema: LayerNodeEntity, port: LayerInputPort) {
         
-        if port == .pinAnchor || port == .pinOffset || port == .pinTo {
-            log("LayerInputObserver init called for pin-related input")
-        }
-        
         self.layer = schema.layer
         self.port = port
         

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
@@ -21,8 +21,43 @@ final class LayerInputObserver {
     let layer: Layer
     var port: LayerInputPort
     
+//    
+//    /*
+//     Only fields on a layer input (not a patch input or layer output) can be blocked,
+//     and a field is blocked regardless of pack vs unpack mode.
+//     
+//     Example use:
+//     
+//     // the entire minSize input blocked:
+//     self.blockedFields.contains(.init(layerInput: .minSize, portType: .packed))
+//     
+//     // just the width field on the minSize input blocked:
+//     self.blockedFields.contains(.init(layerInput: .minSize, portType: .unpacked(.port0)))
+//     */
+//    var blockedFields: Set<LayerInputType>
+    
+    
+    /*
+     Only fields on a layer input (not a patch input or layer output) can be blocked,
+     and a field is blocked regardless of pack vs unpack mode.
+     
+     Example use:
+     
+     // the entire minSize input blocked:
+     self.blockedFields.contains(.packed)
+     
+     // just the width field on the minSize input blocked:
+     self.blockedFields.contains(.unpacked(.port0))
+     */
+    var blockedFields: Set<LayerInputKeyPathType> // = .init()
+    
     @MainActor
     init(from schema: LayerNodeEntity, port: LayerInputPort) {
+        
+        if port == .pinAnchor || port == .pinOffset || port == .pinTo {
+            log("LayerInputObserver init called for pin-related input")
+        }
+        
         self.layer = schema.layer
         self.port = port
         
@@ -45,6 +80,11 @@ final class LayerInputObserver {
                                    port3: .empty(.init(layerInput: port,
                                                        portType: .unpacked(.port3)),
                                                  layer: schema.layer))
+        
+        // When initialized fom schema, blockedFields is empty.
+        // `blockedFields` is populated when we set or update `activeValue`
+        
+        self.blockedFields = .init()
     }
 }
 

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
@@ -20,28 +20,12 @@ final class LayerInputObserver {
     
     let layer: Layer
     var port: LayerInputPort
-    
-//    
-//    /*
-//     Only fields on a layer input (not a patch input or layer output) can be blocked,
-//     and a field is blocked regardless of pack vs unpack mode.
-//     
-//     Example use:
-//     
-//     // the entire minSize input blocked:
-//     self.blockedFields.contains(.init(layerInput: .minSize, portType: .packed))
-//     
-//     // just the width field on the minSize input blocked:
-//     self.blockedFields.contains(.init(layerInput: .minSize, portType: .unpacked(.port0)))
-//     */
-//    var blockedFields: Set<LayerInputType>
-    
-    
+
     /*
      Only fields on a layer input (not a patch input or layer output) can be blocked,
      and a field is blocked regardless of pack vs unpack mode.
      
-     Example use:
+     Example use with LayerInputObserver for the .minSize input:
      
      // the entire minSize input blocked:
      self.blockedFields.contains(.packed)
@@ -82,8 +66,7 @@ final class LayerInputObserver {
                                                  layer: schema.layer))
         
         // When initialized fom schema, blockedFields is empty.
-        // `blockedFields` is populated when we set or update `activeValue`
-        
+        // `blockedFields` is populated when we e.g. update `activeValue`
         self.blockedFields = .init()
     }
 }

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -446,10 +446,22 @@ extension NodeRowViewModel {
             fieldObserverGroup.updateFieldValues(fieldValues: newFields)
         } // zip
         
+        // TODO: OCT 1
+//        if let node = self.nodeDelegate,
+//           let layerInputForThisRow = rowDelegate.id.keyPath {
+//            node.blockOrUnblockFields(newValue: newValue,
+//                                      layerInput: layerInputForThisRow.layerInput)
+//        }
         if let node = self.nodeDelegate,
+           let layerNode = node.layerNodeViewModel,
            let layerInputForThisRow = rowDelegate.id.keyPath {
-            node.blockOrUnblockFields(newValue: newValue,
-                                      layerInput: layerInputForThisRow.layerInput)
+            
+            layerNode.blockOrUnblockFields(newValue: newValue, 
+                                           layerInput: layerInputForThisRow.layerInput)
+            
+//            layerNode.getLayerInputObserver(layerInputForThisRow.layerInput).blockOrUnblockFields(newValue: newValue)
+            
+//            layerNode[keyPath: layerInputForThisRow.layerInput.layerNodeKeyPath].blockOrUnblockFields(newValue: newValue)
         }
     }
 }

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -446,22 +446,12 @@ extension NodeRowViewModel {
             fieldObserverGroup.updateFieldValues(fieldValues: newFields)
         } // zip
         
-        // TODO: OCT 1
-//        if let node = self.nodeDelegate,
-//           let layerInputForThisRow = rowDelegate.id.keyPath {
-//            node.blockOrUnblockFields(newValue: newValue,
-//                                      layerInput: layerInputForThisRow.layerInput)
-//        }
         if let node = self.nodeDelegate,
            let layerNode = node.layerNodeViewModel,
            let layerInputForThisRow = rowDelegate.id.keyPath {
             
             layerNode.blockOrUnblockFields(newValue: newValue, 
                                            layerInput: layerInputForThisRow.layerInput)
-            
-//            layerNode.getLayerInputObserver(layerInputForThisRow.layerInput).blockOrUnblockFields(newValue: newValue)
-            
-//            layerNode[keyPath: layerInputForThisRow.layerInput.layerNodeKeyPath].blockOrUnblockFields(newValue: newValue)
         }
     }
 }

--- a/Stitch/Graph/Node/ViewModel/NodeDelegate.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeDelegate.swift
@@ -73,11 +73,7 @@ protocol NodeDelegate: AnyObject {
     
     @MainActor func updateOutputsObservers(newOutputsValues: PortValuesList,
                                            activeIndex: ActiveIndex)
-    
-    // TODO: OCT 1
-    @MainActor func _blockOrUnblockFields(newValue: PortValue,
-                                          layerInput: LayerInputPort)
-    
+        
     @MainActor func calculate()
 }
 

--- a/Stitch/Graph/Node/ViewModel/NodeDelegate.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeDelegate.swift
@@ -74,8 +74,9 @@ protocol NodeDelegate: AnyObject {
     @MainActor func updateOutputsObservers(newOutputsValues: PortValuesList,
                                            activeIndex: ActiveIndex)
     
-    @MainActor func blockOrUnblockFields(newValue: PortValue,
-                                         layerInput: LayerInputPort)
+    // TODO: OCT 1
+    @MainActor func _blockOrUnblockFields(newValue: PortValue,
+                                          layerInput: LayerInputPort)
     
     @MainActor func calculate()
 }

--- a/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
@@ -90,7 +90,6 @@ extension LayerNodeViewModel {
      self.blockedFields.contains(.init(layerInput: .minSize, portType: .unpacked(.port0)))
      */
     @MainActor
-//    func setBlockStatus(_ layerInputType: LayerInputType, // e.g. minSize packed input, or min
     func setBlockStatus(_ layerInputType: LayerInputType, // e.g. minSize packed input, or min
                         // blocked = add to blocked-set, else remove
                         isBlocked: Bool) {

--- a/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
@@ -95,7 +95,7 @@ extension LayerNodeViewModel {
                         isBlocked: Bool) {
         
         self.getLayerInputObserver(layerInputType.layerInput)
-            .setBlockStatus(layerInputType.portType, isBlocked: isBlocked)
+            .setBlockStatus(layerInputType, isBlocked: isBlocked)
     }
     
     @MainActor
@@ -503,15 +503,30 @@ extension LayerNodeViewModel {
 
 extension LayerInputObserver {
     @MainActor
-    func setBlockStatus(_ keypathPortType: LayerInputKeyPathType, // e.g. minSize packed input, or min
+//    func setBlockStatus(_ keypathPortType: LayerInputKeyPathType, // e.g. minSize packed input, or min
+    func setBlockStatus(_ keypathPortType: LayerInputType, // e.g. minSize packed input, or min
                         // blocked = add to blocked-set, else remove
                         isBlocked: Bool) {
+        
+        let allChanged = keypathPortType.portType == .packed
+                
         if isBlocked {
-            log("LayerInputObserver: setBlockStatus: will block keypathPortType \(keypathPortType)")
-            self.blockedFields.insert(keypathPortType)
+            
+            if allChanged {
+                log("LayerInputObserver: setBlockStatus: will block all")
+                self.blockedFields = .init([.packed])
+            } else {
+                log("LayerInputObserver: setBlockStatus: will block keypathPortType \(keypathPortType)")
+                self.blockedFields.insert(keypathPortType.portType)
+            }
+            
         } else {
-            log("LayerInputObserver: setBlockStatus: will unblock keypathPortType \(keypathPortType)")
-            self.blockedFields.remove(keypathPortType)
+            if allChanged {
+                self.blockedFields = .init()
+            } else {
+                log("LayerInputObserver: setBlockStatus: will unblock keypathPortType \(keypathPortType)")
+                self.blockedFields.remove(keypathPortType.portType)
+            }
         }
     }
 }

--- a/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
@@ -464,12 +464,6 @@ extension LayerNodeViewModel {
 
     @MainActor
     func unblockPositionAndAnchoringInputs() {
-        
-//        // Unblock the layer input port and/or any of its fields
-//        self.blockedFields = self.blockedFields.filter { (layerInputType: LayerInputType) in
-//            layerInputType.layerInput != .position
-//        }
-//        
         setBlockStatus(LayerInputPort.position.asFullInput,
                        isBlocked: false)
         setBlockStatus(LayerInputPort.anchoring.asFullInput,

--- a/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
+++ b/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
@@ -160,17 +160,31 @@ extension VisibleNodesViewModel {
         }
         
         
-        // Special case: we must re-initialize the group orientation input, since its first initialization happens before we have constructed the layer view models that can tell us all the parents
+        // Special case: we must re-initialize the group orientation input, since its first initialization happens before we have constructed the layer view models that can tell us all the parent's children
         // TODO: a better way to handle this?
         self.nodes.forEach { (key: NodeId, value: NodeViewModel) in
             if let layerNode = value.layerNode,
-               layerNode.layer == .group,
-                let groupOrientationInputObserver: InputNodeRowObserver = value.getInputRowObserver(for: .keyPath(.init(
-                    layerInput: .orientation,
-                    // Group Orientation is always packed
-                    portType: .packed))) {
-                value.blockOrUnblockFields(newValue: groupOrientationInputObserver.activeValue,
-                                           layerInput: .orientation)
+               layerNode.layer == .group
+                // ,
+               
+                
+//                let groupOrientationInputObserver: InputNodeRowObserver = value.getInputRowObserver(for: .keyPath(.init(
+//                    layerInput: .orientation,
+//                    // Group Orientation is always packed
+//                    portType: .packed))) 
+            {
+                
+//                layerNode.orientationPort.blockOrUnblockFields(
+//                    newValue: layerNode.orientationPort.activeValue,
+//                    layerInput: .orientation)
+                layerNode
+//                    .orientationPort
+                    .blockOrUnblockFields(
+                    newValue: layerNode.orientationPort.activeValue,
+                    layerInput: .orientation)
+                
+//                value.blockOrUnblockFields(newValue: groupOrientationInputObserver.activeValue,
+//                                           layerInput: .orientation)
             }
         }
     }

--- a/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
+++ b/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
@@ -164,27 +164,10 @@ extension VisibleNodesViewModel {
         // TODO: a better way to handle this?
         self.nodes.forEach { (key: NodeId, value: NodeViewModel) in
             if let layerNode = value.layerNode,
-               layerNode.layer == .group
-                // ,
-               
-                
-//                let groupOrientationInputObserver: InputNodeRowObserver = value.getInputRowObserver(for: .keyPath(.init(
-//                    layerInput: .orientation,
-//                    // Group Orientation is always packed
-//                    portType: .packed))) 
-            {
-                
-//                layerNode.orientationPort.blockOrUnblockFields(
-//                    newValue: layerNode.orientationPort.activeValue,
-//                    layerInput: .orientation)
-                layerNode
-//                    .orientationPort
-                    .blockOrUnblockFields(
+               layerNode.layer == .group {
+                layerNode.blockOrUnblockFields(
                     newValue: layerNode.orientationPort.activeValue,
                     layerInput: .orientation)
-                
-//                value.blockOrUnblockFields(newValue: groupOrientationInputObserver.activeValue,
-//                                           layerInput: .orientation)
             }
         }
     }


### PR DESCRIPTION
Previously we stored `isBlockedOut: Bool` on `FieldViewModel`, but this was inaccurate because:

1. only a layer input/field can be blocked, and 
2. whether a field is blocked or not is independent of packed vs unpacked, inspector vs canvas etc.

`LayerInputObserver` is now responsible for which fields are blocked (`blockedFields`).

This accurate data modeling makes impossible a bug where a field view model would be properly set as blocked but then lose that information when created down the road: https://github.com/StitchDesign/Stitch--Old/issues/6449