### PR TITLE
Do not use hit-area clear rect on empty layer groups that use hug or auto

### DIFF
--- a/Stitch/Graph/Node/Layer/Type/GroupLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/GroupLayerNode.swift
@@ -105,7 +105,7 @@ struct GroupLayerNode: LayerNodeDefinition {
             isPinnedViewRendering: isPinnedViewRendering,
             interactiveLayer: viewModel.interactiveLayer,
             position: viewModel.position.getPosition ?? .zero,
-            size: viewModel.size.getSize ?? defaultTextSize, // CGSize.zero,
+            size: viewModel.size.getSize ?? .defaultLayerGroupSize,
             parentSize: parentSize,
             parentDisablesPosition: parentDisablesPosition,
             isClipped: viewModel.isClipped.getBool ?? DEFAULT_GROUP_CLIP_SETTING,
@@ -130,6 +130,10 @@ struct GroupLayerNode: LayerNodeDefinition {
             gridData: viewModel.getGridData,
             stroke: viewModel.getLayerStrokeData())
     }
+}
+
+extension LayerSize {
+    static let defaultLayerGroupSize = LayerSize(width: .fill, height: .fill)
 }
 
 extension GraphState {

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Layer/LayerDimensionUtils.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Layer/LayerDimensionUtils.swift
@@ -211,6 +211,16 @@ extension LayerDimension {
         }
     }
     
+    // `hug` and `auto` have no fixed size when applied to a LayerGroup i.e. ZStack or HStack
+    var noFixedSizeForLayerGroup: Bool {
+        switch self {
+        case .hug, .auto:
+            return true
+        case .fill, .number, .parentPercent:
+            return false
+        }
+    }
+    
     var isFill: Bool {
         self == .fill
     }


### PR DESCRIPTION
interactions on empty GroupLayers still work: 

https://github.com/user-attachments/assets/f21da2a3-5c50-470b-b051-7c8dfe92a35f

