### PR TITLE
Option+Drag for sidebar layers

### DIFF
--- a/Stitch/Graph/Sidebar/Model/Gesture/SidebarSelectionState.swift
+++ b/Stitch/Graph/Sidebar/Model/Gesture/SidebarSelectionState.swift
@@ -49,6 +49,9 @@ struct SidebarSelectionState: Codable, Equatable, Hashable {
     // avoid this?
     var madeStack: Bool = false
     
+    var haveDuplicated: Bool = false
+    var optionDragInProgress: Bool = false 
+    
     // non-empty only during active layer drag (multi-drag only?)
     var implicitlyDragged = SidebarListItemIdSet()
     

--- a/Stitch/Graph/Sidebar/Util/Gesture/SidebarListUIActions.swift
+++ b/Stitch/Graph/Sidebar/Util/Gesture/SidebarListUIActions.swift
@@ -26,14 +26,20 @@ func moveSidebarListItemIntoGroup(_ item: SidebarListItem,
     var items = items
         
     // Every explicitly dragged item gets the new parent
-    ([item.id] + otherSelections).forEach { otherSelection in
-        var otherItem = retrieveItem(otherSelection, items)
+    for otherSelection in ([item.id] + otherSelections) {
+        guard var otherItem = retrieveItem(otherSelection, items) else {
+            fatalErrorIfDebug("Could not retrieve item")
+            continue
+        }
         otherItem.parentId = proposedGroup.parentId
         otherItem.location.x = proposedGroup.indentationLevel.toXLocation
         items = updateSidebarListItem(otherItem, items)
     }
     
-    let updatedItem = retrieveItem(item.id, items)
+    guard let updatedItem = retrieveItem(item.id, items) else {
+        fatalErrorIfDebug("Could not retrieve item")
+        return items
+    }
     
     return maybeSnapDescendants(updatedItem,
                                 items,
@@ -50,14 +56,20 @@ func moveSidebarListItemToTopLevel(_ item: SidebarListItem,
     var items = items
 
     // Every explicitly dragged item gets its parent and indentation-level wiped
-    ([item.id] + otherSelections).forEach { otherSelection in
-        var otherItem = retrieveItem(otherSelection, items)
+    for otherSelection in ([item.id] + otherSelections) {
+        guard var otherItem = retrieveItem(otherSelection, items) else {
+            fatalErrorIfDebug("Could not retrieve item")
+            continue
+        }
         otherItem.parentId = nil
         otherItem.location.x = 0
         items = updateSidebarListItem(otherItem, items)
     }
     
-    let updatedItem = retrieveItem(item.id, items)
+    guard let updatedItem = retrieveItem(item.id, items) else {
+        fatalErrorIfDebug("Could not retrieve item")
+        return items
+    }
 
     return maybeSnapDescendants(updatedItem,
                                 items,

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
@@ -16,13 +16,11 @@ struct SidebarItemTapped: GraphEvent {
     let id: LayerNodeId
     let shiftHeld: Bool
     let commandHeld: Bool
-    let optionHeld: Bool
     
     func handle(state: GraphState) {
         state.sidebarItemTapped(id: id,
                                 shiftHeld: shiftHeld,
-                                commandHeld: commandHeld,
-                                optionHeld: optionHeld)
+                                commandHeld: commandHeld)
     }
 }
 
@@ -31,8 +29,7 @@ extension GraphState {
     @MainActor
     func sidebarItemTapped(id: LayerNodeId,
                            shiftHeld: Bool,
-                           commandHeld: Bool,
-                           optionHeld: Bool) {
+                           commandHeld: Bool) {
         log("sidebarItemTapped: id: \(id)")
         
         #if DEV_DEBUG
@@ -45,25 +42,6 @@ extension GraphState {
         let originalSelections = self.sidebarSelectionState.inspectorFocusedLayers.focused
         
         log("sidebarItemTapped: originalSelections: \(originalSelections)")
-        
-                
-        if optionHeld {
-            log("sidebarItemTapped: optionHeld: \(optionHeld)")
-            
-            if originalSelections.isEmpty {
-                self.sidebarSelectionState.resetEditModeSelections()
-                self.sidebarSelectionState.inspectorFocusedLayers.focused = .init([id])
-                self.sidebarSelectionState.inspectorFocusedLayers.activelySelected = .init([id])
-                self.sidebarItemSelectedViaEditMode(id, isSidebarItemTapped: true)
-                self.sidebarSelectionState.inspectorFocusedLayers.lastFocusedLayer = id
-                self.deselectAllCanvasItems()
-            }
-            
-            self.sidebarSelectedItemsDuplicatedViaEditMode()
-            
-            return
-        }
-        
         
         if shiftHeld, originalSelections.isEmpty {
             // Special case: if no current selections, shift-click just selects from the top to the clicked item; and the shift-clicked item counts as the 'last selected item'

--- a/Stitch/Graph/Sidebar/Util/SidebarListItemGroupActions.swift
+++ b/Stitch/Graph/Sidebar/Util/SidebarListItemGroupActions.swift
@@ -33,8 +33,11 @@ extension GraphState {
     func deselectDescendantsOfClosedGroup(_ closedParentId: LayerNodeId) {
         
         // Remove any non-edit-mode selected children; we don't want the 'selected sidebar layer' to be hidden
-        let closedParent = retrieveItem(closedParentId.asItemId,
-                                        self.sidebarListState.masterList.items)
+        guard let closedParent = retrieveItem(closedParentId.asItemId,
+                                              self.sidebarListState.masterList.items) else {
+            fatalErrorIfDebug("Could not retrieve item")
+            return
+        }
         
         let descendants = Stitch.getDescendants(closedParent,
                                                 self.sidebarListState.masterList.items)
@@ -118,7 +121,10 @@ func onSidebarListItemGroupOpened(openedId: SidebarListItemId,
     // so that we can unfurl its own children
     masterList.collapsedGroups.remove(openedId)
 
-    let parentItem = retrieveItem(openedId, masterList.items)
+    guard let parentItem = retrieveItem(openedId, masterList.items) else {
+        fatalErrorIfDebug("Could not retrieve item")
+        return masterList
+    }
     let parentIndex = parentItem.itemIndex(masterList.items)
 
     let originalCount = masterList.items.count
@@ -159,7 +165,10 @@ func onSidebarListItemGroupClosed(closedId: SidebarListItemId,
 
     print("onSidebarListItemGroupClosed called")
 
-    let closedParent = retrieveItem(closedId, masterList.items)
+    guard let closedParent = retrieveItem(closedId, masterList.items) else {
+        fatalErrorIfDebug("Could not retrieve item")
+        return masterList
+    }
 
     var masterList = masterList
 

--- a/Stitch/Graph/Sidebar/Util/SidebarListItemToggleHelpers.swift
+++ b/Stitch/Graph/Sidebar/Util/SidebarListItemToggleHelpers.swift
@@ -63,7 +63,10 @@ func hideChildren(closedParentId: SidebarListItemId,
 
     var masterList = masterList
 
-    let closedParent = retrieveItem(closedParentId, masterList.items)
+    guard let closedParent = retrieveItem(closedParentId, masterList.items) else {
+        fatalErrorIfDebug("Could not retrieve item")
+        return masterList
+    }
 
     // if there are no descendants, then we're basically done
 
@@ -262,7 +265,10 @@ func unhideChildren(openedParent: SidebarListItemId,
 
     // log("unhideChildren: parentIndex: \(parentIndex)")
 
-    let parent = retrieveItem(openedParent, masterList.items)
+    guard let parent = retrieveItem(openedParent, masterList.items) else {
+        fatalErrorIfDebug("Could not retrieve item")
+        return (masterList, parentIndex)
+    }
 
     // if you start with the parent, you double add it
     let (updatedMaster, lastIndex, _) = unhideChildrenHelper(
@@ -324,8 +330,8 @@ func adjustNonDescendantsBelow(_ lastIndex: Int, // the last item
 }
 
 func retrieveItem(_ id: SidebarListItemId,
-                  _ items: SidebarListItems) -> SidebarListItem {
-    items.first { $0.id == id }!
+                  _ items: SidebarListItems) -> SidebarListItem? {
+    items.first { $0.id == id }
 }
 
 func hasChildren(_ parentId: SidebarListItemId, _ masterList: MasterList) -> Bool {

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
@@ -122,6 +122,7 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
     
     var shiftHeldDown = false
     var commandHeldDown = false
+    var optionHeldDown = false
 
     init(gestureViewModel: SidebarItemGestureViewModel,
          keyboardObserver: KeyboardObserver,
@@ -153,6 +154,15 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
             self.commandHeldDown = false
         }
         
+        if event.modifierFlags.contains(.alternate) {
+            log("OPTION DOWN")
+            self.optionHeldDown = true
+        } else {
+            log("OPTION NOT DOWN")
+            self.optionHeldDown = false
+        }
+        
+        
         return true
     }
 
@@ -168,7 +178,8 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
         
         dispatch(SidebarItemTapped(id: layerNodeId,
                                    shiftHeld: self.shiftHeldDown,
-                                   commandHeld: self.commandHeldDown))
+                                   commandHeld: self.commandHeldDown,
+                                   optionHeld: self.optionHeldDown))
         
     }
     
@@ -277,7 +288,8 @@ extension SidebarListGestureRecognizer: UIContextMenuInteractionDelegate {
             self.graph.sidebarItemTapped(
                 id: self.layerNodeId,
                 shiftHeld: isShiftDown,
-                commandHeld: self.graph.keypressState.isCommandPressed)
+                commandHeld: self.graph.keypressState.isCommandPressed,
+                optionHeld: self.graph.keypressState.isOptionPressed)
         }
                 
         let selections = self.graph.sidebarSelectionState

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
@@ -122,7 +122,6 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
     
     var shiftHeldDown = false
     var commandHeldDown = false
-    var optionHeldDown = false
 
     init(gestureViewModel: SidebarItemGestureViewModel,
          keyboardObserver: KeyboardObserver,
@@ -154,15 +153,6 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
             self.commandHeldDown = false
         }
         
-        if event.modifierFlags.contains(.alternate) {
-            log("OPTION DOWN")
-            self.optionHeldDown = true
-        } else {
-            log("OPTION NOT DOWN")
-            self.optionHeldDown = false
-        }
-        
-        
         return true
     }
 
@@ -178,8 +168,7 @@ final class SidebarListGestureRecognizer: NSObject, UIGestureRecognizerDelegate 
         
         dispatch(SidebarItemTapped(id: layerNodeId,
                                    shiftHeld: self.shiftHeldDown,
-                                   commandHeld: self.commandHeldDown,
-                                   optionHeld: self.optionHeldDown))
+                                   commandHeld: self.commandHeldDown))
         
     }
     
@@ -288,8 +277,7 @@ extension SidebarListGestureRecognizer: UIContextMenuInteractionDelegate {
             self.graph.sidebarItemTapped(
                 id: self.layerNodeId,
                 shiftHeld: isShiftDown,
-                commandHeld: self.graph.keypressState.isCommandPressed,
-                optionHeld: self.graph.keypressState.isOptionPressed)
+                commandHeld: self.graph.keypressState.isCommandPressed)
         }
                 
         let selections = self.graph.sidebarSelectionState


### PR DESCRIPTION
Note: this will look better once we insert duplicated layer items at their proper place again, instead of just adding them to the top of the list.

### option+dragging two top level items
https://github.com/user-attachments/assets/92a4eae6-d62c-4071-9765-a8645d4d83df

 
### option+dragging a group, one of its children, and another top-level item 
https://github.com/user-attachments/assets/9f2951d3-89f5-45cd-9a55-0dcc5196fe9b



