### PR TITLE
Prefer non-scaled size to determine anchoring position

### DIFF
--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Layer/LayerDimensionUtils.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Layer/LayerDimensionUtils.swift
@@ -158,6 +158,23 @@ extension LayerDimension {
             return parentLength
         }
     }
+    
+    func asCGFloatIfNumber(_ parentLength: CGFloat) -> CGFloat? {
+        switch self {
+        case .number(let cGFloat):
+            return cGFloat
+        case .parentPercent(let double):
+            return parentLength * zeroCompatibleDivision(numerator: double,
+                                                         denominator: 100)
+        case .fill:
+            // Fill is always simply parent's size
+            return parentLength
+            
+        // .auto and .hug mean "Do not apply .frame", and so we must use the layer's .readSize instead
+        case .auto, .hug:
+            return nil
+        }
+    }
 
     func asCGFloat(parentLength: CGFloat,
                    resourceLength: CGFloat) -> CGFloat {

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Layer/LayerSizeUtils.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Layer/LayerSizeUtils.swift
@@ -29,6 +29,19 @@ extension LayerSize {
                height: self.height.asCGFloat(parentSize.height))
     }
 
+    /*
+     Note: The layer view model's `readSize` already includes information about scaling which, if fed to anchor-position logic,
+     means that e.g. the view's top left corner is always flush with the preview window's top left corner,
+     which is incorrect when e.g. a layer is scaled > 1 and has pivot = center.
+     
+     So, we prefer to use the layer's size input, and fall back on `readSize` in cases like `auto` or `hug` where there the size input's layer-dimension has no real number.
+     */
+    // TODO: version of this for `resourceSize` ?
+    func asCGSizeForLayer(parentSize: CGSize, readSize: CGSize) -> CGSize {
+        .init(width: self.width.asCGFloatIfNumber(parentSize.width) ?? readSize.width,
+              height: self.height.asCGFloatIfNumber(parentSize.height) ?? readSize.height)
+    }
+    
     func asCGSize(parentSize: CGSize,
                   // resourceSize = e.g. UIImage.size
                   resourceSize: CGSize) -> CGSize {

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonModifierWithoutFrame.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonModifierWithoutFrame.swift
@@ -61,7 +61,12 @@ struct PreviewCommonModifierWithoutFrame: ViewModifier {
     
     var pos: StitchPosition {
         adjustPosition(
-            size: layerViewModel.readSize,
+//            size: layerViewModel.readSize, // Already includes size-changes from scaling
+//            size: size.asCGSize(parentSize),
+
+            // SEE NOTE IN `asCGSizeForLayer`
+            size: size.asCGSizeForLayer(parentSize: parentSize,
+                                        readSize: layerViewModel.readSize),
             position: position,
             anchor: anchoring,
             parentSize: parentSize)

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
@@ -96,7 +96,9 @@ struct PreviewGroupLayer: View {
     
     var pos: StitchPosition {
         adjustPosition(
-            size: layerViewModel.readSize, // size.asCGSize(parentSize),
+            //size: layerViewModel.readSize, // size.asCGSize(parentSize),
+            size: size.asCGSizeForLayer(parentSize: parentSize,
+                                        readSize: layerViewModel.readSize),
             position: position,
             anchor: anchoring,
             parentSize: parentSize)

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewShapeLayer.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewShapeLayer.swift
@@ -59,7 +59,9 @@ struct PreviewShapeLayer: View {
     var pos: StitchPosition {
         adjustPosition(
             // TODO: use `layerViewModel.readSize` instead?
-            size: layerNodeSize.scaleBy(scale),
+            // size: layerNodeSize.scaleBy(scale),
+            size: size.asCGSizeForLayer(parentSize: parentSize,
+                                        readSize: layerViewModel.readSize),
             position: position,
             anchor: anchoring,
             parentSize: parentSize)


### PR DESCRIPTION
<img width="1440" alt="Screenshot 2024-10-22 at 3 46 51 PM" src="https://github.com/user-attachments/assets/13343f17-77a6-422b-bc8f-22dbe4ddb76a">
