### PR TITLE
Remove extra .padding from Text layer

### DIFF
--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/Text/PreviewText.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/Text/PreviewText.swift
@@ -68,7 +68,7 @@ struct PreviewTextLayer: View {
                                  textDecoration: textDecoration,
                                  textFont: textFont)
             .opacity(opacity)
-            .padding()
+//            .padding()
 
         return view.modifier(PreviewCommonModifier(
             document: document,


### PR DESCRIPTION
### before
<img width="1423" alt="Screenshot 2024-10-08 at 1 04 43 PM" src="https://github.com/user-attachments/assets/c5542b2d-f3cd-49d5-a2e1-6e179e0f118f">


### after
<img width="1435" alt="Screenshot 2024-10-08 at 1 53 20 PM" src="https://github.com/user-attachments/assets/3a8e9098-9d76-4ee5-b98e-c717a11b8e60">
