### PR TITLE
Disable sidebar item swipe menu on Catalyst; improve sidebar item's hover hit area

### DIFF
--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeInnerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeInnerView.swift
@@ -25,6 +25,7 @@ struct SidebarListItemSwipeInnerView: View {
     let isBeingEdited: Bool
     let swipeSetting: SidebarSwipeSetting
     let sidebarWidth: CGFloat
+    let isHovered: Bool
     
     // The actual rendered distance for the swipe distance
     @State var swipeX: CGFloat = 0
@@ -33,7 +34,7 @@ struct SidebarListItemSwipeInnerView: View {
     var showMainItem: Bool { swipeX < DEFAULT_ACTION_THRESHOLD }
     
     var itemIndent: CGFloat { item.location.x }
-    
+        
     @MainActor
     var isHidden: Bool {
         graph.getVisibilityStatus(for: item.id.asNodeId) != .visible
@@ -143,6 +144,8 @@ struct SidebarListItemSwipeInnerView: View {
                 // right-side label overlay comes AFTER x-placement of item,
                 // so as not to be affected by x-placement.
                 .overlay(alignment: .trailing) {
+                    
+#if !targetEnvironment(macCatalyst)
                     SidebarListItemRightLabelView(
                         item: item,
                         isGroup: item.isGroup,
@@ -152,20 +155,42 @@ struct SidebarListItemSwipeInnerView: View {
                         isBeingEdited: isBeingEdited,
                         isHidden: isHidden)
                     .frame(height: SIDEBAR_LIST_ITEM_ICON_AND_TEXT_AREA_HEIGHT)
+                    
+#endif
+                    
+//                    // TODO: revisit this; currently still broken on Catalyst and the UIKitTappableWrapper becomes unresponsive as soon as we apply a SwiftUI .frame or .offset; `Spacer()`s also do not seem to work
+//                    // Hovering can happen on either Catalyst or iPad
+//                    if isHovered {
+//                        HStack {
+//                            Spacer()
+//                            UIKitTappableWrapper {
+//                                log("clicked hover icon for \(layerNodeId)")
+//                                dispatch(SidebarItemHiddenStatusToggled(clickedId: layerNodeId))
+//                            } view: {
+//                                Spacer()
+//                                Image(systemName: isHidden ? SIDEBAR_VISIBILITY_STATUS_HIDDEN_ICON : SIDEBAR_VISIBILITY_STATUS_VISIBLE_ICON)
+//                                    .foregroundColor(fontColor)
+//                            }
+//                        } // HStack
+//                    } // if isHovered
+                    
                 }
                 .padding(.trailing, 2)
                 
             }
             
+#if !targetEnvironment(macCatalyst)
             SidebarListItemSwipeMenu(
                 item: item,
                 swipeOffset: swipeX,
                 visStatusIconName: graph.getLayerNode(id: item.id.id)?.layerNode?.visibilityStatusIcon ?? SIDEBAR_VISIBILITY_STATUS_VISIBLE_ICON,
                 gestureViewModel: self.gestureViewModel)
+#endif
         }
         
         // Animates swipe distance if it gets pinned to its open or closed position.
         // Does NOT animate for normal swiping.
+#if !targetEnvironment(macCatalyst)
         .onChange(of: swipeSetting) { newSwipeSetting in
             switch newSwipeSetting {
             case .closed, .open:
@@ -184,6 +209,7 @@ struct SidebarListItemSwipeInnerView: View {
                 swipeX = min(distance, sidebarWidth)
             }
         }
+#endif
         .animation(.stitchAnimation(duration: 0.25), value: showMainItem)
         .animation(.stitchAnimation(duration: 0.25), value: itemIndent)
     }

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeView.swift
@@ -26,6 +26,8 @@ struct SidebarListItemSwipeView: View {
 
     @Binding var activeSwipeId: SidebarListItemId?
 
+    @State var isHovered = false
+    
     init(graph: Bindable<GraphState>,
          item: SidebarListItem,
          name: String,
@@ -65,6 +67,18 @@ struct SidebarListItemSwipeView: View {
             layerNodeId: item.id.asLayerNodeId)
         .height(CGFloat(CUSTOM_LIST_ITEM_VIEW_HEIGHT))
         .padding(.horizontal, 4)
+        
+        // More accurate: needs to come before the `.offset(y:)` modifier
+        .onHover { hovering in
+            // log("hovering: sidebar item \(item.id.id)")
+            // log("hovering: \(hovering)")
+            self.isHovered = hovering
+            if hovering {
+                dispatch(SidebarLayerHovered(layer: item.id.asLayerNodeId))
+            } else {
+                dispatch(SidebarLayerHoverEnded(layer: item.id.asLayerNodeId))
+            }
+        }
         .offset(y: item.location.y)
         
         #if targetEnvironment(macCatalyst)
@@ -76,7 +90,6 @@ struct SidebarListItemSwipeView: View {
         // could also be a `.simultaneousGesture`?
         .gesture(gestureViewModel.longPressDragGesture)
         #endif
-
         .onChange(of: activeSwipeId) { _ in
             gestureViewModel.resetSwipePosition()
         }
@@ -110,16 +123,8 @@ struct SidebarListItemSwipeView: View {
                 isBeingEdited: isBeingEdited,
                 swipeSetting: gestureViewModel.swipeSetting,
                 sidebarWidth: geometry.size.width,
+                isHovered: isHovered,
                 gestureViewModel: gestureViewModel)
-            .onHover { hovering in
-                // log("hovering: sidebar item \(item.id.id)")
-                // log("hovering: \(hovering)")
-                if hovering {
-                    dispatch(SidebarLayerHovered(layer: item.id.asLayerNodeId))
-                } else {
-                    dispatch(SidebarLayerHoverEnded(layer: item.id.asLayerNodeId))
-                }
-            }
             .padding(1) // ensures .clipped doesn't cut off proposed-group border
             .clipped() // ensures edit buttons don't animate outside sidebar
         }

--- a/Stitch/Graph/Sidebar/ViewModel/SidebarItemGestureViewModel.swift
+++ b/Stitch/Graph/Sidebar/ViewModel/SidebarItemGestureViewModel.swift
@@ -124,11 +124,17 @@ final class SidebarItemGestureViewModel: ObservableObject {
     }
 
     var onItemSwipeChanged: OnDragChangedHandler {
+        
         let onSwipeChanged: OnDragChangedHandler = { (translationWidth: CGFloat) in
             if self.editOn {
                 //                print("SidebarItemGestureViewModel: itemSwipeChangedGesture: currently in edit mode, so cannot swipe")
                 return
             }
+            
+#if targetEnvironment(macCatalyst)
+        return
+#endif
+            
             // if we have no active gesture,
             // and we met the swipe threshold,
             // then we can begin swiping
@@ -154,6 +160,7 @@ final class SidebarItemGestureViewModel: ObservableObject {
     // unless we make a function?
     @MainActor
     var onItemSwipeEnded: OnDragEndedHandler {
+        
         let onSwipeEnded: OnDragEndedHandler = {
             //            print("SidebarItemGestureViewModel: itemSwipeEndedGesture called")
 
@@ -161,6 +168,10 @@ final class SidebarItemGestureViewModel: ObservableObject {
                 //                print("SidebarItemGestureViewModel: itemSwipeEndedGesture: currently in edit mode, so cannot swipe")
                 return
             }
+            
+#if targetEnvironment(macCatalyst)
+        return
+#endif
 
             // if we had been swiping, then we reset activeGesture
             if self.activeGesture.isSwipe {


### PR DESCRIPTION
Design decision to prefer right-click on Catalyst platform over native List-style swipe actions.

Resolves an issue where some UIKit gestures are unresponsive post-Sequoia.