### PR TITLE
SwiftUI views with inherent sizes (like Text) use `Fill` as 100% of parent length

### DIFF
--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonSizeModifier.swift
@@ -14,11 +14,15 @@ extension LayerDimension {
      - a shape (e.g. `Ellipse`) without a .frame *grows* to take up as much space as possible inside its parent.
      - a stack (e.g. `ZStack`) without a .frame *shrinks* to take up only as much space as required by the stack's contents.
      */
-    func asFrameDimension(_ parentLength: CGFloat, isStack: Bool) -> CGFloat? {
+    func asFrameDimension(_ parentLength: CGFloat, 
+                          isStack: Bool,
+                          hasInherentSwiftUISize: Bool) -> CGFloat? {
            switch self {
                
            case .fill:
-               if isStack { // a stack like ZStack, VStack
+               // stack = ZStack, VStack
+               // hasInherentSwiftUI = a view like
+               if isStack || hasInherentSwiftUISize {
                    return parentLength // 100% of parent length
                } else { // e.g. a shpe
                    return nil
@@ -85,27 +89,41 @@ struct PreviewCommonSizeModifier: ViewModifier {
         viewModel.layer == .group
     }
     
+    var hasInherentSwiftUISize: Bool {
+        viewModel.layer.hasInherentSwiftUISize
+    }
+    
     var finalMinWidth: CGFloat? {
-        minWidth?.asFrameDimension(parentSize.width, isStack: isStack)
+        minWidth?.asFrameDimension(parentSize.width, 
+                                   isStack: isStack,
+                                   hasInherentSwiftUISize: hasInherentSwiftUISize)
     }
     
     var finalMaxWidth: CGFloat? {
-        maxWidth?.asFrameDimension(parentSize.width, isStack: isStack)
+        maxWidth?.asFrameDimension(parentSize.width, 
+                                   isStack: isStack,
+                                   hasInherentSwiftUISize: hasInherentSwiftUISize)
     }
     
     var finalMinHeight: CGFloat? {
-        minHeight?.asFrameDimension(parentSize.height, isStack: isStack)
+        minHeight?.asFrameDimension(parentSize.height, 
+                                    isStack: isStack,
+                                    hasInherentSwiftUISize: hasInherentSwiftUISize)
     }
     
     var finalMaxHeight: CGFloat? {
-        maxHeight?.asFrameDimension(parentSize.height, isStack: isStack)
+        maxHeight?.asFrameDimension(parentSize.height, 
+                                    isStack: isStack,
+                                    hasInherentSwiftUISize: hasInherentSwiftUISize)
     }
     
     var finalWidth: CGFloat? {
         if usesParentPercentForWidth && (finalMinWidth.isDefined || finalMaxWidth.isDefined) {
             return nil
         } else {
-            return width.asFrameDimension(parentSize.width, isStack: isStack)
+            return width.asFrameDimension(parentSize.width, 
+                                          isStack: isStack,
+                                          hasInherentSwiftUISize: hasInherentSwiftUISize)
         }
     }
     
@@ -113,7 +131,9 @@ struct PreviewCommonSizeModifier: ViewModifier {
         if usesParentPercentForHeight && (finalMinHeight.isDefined || finalMaxHeight.isDefined) {
             return nil
         } else {
-            return height.asFrameDimension(parentSize.height, isStack: isStack)
+            return height.asFrameDimension(parentSize.height, 
+                                           isStack: isStack,
+                                           hasInherentSwiftUISize: hasInherentSwiftUISize)
         }
     }
     

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
@@ -18,6 +18,25 @@ extension CGFloat {
     }
 }
 
+extension Layer {
+    /*
+     Does this layer's view has an 'inherent SwiftUI size'?
+     
+     e.g. Text and Toggle views in SwiftUI have inherent sizes which do not expand when we apply a larger .frame;
+     compare vs. a SwiftUI Ellipse which expands to fill its provided .frame.
+     
+     Note: for now, we consider media layers to NOT have an inherent SwiftUI size, although the resource has an inherent size.
+     */
+    var hasInherentSwiftUISize: Bool {
+        switch self {
+        case .text, .textField, .progressIndicator, .switchLayer:
+            return true
+        case .oval, .rectangle, .image, .group, .video, .model3D, .realityView, .shape, .colorFill, .hitArea, .canvasSketch, .map, .linearGradient, .radialGradient, .angularGradient, .sfSymbol, .videoStreaming:
+            return false
+        }
+    }
+}
+
 // Directly calling SwiftUI's .frame API
 // NOTE: it is the responsibility of the caller to make sure that sensible nil/non-nil params are passed in
 struct LayerSizeModifier: ViewModifier {


### PR DESCRIPTION
Red text uses Fill x Fill, and has the whole preview window as its parent.
Green text uses Fill x Fill, with Group as parent.
Purple text uses Auto x Auto, with Group as parent.

<img width="1440" alt="Screenshot 2024-10-08 at 4 03 17 PM" src="https://github.com/user-attachments/assets/ee652269-b34d-444b-abe5-1cd3152268c8">
