### PR TITLE
Fix Text layer `alignment` and `vertical alignment` when using a static size

### DIFF
--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
@@ -91,7 +91,9 @@ struct LayerSizeModifier: ViewModifier {
                 .frame(minWidth: usesParentPercentForWidth ? minWidth : nil)
                 .frame(maxWidth: usesParentPercentForWidth ? maxWidth : nil)
                 .frame(width: width)
-                .frame(minHeight: minHeight, maxHeight: maxHeight)
+                .frame(minHeight: minHeight, maxHeight: maxHeight,
+                       // added
+                       alignment: alignment)
         }
         
         // Height is pt, but width is auto (so can use min/max width)
@@ -102,19 +104,31 @@ struct LayerSizeModifier: ViewModifier {
                 .frame(minHeight: usesParentPercentForHeight ? minHeight : nil)
                 .frame(maxHeight: usesParentPercentForHeight ? maxHeight : nil)
                 .frame(height: height)
-                .frame(minWidth: minWidth, maxWidth: maxWidth)
+                .frame(minWidth: minWidth, maxWidth: maxWidth,
+                       // added
+                       alignment: alignment)
         }
         
         // Both height and width are pt (so no min/max size at all)
         else if let width = width, let height = height {
             // logInView("LayerSizeModifier: defined width and height")
-            content
-                .frame(minWidth: usesParentPercentForWidth ? minWidth : nil)
-                .frame(maxWidth: usesParentPercentForWidth ? maxWidth : nil)
-                .frame(width: width)
-                .frame(minHeight: usesParentPercentForHeight ? minHeight : nil)
-                .frame(maxHeight: usesParentPercentForHeight ? maxHeight : nil)
-                .frame(height: height)
+            // If we have a static width and height, and we're not using an parent-percents,
+            // then we can use the SwiftUI API with the specified alignment
+            if !usesParentPercentForWidth && !usesParentPercentForHeight {
+                // logInView("LayerSizeModifier: defined width and height and not using parent percent for width or height")
+                content.frame(width: width,
+                              height: height,
+                              alignment: alignment)
+            } else {
+                
+                content
+                    .frame(minWidth: usesParentPercentForWidth ? minWidth : nil)
+                    .frame(maxWidth: usesParentPercentForWidth ? maxWidth : nil)
+                    .frame(width: width)
+                    .frame(minHeight: usesParentPercentForHeight ? minHeight : nil)
+                    .frame(maxHeight: usesParentPercentForHeight ? maxHeight : nil)
+                    .frame(height: height)
+            }
         }
         
         // Both height and width are auto, so use min/max height and width


### PR DESCRIPTION
If we have static width and height and do not use parent-percent for width or height, use SwiftUI's .frame API that allows for specific `alignment:`.
<img width="1440" alt="Screenshot 2024-10-08 at 1 01 29 PM" src="https://github.com/user-attachments/assets/ba2c8688-6747-4ed8-8c8f-88d27651e923">

