### PR TITLE
Better handling of text alignment when one dimension is non-static

### DIFF
--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
@@ -90,9 +90,10 @@ struct LayerSizeModifier: ViewModifier {
             // Note: parent-percentage supports min/max along a dimension
                 .frame(minWidth: usesParentPercentForWidth ? minWidth : nil)
                 .frame(maxWidth: usesParentPercentForWidth ? maxWidth : nil)
-                .frame(width: width)
-                .frame(minHeight: minHeight, maxHeight: maxHeight,
-                       // added
+                .frame(width: width, 
+                       alignment: alignment)
+                .frame(minHeight: minHeight,
+                       maxHeight: maxHeight,
                        alignment: alignment)
         }
         
@@ -103,9 +104,10 @@ struct LayerSizeModifier: ViewModifier {
             content
                 .frame(minHeight: usesParentPercentForHeight ? minHeight : nil)
                 .frame(maxHeight: usesParentPercentForHeight ? maxHeight : nil)
-                .frame(height: height)
-                .frame(minWidth: minWidth, maxWidth: maxWidth,
-                       // added
+                .frame(height: height, 
+                       alignment: alignment)
+                .frame(minWidth: minWidth,
+                       maxWidth: maxWidth,
                        alignment: alignment)
         }
         
@@ -124,10 +126,10 @@ struct LayerSizeModifier: ViewModifier {
                 content
                     .frame(minWidth: usesParentPercentForWidth ? minWidth : nil)
                     .frame(maxWidth: usesParentPercentForWidth ? maxWidth : nil)
-                    .frame(width: width)
+                    .frame(width: width, alignment: alignment)
                     .frame(minHeight: usesParentPercentForHeight ? minHeight : nil)
                     .frame(maxHeight: usesParentPercentForHeight ? maxHeight : nil)
-                    .frame(height: height)
+                    .frame(height: height, alignment: alignment)
             }
         }
         


### PR DESCRIPTION
Add `alignment:` to more `.frame` uses in `LayerSizeModifier`

<img width="1434" alt="Screenshot 2024-10-08 at 2 22 47 PM" src="https://github.com/user-attachments/assets/56737347-a8b3-491a-be54-1597f0e54c90">
<img width="1430" alt="Screenshot 2024-10-08 at 2 29 57 PM" src="https://github.com/user-attachments/assets/766d0b2f-4802-4b64-8189-bd9e545d1a13">
