### PR TITLE
Fix `development` branch @MainActor compiler errors

### DIFF
--- a/Stitch/Graph/Node/Layer/Type/3DModelLayerNode/PreviewModel3DLayer.swift
+++ b/Stitch/Graph/Node/Layer/Type/3DModelLayerNode/PreviewModel3DLayer.swift
@@ -47,6 +47,7 @@ struct Preview3DModelLayer: View {
         mediaObject?.model3DEntity
     }
     
+    @MainActor
     var layerNode: LayerNodeViewModel? {
         self.graph.getNodeViewModel(layerViewModel.id.layerNodeId.asNodeId)?
             .layerNode

--- a/Stitch/Graph/View/GraphBaseView.swift
+++ b/Stitch/Graph/View/GraphBaseView.swift
@@ -19,6 +19,7 @@ struct GraphBaseView: View {
     @Bindable var graphUI: GraphUIState
     let insertNodeMenuHiddenNodeId: NodeId?
     
+    @MainActor
     var graph: GraphState {
         self.document.visibleGraph
     }


### PR DESCRIPTION
Added `@MainActor` to a couple spots that were preventing compilation on the dev debug and debug build schemes.