### PR TITLE
Group (CMD+G) and Ungroup (CMD+Delete) shortcuts

### DIFF
--- a/Stitch/App/Shortcut/ShortcutsUtils.swift
+++ b/Stitch/App/Shortcut/ShortcutsUtils.swift
@@ -15,6 +15,8 @@ let INSERT_NODE_MENU_SHORTCUT: KeyEquivalent = "I"
 
 let DUPLICATE_SELECTED_NODES_SHORTCUT: KeyEquivalent = "D"
 
+let GROUP_LAYERS_SHORTCUT: KeyEquivalent = "G"
+
 let DELETE_SELECTED_NODES_SHORTCUT: KeyEquivalent = .delete
 let DELETE_SELECTED_NODES_SHORTCUT_MODIFIERS: EventModifiers = []
 

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarGroupCreated.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarGroupCreated.swift
@@ -14,7 +14,7 @@ import SwiftUI
 struct SidebarGroupCreated: StitchDocumentEvent {
 
     func handle(state: StitchDocumentViewModel) {
-        log("_createLayerGroup called")
+        log("SidebarGroupCreated called")
         
         // Create node view model for the new Layer Group
         
@@ -64,8 +64,12 @@ struct SidebarGroupCreated: StitchDocumentEvent {
         // Update legacy state
         state.visibleGraph.updateSidebarListStateAfterStateChange()
         
-        // Reset selections
-        state.visibleGraph.sidebarSelectionState.resetEditModeSelections()
+        // Only reset edit mode selections if we're explicitly in edit mode (i.e. on iPad)
+        if state.graph.sidebarSelectionState.isEditMode {
+            // Reset selections
+            state.visibleGraph.sidebarSelectionState.resetEditModeSelections()
+        }
+
         
         // NOTE: must do this AFTER children have been assigned to the new layer node; else we return preview window size
         

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarGroupUncreated.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarGroupUncreated.swift
@@ -33,7 +33,9 @@ extension GraphState {
             return
         }
         
-        let children = self.orderedSidebarLayers.get(group.id)?.children ?? []
+        // let children = self.orderedSidebarLayers.get(group.id)?.children ?? []
+        let children = self.orderedSidebarLayers.getSidebarLayerData(group.id)?.children ?? []
+        
         let newParentId = self.getNodeViewModel(group.asNodeId)?.layerNode?.layerGroupId
 
         // Update sidebar self

--- a/Stitch/Graph/Sidebar/Util/SidebarVisibilityUtils.swift
+++ b/Stitch/Graph/Sidebar/Util/SidebarVisibilityUtils.swift
@@ -19,12 +19,12 @@ let SIDEBAR_VISIBILITY_STATUS_SECONDARY_HIDDEN_COLOR: Color = Color(uiColor: .da
 let SIDEBAR_VISIBILITY_STATUS_VISIBLE_COLOR: Color = .white
 
 extension GraphState {
+    
+    @MainActor
     func getVisibilityStatus(for layerNodeId: NodeId) -> SidebarVisibilityStatus {
-        
         guard let layerNode = self
             .getLayerNode(id: layerNodeId)?
             .layerNode else {
-            log("getVisibilityStatus: could not find layer node \(layerNodeId)")
             return .visible
         }
         
@@ -40,6 +40,7 @@ extension GraphState {
         return .visible
     }
 
+    @MainActor
     func isUpstreamNodeInvisible(for layerNode: LayerNodeViewModel) -> Bool {
         guard let groupId = layerNode.layerGroupId,
               let layerGroup = self.nodes.get(groupId)?.layerNode else {

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeInnerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeInnerView.swift
@@ -34,6 +34,7 @@ struct SidebarListItemSwipeInnerView: View {
     
     var itemIndent: CGFloat { item.location.x }
     
+    @MainActor
     var isHidden: Bool {
         graph.getVisibilityStatus(for: item.id.asNodeId) != .visible
     }


### PR DESCRIPTION
Note: both shortcuts disabled when no layers actively selected and each shortcut respectively disabled when its specific conditions are not met (e.g. to ungroup, we must have a group selected).

Also fixes two other bugs:
1. do not reset edit-mode selections unless in edit mode when group created
2. retrieve proper children when group uncreated


https://github.com/user-attachments/assets/d43e9fd0-52b0-4c98-b994-d894e1c2f1d2

