### PR TITLE
Fixed copy/paste regressions + components support

### DIFF
--- a/Stitch/App/Serialization/DocumentEncodableUtil.swift
+++ b/Stitch/App/Serialization/DocumentEncodableUtil.swift
@@ -22,14 +22,15 @@ extension DocumentEncodable {
     }
 
     /// Called when GraphState is initialized to build library data and then run first calc.
-    func getDecodedFiles() async -> GraphDecodedFiles? {
+    func getDecodedFiles() -> GraphDecodedFiles? {
         let importedFilesDir = self.readAllImportedFiles()
-        return await self.getDecodedFiles(importedFilesDir: importedFilesDir)
+        return GraphDecodedFiles(importedFilesDir: importedFilesDir)
     }
-    
-    /// Called when GraphState is initialized to build library data and then run first calc.
-    func getDecodedFiles(importedFilesDir: StitchDocumentDirectory,
-                         graphMutation: (@Sendable @MainActor () -> ())? = nil) async -> GraphDecodedFiles? {
+}
+
+extension GraphDecodedFiles {
+    init?(importedFilesDir: StitchDocumentDirectory,
+          graphMutation: (@Sendable @MainActor () -> ())? = nil) {
         let migratedComponents = importedFilesDir.componentDirs.compactMap { componentUrl -> StitchComponentData? in
             do {
                 guard let draft = try StitchComponent.migrateEncodedComponent(from: componentUrl.appendingComponentDraftPath()),
@@ -46,7 +47,7 @@ extension DocumentEncodable {
             }
         }
         
-        return .init(mediaFiles: importedFilesDir.importedMediaUrls,
-                     components: migratedComponents)
+        self.init(mediaFiles: importedFilesDir.importedMediaUrls,
+                  components: migratedComponents)
     }
 }

--- a/Stitch/App/Serialization/DocumentLoading/StitchFileManager.swift
+++ b/Stitch/App/Serialization/DocumentLoading/StitchFileManager.swift
@@ -25,6 +25,7 @@ final class StitchFileManager: FileManager, MiddlewareService {
     
     static var tempDir: URL {
         URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("Stitch")
     }
     
     /// File removal abstraction which enables possible usage of temporary storage for recently deleted items, enabling undo/redo support on deleted files.

--- a/Stitch/App/Serialization/Model/StitchDocumentEncodable.swift
+++ b/Stitch/App/Serialization/Model/StitchDocumentEncodable.swift
@@ -101,3 +101,20 @@ struct GraphDecodedFiles {
     let mediaFiles: [URL]
     let components: [StitchComponentData]
 }
+
+extension [StitchComponentData] {
+    @MainActor
+    func createComponentsDict(parentGraph: GraphState?) -> [UUID: StitchMasterComponent] {
+        self.reduce(into: MasterComponentsDict()) { result, componentEntity in
+            let newComponent = StitchMasterComponent(componentData: componentEntity,
+                                                     parentGraph: nil)  // assigned later
+            
+            // We can initialize delegates from copy/paste actions
+            if let parentGraph = parentGraph {
+                newComponent.initializeDelegate(parentGraph: parentGraph)
+            }
+            
+            result.updateValue(newComponent, forKey: newComponent.id)
+        }
+    }
+}

--- a/Stitch/App/Serialization/StitchFileManagerProject.swift
+++ b/Stitch/App/Serialization/StitchFileManagerProject.swift
@@ -126,7 +126,7 @@ extension DocumentEncodable {
     
     /// Copies files from another directory.
     func copyFiles(from directory: StitchDocumentDirectory,
-                   rootUrl: URL) -> StitchDocumentDirectory {
+                   destUrl: URL) -> StitchDocumentDirectory {
         // Copy selected media
         let newMediaUrls: [URL] = directory.importedMediaUrls.compactMap { mediaUrl in
             switch self.copyToMediaDirectory(originalURL: mediaUrl,
@@ -149,7 +149,7 @@ extension DocumentEncodable {
                 return nil
             }
 
-            let destComponentUrl = rootUrl
+            let destComponentUrl = destUrl
                 .appendingComponentsPath()
             // Append component ID
                 .appendingPathComponent(componentIdPath,

--- a/Stitch/App/Serialization/StitchFileManagerProject.swift
+++ b/Stitch/App/Serialization/StitchFileManagerProject.swift
@@ -125,7 +125,8 @@ extension DocumentEncodable {
     }
     
     /// Copies files from another directory.
-    func copyFiles(from directory: StitchDocumentDirectory) -> StitchDocumentDirectory {
+    func copyFiles(from directory: StitchDocumentDirectory,
+                   rootUrl: URL) -> StitchDocumentDirectory {
         // Copy selected media
         let newMediaUrls: [URL] = directory.importedMediaUrls.compactMap { mediaUrl in
             switch self.copyToMediaDirectory(originalURL: mediaUrl,
@@ -148,7 +149,7 @@ extension DocumentEncodable {
                 return nil
             }
 
-            let destComponentUrl = self.rootUrl
+            let destComponentUrl = rootUrl
                 .appendingComponentsPath()
             // Append component ID
                 .appendingPathComponent(componentIdPath,

--- a/Stitch/Graph/Node/Component/StitchMasterComponent.swift
+++ b/Stitch/Graph/Node/Component/StitchMasterComponent.swift
@@ -82,9 +82,10 @@ extension StitchMasterComponent {
 typealias MasterComponentsDict = [UUID : StitchMasterComponent]
 
 extension MasterComponentsDict {
+    @MainActor
     mutating func sync(with data: [StitchComponentData],
                        parentGraph: GraphState) {
-        self.sync(with: data,
+        self = self.sync(with: data,
                   updateCallback: { viewModel, data in
 //            viewModel.update(from: data)
         }) { data in

--- a/Stitch/Graph/Node/Component/StitchMasterComponent.swift
+++ b/Stitch/Graph/Node/Component/StitchMasterComponent.swift
@@ -24,6 +24,7 @@ final class StitchMasterComponent {
     
     weak var parentGraph: GraphState?
     
+    @MainActor
     init(componentData: StitchComponentData,
          parentGraph: GraphState?) {
         self.id = componentData.draft.id
@@ -66,16 +67,10 @@ extension StitchMasterComponent {
     
     func onPrototypeRestart() { }
     
-    func initializeDelegate(parentGraph: GraphState) {
+    @MainActor func initializeDelegate(parentGraph: GraphState) {
         self.parentGraph = parentGraph
-        
-        Task {
-            await MainActor.run { [weak self] in
-                guard let component = self else { return }
-                component.draftedDocumentEncoder.delegate = component
-                component.publishedDocumentEncoder.delegate = component
-            }
-        }
+        self.draftedDocumentEncoder.delegate = self
+        self.publishedDocumentEncoder.delegate = self
     }
 }
 

--- a/Stitch/Graph/Node/Model/GraphCopyable.swift
+++ b/Stitch/Graph/Node/Model/GraphCopyable.swift
@@ -524,12 +524,13 @@ extension DocumentEncodable {
         await self.importComponentFiles(result.copiedSubdirectoryFiles)
     }
     
+    @MainActor
     func importComponentFiles(_ files: StitchDocumentDirectory,
                               graphMutation: (@Sendable @MainActor () -> ())? = nil) async {
         guard !files.isEmpty else {
             return
         }
         
-        let newFiles = self.copyFiles(from: files)
+        let _ = await self.copyFiles(from: files)
     }
 }

--- a/Stitch/Graph/Node/Model/GraphCopyable.swift
+++ b/Stitch/Graph/Node/Model/GraphCopyable.swift
@@ -521,16 +521,19 @@ extension DocumentEncodable {
         let _ = await T.exportComponent(result.component)
 
         // Process imported media side effects
-        await self.importComponentFiles(result.copiedSubdirectoryFiles)
+        await self.importComponentFiles(result.copiedSubdirectoryFiles,
+                                        rootUrl: result.component.rootUrl)
     }
     
     @MainActor
     func importComponentFiles(_ files: StitchDocumentDirectory,
+                              rootUrl: URL,
                               graphMutation: (@Sendable @MainActor () -> ())? = nil) async {
         guard !files.isEmpty else {
             return
         }
         
-        let _ = await self.copyFiles(from: files)
+        let _ = await self.copyFiles(from: files,
+                                     rootUrl: rootUrl)
     }
 }

--- a/Stitch/Graph/Node/Model/GraphCopyable.swift
+++ b/Stitch/Graph/Node/Model/GraphCopyable.swift
@@ -488,12 +488,12 @@ extension SidebarLayerList {
 
 extension GraphState {
     @MainActor
-    func copyAndPasteSelectedNodes(selectedNodeIds: NodeIdSet) {
+    func copyAndPasteSelectedNodes(selectedNodeIds: NodeIdSet) async {
         let copiedComponentResult = self
             .createCopiedComponent(groupNodeFocused: self.graphUI.groupNodeFocused,
                                    selectedNodeIds: selectedNodeIds)
-        self.insertNewComponent(copiedComponentResult,
-                                encoder: self.documentEncoderDelegate)
+        await self.insertNewComponent(copiedComponentResult,
+                                      encoder: self.documentEncoderDelegate)
     }
 
     @MainActor
@@ -514,7 +514,7 @@ extension DocumentEncodable {
         await self.encodeNewComponent(copiedComponentResult)
         
         let pasteboard = UIPasteboard.general
-        pasteboard.url = copiedComponentResult.component.rootUrl
+        pasteboard.url = copiedComponentResult.component.rootUrl.appendingVersionedSchemaPath()
     }
     
     func encodeNewComponent<T>(_ result: StitchComponentCopiedResult<T>) async where T: StitchComponentable {

--- a/Stitch/Graph/Node/Model/GraphCopyable.swift
+++ b/Stitch/Graph/Node/Model/GraphCopyable.swift
@@ -504,6 +504,9 @@ extension GraphState {
                                    selectedNodeIds: selectedNodeIds)
 
         Task { [weak self] in
+            // Delete all existing items in clipboard
+            try? FileManager.default.removeItem(at: copiedComponentResult.component.rootUrl)
+            
             await self?.documentEncoderDelegate?.processGraphCopyAction(copiedComponentResult)
         }
     }
@@ -522,18 +525,18 @@ extension DocumentEncodable {
 
         // Process imported media side effects
         await self.importComponentFiles(result.copiedSubdirectoryFiles,
-                                        rootUrl: result.component.rootUrl)
+                                        destUrl: result.component.rootUrl)
     }
     
     @MainActor
     func importComponentFiles(_ files: StitchDocumentDirectory,
-                              rootUrl: URL,
+                              destUrl: URL,
                               graphMutation: (@Sendable @MainActor () -> ())? = nil) async {
         guard !files.isEmpty else {
             return
         }
         
         let _ = await self.copyFiles(from: files,
-                                     rootUrl: rootUrl)
+                                     destUrl: destUrl)
     }
 }

--- a/Stitch/Graph/Node/Model/NodeEntity.swift
+++ b/Stitch/Graph/Node/Model/NodeEntity.swift
@@ -73,8 +73,11 @@ extension NodeEntity {
         case .group(let canvas):
             let newCanvas = callback(canvas)
             self.nodeTypeEntity = .group(newCanvas)
-        case .component:
-            return
+        case .component(let component):
+            var component = component
+            let newCanvas = callback(component.canvasEntity)
+            component.canvasEntity = newCanvas
+            self.nodeTypeEntity = .component(component)
         }
     }
     

--- a/Stitch/Graph/Node/Model/StitchClipboardContent.swift
+++ b/Stitch/Graph/Node/Model/StitchClipboardContent.swift
@@ -28,8 +28,11 @@ extension StitchClipboardContent {
     init() {
         self.init(graph: .createEmpty())
     }
-    
     var rootUrl: URL {
+        Self.rootUrl
+    }
+    
+    static var rootUrl: URL {
         StitchFileManager.tempDir
             .appendingPathComponent("copied-data",
                                     conformingTo: Self.unzippedFileType)

--- a/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
+++ b/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
@@ -95,12 +95,16 @@ struct NodeDuplicateDraggedAction: GraphEventWithResponse {
             }
             
             // Copy nodes if no drag started yet
-            state.copyAndPasteSelectedNodes(selectedNodeIds: state.selectedNodeIds.compactMap(\.nodeCase).toSet)
+            Task(priority: .high) { [weak state] in
+                guard let state = state else { return }
+                await state.copyAndPasteSelectedNodes(selectedNodeIds: state.selectedNodeIds.compactMap(\.nodeCase).toSet)
+                state.encodeProjectInBackground()
+            }
             
             state.graphUI.dragDuplication = true
             
-            // log("NodeDuplicateDraggedAction: copied nodes")
-            return .persistenceResponse
+            // Encoded in task above
+            return .noChange
         }
             
         

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
@@ -622,6 +622,7 @@ extension NodeViewModel: NodeDelegate {
 
 extension NodeViewModel {
     // MARK: main actor needed to prevent view updates from background thread
+    @MainActor
     func update(from schema: NodeEntity,
                 components: [UUID : StitchMasterComponent]) async {
         await self.nodeType.update(from: schema.nodeTypeEntity,

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
@@ -628,13 +628,23 @@ extension NodeViewModel {
         await self.nodeType.update(from: schema.nodeTypeEntity,
                                    components: components)
         
-        if self.title != schema.title {
-            self.title = schema.title
+        self.updateTitle(newTitle: schema.title)
+    }
+    
+    func updateTitle(newTitle: String) {
+        if self.title != newTitle {
+            self.title = newTitle
         }
         
         if self._cachedDisplayTitle != self.getDisplayTitle() {
             self._cachedDisplayTitle = self.getDisplayTitle()
         }
+    }
+    
+    @MainActor
+    func update(from schema: NodeEntity) {
+        self.nodeType.update(from: schema.nodeTypeEntity)
+        self.updateTitle(newTitle: schema.title)
     }
 
     @MainActor func createSchema() -> NodeEntity {

--- a/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
@@ -48,7 +48,7 @@ extension NodeViewModelType {
             self = .component(.init(componentId: component.componentId,
                                     canvas: componentCanvas,
                                     
-                                    // TODO: fix this for components
+                                    // TODO: thie gets a new reference later
                                     graph: .createEmpty()))
         }
     }

--- a/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
@@ -19,9 +19,7 @@ enum NodeViewModelType {
 extension NodeViewModelType {
     @MainActor
     init(from nodeType: NodeTypeEntity,
-         nodeId: NodeId,
-         components: [UUID: StitchMasterComponent],
-         parentGraphPath: [UUID]) async {
+         nodeId: NodeId) {
         switch nodeType {
         case .patch(let patchNode):
             let viewModel = PatchNodeViewModel(from: patchNode)
@@ -30,7 +28,7 @@ extension NodeViewModelType {
             let viewModel = LayerNodeViewModel(from: layerNode)
             self = .layer(viewModel)
         case .group(let canvasNode):
-            self = .group(.init(from: canvasNode, 
+            self = .group(.init(from: canvasNode,
                                 id: .node(nodeId),
                                 // Initialize as empty since splitter row observers might not have yet been created
                                 inputRowObservers: [],
@@ -38,6 +36,33 @@ extension NodeViewModelType {
                                 // Irrelevant
                                 unpackedPortParentFieldGroupType: nil,
                                 unpackedPortIndex: nil))
+        case .component(let component):
+            let componentCanvas = CanvasItemViewModel(from: component.canvasEntity,
+                                                      id: .node(nodeId),
+                                                      // Initialize as empty since splitter row observers might not have yet been created
+                                                      inputRowObservers: [],
+                                                      outputRowObservers: [],
+                                                      unpackedPortParentFieldGroupType: nil,
+                                                      unpackedPortIndex: nil)
+            
+            self = .component(.init(componentId: component.componentId,
+                                    canvas: componentCanvas,
+                                    
+                                    // TODO: fix this for components
+                                    graph: .createEmpty()))
+        }
+    }
+    
+    @MainActor
+    init(from nodeType: NodeTypeEntity,
+         nodeId: NodeId,
+         components: [UUID: StitchMasterComponent],
+         parentGraphPath: [UUID]) async {
+        switch nodeType {
+        case .patch, .layer, .group:
+            self = .init(from: nodeType,
+                         nodeId: nodeId)
+        
         case .component:
             // TODO: unwrapping component changes the ID. no idea why.
             guard let componentEntity = nodeType.componentNodeEntity else {
@@ -95,8 +120,7 @@ extension NodeViewModelType {
     }
 
     @MainActor
-    func update(from schema: NodeTypeEntity,
-                components: [UUID: StitchMasterComponent]) async {
+    func update(from schema: NodeTypeEntity) {
         switch (self, schema) {
         case (.patch(let patchViewModel), .patch(let patchEntity)):
             patchViewModel.update(from: patchEntity)
@@ -105,11 +129,25 @@ extension NodeViewModelType {
         case (.group(let canvasViewModel), .group(let canvasEntity)):
             canvasViewModel.update(from: canvasEntity)
         case (.component(let componentViewModel), .component(let component)):
-            await componentViewModel.update(from: component,
-                                            components: components)
+            // not for sync operations
+            return
+//            await componentViewModel.update(from: component,
+//                                            components: components)
         default:
             log("NodeViewModelType.update error: found unequal view model and schema types for some node type.")
             fatalErrorIfDebug()
+        }
+    }
+    
+    @MainActor
+    func update(from schema: NodeTypeEntity,
+                components: [UUID: StitchMasterComponent]) async {
+        switch (self, schema) {
+        case (.component(let componentViewModel), .component(let component)):
+            await componentViewModel.update(from: component,
+                                            components: components)
+        default:
+            self.update(from: schema)
         }
     }
     

--- a/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
@@ -17,6 +17,7 @@ enum NodeViewModelType {
 }
 
 extension NodeViewModelType {
+    @MainActor
     init(from nodeType: NodeTypeEntity,
          nodeId: NodeId,
          components: [UUID: StitchMasterComponent],

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarSelectedItemsDuplicated.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarSelectedItemsDuplicated.swift
@@ -19,6 +19,9 @@ struct SidebarSelectedItemsDuplicated: GraphEventWithResponse {
 extension GraphState {
     @MainActor
     func sidebarSelectedItemsDuplicatedViaEditMode() {
-        self.copyAndPasteSelectedNodes(selectedNodeIds: self.sidebarSelectionState.all.map(\.asNodeId).toSet)
+        Task(priority: .high) { [weak self] in
+            guard let graph = self else { return }
+            await graph.copyAndPasteSelectedNodes(selectedNodeIds: graph.sidebarSelectionState.all.map(\.asNodeId).toSet)
+        }
     }
 }

--- a/Stitch/Graph/Util/GraphActions.swift
+++ b/Stitch/Graph/Util/GraphActions.swift
@@ -50,6 +50,7 @@ extension GraphState: DocumentEncodableDelegate {
         }
     }
     
+    @MainActor
     func importedFilesDirectoryReceived(mediaFiles: [URL],
                                         components: [StitchComponentData]) {        
         // Update draft and published components from disk

--- a/Stitch/Graph/Util/NodeSelection/CopyAndPasteNodesActions.swift
+++ b/Stitch/Graph/Util/NodeSelection/CopyAndPasteNodesActions.swift
@@ -66,35 +66,34 @@ struct SelectedGraphItemsCopied: GraphEvent {
 
 // "Paste" = past shortcut, which pastes BOTH nodes AND comments
 // struct SelectedGraphNodesPasted: AppEnvironmentEvent {
-struct SelectedGraphItemsPasted: GraphEventWithResponse {
+struct SelectedGraphItemsPasted: GraphEvent {
 
-    func handle(state: GraphState) -> GraphResponse {
+    func handle(state: GraphState) {
         
         guard !state.llmRecording.isRecording else {
             log("Paste disabled during LLM Recording")
-            return .noChange
+            return
         }
         
         guard let pasteboardUrl = UIPasteboard.general.url else {
-            return .noChange
+            return
         }
 
         do {
-            let componentData = try Data(
-                contentsOf: pasteboardUrl.appendingDataJsonPath()
-            )
+            let componentData = try Data(contentsOf: pasteboardUrl)
             let newComponent = try getStitchDecoder().decode(StitchClipboardContent.self, from: componentData)
-            let currentDoc = state.createSchema()
             let importedFiles = ComponentEncoder.readAllImportedFiles(rootUrl: pasteboardUrl)
             
-            
-            state.insertNewComponent(component: newComponent,
-                                     encoder: state.documentEncoderDelegate,
-                                     copiedFiles: importedFiles)
-            return .persistenceResponse
+            Task(priority: .high) { [weak state] in
+                guard let state = state else { return }
+    
+                await state.insertNewComponent(component: newComponent,
+                                               encoder: state.documentEncoderDelegate,
+                                               copiedFiles: importedFiles)
+                state.encodeProjectInBackground()
+            }
         } catch {
             log("SelectedGraphItemsPasted error: \(error)")
-            return .noChange
         }
     }
 }

--- a/Stitch/Graph/Util/NodeSelection/CopyAndPasteNodesActions.swift
+++ b/Stitch/Graph/Util/NodeSelection/CopyAndPasteNodesActions.swift
@@ -75,12 +75,10 @@ struct SelectedGraphItemsPasted: GraphEvent {
             return
         }
         
-        guard let pasteboardUrl = UIPasteboard.general.url else {
-            return
-        }
+        let pasteboardUrl = StitchClipboardContent.rootUrl
 
         do {
-            let componentData = try Data(contentsOf: pasteboardUrl)
+            let componentData = try Data(contentsOf: pasteboardUrl.appendingVersionedSchemaPath())
             let newComponent = try getStitchDecoder().decode(StitchClipboardContent.self, from: componentData)
             let importedFiles = ComponentEncoder.readAllImportedFiles(rootUrl: pasteboardUrl)
             

--- a/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
+++ b/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
@@ -14,6 +14,16 @@ struct DuplicateShortcutKeyPressed: StitchDocumentEvent {
     // Duplicates BOTH nodes AND comments
     @MainActor
     func handle(state: StitchDocumentViewModel) {
+        Task(priority: .high) { [weak state] in
+            await state?.duplicateShortcutKeyPressed()
+        }
+    }
+}
+
+extension StitchDocumentViewModel {
+    @MainActor
+    func duplicateShortcutKeyPressed() async {
+        let state = self
         
         guard !state.llmRecording.isRecording else {
             log("Duplication disabled during LLM Recording")
@@ -27,14 +37,16 @@ struct DuplicateShortcutKeyPressed: StitchDocumentEvent {
             state.visibleGraph.sidebarSelectedItemsDuplicatedViaEditMode()
         } else {
             let copiedComponentResult = state.visibleGraph.createCopiedComponent(
-            groupNodeFocused: state.graphUI.groupNodeFocused,
-            selectedNodeIds: state.visibleGraph.selectedNodeIds.compactMap(\.nodeCase).toSet)
-        
-            state.visibleGraph.insertNewComponent(copiedComponentResult,
-                                                  encoder: state.visibleGraph.documentEncoderDelegate)
+                groupNodeFocused: state.graphUI.groupNodeFocused,
+                selectedNodeIds: state.visibleGraph.selectedNodeIds.compactMap(\.nodeCase).toSet)
+            
+            await state.visibleGraph.insertNewComponent(copiedComponentResult,
+                                                        encoder: state.visibleGraph.documentEncoderDelegate)
         }
         
-        state.visibleGraph.encodeProjectInBackground()
+        Task { [weak self] in
+            self?.visibleGraph.encodeProjectInBackground()
+        }
     }
 }
 
@@ -42,16 +54,16 @@ extension GraphState {
     /// Inserts new component in state and processes media effects
     @MainActor
     func insertNewComponent<T>(_ copiedComponentResult: StitchComponentCopiedResult<T>,
-                               encoder: (any DocumentEncodable)?) where T: StitchComponentable {
-        self.insertNewComponent(component: copiedComponentResult.component,
-                                encoder: encoder,
-                                copiedFiles: copiedComponentResult.copiedSubdirectoryFiles)
+                               encoder: (any DocumentEncodable)?) async where T: StitchComponentable {
+        await self.insertNewComponent(component: copiedComponentResult.component,
+                                      encoder: encoder,
+                                      copiedFiles: copiedComponentResult.copiedSubdirectoryFiles)
     }
 
     @MainActor
     func insertNewComponent<T>(component: T,
                                encoder: (any DocumentEncodable)?,
-                               copiedFiles: StitchDocumentDirectory) where T: StitchComponentable {
+                               copiedFiles: StitchDocumentDirectory) async where T: StitchComponentable {
 
         // Change all IDs
         var newComponent = component
@@ -73,23 +85,14 @@ extension GraphState {
 
             return node
         }
-
-        // Display loading status for imported media effects
-//        self.libraryLoadingStatus = .loading
-
-        Task(priority: .high) { [weak encoder, weak self] in
-            guard let encoder = encoder else {
-                return
-            }
-            
-            // Copy files before inserting component
-            await encoder.importComponentFiles(copiedFiles)
-            await self?._insertNewComponent(newComponent)
+        
+        guard let encoder = encoder else {
+            return
         }
-    }
+        
+        // Copy files before inserting component
+        await encoder.importComponentFiles(copiedFiles)
 
-    @MainActor
-    func _insertNewComponent<T>(_ component: T) async where T: StitchComponentable {
         guard let document = self.documentDelegate,
               let encoderDelegate = self.documentEncoderDelegate else {
             fatalErrorIfDebug()
@@ -99,7 +102,7 @@ extension GraphState {
         var graph = self.createSchema()
 
         // Update top-level nodes to match current focused group
-        let newNodes: [NodeEntity] = component.nodes
+        let newNodes: [NodeEntity] = newComponent.nodes
             .map { stitch in
                 var stitch = stitch
                 stitch.canvasEntityMap { node in
@@ -119,7 +122,7 @@ extension GraphState {
 
         // Add new nodes
         graph.nodes += newNodes
-        graph.orderedSidebarLayers = component.graph.orderedSidebarLayers + graph.orderedSidebarLayers
+        graph.orderedSidebarLayers = newComponent.graph.orderedSidebarLayers + graph.orderedSidebarLayers
         await self.update(from: graph)
         self.initializeDelegate(document: document,
                                 documentEncoderDelegate: encoderDelegate)

--- a/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
+++ b/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
@@ -71,7 +71,8 @@ extension GraphState {
         }
         
         // Copy files before inserting component
-        await encoder.importComponentFiles(copiedFiles)
+        await encoder.importComponentFiles(copiedFiles,
+                                           rootUrl: component.rootUrl)
         
         // Update top-level nodes to match current focused group
         let newNodes: [NodeEntity] = self.createNewNodes(from: newComponent)

--- a/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
+++ b/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
@@ -110,10 +110,7 @@ extension GraphState {
         newComponent.graph.nodes = newComponent.nodes.map { node in
             var node = node
             
-            // Update positional data
-            
-            // TODO: explore why position shift didn't work
-            
+            // Update positional data            
             node.canvasEntityMap { node in
                 var node = node
                 node.position.shiftNodePosition()

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -103,11 +103,7 @@ final class GraphState: Sendable {
             return
         }
         
-        let components = decodedFiles.components.reduce(into: MasterComponentsDict()) { result, componentEntity in
-            let newComponent = StitchMasterComponent(componentData: componentEntity,
-                                                     parentGraph: nil)  // assigned later
-            result.updateValue(newComponent, forKey: newComponent.id)
-        }
+        let components = await decodedFiles.components.createComponentsDict(parentGraph: nil)
         
         var nodes = NodesViewModelDict()
         for nodeEntity in schema.nodes {

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -325,14 +325,8 @@ extension GraphState {
         self.updateSynchronousProperties(from: schema)
         
         Task { [weak self] in
+            // Async update data correctly
             await self?.update(from: schema)
-//            guard let decodedFiles = await self?.documentEncoderDelegate?.getDecodedFiles() else {
-//                fatalErrorIfDebug()
-//                return
-//            }
-//            
-//            self?.importedFilesDirectoryReceived(mediaFiles: decodedFiles.mediaFiles,
-//                                                 components: decodedFiles.components)
         }
         
         self.syncNodes(with: schema.nodes)

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -267,6 +267,7 @@ extension GraphState {
         return graph
     }
     
+    @MainActor
     func syncNodes(with entities: [NodeEntity]) async {
         let newDictionary = await self.visibleNodesViewModel.nodes
             .sync(with: entities,
@@ -279,9 +280,7 @@ extension GraphState {
                                 parentGraphPath: self.saveLocation)
         }
         
-        await MainActor.run { [weak self] in
-            self?.visibleNodesViewModel.nodes = newDictionary
-        }
+        self.visibleNodesViewModel.nodes = newDictionary
     }
     
     @MainActor func update(from schema: GraphEntity) async {

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -283,10 +283,30 @@ extension GraphState {
         self.visibleNodesViewModel.nodes = newDictionary
     }
     
-    @MainActor func update(from schema: GraphEntity) async {
+    @MainActor
+    func syncNodes(with entities: [NodeEntity]) {
+        let newDictionary = self.visibleNodesViewModel.nodes
+            .sync(with: entities,
+                  updateCallback: { nodeViewModel, nodeSchema in
+            nodeViewModel.update(from: nodeSchema)
+        }) { nodeSchema in
+            let nodeType = NodeViewModelType(from: nodeSchema.nodeTypeEntity,
+                                             nodeId: nodeSchema.id)
+            return NodeViewModel(from: nodeSchema,
+                                 nodeType: nodeType)
+        }
+        
+        self.visibleNodesViewModel.nodes = newDictionary
+    }
+    
+    private func updateSynchronousProperties(from schema: GraphEntity) {
         self.id = schema.id
         self.name = schema.name
         self.orderedSidebarLayers = schema.orderedSidebarLayers
+    }
+    
+    @MainActor func update(from schema: GraphEntity) async {
+        self.updateSynchronousProperties(from: schema)
         
         guard let decodedFiles = await self.documentEncoderDelegate?.getDecodedFiles() else {
             fatalErrorIfDebug()
@@ -297,6 +317,29 @@ extension GraphState {
                                             components: decodedFiles.components)
         
         await self.syncNodes(with: schema.nodes)
+        
+        if let document = self.documentDelegate,
+           let documentEncoder = self.documentEncoderDelegate {
+            self.initializeDelegate(document: document,
+                                    documentEncoderDelegate: documentEncoder)
+        }
+    }
+    
+    @MainActor func update(from schema: GraphEntity) {
+        self.updateSynchronousProperties(from: schema)
+        
+        Task { [weak self] in
+            await self?.update(from: schema)
+//            guard let decodedFiles = await self?.documentEncoderDelegate?.getDecodedFiles() else {
+//                fatalErrorIfDebug()
+//                return
+//            }
+//            
+//            self?.importedFilesDirectoryReceived(mediaFiles: decodedFiles.mediaFiles,
+//                                                 components: decodedFiles.components)
+        }
+        
+        self.syncNodes(with: schema.nodes)
         
         if let document = self.documentDelegate,
            let documentEncoder = self.documentEncoderDelegate {

--- a/Stitch/Graph/ViewModel/SchemaObserver.swift
+++ b/Stitch/Graph/ViewModel/SchemaObserver.swift
@@ -57,15 +57,16 @@ extension Array where Element: SchemaObserverIdentifiable {
 }
 
 extension Dictionary where Value: Identifiable & AnyObject, Key == Value.ID {
-    mutating func sync<DataElement>(with newEntities: [DataElement],
-                                    updateCallback: @escaping (Value, DataElement) -> (),
-                                    createCallback: @escaping (DataElement) -> Value) where DataElement: Identifiable, DataElement.ID == Value.ID {
+    @MainActor
+    func sync<DataElement>(with newEntities: [DataElement],
+                           updateCallback: @escaping (Value, DataElement) -> (),
+                           createCallback: @escaping (DataElement) -> Value) -> Self where DataElement: Identifiable, DataElement.ID == Value.ID {
         var values = Array(self.values)
         values.sync(with: newEntities,
                     updateCallback: updateCallback,
                     createCallback: createCallback)
         
-        self = values.reduce(into: Self.init()) { result, observer in
+        return values.reduce(into: Self.init()) { result, observer in
             result.updateValue(observer, forKey: observer.id)
         }
     }

--- a/Stitch/Graph/ViewModel/SchemaObserver.swift
+++ b/Stitch/Graph/ViewModel/SchemaObserver.swift
@@ -70,6 +70,7 @@ extension Dictionary where Value: Identifiable & AnyObject, Key == Value.ID {
         }
     }
     
+    @MainActor
     func sync<DataElement>(with newEntities: [DataElement],
                            updateCallback: @escaping (Value, DataElement) async -> (),
                            createCallback: @escaping (DataElement) async -> Value) async -> Self where DataElement: Identifiable, Element: Sendable, DataElement.ID == Value.ID {
@@ -112,13 +113,14 @@ extension Array where Element: Identifiable & AnyObject {
         }
     }
     
+    @MainActor
     func sync<DataElement>(with newEntities: [DataElement],
-                           updateCallback: @escaping (Element, DataElement) async -> (),
-                           createCallback: @escaping (DataElement) async -> Element) async -> [Element] where DataElement: Identifiable, Element: Sendable, DataElement.ID == Element.ID {
+                           updateCallback: @MainActor @escaping (Element, DataElement) async -> (),
+                           createCallback: @MainActor @escaping (DataElement) async -> Element) async -> [Element] where DataElement: Identifiable, Element: Sendable, DataElement.ID == Element.ID {
         
-        let incomingIds: Set<Element.ID> = newEntities.map { $0.id }.toSet
-        let currentIds: Set<Element.ID> = self.map { $0.id }.toSet
-        let entitiesToRemove = currentIds.subtracting(incomingIds)
+//        let incomingIds: Set<Element.ID> = newEntities.map { $0.id }.toSet
+//        let currentIds: Set<Element.ID> = self.map { $0.id }.toSet
+//        let entitiesToRemove = currentIds.subtracting(incomingIds)
 
         let currentEntitiesMap = self.reduce(into: [:]) { result, currentEntity in
             result.updateValue(currentEntity, forKey: currentEntity.id)

--- a/StitchTests/nodeUIGroupingTests.swift
+++ b/StitchTests/nodeUIGroupingTests.swift
@@ -95,7 +95,7 @@ class GroupNodeTests: XCTestCase {
         XCTAssertEqual(graphState.selectedNodeIds.count, 1)
         XCTAssertEqual(graphState.selectedNodeIds.first!, canvasItem.id)
         
-        let _ = DuplicateShortcutKeyPressed().handle(state: document)
+        await document.duplicateShortcutKeyPressed()
         
         XCTAssertEqual(graphState.groupNodes.keys.count, 2)
         


### PR DESCRIPTION
Various copy + paste actions hadn't been properly supported with recent changes to support components. Copy + paste shortcuts now work properly along with shift + click duplication.