### PR TITLE
Do not show aspect ratio, sizing scenario etc. for layers that do not support sizes (gradients, toggle, etc.)

### DIFF
--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -155,11 +155,9 @@ struct LayerInspectorView: View {
             .listSectionSpacing(.compact) // reduce spacing between sections
             .scrollContentBackground(.hidden)
             
-//            .listStyle(.plain)
-//            .background(Color.SWIFTUI_LIST_BACKGROUND_COLOR)
-                        
-            // Note: hard to be exact here
-            // The default ListStyle adds padding (visible if we do not use Color.clear as list row background), but using e.g. ListStyle.plain introduces sticky header sections that we do not want.
+            // Note: Need to use `.plain` style so that layers with fewer sections (e.g. Linear Gradient layer, vs Text layer) do not default to a different list style
+            .listStyle(.plain)
+            
         } // VStack
     }
 }

--- a/Stitch/Graph/Node/Layer/Type/AngularGradientNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/AngularGradientNode.swift
@@ -28,8 +28,7 @@ struct AngularGradientLayerNode: LayerNodeDefinition {
         .zIndex
     ])
         .union(.layerEffects)
-        .union(.aspectRatio)
-        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
+        .union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
     
     static func content(document: StitchDocumentViewModel,
                         graph: GraphState,

--- a/Stitch/Graph/Node/Layer/Type/ColorFillLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/ColorFillLayerNode.swift
@@ -23,9 +23,7 @@ struct ColorFillLayerNode: LayerNodeDefinition {
         .opacity,
         .zIndex
     ])
-        .union(.layerEffects)
-        .union(.aspectRatio)
-        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
+        .union(.layerEffects).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
     
     static func content(document: StitchDocumentViewModel,
                         graph: GraphState,

--- a/Stitch/Graph/Node/Layer/Type/LinearGradientNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/LinearGradientNode.swift
@@ -28,9 +28,7 @@ struct LinearGradientLayerNode: LayerNodeDefinition {
         .startColor,
         .endColor
     ])
-        .union(.layerEffects)
-        .union(.aspectRatio)
-        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
+        .union(.layerEffects).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
     
     
     static func content(document: StitchDocumentViewModel,

--- a/Stitch/Graph/Node/Layer/Type/ProgressIndicatorLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/ProgressIndicatorLayerNode.swift
@@ -29,8 +29,7 @@ struct ProgressIndicatorLayerNode: LayerNodeDefinition {
     ])
         .union(.layerEffects)
         .union(.strokeInputs)
-        .union(.aspectRatio)
-        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
+        .union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
     
     static func content(document: StitchDocumentViewModel,
                         graph: GraphState,

--- a/Stitch/Graph/Node/Layer/Type/RadialGradientNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/RadialGradientNode.swift
@@ -28,8 +28,7 @@ struct RadialGradientLayerNode: LayerNodeDefinition {
         .zIndex
     ])
         .union(.layerEffects)
-        .union(.aspectRatio)
-        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
+        .union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
     
     static func content(document: StitchDocumentViewModel,
                         graph: GraphState,

--- a/Stitch/Graph/Node/Layer/Type/SwitchLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/SwitchLayerNode.swift
@@ -38,8 +38,7 @@ struct SwitchLayerNode: LayerNodeDefinition {
     ])
         .union(.layerEffects)
         .union(.strokeInputs)
-        .union(.aspectRatio)
-        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
+        .union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
     
     static func content(document: StitchDocumentViewModel,
                         graph: GraphState,

--- a/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
@@ -247,7 +247,7 @@ extension LayerNodeViewModel {
     @MainActor
     func sizingScenarioUpdated(scenario: SizingScenario) {
         
-        log("sizingScenarioUpdated: scenario: \(scenario)")
+        // log("sizingScenarioUpdated: scenario: \(scenario)")
         
         let stitch = self
                 


### PR DESCRIPTION
<img width="1440" alt="Screenshot 2024-10-10 at 4 39 52 PM" src="https://github.com/user-attachments/assets/14047126-d8d1-41a4-82e1-c7f8eb18ef9f">
<img width="1440" alt="Screenshot 2024-10-10 at 4 39 58 PM" src="https://github.com/user-attachments/assets/e5d71571-655f-491c-abe3-b5f4a8e09efe">

### Note the UI change with hanging headers; had to introduce that in order to avoid this strange default List UI change when there were few sections

<img width="1440" alt="Screenshot 2024-10-10 at 4 22 57 PM" src="https://github.com/user-attachments/assets/6f60532e-6aa3-4ba1-a1af-8792e8221cca">
