### PR TITLE
Shift + canvas item cursor selection box now allows multiple additions of canvas items

### DIFF
--- a/Stitch/Graph/Gesture/Util/GraphUICursorSelectionActions.swift
+++ b/Stitch/Graph/Gesture/Util/GraphUICursorSelectionActions.swift
@@ -37,7 +37,8 @@ extension StitchDocumentViewModel {
                            location: CGPoint,
                            velocity: CGPoint,
                            numberOfTouches: Int,
-                           gestureState: UIGestureRecognizer.State) {
+                           gestureState: UIGestureRecognizer.State,
+                           shiftHeld: Bool) {
         //        log("TrackpadClickDragEvent")
 
         let spaceHeld = self.keypressState.isSpacePressed
@@ -108,7 +109,8 @@ extension StitchDocumentViewModel {
             self.clickDragAsNodeSelection(translation: translation,
                                           location: location,
                                           gestureState: gestureState,
-                                          numberOfTouches: numberOfTouches)
+                                          numberOfTouches: numberOfTouches,
+                                          shiftHeld: shiftHeld)
             return
         }
     }
@@ -117,7 +119,8 @@ extension StitchDocumentViewModel {
     func clickDragAsNodeSelection(translation: CGSize,
                                   location: CGPoint,
                                   gestureState: UIGestureRecognizer.State,
-                                  numberOfTouches: Int) {
+                                  numberOfTouches: Int,
+                                  shiftHeld: Bool) {
         switch gestureState {
         case .began:
             //        return handleTrackpadDragStarted(
@@ -131,7 +134,8 @@ extension StitchDocumentViewModel {
             if numberOfTouches == 1 {
                 self.handleTrackpadGraphDragChanged(
                     gestureTranslation: translation,
-                    gestureLocation: location)
+                    gestureLocation: location,
+                    shiftHeld: shiftHeld)
             }
 
         case .ended, .cancelled:
@@ -157,11 +161,22 @@ extension StitchDocumentViewModel {
 
     @MainActor
     func handleTrackpadGraphDragChanged(gestureTranslation: CGSize,
-                                        gestureLocation: CGPoint) {
+                                        gestureLocation: CGPoint,
+                                        shiftHeld: Bool) {
         if !self.graphUI.selection.isSelecting {
-            log("TrackpadGraphDragChangedAction called but we weren't selecting...")
+            log("handleTrackpadGraphDragChanged: TrackpadGraphDragChangedAction called but we weren't selecting...")
         }
 
+        if shiftHeld {
+            log("handleTrackpadGraphDragChanged: had shift")
+//            self.keypressState.modifiers.insert(.shift)
+            self.keypressState.shiftHeldDuringGesture = true
+        } else {
+            log("handleTrackpadGraphDragChanged: did not have shift")
+//            self.keypressState.modifiers.remove(.shift)
+            self.keypressState.shiftHeldDuringGesture = false
+        }
+        
         self.graphUI.selection.isSelecting = true
         self.graphUI.selection.dragCurrentLocation = gestureLocation
         self.handleGraphDraggedDuringSelection(gestureLocation)

--- a/Stitch/Graph/Model/KeyPressState.swift
+++ b/Stitch/Graph/Model/KeyPressState.swift
@@ -8,6 +8,10 @@
 import UIKit
 
 struct KeyPressState: Equatable, Hashable {
+    
+    // TODO: figure out a better way to listen for key presses, i.e. to not lose shift-key
+    var shiftHeldDuringGesture: Bool = false
+    
     // modifiers and non-character keys like `TAB`
     var modifiers = Set<StitchKeyModifier>()
     

--- a/Stitch/Graph/View/Gesture/GraphBackgroundGestureView.swift
+++ b/Stitch/Graph/View/Gesture/GraphBackgroundGestureView.swift
@@ -82,6 +82,8 @@ struct GraphGestureBackgroundView<T: View>: UIViewControllerRepresentable {
 final class NodeSelectionGestureRecognizer: NSObject, UIGestureRecognizerDelegate {
     weak var document: StitchDocumentViewModel?
 
+    var shiftHeld: Bool = false
+    
     init(document: StitchDocumentViewModel) {
         super.init()
         self.document = document
@@ -91,6 +93,22 @@ final class NodeSelectionGestureRecognizer: NSObject, UIGestureRecognizerDelegat
         true
     }
 
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
+                           shouldReceive event: UIEvent) -> Bool {
+         log("NodeSelectionGestureRecognizer: gestureRecognizer: should receive event")
+
+        if event.modifierFlags.contains(.shift) {
+             log("NodeSelectionGestureRecognizer: SHIFT DOWN")
+            self.shiftHeld = true
+        } else {
+             log("NodeSelectionGestureRecognizer: SHIFT NOT DOWN")
+            self.shiftHeld = false
+        }
+        
+        return true
+    }
+        
+    
     @objc func longPressInView(_ gestureRecognizer: UILongPressGestureRecognizer) {
         switch gestureRecognizer.state {
         case .began:
@@ -122,7 +140,8 @@ final class NodeSelectionGestureRecognizer: NSObject, UIGestureRecognizerDelegat
             location: location,
             velocity: velocity,
             numberOfTouches: gestureRecognizer.numberOfTouches,
-            gestureState: gestureRecognizer.state)
+            gestureState: gestureRecognizer.state,
+            shiftHeld: self.shiftHeld)
     }
 
     @MainActor

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -31,6 +31,9 @@ struct ActiveDragInteractionNodeVelocityData: Equatable, Hashable {
 @Observable
 final class GraphUIState {
 
+    // Only for node cursor selection box done when shift held
+    var nodesAlreadySelectedAtStartOfShiftNodeCursorBoxDrag: CanvasItemIdSet? = nil
+    
     let propertySidebar = PropertySidebarObserver()
         
     var nodesThatWereOnScreenPriorToEnteringFullScreen = CanvasItemIdSet()


### PR DESCRIPTION
Shift+NodeCursorBox does not reset selection state of canvas items that were selected previous to the gesture.


https://github.com/user-attachments/assets/a51460f1-b100-465d-9b51-48023f5efcac

