### PR TITLE
Improved project thumbnail loading

### DIFF
--- a/Stitch/App/Model/LoadingStatus.swift
+++ b/Stitch/App/Model/LoadingStatus.swift
@@ -35,6 +35,15 @@ extension DocumentLoadingStatus: Hashable {
             hasher.combine(image.hashValue)
         }
     }
+    
+    var document: StitchDocument? {
+        switch self {
+        case .loaded(let document, _):
+            return document
+        default:
+            return nil
+        }
+    }
 }
 
 extension DocumentLoadingStatus: Equatable {

--- a/Stitch/App/Model/LoadingStatus.swift
+++ b/Stitch/App/Model/LoadingStatus.swift
@@ -5,7 +5,7 @@
 //  Created by Elliot Boschwitz on 12/24/22.
 //
 
-import Foundation
+import SwiftUI
 import StitchSchemaKit
 
 enum LoadingState: Equatable {
@@ -18,7 +18,7 @@ enum DocumentLoadingStatus: Sendable {
     case initialized
     case failed
     case loading
-    case loaded(StitchDocument)
+    case loaded(StitchDocument, UIImage?)
 }
 
 extension DocumentLoadingStatus: Hashable {
@@ -30,8 +30,9 @@ extension DocumentLoadingStatus: Hashable {
             hasher.combine("failed")
         case .loading:
             hasher.combine("loading")
-        case .loaded(let document):
+        case .loaded(let document, let image):
             hasher.combine(document.id)
+            hasher.combine(image.hashValue)
         }
     }
 }

--- a/Stitch/App/Serialization/DocumentLoading/ProjectLoader.swift
+++ b/Stitch/App/Serialization/DocumentLoading/ProjectLoader.swift
@@ -29,6 +29,11 @@ final class ProjectLoader: Sendable {
 
 extension ProjectLoader: Identifiable {
     var id: Int { self.url.hashValue }
+    
+    func resetData() {
+        self.loadingDocument = .loading
+        self.thumbnail = nil
+    }
 }
 
 extension [ProjectLoader] {

--- a/Stitch/App/Serialization/DocumentLoading/ProjectLoader.swift
+++ b/Stitch/App/Serialization/DocumentLoading/ProjectLoader.swift
@@ -14,6 +14,7 @@ final class ProjectLoader: Sendable {
     var modifiedDate: Date
     var url: URL
     var loadingDocument: DocumentLoadingStatus = .initialized
+    var thumbnail: UIImage?
 
     /// Initialzes object with some URL, not yet loading document until loaded in lazy view.
     init(url: URL) {

--- a/Stitch/App/Serialization/FileDropHandling.swift
+++ b/Stitch/App/Serialization/FileDropHandling.swift
@@ -45,7 +45,7 @@ func handleOnDrop(providers: [NSItemProvider],
                     do {
                         switch await store?.documentLoader.loadDocument(from: tempURL,
                                                                         isImport: true) {
-                        case .loaded(let data):
+                        case .loaded(let data, _):
                             DispatchQueue.main.async { [weak store] in
                                 store?.openProjectAction(from: data)
                             }

--- a/Stitch/App/Serialization/FileDropHandling.swift
+++ b/Stitch/App/Serialization/FileDropHandling.swift
@@ -41,15 +41,13 @@ func handleOnDrop(providers: [NSItemProvider],
 
             // Opens stitch documents
             guard tempURL.pathExtension != STITCH_EXTENSION_RAW else {
-                Task { [weak store] in
+                Task(priority: .high) { [weak store] in
                     do {
                         switch await store?.documentLoader.loadDocument(from: tempURL,
                                                                         isImport: true) {
                         case .loaded(let data, _):
-                            DispatchQueue.main.async { [weak store] in
-                                store?.openProjectAction(from: data)
-                            }
-                        default:
+                            await store?.createNewProject(from: data)
+                       default:
                             DispatchQueue.main.async {
                                 dispatch(DisplayError(error: .unsupportedProject))
                             }

--- a/Stitch/App/Serialization/Util/File/StitchCustomURL.swift
+++ b/Stitch/App/Serialization/Util/File/StitchCustomURL.swift
@@ -77,24 +77,19 @@ func onCampsiteURLOpen(_ url: URL, store: StitchStore) async throws {
         let localURL = try! await downloadFile(from: httpsURL)
         log("onCampsiteURLOpen: localURL: \(localURL)")
         
-        switch await store.documentLoader.loadDocument(
-            from: localURL,
+        guard let document = try await StitchDocument.openDocument(
+            from: url,
             isImport: true,
-            isNonICloudDocumentsFile: true) {
-            
-        case .loaded(let data, _):
-            DispatchQueue.main.async { [weak store] in
-                log("onCampsiteURLOpen: will open project from document")
-                store?.openProjectAction(from: data)
-            }
-            
-        default:
+            isNonICloudDocumentsFile: true) else {
             DispatchQueue.main.async {
                 log("onCampsiteURLOpen: unsupported project")
                 dispatch(DisplayError(error: .unsupportedProject))
             }
             return
         }
+            
+        log("onCampsiteURLOpen: will open project from document")
+        await store.createNewProject(from: document)
     }
     
     return

--- a/Stitch/App/Serialization/Util/File/StitchCustomURL.swift
+++ b/Stitch/App/Serialization/Util/File/StitchCustomURL.swift
@@ -82,7 +82,7 @@ func onCampsiteURLOpen(_ url: URL, store: StitchStore) async throws {
             isImport: true,
             isNonICloudDocumentsFile: true) {
             
-        case .loaded(let data):
+        case .loaded(let data, _):
             DispatchQueue.main.async { [weak store] in
                 log("onCampsiteURLOpen: will open project from document")
                 store?.openProjectAction(from: data)

--- a/Stitch/App/Shortcut/ProjectsHomeCommands.swift
+++ b/Stitch/App/Shortcut/ProjectsHomeCommands.swift
@@ -172,7 +172,7 @@ struct ProjectsHomeCommands: Commands {
                 if activeProject {
                     INSERT_NODE_ACTION()
                 } else {
-                    store.projectCreatedAction()
+                    store.createNewProject()
                 }
             }
 

--- a/Stitch/App/View/StitchRootModifier.swift
+++ b/Stitch/App/View/StitchRootModifier.swift
@@ -44,7 +44,7 @@ struct StitchRootModifier: ViewModifier {
                                           isImport: true) else {
                             return
                         }
-                        store?.openProjectAction(from: importedDoc)
+                        await store?.createNewProject(from: importedDoc)
                     }
                 }
             } // .onOpenURL
@@ -52,7 +52,7 @@ struct StitchRootModifier: ViewModifier {
                 // Only open document if one is imported
                 if docs.count == 1,
                    let firstDoc = docs.first {
-                    store.openProjectAction(from: firstDoc)
+                    store.createNewProject(from: firstDoc)
                 }
 
                 return true

--- a/Stitch/Graph/Util/ProjectThumbnailActions.swift
+++ b/Stitch/Graph/Util/ProjectThumbnailActions.swift
@@ -52,15 +52,9 @@ extension StitchStore {
             do {
                 try data.write(to: filename)
                 
-                // log("GenerateProjectThumbnailEvent: wrote thumbnail")
-                
-                // TODO: a better way to trigger an update of the project's icon on the homescreen? Even modifying the modifiedDate directly would cause the project to jump to the front of the homescreen grid
-                
-                // TODO: for some projects, `graph.encodeProject` fails because the StoreDelegate is missing / has no documentLoader
-                //                 graph.encodeProjectInBackground()
-                
-                // TODO: thumbnail hack no longer works
-//                try await DocumentLoader.encodeDocument(documentData, to: documentData.document.rootUrl)
+                // Force reload of home-screen thumbnail by setting local state to initialized
+                // For some projects, `graph.encodeProject` fails because the StoreDelegate is missing / has no documentLoader
+                await store.documentLoader.storage.get(rootUrl)?.loadingDocument = .initialized
             } catch {
                 log("GenerateProjectThumbnailEvent: error: \(error)")
             }

--- a/Stitch/Graph/Util/ProjectThumbnailActions.swift
+++ b/Stitch/Graph/Util/ProjectThumbnailActions.swift
@@ -32,6 +32,8 @@ extension StitchStore {
         let rootUrl = document.rootUrl
         let filename = rootUrl.appendProjectThumbnailPath()
         
+        documentViewModel.projectLoader?.resetData()
+        
         Task { [weak self] in
             guard let store = self else {
                 log("GenerateProjectThumbnailEvent: no image")

--- a/Stitch/Graph/Util/ProjectThumbnailActions.swift
+++ b/Stitch/Graph/Util/ProjectThumbnailActions.swift
@@ -54,7 +54,7 @@ extension StitchStore {
                 
                 // Force reload of home-screen thumbnail by setting local state to initialized
                 // For some projects, `graph.encodeProject` fails because the StoreDelegate is missing / has no documentLoader
-                await store.documentLoader.storage.get(rootUrl)?.loadingDocument = .initialized
+                await store.documentLoader.refreshDocument(url: rootUrl)
             } catch {
                 log("GenerateProjectThumbnailEvent: error: \(error)")
             }

--- a/Stitch/Graph/Util/ProjectThumbnailActions.swift
+++ b/Stitch/Graph/Util/ProjectThumbnailActions.swift
@@ -12,6 +12,8 @@ import StitchSchemaKit
 extension StitchStore {
     @MainActor
     func createThumbnail(from documentViewModel: StitchDocumentViewModel) {
+        guard documentViewModel.didDocumentChange else { return }
+        
         // Note: we need to modify some views
         documentViewModel.isGeneratingProjectThumbnail = true
         

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -58,11 +58,13 @@ final class StitchDocumentViewModel: Sendable {
     
     // Keeps reference to store
     weak var storeDelegate: StoreDelegate?
+    weak var projectLoader: ProjectLoader?
     
     init(from schema: StitchDocument,
          graph: GraphState,
          documentEncoder: DocumentEncoder,
          isPhoneDevice: Bool,
+         projectLoader: ProjectLoader,
          store: StoreDelegate?) {
         self.documentEncoder = documentEncoder
         self.previewWindowSize = schema.previewWindowSize
@@ -72,6 +74,7 @@ final class StitchDocumentViewModel: Sendable {
         self.graphMovement.localPosition = schema.localPosition
         self.graphUI = GraphUIState(isPhoneDevice: isPhoneDevice)
         self.graph = graph
+        self.projectLoader = projectLoader
         
         if let store = store {
             DispatchQueue.main.async { [weak self, weak store] in
@@ -96,6 +99,7 @@ final class StitchDocumentViewModel: Sendable {
     
     convenience init?(from schema: StitchDocument,
                       isPhoneDevice: Bool,
+                      projectLoader: ProjectLoader,
                       store: StoreDelegate?) async {
         let documentEncoder = DocumentEncoder(document: schema)
 
@@ -106,6 +110,7 @@ final class StitchDocumentViewModel: Sendable {
                   graph: graph,
                   documentEncoder: documentEncoder,
                   isPhoneDevice: isPhoneDevice,
+                  projectLoader: projectLoader,
                   store: store)
     }
 }
@@ -291,6 +296,7 @@ extension StitchDocumentViewModel {
               graph: .init(),
               documentEncoder: .init(document: .init()),
               isPhoneDevice: false,
+              projectLoader: .init(url: URL(fileURLWithPath: "")),
               store: nil)
     }
 }

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -47,6 +47,9 @@ final class StitchDocumentViewModel: Sendable {
     var keypressState = KeyPressState()
     var llmRecording = LLMRecordingState()
     
+    // Remains false if an encoding action never happened (used for thumbnail creation)
+    var didDocumentChange: Bool = false
+    
     // Singleton instances
     var locationManager: LoadingStatus<StitchSingletonMediaObject>?
     var cameraFeedManager: LoadingStatus<StitchSingletonMediaObject>?
@@ -114,7 +117,10 @@ extension StitchDocumentViewModel: DocumentEncodableDelegate {
         }
     }
     
-    func willEncodeProject(schema: StitchDocument) { }
+    func willEncodeProject(schema: StitchDocument) {
+        // Signals to project thumbnail logic to create a new one when project closes
+        self.didDocumentChange = true
+    }
 }
 
 extension StitchDocumentViewModel {

--- a/Stitch/Home/Util/ProjectCreatedActions.swift
+++ b/Stitch/Home/Util/ProjectCreatedActions.swift
@@ -21,13 +21,15 @@ extension StitchStore {
 
             // Open doc
             await MainActor.run { [weak self] in
-                self?.openProjectAction(from: newDoc)
+                self?.openProjectAction(from: newDoc,
+                                        isNewProject: true)
             }
         }
     }
 
     @MainActor
-    func openProjectAction(from document: StitchDocument) {
+    func openProjectAction(from document: StitchDocument,
+                           isNewProject: Bool = false) {
         // Get latest preview window size
         let previewDeviceString = UserDefaults.standard.string(forKey: DEFAULT_PREVIEW_WINDOW_DEVICE_KEY_NAME) ??
             PreviewWindowDevice.defaultPreviewWindowDevice.rawValue
@@ -47,6 +49,10 @@ extension StitchStore {
                 isPhoneDevice: isPhoneDevice,
                 store: store
             )
+            
+            if isNewProject {
+                document?.didDocumentChange = true // creates fresh thumbnail
+            }
             
             await MainActor.run { [weak document, weak store] in
                 guard let document = document else { return }

--- a/Stitch/Home/Util/ProjectCreatedActions.swift
+++ b/Stitch/Home/Util/ProjectCreatedActions.swift
@@ -12,62 +12,24 @@ import StitchSchemaKit
 extension StitchStore {
     @MainActor
     func createNewProject(from document: StitchDocument = .init()) {
+        let isPhoneDevice = GraphUIState.isPhoneDevice
+        
         Task(priority: .high) { [weak self] in
             guard let store = self else { return }
-            await store.createNewProject(from: document)
+            await store.createNewProject(from: document,
+                                         isPhoneDevice: isPhoneDevice)
         }
     }
     
-    func createNewProject(from document: StitchDocument = .init()) async {
+    func createNewProject(from document: StitchDocument = .init(),
+                          isPhoneDevice: Bool) async {
         do {
             try await self.documentLoader.createNewProject(from: document,
+                                                           isPhoneDevice: isPhoneDevice,
                                                            store: self)
         } catch {
             log("StitchStore.createNewProject error: \(error.localizedDescription)")
             fatalErrorIfDebug(error.localizedDescription)
-        }
-    }
-
-    @MainActor
-    func openProjectAction(projectLoader: ProjectLoader,
-                           isNewProject: Bool = false) {
-        guard let document = projectLoader.loadingDocument.document else {
-            fatalErrorIfDebug()
-            return
-        }
-        
-        // Get latest preview window size
-        let previewDeviceString = UserDefaults.standard.string(forKey: DEFAULT_PREVIEW_WINDOW_DEVICE_KEY_NAME) ??
-            PreviewWindowDevice.defaultPreviewWindowDevice.rawValue
-        
-        let isPhoneDevice = GraphUIState.isPhoneDevice
-
-        guard let previewDevice = PreviewWindowDevice(rawValue: previewDeviceString) else {
-            fatalErrorIfDebug()
-            return
-        }
-
-        Task { [weak self] in
-            guard let store = self else { return }
-            
-            let document = await StitchDocumentViewModel(
-                from: document,
-                isPhoneDevice: isPhoneDevice,
-                projectLoader: projectLoader,
-                store: store
-            )
-            
-            if isNewProject {
-                document?.didDocumentChange = true // creates fresh thumbnail
-            }
-            
-            await MainActor.run { [weak document, weak store] in
-                guard let document = document else { return }
-                
-                document.previewSizeDevice = previewDevice
-                document.previewWindowSize = previewDevice.previewWindowDimensions
-                store?.navPath = [document]
-            }
         }
     }
 

--- a/Stitch/Home/View/ProjectItem/ProjectsListItemView.swift
+++ b/Stitch/Home/View/ProjectItem/ProjectsListItemView.swift
@@ -113,7 +113,7 @@ struct ProjectsListItemView: View {
                     .onTapGesture {
                         self.isLoadingForPresentation = true
                         
-                        store.handleProjectTapped(document: document,
+                        store.handleProjectTapped(projectLoader: self.projectLoader,
                                                   isPhoneDevice: GraphUIState.isPhoneDevice) {
                             self.isLoadingForPresentation = false
                         }

--- a/Stitch/Home/View/ProjectItem/ProjectsListItemView.swift
+++ b/Stitch/Home/View/ProjectItem/ProjectsListItemView.swift
@@ -85,7 +85,7 @@ struct ProjectsListItemView: View {
 
     var document: StitchDocument? {
         switch projectLoader.loadingDocument {
-        case .loaded(let data):
+        case .loaded(let data, _):
             return data
         default:
             return nil
@@ -101,12 +101,12 @@ struct ProjectsListItemView: View {
                 ProjectsListItemIconView(projectThumbnail: nil,
                                          previewWindowBackgroundColor: nil)
                     .modifier(ProjectsListItemErrorOverlayViewModifer())
-            case .loaded(let document):
+            case .loaded(let document, let thumbnail):
                 #if DEV_DEBUG
                 logInView("LOADED: \(document.name) \(document.id)")
                 #endif
                 ProjectsListItemIconView(
-                    projectThumbnail: DocumentEncoder.getProjectThumbnailImage(rootUrl: document.rootUrl),
+                    projectThumbnail: thumbnail,
                     previewWindowBackgroundColor: document.previewWindowBackgroundColor,
                     modifiedDate: projectLoader.modifiedDate,
                     isLoading: self.isLoadingForPresentation)
@@ -122,7 +122,7 @@ struct ProjectsListItemView: View {
             }
         } labelView: {
             switch projectLoader.loadingDocument {
-            case .loaded(let document):
+            case .loaded(let document, _):
                 ProjectThumbnailTextField(document: document,
                                           namespace: namespace)
             default:

--- a/Stitch/Home/View/ProjectsHomeView.swift
+++ b/Stitch/Home/View/ProjectsHomeView.swift
@@ -23,7 +23,7 @@ struct ProjectsHomeView: View {
             return store.allProjectUrls
         } else {
             return store.allProjectUrls.filter { projectLoader in
-                if case .loaded(let document) = projectLoader.loadingDocument {
+                if case .loaded(let document, _) = projectLoader.loadingDocument {
                     return document.name.localizedCaseInsensitiveContains(searchQuery)
                 }
                 return false

--- a/Stitch/Home/View/ProjectsHomeViewWrapper.swift
+++ b/Stitch/Home/View/ProjectsHomeViewWrapper.swift
@@ -50,7 +50,7 @@ struct ProjectsHomeViewWrapper: View {
 
                         CatalystHomescreenNavBarButton(
                             action: {
-                                store.projectCreatedAction()
+                                store.createNewProject()
                             },
                             iconName: NEW_PROJECT_ICON_NAME)
 


### PR DESCRIPTION
Changes:
* Thumbnails don't re-load if no changes were processed, and thus don't re-sort project thumbnails on quick open/close
* Improved concurrency to ensure thumbnails are reloaded