### PR TITLE
Improve LayerInfo size-reading accuracy when moving a child out of a layer group makes that layer group empty

### DIFF
--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonSizeModifier.swift
@@ -93,10 +93,19 @@ struct PreviewCommonSizeModifier: ViewModifier {
         viewModel.layer.hasInherentSwiftUISize
     }
     
+    // Force a minimum
     var finalMinWidth: CGFloat? {
-        minWidth?.asFrameDimension(parentSize.width, 
+        var k = minWidth?.asFrameDimension(parentSize.width,
                                    isStack: isStack,
                                    hasInherentSwiftUISize: hasInherentSwiftUISize)
+        // HACK:
+        if viewModel.layer == .group,
+           size.width == .hug,
+           !k.isDefined {
+            return 1
+        }
+        
+        return k
     }
     
     var finalMaxWidth: CGFloat? {
@@ -106,9 +115,18 @@ struct PreviewCommonSizeModifier: ViewModifier {
     }
     
     var finalMinHeight: CGFloat? {
-        minHeight?.asFrameDimension(parentSize.height, 
+        var k = minHeight?.asFrameDimension(parentSize.height,
                                     isStack: isStack,
                                     hasInherentSwiftUISize: hasInherentSwiftUISize)
+        
+        // HACK:
+        if viewModel.layer == .group,
+           size.height == .hug,
+           !k.isDefined {
+            return 1
+        }
+        
+        return k
     }
     
     var finalMaxHeight: CGFloat? {


### PR DESCRIPTION
We now provide min height and min width on layer groups with hug to avoid NaN in LayerSizeReader.

Note there are still issues around the proper reading of the size of the now-empty layer group using hug, including when a project is first opened.



https://github.com/user-attachments/assets/985525fd-b1a6-452c-b62b-56b8669087ca


