### PR TITLE
Do not assign tap gesture in GraphGestureDelegate

### DIFF
--- a/Stitch/Graph/View/Gesture/GraphGestureView.swift
+++ b/Stitch/Graph/View/Gesture/GraphGestureView.swift
@@ -42,11 +42,12 @@ struct GraphGestureView<T: View>: UIViewControllerRepresentable {
         trackpadPanGesture.delegate = delegate
         vc.view.addGestureRecognizer(trackpadPanGesture)
 
-        let tapGesture = UITapGestureRecognizer(
-            target: delegate,
-            action: #selector(delegate.tapInView))
-        tapGesture.delegate = delegate
-        vc.view.addGestureRecognizer(tapGesture)
+        // TODO: intermittently, this tap gesture would be recognized during a double tap instead of the defined `TapGesture(count: 2)` 
+//        let tapGesture = UITapGestureRecognizer(
+//            target: delegate,
+//            action: #selector(delegate.tapInView))
+//        tapGesture.delegate = delegate
+//        vc.view.addGestureRecognizer(tapGesture)
 
         /*
          Note: we allow single and double taps on graph to happen simultaneously,
@@ -97,9 +98,9 @@ class GraphGestureDelegate: NSObject, UIGestureRecognizerDelegate {
         self.trackpadGraphBackgroundPan(gestureRecognizer)
     }
 
-    @objc func tapInView(_ gestureRecognizer: UITapGestureRecognizer) {
-        // graph?.graphTappedDuringMouseScroll()
-    }
+//    @objc func tapInView(_ gestureRecognizer: UITapGestureRecognizer) {
+//        // graph?.graphTappedDuringMouseScroll()
+//    }
 
     private static func shouldDisableDueToPinchGesture(_ gestureRecognizer: UIGestureRecognizer,
                                                        otherGestureRecognizer: UIGestureRecognizer) -> Bool {


### PR DESCRIPTION
I've noticed a couple times now that graph double tap seems to stop working, and it seems to be that only the UIKit single tap gesture is being recognized. 

Since we're not actually using the `tapInView` method, I've commented out the assignment for now.