### PR TITLE
Inspector rows with off-screen connected canvas items now start with correct value

### DIFF
--- a/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
+++ b/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
@@ -204,11 +204,23 @@ extension InputLayerNodeRowData {
                 unpackedPortParentFieldGroupType: FieldGroupType?,
                 unpackedPortIndex: Int?) {
         self.rowObserver.id.nodeId = nodeId
+            
+        if layerInputType.layerInput == .size {
+            log("InputLayerNodeRowData: update: size input")
+        }
                 
         if let canvas = schema.canvasItem {
             if let canvasObserver = self.canvasObserver {
+                if layerInputType.layerInput == .size {
+                    log("InputLayerNodeRowData: update: size input: had canvas observer")
+                }
                 canvasObserver.update(from: canvas)
+                
             } else {
+                if layerInputType.layerInput == .size {
+                    log("InputLayerNodeRowData: update: size input: will create canvas observer")
+                }
+                
                 // Make new canvas observer since none yet created
                 let canvasId = CanvasItemId.layerInput(.init(node: nodeId,
                                                              keyPath: layerInputType))
@@ -223,6 +235,9 @@ extension InputLayerNodeRowData {
                 self.inspectorRowViewModel.canvasItemDelegate = self.canvasObserver
             }
         } else {
+            if layerInputType.layerInput == .size {
+                log("InputLayerNodeRowData: update: size input: no canvas on schema")
+            }
             self.canvasObserver = nil
         }
     }
@@ -291,7 +306,7 @@ extension LayerInputObserver {
                                     unpackedPortIndex: portId)
         }
         
-        // Update values once mode is known (requires updating canvas items first
+        // Update values once mode is known (requires updating canvas items first)
         // This logic is needed to prevent a bug where unpacked mode updates packed observer values despite upstream connection
         switch self.observerMode {
         case .packed(let packedObserver):

--- a/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
+++ b/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
@@ -204,24 +204,12 @@ extension InputLayerNodeRowData {
                 unpackedPortParentFieldGroupType: FieldGroupType?,
                 unpackedPortIndex: Int?) {
         self.rowObserver.id.nodeId = nodeId
-            
-        if layerInputType.layerInput == .size {
-            log("InputLayerNodeRowData: update: size input")
-        }
-        
-        
+                    
         if let canvas = schema.canvasItem {
             if let canvasObserver = self.canvasObserver {
-                if layerInputType.layerInput == .size {
-                    log("InputLayerNodeRowData: update: size input: had canvas observer")
-                }
                 canvasObserver.update(from: canvas)
                 
             } else {
-                if layerInputType.layerInput == .size {
-                    log("InputLayerNodeRowData: update: size input: will create canvas observer")
-                }
-                
                 // Make new canvas observer since none yet created
                 let canvasId = CanvasItemId.layerInput(.init(node: nodeId,
                                                              keyPath: layerInputType))
@@ -232,13 +220,11 @@ extension InputLayerNodeRowData {
                                             outputRowObservers: [],
                                             unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
                                             unpackedPortIndex: unpackedPortIndex)
-                
+
+                // NOTE: DO NOT SET A CANVAS ITEM DELEGATE ON AN INSPECTOR ROW VIEW MODEL
 //                self.inspectorRowViewModel.canvasItemDelegate = self.canvasObserver
             }
         } else {
-            if layerInputType.layerInput == .size {
-                log("InputLayerNodeRowData: update: size input: no canvas on schema")
-            }
             self.canvasObserver = nil
         }
     }

--- a/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
+++ b/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
@@ -208,7 +208,8 @@ extension InputLayerNodeRowData {
         if layerInputType.layerInput == .size {
             log("InputLayerNodeRowData: update: size input")
         }
-                
+        
+        
         if let canvas = schema.canvasItem {
             if let canvasObserver = self.canvasObserver {
                 if layerInputType.layerInput == .size {
@@ -232,7 +233,7 @@ extension InputLayerNodeRowData {
                                             unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
                                             unpackedPortIndex: unpackedPortIndex)
                 
-                self.inspectorRowViewModel.canvasItemDelegate = self.canvasObserver
+//                self.inspectorRowViewModel.canvasItemDelegate = self.canvasObserver
             }
         } else {
             if layerInputType.layerInput == .size {

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
@@ -40,6 +40,14 @@ final class LayerInputObserver {
         self.layer = schema.layer
         self.port = port
         
+        if port == .size {
+            log("LayerInputObserver: had size port: schema.positionPort.encodedValues: \(schema.positionPort.encodedValues)")
+        }
+        
+        if port == .position {
+            log("LayerInputObserver: had position port: schema.positionPort.encodedValues: \(schema.positionPort.encodedValues)")
+        }
+            
         self._packedData = .empty(.init(layerInput: port,
                                         portType: .packed),
                                   layer: schema.layer)

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
@@ -39,15 +39,7 @@ final class LayerInputObserver {
         
         self.layer = schema.layer
         self.port = port
-        
-        if port == .size {
-            log("LayerInputObserver: had size port: schema.positionPort.encodedValues: \(schema.positionPort.encodedValues)")
-        }
-        
-        if port == .position {
-            log("LayerInputObserver: had position port: schema.positionPort.encodedValues: \(schema.positionPort.encodedValues)")
-        }
-            
+                    
         self._packedData = .empty(.init(layerInput: port,
                                         portType: .packed),
                                   layer: schema.layer)

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
@@ -55,43 +55,7 @@ extension NodeRowObserver {
     /// Updates port view models when the backend port observer has been updated.
     /// Also invoked when nodes enter the viewframe incase they need to be udpated.
     func updatePortViewModels() {
-        let rowViewModels = self.getVisibleRowViewModels()
-        
-        let isPositionInput = self.id.keyPath?.layerInput == .position
-        let isSizeInput = self.id.keyPath?.layerInput == .size
-        
-//        if self.activeValue.getPosition.isDefined {
-        if isPositionInput {
-            log("NodeRowObserver: updatePortViewModels: row observer for: position, rowViewModels.count: \(rowViewModels.count)")
-        }
-
-        // .getSize is for min and max size as well
-        if isSizeInput {
-//            if self.activeValue.getSize.isDefined {
-            log("NodeRowObserver: updatePortViewModels: row observer for: size, rowViewModels.count: \(rowViewModels.count)")
-        }
-        
-        rowViewModels.forEach { rowViewModel in
-            
-            switch rowViewModel.id.graphItemType {
-            case .layerInspector(let x):
-                log("NodeRowObserver: updatePortViewModels: layer inspector x \(x)")
-                if isPositionInput {
-                    log("NodeRowObserver: updatePortViewModels: layer inspector x: position")
-                }
-                if isSizeInput {
-                    log("NodeRowObserver: updatePortViewModels: layer inspector x: size")
-                }
-            case .node(let x):
-                log("NodeRowObserver: updatePortViewModels: node x \(x)")
-                if isPositionInput {
-                    log("NodeRowObserver: updatePortViewModels: node x: position")
-                }
-                if isSizeInput {
-                    log("NodeRowObserver: updatePortViewModels: node x: size")
-                }
-            }
-                
+        self.getVisibleRowViewModels().forEach { rowViewModel in
             rowViewModel.didPortValuesUpdate(values: self.allLoopedValues)
         }
     }

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
@@ -55,7 +55,43 @@ extension NodeRowObserver {
     /// Updates port view models when the backend port observer has been updated.
     /// Also invoked when nodes enter the viewframe incase they need to be udpated.
     func updatePortViewModels() {
-        self.getVisibleRowViewModels().forEach { rowViewModel in
+        let rowViewModels = self.getVisibleRowViewModels()
+        
+        let isPositionInput = self.id.keyPath?.layerInput == .position
+        let isSizeInput = self.id.keyPath?.layerInput == .size
+        
+//        if self.activeValue.getPosition.isDefined {
+        if isPositionInput {
+            log("NodeRowObserver: updatePortViewModels: row observer for: position, rowViewModels.count: \(rowViewModels.count)")
+        }
+
+        // .getSize is for min and max size as well
+        if isSizeInput {
+//            if self.activeValue.getSize.isDefined {
+            log("NodeRowObserver: updatePortViewModels: row observer for: size, rowViewModels.count: \(rowViewModels.count)")
+        }
+        
+        rowViewModels.forEach { rowViewModel in
+            
+            switch rowViewModel.id.graphItemType {
+            case .layerInspector(let x):
+                log("NodeRowObserver: updatePortViewModels: layer inspector x \(x)")
+                if isPositionInput {
+                    log("NodeRowObserver: updatePortViewModels: layer inspector x: position")
+                }
+                if isSizeInput {
+                    log("NodeRowObserver: updatePortViewModels: layer inspector x: size")
+                }
+            case .node(let x):
+                log("NodeRowObserver: updatePortViewModels: node x \(x)")
+                if isPositionInput {
+                    log("NodeRowObserver: updatePortViewModels: node x: position")
+                }
+                if isSizeInput {
+                    log("NodeRowObserver: updatePortViewModels: node x: size")
+                }
+            }
+                
             rowViewModel.didPortValuesUpdate(values: self.allLoopedValues)
         }
     }

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverSchemaObserverIdentifiable.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverSchemaObserverIdentifiable.swift
@@ -28,16 +28,7 @@ extension InputNodeRowObserver: SchemaObserverIdentifiable {
     /// Schema updates from layer.
     func update(from nodeConnection: NodeConnectionType,
                 inputType: LayerInputType) {
-        
-        let isSize = self.id.keyPath?.layerInput == .size
-        let isPosition = self.id.keyPath?.layerInput == .position
-        if isSize {
-            log("InputNodeRowObserver: had size input: nodeConnection: \(nodeConnection)")
-        }
-        if isPosition {
-            log("InputNodeRowObserver: had position input: nodeConnection: \(nodeConnection)")
-        }
-                
+                        
         switch nodeConnection {
         case .upstreamConnection(let upstreamOutputCoordinate):
             self.upstreamOutputCoordinate = upstreamOutputCoordinate

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverSchemaObserverIdentifiable.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverSchemaObserverIdentifiable.swift
@@ -13,6 +13,7 @@ extension InputNodeRowObserver: SchemaObserverIdentifiable {
         self.init(from: entity)
     }
 
+    // for easier search: `updateInputNodeRowObserverFromSchema`
     /// Updates values for inputs.
     func update(from schema: NodePortInputEntity) {
         self.upstreamOutputCoordinate = schema.portData.upstreamConnection
@@ -23,9 +24,20 @@ extension InputNodeRowObserver: SchemaObserverIdentifiable {
         }
     }
 
+    // for easier search: `updateInputNodeRowObserverFromConnectionType`
     /// Schema updates from layer.
     func update(from nodeConnection: NodeConnectionType,
                 inputType: LayerInputType) {
+        
+        let isSize = self.id.keyPath?.layerInput == .size
+        let isPosition = self.id.keyPath?.layerInput == .position
+        if isSize {
+            log("InputNodeRowObserver: had size input: nodeConnection: \(nodeConnection)")
+        }
+        if isPosition {
+            log("InputNodeRowObserver: had position input: nodeConnection: \(nodeConnection)")
+        }
+                
         switch nodeConnection {
         case .upstreamConnection(let upstreamOutputCoordinate):
             self.upstreamOutputCoordinate = upstreamOutputCoordinate

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowViewModel.swift
@@ -364,12 +364,31 @@ extension OutputNodeRowViewModel {
     }
 }
 
+
+/// this is impossible to find via a code search and impossible to remember as a concept
 extension Array where Element: NodeRowViewModel {
+    // easier search: `syncRowViewModelsViaSchemaEntities`
     /// Syncing logic as influced from `SchemaObserverIdentifiable`.
     mutating func sync(with newEntities: [Element.RowObserver],
                        canvas: CanvasItemViewModel,
                        unpackedPortParentFieldGroupType: FieldGroupType?,
                        unpackedPortIndex: Int?) {
+        
+        let isSizeLIG = canvas.id.layerInputCase?.keyPath.layerInput == .size
+        let isPositionLIG = canvas.id.layerInputCase?.keyPath.layerInput == .position
+        
+        // The actual initializer of the `InputNodeRowViewModel` doesn't really do anything besides assigning the canvas item, node and node row observer delegates
+        
+        // You want to know, why did we not create a node row view model for
+        
+        if isSizeLIG {
+            log("Array where Element: NodeRowViewModel: sync: had size")
+        } // ^^ never gets hit
+        
+        if isPositionLIG {
+            log("Array where Element: NodeRowViewModel: sync: had position")
+        }
+        
         // This will be nil for some inits--that's ok, just need to set delegate after
         let node = canvas.nodeDelegate
         
@@ -388,7 +407,10 @@ extension Array where Element: NodeRowViewModel {
 
         // Create or update entities from new list
         self = newEntities.enumerated().map { portIndex, newEntity in
+            log("Array where Element: NodeRowViewModel: sync: portIndex \(portIndex), newEntity.id \(newEntity.id)")
+            
             if let entity = currentEntitiesMap.get(newEntity.id) {
+                log("Array where Element: NodeRowViewModel: sync: ENTITY ALREADY EXISTS")
                 // Update index if ports for node were removed
                 entity.id = .init(graphItemType: entity.id.graphItemType,
                                   nodeId: entity.id.nodeId,
@@ -396,6 +418,7 @@ extension Array where Element: NodeRowViewModel {
                 
                 return entity
             } else {
+                log("Array where Element: NodeRowViewModel: sync: WILL CREATE NEW NODE ROW VIEW MODEL")
                 let rowId = NodeRowViewModelId(graphItemType: .node(canvas.id),
                                                // Important this is the node ID from canvas for group nodes
                                                nodeId: canvas.nodeDelegate?.id ?? newEntity.id.nodeId,

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowViewModel.swift
@@ -366,31 +366,25 @@ extension OutputNodeRowViewModel {
     }
 }
 
-
-/// this is impossible to find via a code search and impossible to remember as a concept
 extension Array where Element: NodeRowViewModel {
-    // easier search: `syncRowViewModelsViaSchemaEntities`
+    // easier code search
+    mutating func syncRowViewModelsWithCanvasItem(with newEntities: [Element.RowObserver],
+                                                  canvas: CanvasItemViewModel,
+                                                  unpackedPortParentFieldGroupType: FieldGroupType?,
+                                                  unpackedPortIndex: Int?) {
+        self.sync(with: newEntities,
+                  canvas: canvas,
+                  unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
+                  unpackedPortIndex: unpackedPortIndex)
+    }
+    
+    // TODO: This is impossible to find via a code search; too many methods are called `sync`
     /// Syncing logic as influced from `SchemaObserverIdentifiable`.
     mutating func sync(with newEntities: [Element.RowObserver],
                        canvas: CanvasItemViewModel,
                        unpackedPortParentFieldGroupType: FieldGroupType?,
                        unpackedPortIndex: Int?) {
-        
-        let isSizeLIG = canvas.id.layerInputCase?.keyPath.layerInput == .size
-        let isPositionLIG = canvas.id.layerInputCase?.keyPath.layerInput == .position
-        
-        // The actual initializer of the `InputNodeRowViewModel` doesn't really do anything besides assigning the canvas item, node and node row observer delegates
-        
-        // You want to know, why did we not create a node row view model for
-        
-        if isSizeLIG {
-            log("Array where Element: NodeRowViewModel: sync: had size")
-        } // ^^ never gets hit
-        
-        if isPositionLIG {
-            log("Array where Element: NodeRowViewModel: sync: had position")
-        }
-        
+            
         // This will be nil for some inits--that's ok, just need to set delegate after
         let node = canvas.nodeDelegate
         
@@ -409,10 +403,7 @@ extension Array where Element: NodeRowViewModel {
 
         // Create or update entities from new list
         self = newEntities.enumerated().map { portIndex, newEntity in
-            log("Array where Element: NodeRowViewModel: sync: portIndex \(portIndex), newEntity.id \(newEntity.id)")
-            
             if let entity = currentEntitiesMap.get(newEntity.id) {
-                log("Array where Element: NodeRowViewModel: sync: ENTITY ALREADY EXISTS")
                 // Update index if ports for node were removed
                 entity.id = .init(graphItemType: entity.id.graphItemType,
                                   nodeId: entity.id.nodeId,
@@ -420,7 +411,6 @@ extension Array where Element: NodeRowViewModel {
                 
                 return entity
             } else {
-                log("Array where Element: NodeRowViewModel: sync: WILL CREATE NEW NODE ROW VIEW MODEL")
                 let rowId = NodeRowViewModelId(graphItemType: .node(canvas.id),
                                                // Important this is the node ID from canvas for group nodes
                                                nodeId: canvas.nodeDelegate?.id ?? newEntity.id.nodeId,

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowViewModel.swift
@@ -238,6 +238,8 @@ final class InputNodeRowViewModel: NodeRowViewModel {
     var portViewData: PortViewType?
     weak var nodeDelegate: NodeDelegate?
     weak var rowDelegate: InputNodeRowObserver?
+    
+    // TODO: input node row view model for an inspector should NEVER have canvasItemDelegate
     weak var canvasItemDelegate: CanvasItemViewModel? // also nil when the layer input is not on the canvas
     
     // TODO: temporary property for old-style layer nodes

--- a/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
@@ -118,13 +118,6 @@ final class CanvasItemViewModel: Identifiable {
         self.parentGroupNodeId = parentGroupNodeId
         self.nodeDelegate = nodeDelegate
         
-        log("CanvasItemViewModel: id: \(id)")
-        log("CanvasItemViewModel: inputRowObservers.first?.allLoopedValues: \(inputRowObservers.first?.allLoopedValues)")
-        
-        if id.layerInputCase?.keyPath.layerInput == .size {
-            log("CanvasItemViewModel: had size input")
-        }
-        
         // Instantiate input and output row view models
         self.syncRowViewModels(inputRowObservers: inputRowObservers,
                                outputRowObservers: outputRowObservers,
@@ -150,22 +143,13 @@ extension CanvasItemViewModel {
                                    unpackedPortIndex: nil)
     }
     
+    // Only called at project open?
     convenience init(from canvasEntity: CanvasNodeEntity,
                      id: CanvasItemId,
                      inputRowObservers: [InputNodeRowObserver],
                      outputRowObservers: [OutputNodeRowObserver],
                      unpackedPortParentFieldGroupType: FieldGroupType?,
                      unpackedPortIndex: Int?) {
-        
-        // ONLY CALLED AT PROJECT OPEN, AND ROW OBSERVERS HAVE DEFAULT VALUES
-        if id.layerInputCase?.keyPath.layerInput == .size {
-            log("CanvasItemViewModel: convenience init: had size input: inputRowObservers.first?.allLoopedValues: \(inputRowObservers.first?.allLoopedValues)")
-        }
-        
-        if id.layerInputCase?.keyPath.layerInput == .position {
-            log("CanvasItemViewModel: convenience init: had position input: inputRowObservers.first?.allLoopedValues: \(inputRowObservers.first?.allLoopedValues)")
-        }
-        
         self.init(id: id,
                   position: canvasEntity.position,
                   zIndex: canvasEntity.zIndex,

--- a/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
@@ -118,6 +118,13 @@ final class CanvasItemViewModel: Identifiable {
         self.parentGroupNodeId = parentGroupNodeId
         self.nodeDelegate = nodeDelegate
         
+        log("CanvasItemViewModel: id: \(id)")
+        log("CanvasItemViewModel: inputRowObservers.first?.allLoopedValues: \(inputRowObservers.first?.allLoopedValues)")
+        
+        if id.layerInputCase?.keyPath.layerInput == .size {
+            log("CanvasItemViewModel: had size input")
+        }
+        
         // Instantiate input and output row view models
         self.syncRowViewModels(inputRowObservers: inputRowObservers,
                                outputRowObservers: outputRowObservers,
@@ -149,6 +156,16 @@ extension CanvasItemViewModel {
                      outputRowObservers: [OutputNodeRowObserver],
                      unpackedPortParentFieldGroupType: FieldGroupType?,
                      unpackedPortIndex: Int?) {
+        
+        // ONLY CALLED AT PROJECT OPEN, AND ROW OBSERVERS HAVE DEFAULT VALUES
+        if id.layerInputCase?.keyPath.layerInput == .size {
+            log("CanvasItemViewModel: convenience init: had size input: inputRowObservers.first?.allLoopedValues: \(inputRowObservers.first?.allLoopedValues)")
+        }
+        
+        if id.layerInputCase?.keyPath.layerInput == .position {
+            log("CanvasItemViewModel: convenience init: had position input: inputRowObservers.first?.allLoopedValues: \(inputRowObservers.first?.allLoopedValues)")
+        }
+        
         self.init(id: id,
                   position: canvasEntity.position,
                   zIndex: canvasEntity.zIndex,
@@ -241,6 +258,7 @@ extension CanvasItemViewModel {
 extension InputLayerNodeRowData {
     static func empty(_ layerInputType: LayerInputType,
                       layer: Layer) -> Self {
+        // Take the data from the schema!! 
         let rowObserver = InputNodeRowObserver(values: [layerInputType.getDefaultValue(for: layer)],
                                                nodeKind: .layer(layer),
                                                userVisibleType: nil,


### PR DESCRIPTION
Also: the below means we're taking perf hits for updating "off-screen" inspector inputs

<img width="859" alt="Screenshot 2024-10-11 at 7 38 45 PM" src="https://github.com/user-attachments/assets/edaaae46-1d85-4220-b510-468f8b815ff9">
