### PR TITLE
Listen for CMD via UIGestureRecognizerDelegate for CMD+panning zoom

### DIFF
--- a/Stitch/Graph/CommentBox/Util/CommentBoxGestureActions.swift
+++ b/Stitch/Graph/CommentBox/Util/CommentBoxGestureActions.swift
@@ -13,6 +13,7 @@ extension StitchDocumentViewModel {
     @MainActor
     func commentBoxTapped(box: CommentBoxViewModel) {
         // If CMD held:
+        // TODO: pass this down from the gesture handler
         if self.keypressState.isCommandPressed {
             if self.graphUI.selection
                 .selectedCommentBoxes.contains(id) {

--- a/Stitch/Graph/Gesture/Util/GestureUtils.swift
+++ b/Stitch/Graph/Gesture/Util/GestureUtils.swift
@@ -71,6 +71,22 @@ extension NodeSelectionGestureRecognizer {
 }
 
 extension GraphGestureDelegate {
+    
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
+                           shouldReceive event: UIEvent) -> Bool {
+        log("GraphGestureDelegate: gestureRecognizer: should receive event")
+
+        if event.modifierFlags.contains(.command) {
+            log("GraphGestureDelegate: CMD DOWN")
+            self.commandHeldDown = true
+        } else {
+            log("GraphGestureDelegate: CMD NOT DOWN")
+            self.commandHeldDown = false
+        }
+        
+        return true
+    }
+        
     @MainActor
     func trackpadGraphBackgroundPan(_ gestureRecognizer: UIPanGestureRecognizer) {
        
@@ -81,7 +97,8 @@ extension GraphGestureDelegate {
         let translation = gestureRecognizer.translation(in: view)
 
         // Check if Command key is pressed
-        if self.document?.keypressState.isCommandPressed == true {
+        // Note: prefer listening to UIGesture delegate's `shouldReceive` vs our currently finicking key listening logic
+        if self.commandHeldDown {
             // Determine zoom direction based on the y-direction of the translation
             switch gestureRecognizer.state {
             case .changed:

--- a/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
+++ b/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
@@ -168,6 +168,7 @@ extension GraphState {
          Normally this is fine, except when we hold command:
          long press would fire and see that the node was not yet selected, so it would select it; then tap would fire and see that the node was already selected, so it would de-select that same node.
          */
+        // TODO: pass isCommandPressed down from the gesture handler
         if !wasDrag && (self.documentDelegate?.keypressState.isCommandPressed ?? false) {
             #if DEV_DEBUG
             log("canvasItemMoved: we long pressed while holding command; doing nothing; this logic will instead be handled by NodeTapped")

--- a/Stitch/Graph/Node/Util/Movement/NodePositionUtils.swift
+++ b/Stitch/Graph/Node/Util/Movement/NodePositionUtils.swift
@@ -35,6 +35,7 @@ extension CanvasItemViewModel {
         log("canvasItemTapped: id: \(self.id)")
         
         // when holding CMD ...
+        // TODO: pass this down from the gesture handler or fix key listening
         if document.keypressState.isCommandPressed {
             // toggle selection
             if self.isSelected {

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
@@ -282,7 +282,7 @@ extension SidebarListGestureRecognizer: UIContextMenuInteractionDelegate {
                 
         let selections = self.graph.sidebarSelectionState
         let groups = self.graph.getSidebarGroupsDict()
-        let sidebarDeps =  SidebarDeps(layerNodes: .fromLayerNodesDict( nodes: self.graph.layerNodes, orderedSidebarItems: self.graph.orderedSidebarLayers),
+        let sidebarDeps = SidebarDeps(layerNodes: .fromLayerNodesDict( nodes: self.graph.layerNodes, orderedSidebarItems: self.graph.orderedSidebarLayers),
                                        groups: groups,
                                        expandedItems: self.graph.getSidebarExpandedItems())
         let layerNodes = sidebarDeps.layerNodes

--- a/Stitch/Graph/View/Gesture/GraphGestureView.swift
+++ b/Stitch/Graph/View/Gesture/GraphGestureView.swift
@@ -70,6 +70,8 @@ class GraphGestureDelegate: NSObject, UIGestureRecognizerDelegate {
     
     weak var document: StitchDocumentViewModel?
 
+    var commandHeldDown: Bool = false 
+    
     init(document: StitchDocumentViewModel) {
         super.init()
         self.document = document


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/6461#issuecomment-2397495071

Generally we should either pass down the `command is pressed` Bool from the UIKit gesture recognizer or improve our key listening logic on Catalyst.