### PR TITLE
Do not use sidebar layer hover on release build scheme

### DIFF
--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewSidebarHighlightModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewSidebarHighlightModifier.swift
@@ -32,9 +32,7 @@ struct PreviewSidebarHighlightModifier: ViewModifier {
     }
     
     var isHighlighted: Bool {
-        
-        return highlightedSidebarLayers.contains(nodeId)
-        
+                
         // TODO: reads here cause a crash nodes once connected to layer inputs nodes
         /// https://github.com/StitchDesign/Stitch/issues/264
         #if DEV_DEBUG

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewSidebarHighlightModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewSidebarHighlightModifier.swift
@@ -31,6 +31,7 @@ struct PreviewSidebarHighlightModifier: ViewModifier {
         isPinned && !isPinnedViewRendering
     }
     
+    @MainActor
     var isHighlighted: Bool {
                 
         // TODO: reads here cause a crash nodes once connected to layer inputs nodes
@@ -54,6 +55,7 @@ struct PreviewSidebarHighlightModifier: ViewModifier {
         }
     }
     
+    @MainActor
     var borderOpacity: CGFloat {
         (isHighlighted && !isGhostView) ? 1 : 0
     }


### PR DESCRIPTION
Continuing to avoid sidebar layer hover on release builds until we get to root of bad access crash.