### PR TITLE
Avoid access crashes when using edge-edit-mode

### DIFF
--- a/Stitch/App/Util/Action/HandleStitchAction.swift
+++ b/Stitch/App/Util/Action/HandleStitchAction.swift
@@ -25,6 +25,7 @@ struct ESCKeyPressed: StitchStoreEvent {
 struct KeyCharacterPressBegan: StitchStoreEvent {
     let char: Character
     
+    @MainActor
     func handle(store: StitchStore) -> ReframeResponse<NoState> {
         store.keyCharacterPressBegan(char: char)
         return .noChange

--- a/Stitch/App/View/ViewUtil/StitchHostingController.swift
+++ b/Stitch/App/View/ViewUtil/StitchHostingController.swift
@@ -65,6 +65,7 @@ class StitchHostingController<T: View>: UIHostingController<T> {
     //    }
     //    #endif
 
+    @MainActor
     override func pressesBegan(_ presses: Set<UIPress>,
                                with event: UIPressesEvent?) {
         // log("KEY: StitchHostingController: name: \(name): pressesBegan: presses.first?.key: \(presses.first?.key)")
@@ -90,6 +91,7 @@ class StitchHostingController<T: View>: UIHostingController<T> {
         #endif
     }
 
+    @MainActor
     override func pressesEnded(_ presses: Set<UIPress>,
                                with event: UIPressesEvent?) {
         // log("KEY: StitchHostingController: name: \(name): pressesEnded: presses.first?.key: \(presses.first?.key)")
@@ -97,6 +99,7 @@ class StitchHostingController<T: View>: UIHostingController<T> {
         super.pressesEnded(presses, with: event)
     }
 
+    @MainActor
     override func pressesCancelled(_ presses: Set<UIPress>,
                                    with event: UIPressesEvent?) {
         // log("KEY: StitchHostingController: name: \(name): pressesCancelled: presses.first?.key: \(presses.first?.key)")
@@ -104,6 +107,7 @@ class StitchHostingController<T: View>: UIHostingController<T> {
         super.pressesCancelled(presses, with: event)
     }
 
+    @MainActor
     func keyPressed(_ key: UIKey) {
         // log("KEY: StitchHostingController: name: \(name): keyPressed: key: \(key)")
         
@@ -115,6 +119,7 @@ class StitchHostingController<T: View>: UIHostingController<T> {
         }
     }
 
+    @MainActor
     func keyReleased(_ key: UIKey) {
         // log("KEY: StitchHostingController: name: \(name): keyReleased: key: \(key)")
         if let modifiers = key.asStitchKeyModifiers {

--- a/Stitch/App/ViewModel/StitchStore.swift
+++ b/Stitch/App/ViewModel/StitchStore.swift
@@ -90,6 +90,7 @@ extension StitchStore {
 }
 
 extension StitchStore: GlobalDispatchDelegate {
+    @MainActor
     func reswiftDispatch(_ legacyAction: Action) {
         _handleAction(store: self, action: legacyAction)
     }

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -40,6 +40,7 @@ final class GraphUIState {
     // e.g. user is hovering over or has selected a layer in the sidebar, which we then highlight in the preview window itself
     var highlightedSidebarLayers: LayerIdSet = .init()
 
+    @MainActor
     var edgeEditingState: EdgeEditingState?
 
     var restartPrototypeWindowIconRotationZ: CGFloat = .zero


### PR DESCRIPTION
Use `@MainActor` for EdgeEditMode

An attempt to address `exclusive_access` crashes when adding or removing edges via edge-edit-mode.