### PR TITLE
Improve shrinking or expanding of shift-select range in layer sidebar

### DIFF
--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
@@ -135,6 +135,7 @@ extension GraphState {
                 
             } else {
                 log("sidebarItemTapped: did not have itemsBetween")
+                // TODO: this can happen when just-clicked == last-clicked, but some apps do not any deselection etc.
             }
         } 
 //        else {

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
@@ -95,11 +95,22 @@ extension GraphState {
                 
                 self.sidebarSelectionState.inspectorFocusedLayers.activelySelected = self.sidebarSelectionState.inspectorFocusedLayers.focused.union(itemsBetweenSet)
                   
+                self.handleShiftClick(flatList: flatList,
+                                      itemsBetween: itemsBetween,
+                                      originalIsland: originalIsland,
+                                      lastClickedItem: lastClickedItem,
+                                      justClickedItem: clickedItem)
+                
+//                self.shrinkExpansions(flatList: flatList,
+//                                      originalIsland: originalIsland,
+//                                      newIsland: itemsBetween,
+//                                      lastClickedItem: lastClickedItem)
+                
                 // Modifies `originalIsland`
-                self.expandOrShrinkExpansions(flatList: flatList,
-                                              originalIsland: originalIsland,
-                                              newIsland: itemsBetween,
-                                              lastClickedItem: lastClickedItem)
+//                self.expandOrShrinkExpansions(flatList: flatList,
+//                                              originalIsland: originalIsland,
+//                                              newIsland: itemsBetween,
+//                                              lastClickedItem: lastClickedItem)
                                 
                 // Shift click does NOT change the `lastFocusedLayer`
                 // self.sidebarSelectionState.inspectorFocusedLayers.lastFocusedLayer = id

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
@@ -27,21 +27,29 @@ extension GraphState {
     @MainActor
     func sidebarItemTapped(id: LayerNodeId, shiftHeld: Bool) {
         log("sidebarItemTapped: id: \(id)")
+        let _layer = self.getNode(id.asNodeId)!.layerNode!.layer
+        log("sidebarItemTapped: layer: \(_layer)")
         log("sidebarItemTapped: shiftHeld: \(shiftHeld)")
-        
+                
         let originalSelections = self.sidebarSelectionState.inspectorFocusedLayers.focused
+        
+        log("sidebarItemTapped: originalSelections: \(originalSelections)")
         
         if shiftHeld, originalSelections.isEmpty {
             // Special case: if no current selections, shift-click just selects from the top to the clicked item; and the shift-clicked item counts as the 'last selected item'
             let flatList = self.orderedSidebarLayers.getFlattenedList()
             if let indexOfTappedItem = flatList.firstIndex(where: { $0.id == id.asNodeId }) {
+                
                 let selectionsFromTop = flatList[0...indexOfTappedItem].map(\.id)
+                
                 self.sidebarSelectionState.inspectorFocusedLayers.focused = .init(selectionsFromTop.map(\.asLayerNodeId))
                 self.sidebarSelectionState.inspectorFocusedLayers.activelySelected = .init(selectionsFromTop.map(\.asLayerNodeId))
+                
                 self.sidebarSelectionState.inspectorFocusedLayers.lastFocusedLayer = id
+                
                 self.editModeSelectTappedItems(tappedItems: self.sidebarSelectionState.inspectorFocusedLayers.focused)
             } else {
-                log("sidebarItemTapped: could not retrieve index of tapped item when no oge")
+                log("sidebarItemTapped: could not retrieve index of tapped item when")
                 fatalErrorIfDebug()
             }
             
@@ -78,7 +86,7 @@ extension GraphState {
                 // Look at focused layers
                 selections: originalSelections) {
                 
-                 log("sidebarItemTapped: itemsBetween: \(itemsBetween.map(\.id))")
+                log("sidebarItemTapped: itemsBetween: \(itemsBetween.map(\.id))")
                 let itemsBetweenSet: LayerIdSet = itemsBetween.map(\.id.asLayerNodeId).toSet
                 
                 // ORIGINAL
@@ -99,6 +107,7 @@ extension GraphState {
                 // If we ended up selecting the exact same as the original,
                 // then we actually DE-SELECTED the range.
                 let newSelections = self.sidebarSelectionState.inspectorFocusedLayers.focused
+                log("sidebarItemTapped: selected range: newSelections: \(newSelections)")
                 if newSelections == originalSelections {
                     log("sidebarItemTapped: selected range; will wipe inspectorFocusedLayers")
                                         

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarListItemSelectionHelpers.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarListItemSelectionHelpers.swift
@@ -89,7 +89,8 @@ extension GraphState {
                                   newIsland: [ListItem],
                                   lastClickedItem: ListItem) {
         
-        var shrunk = false
+//        var shrunk = false
+        var shrunk = true
         
         if let originalIslandTop = originalIsland.first,
            let originalIslandTopIndex = flatList.firstIndex(of: originalIslandTop),
@@ -105,30 +106,100 @@ extension GraphState {
            
             let lastClickedItemIndex = flatList.firstIndex(of: lastClickedItem) {
             
+            log("expandOrShrinkExpansions: originalIslandTopIndex \(originalIslandTopIndex)")
+            log("expandOrShrinkExpansions: originalIslandBottomIndex \(originalIslandBottomIndex)")
+            log("expandOrShrinkExpansions: newIslandTopIndex \(newIslandTopIndex)")
+            log("expandOrShrinkExpansions: newIslandBottomIndex \(newIslandBottomIndex)")
+            log("expandOrShrinkExpansions: lastClickedItemIndex \(lastClickedItemIndex)")
+                   
+            let originalBottomBelowLastClicked = originalIslandBottomIndex > lastClickedItemIndex
+            
+            let newBottomBelowLastClicked = newIslandBottomIndex > lastClickedItemIndex
+            
+            log("expandOrShrinkExpansions: originalBottomBelowLastClicked \(originalBottomBelowLastClicked)")
+            log("expandOrShrinkExpansions: newBottomBelowLastClicked \(newBottomBelowLastClicked)")
+            
+            let originalTopAboveLastClicked = originalIslandTopIndex < lastClickedItemIndex
+            let newTopAboveLastClicked = newIslandTopIndex < lastClickedItemIndex
+            
+            log("expandOrShrinkExpansions: originalTopAboveLastClicked \(originalTopAboveLastClicked)")
+            log("expandOrShrinkExpansions: newTopAboveLastClicked \(newTopAboveLastClicked)")
+            
+            let originalTopAboveNewTop = originalIslandTopIndex < newIslandTopIndex
+//            let originalTopBelowNewTop = originalIslandTopIndex > newIslandTopIndex
+            
+            let newTopAboveOriginalTop = newIslandTopIndex < originalIslandTopIndex
+            
+//            let originalBottomAboveNewBottom = originalIslandBottomIndex < newIslandBottomIndex
+            let newBottomAboveOriginalBottom = newIslandBottomIndex < originalIslandBottomIndex
+            
+            // We also shrink if new t
+            
+            
+//            log("expandOrShrinkExpansions: originalTopAboveNewTop \(originalTopAboveNewTop)")
+//            log("expandOrShrinkExpansions: newTopAboveOriginalTop \(newTopAboveOriginalTop)")
+                        
             // If both original and new range expanded downward from the non-shift-click point, then we expanded
-            if originalIslandBottomIndex > lastClickedItemIndex && newIslandBottomIndex > lastClickedItemIndex {
+//            if originalIslandBottomIndex > lastClickedItemIndex && newIslandBottomIndex > lastClickedItemIndex {
+            if originalBottomBelowLastClicked && newBottomBelowLastClicked {
+                log("expandOrShrinkExpansions: original bottom was below last clicked AND new bottom is below last clicked")
                 shrunk = false
             }
 
             // If both original and new range expanded upward from the non-shift-click point, then we expanded
-            else if originalIslandTopIndex < lastClickedItemIndex && newIslandTopIndex < lastClickedItemIndex {
-
+//            else if originalIslandTopIndex < lastClickedItemIndex && newIslandTopIndex < lastClickedItemIndex {
+//            if originalIslandTopIndex < lastClickedItemIndex && newIslandTopIndex < lastClickedItemIndex {
+            if originalTopAboveLastClicked && newTopAboveLastClicked {
+                log("expandOrShrinkExpansions: original top was above last clicked AND new bottom is above last clicked")
                 shrunk = false
             }
             
-            // Else assume we shrunk?
-            else {
+
+            // If the new top is above the old top, we shrunk? But only if the original top was below the last clicked
+//            if newTopAboveLastClicked && originalBottomBelowLastClicked {
+            if originalBottomBelowLastClicked && newBottomAboveOriginalBottom {
+                log("expandOrShrinkExpansions: new bottom is above old bottom and the old bottom was below last clicked; so we shrunk")
                 shrunk = true
             }
+            
+//            originalBelow
+            
+            
+//            // Else assume we shrunk?
+//            else {
+//                log("expandOrShrinkExpansions: defaulting to true")
+//                shrunk = true
+//            }
         }
-                        
-        originalIsland.forEach {
-//                    if $0 != lastClickedItem && clickedEarlierThanStart {
-            if $0 != lastClickedItem && shrunk {
-                self.sidebarSelectionState.inspectorFocusedLayers.focused.remove($0.id.asLayerNodeId)
-                self.sidebarSelectionState.inspectorFocusedLayers.activelySelected.remove($0.id.asLayerNodeId)
+        
+        log("expandOrShrinkExpansions: shrunk \(shrunk)")
+        
+        if shrunk {
+            // If we shrunk, remove the items that are in the original island but not the new island
+            flatList.forEach { item in
+                let itemIsInNewIsland = newIsland.contains(item)
+                let itemIsInOldIsland = originalIsland.contains(item)
+                
+                if itemIsInOldIsland
+                    && !itemIsInNewIsland
+                    && item != lastClickedItem {
+                    
+                    log("expandOrShrinkExpansions: will remove item \(item)")
+                    self.sidebarSelectionState.inspectorFocusedLayers.focused.remove(item.id.asLayerNodeId)
+                    self.sidebarSelectionState.inspectorFocusedLayers.activelySelected.remove(item.id.asLayerNodeId)
+                }
             }
+            
         }
+        
+//        originalIsland.forEach {
+//        newIsland.forEach {
+//            if $0 != lastClickedItem && shrunk {
+//                log("expandOrShrinkExpansions: will remove \($0)")
+//                self.sidebarSelectionState.inspectorFocusedLayers.focused.remove($0.id.asLayerNodeId)
+//                self.sidebarSelectionState.inspectorFocusedLayers.activelySelected.remove($0.id.asLayerNodeId)
+//            }
+//        }
     }
     
     /*

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
@@ -121,6 +121,7 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
     var layerNodeId: LayerNodeId
     
     var shiftHeldDown = false
+    var commandHeldDown = false
 
     init(gestureViewModel: SidebarItemGestureViewModel,
          keyboardObserver: KeyboardObserver,
@@ -146,6 +147,12 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
             self.shiftHeldDown = false
         }
         
+        if event.modifierFlags.contains(.command) {
+            self.commandHeldDown = true
+        } else {
+            self.commandHeldDown = false
+        }
+        
         return true
     }
 
@@ -160,7 +167,8 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
         }
         
         dispatch(SidebarItemTapped(id: layerNodeId,
-                                   shiftHeld: self.shiftHeldDown))
+                                   shiftHeld: self.shiftHeldDown,
+                                   commandHeld: self.commandHeldDown))
         
     }
     
@@ -268,7 +276,8 @@ extension SidebarListGestureRecognizer: UIContextMenuInteractionDelegate {
             // Note: we do the selection logic in here so that
             self.graph.sidebarItemTapped(
                 id: self.layerNodeId,
-                shiftHeld: isShiftDown)
+                shiftHeld: isShiftDown,
+                commandHeld: self.graph.keypressState.isCommandPressed)
         }
                 
         let selections = self.graph.sidebarSelectionState


### PR DESCRIPTION
- properly handle some cases where the contiguous range may have shrunk or expanded
- if just-clicked item == last-clicked-item, then deselect everything in the contiguous range but the clicked item
- prefer listening to Command Key via UIKit tap gesture; more accurate

https://github.com/user-attachments/assets/f77b17f9-d285-48dc-a726-59b9db9ec687

