### PR TITLE
Proper speed for single tap 

### DIFF
--- a/Stitch/Graph/Node/ViewModel/InteractionLayer.swift
+++ b/Stitch/Graph/Node/ViewModel/InteractionLayer.swift
@@ -16,6 +16,9 @@ final class InteractiveLayer {
         self.id = id
     }
     
+    var singleTapped: Bool = false
+    var doubleTapped: Bool = false
+    
     var firstPressEnded: TimeInterval?
     var secondPressEnded: TimeInterval?
 


### PR DESCRIPTION
TODO: this fix also allows Allow simultaneous Single and Double Taps on the Press Interaction node, which may not be quite what we want in a variety of use cases.

### before

https://github.com/user-attachments/assets/65b0ee92-94a7-4991-9f8b-2a4b3d71971d



### after

https://github.com/user-attachments/assets/80b35ee6-0ad5-4ebb-8147-648ee9efe4a8


