### PR TITLE
Fixed project thumbnail ordering on component edits

### DIFF
--- a/Stitch/App/FeatureFlags.swift
+++ b/Stitch/App/FeatureFlags.swift
@@ -11,5 +11,5 @@ import StitchSchemaKit
 // Currently unused but will keep alive here.
 struct FeatureFlags {
     static let USE_COMMENT_BOX_FLAG: Bool = false
-    static let USE_COMPONENTS = true
+    static let USE_COMPONENTS = false
 }

--- a/Stitch/App/FeatureFlags.swift
+++ b/Stitch/App/FeatureFlags.swift
@@ -11,5 +11,5 @@ import StitchSchemaKit
 // Currently unused but will keep alive here.
 struct FeatureFlags {
     static let USE_COMMENT_BOX_FLAG: Bool = false
-    static let USE_COMPONENTS = false
+    static let USE_COMPONENTS = true
 }

--- a/Stitch/App/Serialization/DocumentLoading/DocumentEncodable.swift
+++ b/Stitch/App/Serialization/DocumentLoading/DocumentEncodable.swift
@@ -44,14 +44,12 @@ extension DocumentEncodable {
     
     @MainActor func encodeProjectInBackground(from graph: GraphState?,
                                               temporaryUrl: URL? = nil,
-                                              enableUndo: Bool = true,
-                                              wasUndo: Bool = false) {
+                                              willUpdateUndoHistory: Bool = true) {
         self.encodeProjectInBackground(from: graph,
                                        temporaryUrl: temporaryUrl,
-                                       enableUndo: enableUndo,
-                                       wasUndo: wasUndo) { delegate, oldSchema, newSchema in
+                                       willUpdateUndoHistory: willUpdateUndoHistory) { delegate, oldSchema, newSchema in
             
-            if enableUndo,
+            if willUpdateUndoHistory,
                let graph = graph {
                 graph.storeDelegate?.saveUndoHistory(from: delegate,
                                                      oldSchema: oldSchema,
@@ -64,13 +62,11 @@ extension DocumentEncodable {
     @MainActor func encodeProjectInBackground(from graph: GraphState?,
                                               undoEvents: [Action],
                                               temporaryUrl: URL? = nil,
-                                              enableUndo: Bool = true,
-                                              wasUndo: Bool = false) {
+                                              willUpdateUndoHistory: Bool = true) {
         self.encodeProjectInBackground(from: graph,
                                        temporaryUrl: temporaryUrl,
-                                       enableUndo: enableUndo,
-                                       wasUndo: wasUndo) { delegate, oldSchema, newSchema in
-            if enableUndo,
+                                       willUpdateUndoHistory: willUpdateUndoHistory) { delegate, oldSchema, newSchema in
+            if willUpdateUndoHistory,
                 let graph = graph {
                 graph.storeDelegate?.saveUndoHistory(from: delegate,
                                                      oldSchema: oldSchema,
@@ -83,8 +79,8 @@ extension DocumentEncodable {
     
     @MainActor func encodeProjectInBackground(from graph: GraphState?,
                                               temporaryUrl: URL? = nil,
-                                              enableUndo: Bool = true,
-                                              wasUndo: Bool = false,
+//                                              enableUndo: Bool = true,
+                                              willUpdateUndoHistory: Bool = true,
                                               saveUndoHistory: @escaping (DocumentDelegate, CodableDocument, CodableDocument) -> ()) {
         guard let delegate = self.delegate else {
             fatalErrorIfDebug()
@@ -98,13 +94,13 @@ extension DocumentEncodable {
         let oldSchema = self.lastEncodedDocument
         
         // Update undo only if the caller here wasn't undo itself--this breaks redo
-        if !wasUndo && enableUndo {
+        if willUpdateUndoHistory {
             saveUndoHistory(delegate, oldSchema, newSchema)
         }
         
         Task(priority: .background) {
             await self.encodeProject(newSchema,
-                                     enableUndo: enableUndo,
+                                     willUpdateUndoHistory: willUpdateUndoHistory,
                                      temporaryURL: temporaryUrl)
         }
     }
@@ -118,7 +114,7 @@ extension DocumentEncodable {
     }
     
     func encodeProject(_ document: Self.CodableDocument,
-                       enableUndo: Bool = true,
+                       willUpdateUndoHistory: Bool = true,
                        temporaryURL: URL? = nil) async -> StitchFileVoidResult {
         let rootDocUrl = temporaryURL ?? self.rootUrl.appendingVersionedSchemaPath()
         
@@ -130,7 +126,7 @@ extension DocumentEncodable {
             log("encodeProject success")
 
             // Save data for last encoded document whenever there was undo history saved
-            if enableUndo {
+            if willUpdateUndoHistory {
                 await MainActor.run { [weak self] in
                     self?.lastEncodedDocument = document
                 }

--- a/Stitch/App/Serialization/DocumentLoading/DocumentEncodable.swift
+++ b/Stitch/App/Serialization/DocumentLoading/DocumentEncodable.swift
@@ -79,7 +79,6 @@ extension DocumentEncodable {
     
     @MainActor func encodeProjectInBackground(from graph: GraphState?,
                                               temporaryUrl: URL? = nil,
-//                                              enableUndo: Bool = true,
                                               willUpdateUndoHistory: Bool = true,
                                               saveUndoHistory: @escaping (DocumentDelegate, CodableDocument, CodableDocument) -> ()) {
         guard let delegate = self.delegate else {

--- a/Stitch/App/ViewModel/StitchUndoManager.swift
+++ b/Stitch/App/ViewModel/StitchUndoManager.swift
@@ -70,7 +70,9 @@ extension StitchStore {
         self.undoManager.undoManager.registerUndo(withTarget: encoderDelegate) { delegate in            
             Task(priority: .high) { [weak self, weak delegate] in
                 await delegate?.update(from: oldSchema)
-                await self?.encodeCurrentProject(wasUndo: true)
+                
+                // Don't update undo history from this action
+                await self?.encodeCurrentProject(willUpdateUndoHistory: false)
             }
             
             undoEffectsData?.undoCallback?()

--- a/Stitch/Graph/Node/Component/StitchMasterComponent.swift
+++ b/Stitch/Graph/Node/Component/StitchMasterComponent.swift
@@ -91,6 +91,11 @@ extension MasterComponentsDict {
 
 extension StitchMasterComponent: DocumentEncodableDelegate, Identifiable {
     func willEncodeProject(schema: StitchComponent) {
+        // Updates thumbnail
+//        if let document = self.parentGraph?.documentDelegate {
+//            document.encodeProjectInBackground(willUpdateUndoHistory: false)
+//        }
+        
         // Find all graphs using this component
         guard let graphs = self.parentGraph?.findComponentGraphStates(componentId: self.lastEncodedDocument.id) else {
             fatalErrorIfDebug()

--- a/Stitch/Graph/Node/Component/StitchMasterComponent.swift
+++ b/Stitch/Graph/Node/Component/StitchMasterComponent.swift
@@ -92,9 +92,9 @@ extension MasterComponentsDict {
 extension StitchMasterComponent: DocumentEncodableDelegate, Identifiable {
     func willEncodeProject(schema: StitchComponent) {
         // Updates thumbnail
-//        if let document = self.parentGraph?.documentDelegate {
-//            document.encodeProjectInBackground(willUpdateUndoHistory: false)
-//        }
+        if let document = self.parentGraph?.documentDelegate {
+            document.encodeProjectInBackground(willUpdateUndoHistory: false)
+        }
         
         // Find all graphs using this component
         guard let graphs = self.parentGraph?.findComponentGraphStates(componentId: self.lastEncodedDocument.id) else {

--- a/Stitch/Graph/Util/GraphActions.swift
+++ b/Stitch/Graph/Util/GraphActions.swift
@@ -39,7 +39,12 @@ extension GraphState: DocumentEncodableDelegate {
         }
     }
     
-    func willEncodeProject(schema: GraphEntity) { }
+    func willEncodeProject(schema: GraphEntity) {
+        // Updates thumbnail
+        // if let document = self.documentDelegate {
+        //     document.encodeProjectInBackground(willUpdateUndoHistory: false)
+        // }
+    }
     
     func createSchema(from graph: GraphState?) -> GraphEntity {
         self.createSchema()

--- a/Stitch/Graph/Util/GraphActions.swift
+++ b/Stitch/Graph/Util/GraphActions.swift
@@ -41,9 +41,9 @@ extension GraphState: DocumentEncodableDelegate {
     
     func willEncodeProject(schema: GraphEntity) {
         // Updates thumbnail
-        // if let document = self.documentDelegate {
-        //     document.encodeProjectInBackground(willUpdateUndoHistory: false)
-        // }
+         if let document = self.documentDelegate {
+             document.encodeProjectInBackground(willUpdateUndoHistory: false)
+         }
     }
     
     func createSchema(from graph: GraphState?) -> GraphEntity {

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -398,22 +398,20 @@ extension GraphState {
     
     @MainActor
     func encodeProjectInBackground(temporaryURL: URL? = nil,
-                                   enableUndo: Bool = true,
-                                   wasUndo: Bool = false) {
+                                   willUpdateUndoHistory: Bool = true) {
         self.documentEncoderDelegate?.encodeProjectInBackground(from: self,
                                                                 temporaryUrl: temporaryURL,
-                                                                enableUndo: enableUndo,
-                                                                wasUndo: wasUndo)
+                                                                willUpdateUndoHistory: willUpdateUndoHistory)
     }
     
     @MainActor
     func encodeProjectInBackground(temporaryURL: URL? = nil,
                                    undoEvents: [Action],
-                                   wasUndo: Bool = false) {
+                                   willUpdateUndoHistory: Bool = true) {
         self.documentEncoderDelegate?.encodeProjectInBackground(from: self,
                                                                 undoEvents: undoEvents,
                                                                 temporaryUrl: temporaryURL,
-                                                                wasUndo: false)
+                                                                willUpdateUndoHistory: willUpdateUndoHistory)
     }
     
     func getPatchNode(id nodeId: NodeId) -> PatchNode? {

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -176,7 +176,8 @@ extension StitchDocumentViewModel {
     }
 
     @MainActor
-    func encodeProjectInBackground(temporaryURL: URL? = nil) {
+    func encodeProjectInBackground(temporaryURL: URL? = nil,
+                                   willUpdateUndoHistory: Bool = true) {
         self.documentEncoder.encodeProjectInBackground(from: self.graph,
                                                        temporaryUrl: temporaryURL)
     }

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -179,7 +179,8 @@ extension StitchDocumentViewModel {
     func encodeProjectInBackground(temporaryURL: URL? = nil,
                                    willUpdateUndoHistory: Bool = true) {
         self.documentEncoder.encodeProjectInBackground(from: self.graph,
-                                                       temporaryUrl: temporaryURL)
+                                                       temporaryUrl: temporaryURL,
+                                                       willUpdateUndoHistory: willUpdateUndoHistory)
     }
     
     /// Determines if camera is in use by looking at main graph + all component graphs to determine if any camera

--- a/Stitch/Home/Util/ProjectCreatedActions.swift
+++ b/Stitch/Home/Util/ProjectCreatedActions.swift
@@ -36,11 +36,11 @@ extension StitchStore {
     /// Called in the event where project saved in iCloud is deleted
     /// from another device, but user opts to re-save.
     @MainActor
-    func encodeCurrentProject(wasUndo: Bool = false) {
+    func encodeCurrentProject(willUpdateUndoHistory: Bool = true) {
         guard let graphState = self.currentDocument?.visibleGraph else {
             return
         }
 
-        graphState.encodeProjectInBackground(wasUndo: wasUndo)
+        graphState.encodeProjectInBackground(willUpdateUndoHistory: willUpdateUndoHistory)
     }
 }

--- a/Stitch/Home/View/ProjectItem/ProjectsListItemView.swift
+++ b/Stitch/Home/View/ProjectItem/ProjectsListItemView.swift
@@ -134,8 +134,10 @@ struct ProjectsListItemView: View {
             if self.projectLoader.loadingDocument == .initialized {
                 projectLoader.loadingDocument = .loading
                 
-                Task.detached(priority: .background) {
-                    await documentLoader.loadDocument(projectLoader)
+                Task.detached(priority: .background) { [weak documentLoader, weak projectLoader] in
+                    if let projectLoader = projectLoader {
+                        await documentLoader?.loadDocument(projectLoader)                        
+                    }
                 }
             }
         }


### PR DESCRIPTION
Component encodings don't directly encode the document, therefore the project thumbnails weren't re-ordering. The fix is to call document encoding even on component encoding.