### PR TITLE
Properly defocus project title in state

### DIFF
--- a/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
+++ b/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
@@ -47,8 +47,10 @@ struct CatalystNavBarTitleEditField: View {
                 } else {
                     // log("CatalystNavBarTitleEditField: defocused, so will commit")
                     graph.name = graph.name.validateProjectTitle()
+                    dispatch(ReduxFieldDefocused(focusedField: .projectTitle))
                     // Commit project name to disk
                     graph.encodeProjectInBackground()
+                    
                 }
             }
     }


### PR DESCRIPTION
Defocus ReduxFocusedField when project title TextField is defocused.

Noticed with bug where edge-edit mode shortcut was being ignored.