### PR TITLE
Fixed media issues on prototype restart

### DIFF
--- a/Stitch/Graph/Node/Eval/AsyncSingletonMediaEval.swift
+++ b/Stitch/Graph/Node/Eval/AsyncSingletonMediaEval.swift
@@ -29,6 +29,10 @@ actor SingletonMediaNodeCoordinator: NodeEphemeralObservable {
     }
 }
 
+extension SingletonMediaNodeCoordinator {
+    nonisolated func onPrototypeRestart() { }
+}
+
 /// Used for nodes like location and camera.
 @MainActor
 func asyncSingletonMediaEval(node: PatchNode,

--- a/Stitch/Graph/Node/Eval/EphemeralObserver/NodeEphemeralObservable.swift
+++ b/Stitch/Graph/Node/Eval/EphemeralObserver/NodeEphemeralObservable.swift
@@ -19,6 +19,8 @@ protocol NodeEphemeralObservable: AnyObject {
     func nodeTypeChanged(oldType: UserVisibleType,
                          newType: UserVisibleType,
                          kind: NodeKind)
+    
+    @MainActor func onPrototypeRestart()
 }
 
 extension NodeEphemeralObservable {
@@ -54,6 +56,18 @@ final class ComputedNodeState: NodeEphemeralObservable {
 }
 
 extension ComputedNodeState {
+    func onPrototypeRestart() {
+        self.previousValue = nil
+        self.preservedValues = .init()
+        self.stopwatchIsRunning = false
+        self.stopwatchStartGraphTime = nil
+        self.queue = nil
+        self.springAnimationState = nil
+        self.classicAnimationState = nil
+        self.smoothValueAnimationState = nil
+        self.sampleRangeState = nil
+    }
+    
     func nodeTypeChanged(oldType: UserVisibleType,
                          newType: UserVisibleType,
                          kind: NodeKind) {

--- a/Stitch/Graph/Node/Eval/MediaEvalOpObservable.swift
+++ b/Stitch/Graph/Node/Eval/MediaEvalOpObservable.swift
@@ -26,6 +26,23 @@ final class MediaEvalOpObserver: MediaEvalOpObservable {
     internal let mediaActor = MediaEvalOpCoordinator()
 }
 
+extension MediaEvalOpObserver {
+    @MainActor func onPrototypeRestart() {
+        switch currentMedia?.mediaObject {
+        case .video(let videoPlayer):
+            videoPlayer.resetPlayer()
+        case .soundfile(let soundPlayer):
+            soundPlayer.delegate.setJumpTime(.zero)
+        case .model3D(let stitchEntity):
+            stitchEntity.entityStatus.loadedInstance?.transform = .init()
+        case .arAnchor(let anchorEntity):
+            anchorEntity.transform = .init()
+        default:
+            return
+        }
+    }
+}
+
 extension MediaEvalOpObservable {
     /// Condtionally gets or creates new media object based on input media and possible existence of current media
     /// at this loop index.

--- a/Stitch/Graph/Node/Patch/Type/Delay/DelayNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Delay/DelayNode.swift
@@ -63,6 +63,13 @@ final class NodeTimerEphemeralObserver: NodeEphemeralObservable {
     var prevDelayInputValue: PortValue?
 }
 
+extension NodeTimerEphemeralObserver {
+    @MainActor func onPrototypeRestart() {
+        self.runningTimers = .init()
+        self.prevDelayInputValue = nil
+    }
+}
+
 final class DelayNodeTimer {
     private var timer: Timer?
 

--- a/Stitch/Graph/Node/Patch/Type/DelayOneNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/DelayOneNode.swift
@@ -65,3 +65,9 @@ Delays the incoming value by one frame. Note that Stitch runs between 60-120 FPS
 final class DelayOneEvalObserver: NodeEphemeralObservable {
     var nextOutput = DelayOneNode.defaultUserVisibleType.defaultPortValue
 }
+
+extension DelayOneEvalObserver {
+    func onPrototypeRestart() {
+        self.nextOutput = DelayOneNode.defaultUserVisibleType.defaultPortValue
+    }
+}

--- a/Stitch/Graph/Node/Patch/Type/Interaction/DragInteractionPatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/DragInteractionPatchNode.swift
@@ -86,6 +86,15 @@ final class DragInteractionNodeState: NodeEphemeralObservable {
     var prevPositionStart: CGPoint = .zero
 }
 
+extension DragInteractionNodeState {
+    func onPrototypeRestart() {
+        self.momentum = .init()
+        self.reset = .init()
+        self.wasDragging = false
+        self.prevPositionStart = .zero
+    }
+}
+
 /*
  This node eval is called in several different cases,
  and we use guard statements to handle the d

--- a/Stitch/Graph/Node/Patch/Type/Interaction/PressInteractionPatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/PressInteractionPatchNode.swift
@@ -67,6 +67,12 @@ final class PressInteractionNodeObserver: NodeEphemeralObservable, Sendable {
     let actor: PressInteractionActor = .init()
 }
 
+extension PressInteractionNodeObserver {
+    func onPrototypeRestart() {
+        self.prevTapTime = nil
+    }
+}
+
 actor PressInteractionActor {
     func delayTap(delayValue: Double,
                   newTapTime: Double,

--- a/Stitch/Graph/Node/Patch/Type/Interaction/Scroll/ScrollData.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/Scroll/ScrollData.swift
@@ -20,6 +20,11 @@ final class ScrollInteractionState: NodeEphemeralObservable {
 }
 
 extension ScrollInteractionState {
+    func onPrototypeRestart() {
+        self.lastDragStartingPoint = nil
+        self.reset()
+    }
+    
     func reset() {
         self.xScroll = .none
         self.yScroll = .none

--- a/Stitch/Graph/Node/Patch/Type/Loop/LoopInsert.swift
+++ b/Stitch/Graph/Node/Patch/Type/Loop/LoopInsert.swift
@@ -60,6 +60,10 @@ final class LoopingEphemeralObserver: NodeEphemeralObservable {
     var previousValues: PortValues = []
 }
 
+extension LoopingEphemeralObserver {
+    func onPrototypeRestart() { }
+}
+
 extension PortValues {
     var unwrapAsPulses: [TimeInterval] {
         let asPulses = self.compactMap(\.getPulse)

--- a/Stitch/Graph/Node/Patch/Type/Media/ARAnchorNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Media/ARAnchorNode.swift
@@ -53,6 +53,10 @@ final class ARAnchorObserver: MediaEvalOpObservable {
     weak var nodeDelegate: NodeDelegate?
 }
 
+extension ARAnchorObserver {
+    func onPrototypeRestart() { }
+}
+
 @MainActor
 func arAnchorEval(node: PatchNode) -> EvalResult {
     node.loopedEval(ARAnchorObserver.self) { values, mediaObserver, loopIndex in

--- a/Stitch/Graph/Node/Patch/Type/Media/SoundImportNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Media/SoundImportNode.swift
@@ -101,7 +101,7 @@ func soundImportEval(node: PatchNode) -> EvalResult {
         let playRate: Double = values[safe: 5]?.getNumber ?? 1
         
         // Get previously saved playback time in case video is paused
-        var currentPlaybackTime = values[9].getNumber ?? .zero
+        var currentPlaybackTime = values[safe: 9]?.getNumber ?? .zero
 
         if playing {
             currentPlaybackTime = delegate.getCurrentPlaybackTime()

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
@@ -240,17 +240,6 @@ extension GraphState {
     }
 }
 
-extension NodeRowObserver {
-    @MainActor
-    func mediaObjectCreationFailed(loopIndex: Int) {
-        guard self.allLoopedValues.count > loopIndex else {
-            return
-        }
-        
-        self.allLoopedValues[loopIndex] = .asyncMedia(nil)
-    }
-}
-
 extension StitchDocumentViewModel {
     @MainActor
     func realityViewCreatedWithoutCamera(graph: GraphState,

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
@@ -655,7 +655,9 @@ extension NodeViewModel {
     
     @MainActor func onPrototypeRestart() {
         // Reset ephemeral observers
-        self.createEphemeralObservers()
+        self.ephemeralObservers?.forEach {
+            $0.onPrototypeRestart()
+        }
         
         // Reset outputs
         // TODO: should we really be resetting inputs?


### PR DESCRIPTION
The issue was caused from re-initializing ephemeral observers. This didn't play nicely with media which we want to keep around. The fix was creating a new protocol function that requires functionality to be defined on prototype restart for each ephemeral observer type.

For the most part we just re-initialize values, except for media observers now.