### PR TITLE
Use gray for hidden or secondarily-selected layers in sidebar

### DIFF
--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeInnerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeInnerView.swift
@@ -71,11 +71,8 @@ struct SidebarListItemSwipeInnerView: View {
         
 #endif
         
-        if isBeingEdited {
-            return selection.color(isHidden)
-        } else {
-            return SIDE_BAR_OPTIONS_TITLE_FONT_COLOR
-        }
+        // Note: this means secondarily-selected layers (i.e. children of a primarily-selected parent) are gray even when not in edit mode
+        return selection.color(isHidden)
     }
     
     var layerNodeId: LayerNodeId {


### PR DESCRIPTION
### hidden
<img width="329" alt="Screenshot 2024-10-08 at 12 16 33 PM" src="https://github.com/user-attachments/assets/9aad6ef6-4510-4d09-bfc9-187829f7150b">

### secondarily selected (selected because parent was selected)
<img width="330" alt="Screenshot 2024-10-08 at 12 16 25 PM" src="https://github.com/user-attachments/assets/5f21141c-5d4e-43ac-9cbb-72628e908c65">
