### PR TITLE
Use 0.4 as Smooth Value node's Hysteresis input's default value

### DIFF
--- a/Stitch/Graph/Node/Patch/Type/Animation/SmoothValueNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Animation/SmoothValueNode.swift
@@ -20,7 +20,7 @@ struct SmoothValueNode: PatchNodeDefinition {
                     label: "Value"
                 ),
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [.number(0.4)],
                     label: "Hysteresis"
                 ),
                 .init(


### PR DESCRIPTION
<img width="461" alt="Screenshot 2024-10-08 at 12 22 53 PM" src="https://github.com/user-attachments/assets/30af7ee0-5129-4789-af0a-b6ae729de31e">
