### PR TITLE
Remove Layer Group `.padding` input in app, but keep in schema for now

### DIFF
--- a/Stitch/Graph/LayerInspector/LayerInspectorState.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorState.swift
@@ -243,7 +243,7 @@ extension LayerInspectorView {
         
         .orientation,
         
-        .padding,
+//        .padding,
         .spacing, // added
         
         // Grid

--- a/Stitch/Graph/Node/Layer/Type/GroupLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/GroupLayerNode.swift
@@ -85,7 +85,10 @@ struct GroupLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
+        .union(.sizing)
+        .union(.pinning)
+        .union(.layerPaddingAndMargin)
+        .union(.offsetInGroup)
         .union(.paddingAndSpacing)
     
     static func content(document: StitchDocumentViewModel,
@@ -114,7 +117,6 @@ struct GroupLayerNode: LayerNodeDefinition {
             opacity: viewModel.opacity.getNumber ?? 1,
             pivot: viewModel.pivot.getAnchoring ?? .defaultPivot,
             orientation: viewModel.orientation.getOrientation ?? .defaultOrientation,
-            padding: viewModel.padding.getPadding ?? .defaultPadding,
             spacing: viewModel.spacing.getStitchSpacing ?? .defaultStitchSpacing,
             cornerRadius: viewModel.cornerRadius.getNumber ?? .zero,
             blurRadius: viewModel.blur.getNumber ?? .zero,

--- a/Stitch/Graph/Node/Layer/Type/ShapeLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/ShapeLayerNode.swift
@@ -59,7 +59,7 @@ extension LayerInputTypeSet {
     // LayerGroup only?
     @MainActor
     static let paddingAndSpacing: LayerInputTypeSet = [
-        .padding,
+//        .padding,
         .spacing
     ]
     

--- a/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
@@ -27,7 +27,6 @@ struct GeneratePreview: View {
                           parentSize: document.previewWindowSize,
                           parentId: nil,
                           parentOrientation: .none,
-                          parentPadding: .zero,
                           parentSpacing: .zero,
                           parentCornerRadius: 0,
                           parentUsesHug: false,
@@ -41,7 +40,6 @@ struct GeneratePreview: View {
                               parentSize: document.previewWindowSize,
                               parentId: nil,
                               parentOrientation: .none,
-                              parentPadding: .zero,
                               parentSpacing: .zero,
                               parentCornerRadius: 0,
                               parentUsesHug: false,
@@ -78,10 +76,7 @@ struct PreviewLayersView: View {
     
     // Are we a ZStack, an HStack, a VStack or an Adaptive Grid?
     var parentOrientation: StitchOrientation // = .none
-    
-    // Padding on the children overall
-    var parentPadding: StitchPadding // = .init()
-    
+        
     // Spacing between the children; N/A for ZStack
     var parentSpacing: StitchSpacing // = .defaultStitchSpacing
     
@@ -164,10 +159,6 @@ struct PreviewLayersView: View {
             ZStack {
                 // Note: we previously wrapped the HStack / VStack layer group orientations in a scroll-disabled ScrollView so that the children would touch,
                 orientationFromParent
-                    .padding(.top, parentPadding.top)
-                    .padding(.bottom, parentPadding.bottom)
-                    .padding(.leading, parentPadding.left)
-                    .padding(.trailing, parentPadding.right)
 
                 ForEach(pinsInOrientationView) { layerData in
                     LayerDataView(document: document,

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
@@ -55,7 +55,6 @@ struct PreviewGroupLayer: View {
     let pivot: Anchoring
 
     let orientation: StitchOrientation
-    let padding: StitchPadding
     let spacing: StitchSpacing
     
     let cornerRadius: CGFloat
@@ -201,7 +200,6 @@ struct PreviewGroupLayer: View {
                           parentSize: _size,
                           parentId: interactiveLayer.id.layerNodeId,
                           parentOrientation: orientation,
-                          parentPadding: padding, 
                           parentSpacing: spacing,
                           parentCornerRadius: cornerRadius,
                           // i.e. if this view (a LayerGroup) uses .hug, then its children will not use their own .position values.


### PR DESCRIPTION
Note: 
- `.layerPadding` is what is actually used now.
- we'll need a proper migration before we can completely remove the `.padding` input (i.e. `LayerInputPort.padding` case)

<img width="1440" alt="Screenshot 2024-10-15 at 3 15 14 PM" src="https://github.com/user-attachments/assets/8d3fe695-1523-42a4-91b3-e4f37d8c2e30">


