### PR TITLE
Use `fill` with 3D Model layer; improve 'jump to layer input on canvas' hit area in Catalyst

### DIFF
--- a/Stitch/Graph/Node/Layer/Type/3DModelLayerNode/PreviewModel3DLayer.swift
+++ b/Stitch/Graph/Node/Layer/Type/3DModelLayerNode/PreviewModel3DLayer.swift
@@ -72,7 +72,7 @@ struct Preview3DModelLayer: View {
     }
 
     var sceneSize: CGSize {
-        let _sceneSize = size.asSceneSize
+        let _sceneSize = size.asSceneSize(parentSize: parentSize)
         // log("sceneSize: \(_sceneSize)")
         return _sceneSize
     }

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Layer/LayerDimensionUtils.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Layer/LayerDimensionUtils.swift
@@ -176,17 +176,20 @@ extension LayerDimension {
 
     // Useful eg when converting from .size -> .position,
     // or .layerDimension -> .number
+    // TODO: in which contexts is this used? ... we don't always know the parent's size, or the parent's size may not apply (e.g. turning a LayerDimension into a Point3D)
     var asNumber: Double {
         switch self {
         case .number(let cGFloat):
             return cGFloat
-        case .auto:
-            return 0
+        
+        // TODO: need actual parent size?
         case .parentPercent(let x):
             return zeroCompatibleDivision(numerator: x,
                                           denominator: 100)
-        case .fill, .hug:
-            // TODO: LayerDimension.fill
+        
+        // TODO: .fill should actually be "100% of parent"
+        case .auto, .fill, .hug:
+            // TODO: LayerDimension.fill should be 100% of parent
             return 0
         }
     }

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Layer/LayerSizeUtils.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Layer/LayerSizeUtils.swift
@@ -52,6 +52,7 @@ extension LayerSize {
         }
     }
 
+    // TODO: "Algebraic Size" defaults every non-number case to 0 or some %
     var asAlgebraicCGSize: CGSize {
 
         // `auto` defaults to zero when used in algebraic contexts
@@ -65,8 +66,8 @@ extension LayerSize {
                height: self.height.asNumber)
     }
 
-    var asSceneSize: CGSize {
-        var sceneSize: CGSize = self.asAlgebraicCGSize
+    func asSceneSize(parentSize: CGSize) -> CGSize {
+        var sceneSize: CGSize = self.asCGSize(parentSize)
         
         sceneSize.width =  sceneSize.width >= max1DTextureWidth ? max1DTextureWidth : sceneSize.width
         


### PR DESCRIPTION
<img width="1440" alt="Screenshot 2024-10-21 at 5 22 22 PM" src="https://github.com/user-attachments/assets/a3665e81-6fa4-46a9-a3a8-16319b0c6874">
