### PR TITLE
Improved undo for components

### DIFF
--- a/Stitch/App/Serialization/DocumentLoading/DocumentEncodable.swift
+++ b/Stitch/App/Serialization/DocumentLoading/DocumentEncodable.swift
@@ -26,9 +26,9 @@ protocol DocumentEncodableDelegate: AnyObject {
     
     @MainActor func createSchema(from graph: GraphState?) -> CodableDocument
     
+    func update(from schema: CodableDocument) async
+    
     @MainActor func willEncodeProject(schema: CodableDocument)
-
-    func updateOnUndo(schema: CodableDocument)
     
     var storeDelegate: StoreDelegate? { get }
 }

--- a/Stitch/App/System/StitchSystemViewModel.swift
+++ b/Stitch/App/System/StitchSystemViewModel.swift
@@ -50,5 +50,8 @@ extension StitchSystemViewModel: DocumentEncodableDelegate {
     
     @MainActor func willEncodeProject(schema: StitchSystem) { }
 
-    func updateOnUndo(schema: StitchSystem) { }
+    func update(from schema: StitchSystem) async {
+        // TODO: come back here
+        fatalError()
+    }
 }

--- a/Stitch/App/ViewModel/StitchStore.swift
+++ b/Stitch/App/ViewModel/StitchStore.swift
@@ -75,7 +75,7 @@ final class ClipboardEncoderDelegate: DocumentEncodableDelegate {
     
     func willEncodeProject(schema: StitchClipboardContent) {}
     
-    func updateOnUndo(schema: StitchClipboardContent) { }
+    func update(from schema: StitchClipboardContent) async { }
     
     var storeDelegate: (any StoreDelegate)? {
         self.store

--- a/Stitch/App/ViewModel/StoreDelegate.swift
+++ b/Stitch/App/ViewModel/StoreDelegate.swift
@@ -17,8 +17,6 @@ protocol StoreDelegate: AnyObject {
     @MainActor
     func saveProjectDeletionUndoHistory(undoActions: [Action],
                                         redoActions: [Action])
-    
-    @MainActor func undoManagerInvoked(newState: StitchDocument?)
 
     @MainActor
     func saveUndoHistory<EncoderDelegate>(from encoderDelegate: EncoderDelegate,

--- a/Stitch/Graph/Node/Component/StitchMasterComponent.swift
+++ b/Stitch/Graph/Node/Component/StitchMasterComponent.swift
@@ -103,7 +103,7 @@ extension StitchMasterComponent: DocumentEncodableDelegate, Identifiable {
         }
     }
     
-    func updateOnUndo(schema: StitchComponent) {
+    func update(from schema: StitchComponent) async {
         guard let document = self.parentGraph?.documentDelegate else {
             return
         }
@@ -116,9 +116,7 @@ extension StitchMasterComponent: DocumentEncodableDelegate, Identifiable {
                 continue
             }
             
-            Task(priority: .high) { [weak component] in
-                await component?.graph.update(from: schema.graph)
-            }
+            await component.graph.update(from: schema.graph)
         }
     }
     

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -115,13 +115,7 @@ final class StitchDocumentViewModel: Sendable {
     }
 }
 
-extension StitchDocumentViewModel: DocumentEncodableDelegate {
-    func updateOnUndo(schema: StitchDocument) {
-        DispatchQueue.main.async { [weak self] in
-            self?.storeDelegate?.undoManagerInvoked(newState: schema)
-        }
-    }
-    
+extension StitchDocumentViewModel: DocumentEncodableDelegate {    
     func willEncodeProject(schema: StitchDocument) {
         // Signals to project thumbnail logic to create a new one when project closes
         self.didDocumentChange = true

--- a/Stitch/Home/Util/ProjectCreatedActions.swift
+++ b/Stitch/Home/Util/ProjectCreatedActions.swift
@@ -36,11 +36,11 @@ extension StitchStore {
     /// Called in the event where project saved in iCloud is deleted
     /// from another device, but user opts to re-save.
     @MainActor
-    func encodeCurrentProject() {
+    func encodeCurrentProject(wasUndo: Bool = false) {
         guard let graphState = self.currentDocument?.visibleGraph else {
             return
         }
 
-        graphState.encodeProjectInBackground()
+        graphState.encodeProjectInBackground(wasUndo: wasUndo)
     }
 }


### PR DESCRIPTION
This moves project encoding logic once invoked just for the top-level document to be abstract, working for other encoders and any file type.