### PR TITLE
Improved perf for node dragging on large graphs

### DIFF
--- a/Stitch/Graph/Edge/ViewModel/EdgeDrawingObserver.swift
+++ b/Stitch/Graph/Edge/ViewModel/EdgeDrawingObserver.swift
@@ -17,9 +17,19 @@ final class EdgeDrawingObserver {
 
 extension EdgeDrawingObserver {
     func reset() {
-        self.nearestEligibleInput = nil
-        self.drawingGesture = .none
-        self.recentlyDrawnEdge = nil
+        // MARK: we need equality checks to reduce render cycles
+        
+        if self.nearestEligibleInput != nil {
+            self.nearestEligibleInput = nil
+        }
+        
+        if self.drawingGesture != nil {
+            self.drawingGesture = nil
+        }
+        
+        if self.recentlyDrawnEdge != nil {
+            self.recentlyDrawnEdge = nil
+        }
     }
 }
 

--- a/Stitch/Graph/Node/Port/View/PortView.swift
+++ b/Stitch/Graph/Node/Port/View/PortView.swift
@@ -29,11 +29,6 @@ struct PortEntryView<NodeRowViewModelType: NodeRowViewModel>: View {
         rowViewModel.portColor.color(theme)
     }
     
-    @MainActor
-    var isNodeMoving: Bool {
-        rowViewModel.canvasItemDelegate?.isMoving ?? false
-    }
-    
     var body: some View {
         
         ZStack {


### PR DESCRIPTION
Caused by updating publishers on a `reset` function. We just needed equality checks to reduce render cycles there.

Reduces ~63% of render cycles in the Humane demo.