### PR TITLE
Only show 'auto' for min and max size layer dimensions

### DIFF
--- a/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
@@ -199,7 +199,10 @@ struct InputValueView: View {
                                  rowObserverCoordinate: rowObserverId,
                                  isCanvasItemSelected: isCanvasItemSelected,
                                  // TODO: perf implications? split into separate view?
-                                 choices: graph.getFilteredLayerDimensionChoices(nodeId: fieldCoordinate.rowId.nodeId, nodeKind: nodeKind).map(\.rawValue),
+                                 choices: graph.getFilteredLayerDimensionChoices(nodeId: fieldCoordinate.rowId.nodeId,
+                                                                                 nodeKind: nodeKind,
+                                                                                 layerInputObserver: layerInputObserver)
+                                    .map(\.rawValue),
                                  adjustmentBarSessionId: adjustmentBarSessionId,
                                  forPropertySidebar: forPropertySidebar,
                                  propertyIsAlreadyOnGraph: propertyIsAlreadyOnGraph,

--- a/Stitch/Graph/Node/View/NodeViewType.swift
+++ b/Stitch/Graph/Node/View/NodeViewType.swift
@@ -124,7 +124,11 @@ struct DefaultNodeInputView: View {
                            rowViewModels: canvas.inputViewModels,
                            nodeIO: .input,
                            adjustmentBarSessionId: adjustmentBarSessionId) { rowObserver, rowViewModel in
-            NodeInputView(graph: graph, 
+                        
+            let layerInputObserver: LayerInputObserver? = rowObserver.id.layerInput
+                .flatMap { node.layerNode?.getLayerInputObserver($0.layerInput) }
+            
+            NodeInputView(graph: graph,
                           nodeId: node.id,
                           nodeKind: node.kind,
                           hasIncomingEdge: rowObserver.upstreamOutputCoordinate.isDefined,
@@ -132,8 +136,9 @@ struct DefaultNodeInputView: View {
                           rowObserver: rowObserver,
                           rowViewModel: rowViewModel,
                           fieldValueTypes: rowViewModel.fieldValueTypes,
-                          layerInputObserver: nil, // Always nil, since this is a canvas item not an inspector-row
-                          forPropertySidebar: false,
+                          // Pass down the layerInputObserver if we have a 'layer input on the canvas'
+                          layerInputObserver: layerInputObserver,
+                          forPropertySidebar: false, // Always false, since not an inspector-row
                           propertyIsSelected: false,
                           propertyIsAlreadyOnGraph: true, // Irrelevant?
                           isCanvasItemSelected: isNodeSelected,


### PR DESCRIPTION
Also: pass down LayerInputObserver to layer inputs on graph

<img width="1391" alt="Screenshot 2024-10-18 at 10 52 55 AM" src="https://github.com/user-attachments/assets/a02e0c46-4af4-4bac-8539-f7c371c6a716">
<img width="1388" alt="Screenshot 2024-10-18 at 9 57 37 AM" src="https://github.com/user-attachments/assets/84774951-08cc-411d-9467-9e3da9ae90c5">
