### PR TITLE
Shift-select nested sidebar layers

### DIFF
--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarListItemSelectionHelpers.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarListItemSelectionHelpers.swift
@@ -223,9 +223,21 @@ extension GraphState {
 
 extension SidebarLayerList {
     func getFlattenedList() -> [ListItem] {
-        self.flatMap { [$0] + ($0.children ?? []) }
+        flattenListItems(self, acc: .init())
     }
 }
+
+func flattenListItems(_ items: [ListItem],
+                      acc: [ListItem]) -> [ListItem] {
+    var acc = acc
+    items.forEach { item in
+        acc.append(item)
+        let accFromChildren = flattenListItems(item.children ?? [], acc: .init())
+        acc += accFromChildren
+    }
+    return acc
+}
+
 
 // Function to find all items between the smallest and largest consecutive selected items (inclusive)
 // `findItemsBetweenSmallestAndLargestSelected`


### PR DESCRIPTION
We now properly flatten the nested ordered-sidebar-layers list.

https://github.com/user-attachments/assets/bd1c5bf3-501e-4939-a195-85b877851a75

