### PR TITLE
Use proper output value type on Delay node on project open and reset

### DIFF
--- a/Stitch/Graph/Node/Patch/Type/Delay/DelayNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Delay/DelayNode.swift
@@ -117,15 +117,22 @@ func delayEval(node: PatchNode) -> EvalResult {
 //        let inputCoordinate = InputCoordinate(portId: 0, nodeId: node.id)
         let prevDelayInputValue = timerObserver.prevDelayInputValue
 
-        guard let inputValue = values.first,
-              let delayValue = values[safe: 1]?.getNumber,
+        guard let inputValue = values.first else {
+            return [node.userVisibleType?.defaultPortValue ?? .number(.zero)]
+        }
+        
+        guard let delayValue = values[safe: 1]?.getNumber,
               let style = values[safe: 2]?.delayStyle else {
-            return node.defaultOutputs
+            return [inputValue.defaultFalseValue]
         }
         
         // If there's no current output (graph just opened or reset),
         // use the default-false-value for this same input kind.
-        let currentOutput = values[safe: 3] ?? inputValue.defaultFalseValue
+        
+        var currentOutput = values[safe: 3] ?? inputValue.defaultFalseValue
+        if currentOutput.toNodeType != inputValue.toNodeType {
+            currentOutput = inputValue.defaultFalseValue
+        }
 
         let createTimer = {
             let id = UUID()

--- a/Stitch/Graph/Node/Patch/Type/Delay/DelayNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Delay/DelayNode.swift
@@ -119,11 +119,13 @@ func delayEval(node: PatchNode) -> EvalResult {
 
         guard let inputValue = values.first,
               let delayValue = values[safe: 1]?.getNumber,
-              let style = values[safe: 2]?.delayStyle,
-              // This MUST be the `PortValueComparable` type
-              let currentOutput = values[safe: 3] else {
+              let style = values[safe: 2]?.delayStyle else {
             return node.defaultOutputs
         }
+        
+        // If there's no current output (graph just opened or reset),
+        // use the default-false-value for this same input kind.
+        let currentOutput = values[safe: 3] ?? inputValue.defaultFalseValue
 
         let createTimer = {
             let id = UUID()


### PR DESCRIPTION
Delay node output: use default false value of input's kind when graph opened or reset


https://github.com/user-attachments/assets/9e545e3c-64d2-413b-891d-8fc776ec2b18



https://github.com/user-attachments/assets/2001ea50-5c95-43be-ab22-f15a6f81fe14

