### PR TITLE
Use flyout for color picker on iPad to avoid popover cutoff

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -459,6 +459,8 @@
 		EC47F54228D18AB0009EE90E /* HapticFeedbackNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC47F54128D18AB0009EE90E /* HapticFeedbackNode.swift */; };
 		EC48F0312C65975300DB3ACB /* PinningUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC48F0302C65975200DB3ACB /* PinningUtils.swift */; };
 		EC48F0332C668B6C00DB3ACB /* PreviewWindowCoordinateSpaceReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC48F0322C668B6C00DB3ACB /* PreviewWindowCoordinateSpaceReader.swift */; };
+		EC49069D2CCACD4000165554 /* StitchCustomColorPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC49069C2CCACD4000165554 /* StitchCustomColorPickerView.swift */; };
+		EC49069F2CCACF0100165554 /* ColorFlyoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC49069E2CCACF0100165554 /* ColorFlyoutView.swift */; };
 		EC49148C29357DF400D74344 /* GreaterThanNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC49148B29357DF400D74344 /* GreaterThanNode.swift */; };
 		EC49148F293580EE00D74344 /* ColorToHSLNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC49148E293580EE00D74344 /* ColorToHSLNode.swift */; };
 		EC4914912935891700D74344 /* HSLColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC4914902935891700D74344 /* HSLColor.swift */; };
@@ -1398,6 +1400,8 @@
 		EC47F54128D18AB0009EE90E /* HapticFeedbackNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticFeedbackNode.swift; sourceTree = "<group>"; };
 		EC48F0302C65975200DB3ACB /* PinningUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinningUtils.swift; sourceTree = "<group>"; };
 		EC48F0322C668B6C00DB3ACB /* PreviewWindowCoordinateSpaceReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewWindowCoordinateSpaceReader.swift; sourceTree = "<group>"; };
+		EC49069C2CCACD4000165554 /* StitchCustomColorPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StitchCustomColorPickerView.swift; sourceTree = "<group>"; };
+		EC49069E2CCACF0100165554 /* ColorFlyoutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorFlyoutView.swift; sourceTree = "<group>"; };
 		EC49148B29357DF400D74344 /* GreaterThanNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GreaterThanNode.swift; sourceTree = "<group>"; };
 		EC49148E293580EE00D74344 /* ColorToHSLNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorToHSLNode.swift; sourceTree = "<group>"; };
 		EC4914902935891700D74344 /* HSLColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HSLColor.swift; sourceTree = "<group>"; };
@@ -2001,6 +2005,7 @@
 				B50F41702C1F52C00082262F /* LayerInspectorView.swift */,
 				ECEA12FB2C45B67D0058CD6A /* GenericFlyoutView.swift */,
 				EC2C8C982C654D5300D067B8 /* OpenFlyoutView.swift */,
+				EC49069E2CCACF0100165554 /* ColorFlyoutView.swift */,
 				ECE639212C489C6900FB8D5F /* FlyoutUtils.swift */,
 				ECE6391F2C489C4F00FB8D5F /* ShadowFlyoutView.swift */,
 				EC5F642C2C29E68500A9E52F /* LayerInspectorPortView.swift */,
@@ -3838,6 +3843,7 @@
 			isa = PBXGroup;
 			children = (
 				ECB9A8642AEB48A2006E65EE /* StitchColorPickerView.swift */,
+				EC49069C2CCACD4000165554 /* StitchCustomColorPickerView.swift */,
 				ECB9A8662AEB48FF006E65EE /* HSLSliderView.swift */,
 				ECB9A8682AEB4922006E65EE /* HueSliderView.swift */,
 				ECB9A86A2AEB4935006E65EE /* SaturationSliderView.swift */,
@@ -4656,6 +4662,7 @@
 				EC4BD89A2BA1350300B8F38A /* SidebarLayerData.swift in Sources */,
 				ECBD32FD2988A31E00C778BE /* ImpureEvaluation.swift in Sources */,
 				EC9AB63D28DFE33A002810BC /* LayerDragEndedActions.swift in Sources */,
+				EC49069F2CCACF0100165554 /* ColorFlyoutView.swift in Sources */,
 				EC17ACC426B4BC5900137EA5 /* StitchVideoMetadata.swift in Sources */,
 				EC5F64312C2B451C00A9E52F /* LLMActions.swift in Sources */,
 				ECE7086A2B8D4AF8009F4525 /* CurveToPackNode.swift in Sources */,
@@ -5268,6 +5275,7 @@
 				EC9D16E22808D97A00684978 /* InputValueEntry.swift in Sources */,
 				B56FFB2D2C18B7B400623CC7 /* SupportedMediaFormat.swift in Sources */,
 				B55500BD2C1B9A1B0081C3F1 /* JSONReplViews.swift in Sources */,
+				EC49069D2CCACD4000165554 /* StitchCustomColorPickerView.swift in Sources */,
 				EC609DC42935468000BF60A5 /* SubtractNode.swift in Sources */,
 				EC89F7E127602C0700C4447A /* ExpansionBox.swift in Sources */,
 				ECF6AEF7263CB7C70011C679 /* NotNode.swift in Sources */,

--- a/Stitch/Graph/LayerInspector/ColorFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/ColorFlyoutView.swift
@@ -1,0 +1,68 @@
+//
+//  ColorFlyoutView.swift
+//  Stitch
+//
+//  Created by Christian J Clampitt on 10/24/24.
+//
+
+import SwiftUI
+
+extension LayerInputPort {
+    var usesColor: Bool {
+        // NOTE: `for: Layer` only matters size input
+        self.getDefaultValue(for: .rectangle).getColor.isDefined
+    }
+}
+
+// Color is always .packed
+struct ColorFlyoutView: View {
+    
+    @State var height: CGFloat? = nil
+    
+    @Bindable var graph: GraphState
+    
+    let layerInputObserver: LayerInputObserver
+    let nodeId: NodeId
+    
+    @State var chosenColor: Color = .white
+
+    var activeColor: Color {
+        if let color = layerInputObserver.activeValue.getColor {
+            return color
+        } else {
+            fatalErrorIfDebug()
+            return .clear
+        }
+    }
+    
+    var body: some View {
+        if let fieldObserver = layerInputObserver.fieldValueTypes.first?.fieldObservers.first,
+           let rowId = fieldObserver.rowDelegate?.id {
+            
+            StitchCustomColorPickerView(
+                rowId: rowId,
+                fieldCoordinate: fieldObserver.id,
+                isFieldInsideLayerInspector: true, // true for purposes of editing multiple layers
+                isForPreviewWindowBackgroundPicker: false,
+                isForIPhone: false,
+                // i.e. the current active value
+                chosenColor: self.$chosenColor,
+                graph: graph)
+            .modifier(FlyoutBackgroundColorModifier(
+                width: nil, // rely on default width from color picker
+                height: self.$height))
+            .onAppear(perform: {
+                self.chosenColor = activeColor
+            })
+            .onChange(of: self.chosenColor) { oldColor, newColor in
+                dispatch(PickerOptionSelected(
+                    input: rowId,
+                    choice: .color(newColor),
+                    isFieldInsideLayerInspector: true,
+                    // Lots of small changes so don't persist everything
+                    isPersistence: false))
+            }
+            
+        }
+    }
+}

--- a/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
@@ -12,6 +12,24 @@ extension Color {
     static let SWIFTUI_LIST_BACKGROUND_COLOR = Color(uiColor: .secondarySystemBackground)
 }
 
+struct FlyoutHeader: View {
+    
+    let flyoutTitle: String
+    
+    var body: some View {
+        HStack {
+            StitchTextView(string: flyoutTitle).font(.title3)
+            Spacer()
+            Image(systemName: "xmark.circle.fill")
+                .onTapGesture {
+                    withAnimation {
+                        dispatch(FlyoutClosed())
+                    }
+                }
+        }
+    }
+}
+
 struct GenericFlyoutView: View {
     
     static let DEFAULT_FLYOUT_WIDTH: CGFloat = 256.0 // Per Figma
@@ -186,7 +204,7 @@ struct GenericFlyoutRowView: View {
 
 struct FlyoutBackgroundColorModifier: ViewModifier {
     
-    let width: CGFloat
+    let width: CGFloat?
     @Binding var height: CGFloat?
     
     func body(content: Content) -> some View {

--- a/Stitch/Graph/LayerInspector/LayerInspectorState.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorState.swift
@@ -59,13 +59,6 @@ struct PropertySidebarFlyoutState: Equatable {
     var flyoutNode: NodeId
     
     var keyboardIsOpen: Bool = false
-    
-    var input: InputCoordinate {
-        // TODO: flyouts only for packed state?
-        InputCoordinate(portType: .keyPath(.init(layerInput: flyoutInput,
-                                                 portType: .packed)),
-                        nodeId: self.flyoutNode)
-    }
 }
 
 struct LayerInspectorSectionData: Equatable, Hashable {

--- a/Stitch/Graph/LayerInspector/OpenFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/OpenFlyoutView.swift
@@ -14,8 +14,8 @@ struct OpenFlyoutView: View, KeyboardReadable {
     
     var body: some View {
         if let flyoutState = graph.graphUI.propertySidebar.flyoutState,
-           let node = graph.getNodeViewModel(flyoutState.input.nodeId),
-           let layerNode = node.layerNode,
+           let node: NodeViewModel = graph.getNodeViewModel(flyoutState.flyoutNode),
+           let layerNode: LayerNodeViewModel = node.layerNode,
            let entry = graph.graphUI.propertySidebar.propertyRowOrigins.get(flyoutState.flyoutInput) {
             
             let flyoutSize = flyoutState.flyoutSize
@@ -69,6 +69,10 @@ struct OpenFlyoutView: View, KeyboardReadable {
                        ShadowFlyoutView(node: node,
                                         layerNode: layerNode,
                                         graph: graph)
+                    } else if flyoutInput.usesColor {
+                        ColorFlyoutView(graph: graph,
+                                        layerInputObserver: portObserver,
+                                        nodeId: node.id)
                     }
                     // One multifield input presented in separate rows in the flyout
                     else {                        

--- a/Stitch/Graph/LayerInspector/ShadowFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/ShadowFlyoutView.swift
@@ -11,24 +11,6 @@ import StitchSchemaKit
 // Represents "packed" shadow
 let SHADOW_FLYOUT_LAYER_INPUT_PROXY = LayerInputPort.shadowColor
 
-struct FlyoutHeader: View {
-    
-    let flyoutTitle: String
-    
-    var body: some View {
-        HStack {
-            StitchTextView(string: flyoutTitle).font(.title3)
-            Spacer()
-            Image(systemName: "xmark.circle.fill")
-                .onTapGesture {
-                    withAnimation {
-                        dispatch(FlyoutClosed())
-                    }
-                }
-        }
-    }
-}
-
 struct ShadowFlyoutView: View {
     
     static let SHADOW_FLYOUT_WIDTH: CGFloat = 256.0
@@ -43,15 +25,7 @@ struct ShadowFlyoutView: View {
         
         VStack(alignment: .leading) {
             FlyoutHeader(flyoutTitle: "Shadow")
-            
-            // TODO: why does UIKitWrapper mess up padding so badly?
-//            UIKitWrapper(ignoresKeyCommands: false,
-//                         name: "ShadowFlyout") {
-                rows
-//            }
-//                         .border(.yellow)
-//                         .padding()
-//                         .border(.red)
+            rows
         }
         .modifier(FlyoutBackgroundColorModifier(width: Self.SHADOW_FLYOUT_WIDTH,
                                                 height: self.$height))

--- a/Stitch/Graph/Menu/ProjectSettingsView.swift
+++ b/Stitch/Graph/Menu/ProjectSettingsView.swift
@@ -121,6 +121,7 @@ struct ProjectSettingsView: View {
             layerInputObserver: nil,
             fieldCoordinate: .fakeFieldCoordinate,
             isFieldInsideLayerInspector: false,
+            isForFlyout: false,
             isForPreviewWindowBackgroundPicker: true,
             isForIPhone: isPhoneDevice(),
             chosenColor: binding, 

--- a/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
@@ -324,6 +324,7 @@ struct InputValueView: View {
         case .color(let color):
             ColorOrbValueButtonView(fieldViewModel: viewModel, 
                                     layerInputObserver: layerInputObserver,
+                                    isForFlyout: isForFlyout,
                                     nodeId: rowObserverId.nodeId,
                                     id: rowObserverId,
                                     currentColor: color,

--- a/Stitch/Graph/Node/Port/View/Field/ValueButton/ColorOrbValueButtonView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/ValueButton/ColorOrbValueButtonView.swift
@@ -8,17 +8,13 @@
 import SwiftUI
 import StitchSchemaKit
 
-/*
- NOTE: native SwiftUI ColorPicker is rendered differently
- on Catalyst vs iPad.
- Hence we make our custom adjustments.
- */
 struct ColorOrbValueButtonView: View {
     @State private var colorState: Color = .white
     @State private var show = false
 
     let fieldViewModel: InputFieldViewModel
     let layerInputObserver: LayerInputObserver?
+    let isForFlyout: Bool
     let nodeId: NodeId
     let id: InputCoordinate
     let currentColor: Color // the current color, from input
@@ -53,6 +49,7 @@ struct ColorOrbValueButtonView: View {
                               layerInputObserver: layerInputObserver,
                               fieldCoordinate: fieldViewModel.id,
                               isFieldInsideLayerInspector: fieldViewModel.isFieldInsideLayerInspector,
+                              isForFlyout: isForFlyout,
                               chosenColor: binding,
                               graph: graph)
         .onAppear {

--- a/Stitch/Graph/Node/Port/View/Field/ValueButton/StitchColorPicker/StitchColorPickerView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/ValueButton/StitchColorPicker/StitchColorPickerView.swift
@@ -58,6 +58,7 @@ struct StitchColorPickerView: View {
     let layerInputObserver: LayerInputObserver?
     let fieldCoordinate: FieldCoordinate
     let isFieldInsideLayerInspector: Bool
+    let isForFlyout: Bool
     var isForPreviewWindowBackgroundPicker: Bool = false
     var isForIPhone: Bool = false
 
@@ -66,6 +67,12 @@ struct StitchColorPickerView: View {
     @Binding var chosenColor: Color
     let graph: GraphState
         
+#if targetEnvironment(macCatalyst)
+    let isCatalyst: Bool = true
+#else
+    let isCatalyst: Bool = false
+#endif
+    
     @MainActor
     var isMultiselectInspectorInputWithHeterogenousValues: Bool {
         if let layerInputObserver = layerInputObserver {
@@ -87,10 +94,36 @@ struct StitchColorPickerView: View {
             StitchColorPickerOrb(chosenColor: chosenColor,
                                  isMultiselectInspectorInputWithHeterogenousValues: isMultiselectInspectorInputWithHeterogenousValues)
                 .popover(isPresented: $show, content: {
-                    colorPopover.padding()
+                    StitchCustomColorPickerView(
+                        rowId: rowId,
+                        fieldCoordinate: fieldCoordinate,
+                        isFieldInsideLayerInspector: isFieldInsideLayerInspector,
+                        isForPreviewWindowBackgroundPicker: isForPreviewWindowBackgroundPicker,
+                        isForIPhone: isForIPhone,
+                        chosenColor: self.$chosenColor,
+                        graph: graph)
+                    .padding()
+                    
                 })
                 .onTapGesture {
-                    show.toggle()
+//                    if !isCatalyst && isForFlyout {
+                    
+                    // iPad layer inspector uses flyout, due to iPad-platform-specifci shrinking
+                    if !isCatalyst,
+                       // isForFlyout, // TODO: always false?
+                       isFieldInsideLayerInspector,
+                       !isForPreviewWindowBackgroundPicker,
+                       !isForIPhone,
+                       let layerInputObserver = layerInputObserver,
+                       let nodeId = rowId?.nodeId {
+                        // iPad
+                        dispatch(FlyoutToggled(flyoutInput: layerInputObserver.port,
+                                               flyoutNodeId: nodeId,
+                                               fieldToFocus: nil))
+                    } else {
+                        show.toggle()
+                    }
+                    
                 }
         } // ZStack
     }
@@ -102,193 +135,6 @@ struct StitchColorPickerView: View {
             .padding()
     }
 
-    @MainActor
-    var colorPopover: some View {
-        HStack(alignment: .top) {
-
-            //            debugColorCircle
-
-            VStack(alignment: .leading) {
-                sliders
-                hexEditAndDisplay.padding([.top])
-            }.padding([.leading])
-
-            colorGrid.padding()
-        }
-        // TODO: try to get `ViewThatFits` to work? Need to specify axis etc.? Or figure out why `GraphUIState.isPortraitMode` is not accurate on iPhone? (Maybe because on iPhone we don't render the ContentView that is responsible for reading screen size and updating GraphUIState`?)
-        .scaleEffect(isForIPhone ? 0.7 : 1)
-        .onAppear {
-            //            log("StitchColorPickerView: onAppear: hexEdit was: \(self.hexEdit)")
-            self.hexEdit = chosenColor.asHexDisplay
-            //            log("StitchColorPickerView: onAppear: hexEdit is now: \(self.hexEdit)")
-        }
-        .onDisappear {
-            //            log("StitchColorPickerView: onDisappear: hexEdit was: \(self.hexEdit)")
-            // treat closing the popover as committing the hex edit
-            //            self.chosenColor = .init(hex: self.hexEdit)
-
-            self.chosenColor = ColorConversionUtils.hexToColor(self.hexEdit) ?? .black
-
-            // Not needed?: defocus the field
-            self.hexFocus = false
-
-            // Reset hexEdit field`
-            self.hexEdit = ""
-
-            //            log("StitchColorPickerView: onDisappear: hexEdit is now: \(self.hexEdit)")
-        }
-        // a cycle: changing current color causes us to change the hexEdit; but changing the hexEdit causes us to change current color;
-        // so we only change currentColor to hexString when we submit text field
-        .onChange(of: self.chosenColor) { _, newValue in
-            //            log("StitchColorPickerView: onChange of self.chosenColor: hexEdit was: \(self.hexEdit)")
-
-            self.hexEdit = ColorConversionUtils.colorToHex(newValue) ?? "failed"
-
-            //            log("StitchColorPickerView: onChange of self.chosenColor: hexEdit is now: \(self.hexEdit)")
-        }
-    }
-
-    // -- MARK: HEX CODE INPUT FIELD
-
-    var hexEditAndDisplay: some View {
-        HStack {
-            Text("Hex: ")
-            hextTextField
-        }
-        .frame(width: 150)
-    }
-
-    @State var hexEdit = ""
-    @FocusState var hexFocus: Bool
-
-    // changed whenever we copy-paste a hex or select a color-grid item;
-    // manual control of re-rendering
-    @State var sliderId = UUID()
-
-    var hextTextField: some View {
-        TextField(chosenColor.asHexDisplay,
-                  text: self.$hexEdit)
-            //            .focused($hexFocus) // not needed?
-        
-        .focusedValue(\.focusedField, .textInput(fieldCoordinate))
-        
-            .onSubmit {
-                //                log("StitchColorPickerView: onSubmit: self.hexEdit: \(self.hexEdit)")
-                // invalid edits are coerced to "white"
-                //                self.chosenColor = Color.init(hex: self.hexEdit)
-                self.chosenColor = ColorConversionUtils.hexToColor(self.hexEdit) ?? .black
-                self.sliderId = .init()
-            }
-            .background(Color.gray.opacity(0.5))
-            .frame(width: 90)
-            .fixedSize(horizontal: true, vertical: false)
-    }
-
-    // -- MARK: HSLA SLIDERS
-
-    var sliders: some View {
-        HStack(alignment: .center) {
-            HueSliderView(chosenColor: $chosenColor, 
-                          graph: graph)
-            Spacer()
-            SaturationSliderView(chosenColor: $chosenColor, 
-                                 graph: graph)
-            Spacer()
-            LightnessSliderView(chosenColor: $chosenColor,
-                                graph: graph)
-
-            // Do not allow alpha adjustments for preview window's background color
-            if !isForPreviewWindowBackgroundPicker {
-                Spacer()
-                AlphaSliderView(chosenColor: $chosenColor,
-                                graph: graph)
-            }
-            //            Spacer()
-            //            AlphaSliderView(chosenColor: $chosenColor)
-        }
-        .frame(width: 150)
-        .id(sliderId)
-    }
-
-    // -- MARK: COLOR CIRCLE GRID
-
-    // https://developer.apple.com/documentation/swiftui/grid
-
-    func suggestedColorsArray() -> [Color] {
-        [
-            .red, .orange, .yellow
-            , .green, .cyan, .blue
-            , .teal, .indigo, .purple
-            , .black, .gray, .white
-        ]
-
-        ////  Alternatively, adjusting current hue's alpha:
-        //        let rgba = self.currentColor.asRGBA
-        //        var colors = [Color]()
-        //        (0..<9).forEach { index in
-        //            let alpha = rgba.alpha * CGFloat((Double(index) * 0.1))
-        //            let color = Color.init(
-        //                rgba: .init(red: rgba.red,
-        //                            green: rgba.green,
-        //                            blue: rgba.blue,
-        //                            alpha: alpha))
-        //            colors.append(color)
-        //        }
-        //        return colors
-
-    }
-
-    @MainActor
-    func colorGridItem(_ color: Color) -> some View {
-        Circle().fill(color)
-            //            .stroke(.black)
-            .frame(width: 50)
-            .modifier(ColorOrbWrapperModifier())
-            .onTapGesture {
-
-                // When user manually clicks a pre-selected color,
-                // we should persist that change.
-                if let inputId = rowId,
-                   self.chosenColor.asHexDisplay != color.asHexDisplay {
-                    dispatch(PickerOptionSelected(
-                        input: inputId,
-                        choice: .color(color), 
-                        isFieldInsideLayerInspector: isFieldInsideLayerInspector,
-                        // Lots of small changes so don't persist everything
-                        isPersistence: true))
-                }
-
-                self.chosenColor = color
-                self.hexEdit = color.asHexDisplay
-                self.sliderId = .init()
-            }
-    }
-
-    @MainActor
-    var colorGrid: some View {
-
-        let colors = suggestedColorsArray()
-
-        return Grid(alignment: .center) {
-
-            GridRow(alignment: .center) {
-                ForEach(0..<4) {
-                    colorGridItem(colors[$0])
-                }
-            }
-            GridRow(alignment: .center) {
-                ForEach(4..<8) {
-                    colorGridItem(colors[$0])
-                }
-            }
-
-            GridRow(alignment: .center) {
-                ForEach(8..<12) {
-                    colorGridItem(colors[$0])
-                }
-            }
-        }
-    }
 }
 
 //#Preview {

--- a/Stitch/Graph/Node/Port/View/Field/ValueButton/StitchColorPicker/StitchCustomColorPickerView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/ValueButton/StitchColorPicker/StitchCustomColorPickerView.swift
@@ -1,0 +1,213 @@
+//
+//  StitchCustomColorPickerView.swift
+//  Stitch
+//
+//  Created by Christian J Clampitt on 10/24/24.
+//
+
+import SwiftUI
+
+struct StitchCustomColorPickerView: View {
+    
+    let rowId: NodeIOCoordinate?
+    let fieldCoordinate: FieldCoordinate
+    let isFieldInsideLayerInspector: Bool
+    let isForPreviewWindowBackgroundPicker: Bool
+    let isForIPhone: Bool
+    
+    @Binding var chosenColor: Color
+    let graph: GraphState
+    
+    var body: some View {
+        colorPopover
+    }
+    
+    @MainActor
+    var colorPopover: some View {
+        HStack(alignment: .top) {
+
+            //            debugColorCircle
+
+            VStack(alignment: .leading) {
+                sliders
+                hexEditAndDisplay.padding([.top])
+            }.padding([.leading])
+
+            colorGrid
+                .padding()
+        }
+        // TODO: try to get `ViewThatFits` to work? Need to specify axis etc.? Or figure out why `GraphUIState.isPortraitMode` is not accurate on iPhone? (Maybe because on iPhone we don't render the ContentView that is responsible for reading screen size and updating GraphUIState`?)
+        .scaleEffect(isForIPhone ? 0.7 : 1)
+        .onAppear {
+            //            log("StitchColorPickerView: onAppear: hexEdit was: \(self.hexEdit)")
+            self.hexEdit = chosenColor.asHexDisplay
+            //            log("StitchColorPickerView: onAppear: hexEdit is now: \(self.hexEdit)")
+        }
+        .onDisappear {
+            //            log("StitchColorPickerView: onDisappear: hexEdit was: \(self.hexEdit)")
+            // treat closing the popover as committing the hex edit
+            //            self.chosenColor = .init(hex: self.hexEdit)
+
+            self.chosenColor = ColorConversionUtils.hexToColor(self.hexEdit) ?? .black
+
+            // Not needed?: defocus the field
+            self.hexFocus = false
+
+            // Reset hexEdit field`
+            self.hexEdit = ""
+
+            //            log("StitchColorPickerView: onDisappear: hexEdit is now: \(self.hexEdit)")
+        }
+        // a cycle: changing current color causes us to change the hexEdit; but changing the hexEdit causes us to change current color;
+        // so we only change currentColor to hexString when we submit text field
+        .onChange(of: self.chosenColor) { _, newValue in
+            //            log("StitchColorPickerView: onChange of self.chosenColor: hexEdit was: \(self.hexEdit)")
+
+            self.hexEdit = ColorConversionUtils.colorToHex(newValue) ?? "failed"
+
+            //            log("StitchColorPickerView: onChange of self.chosenColor: hexEdit is now: \(self.hexEdit)")
+        }
+    }
+
+    // -- MARK: HEX CODE INPUT FIELD
+
+    var hexEditAndDisplay: some View {
+        HStack {
+            Text("Hex: ")
+            hextTextField
+        }
+        .frame(width: 150)
+    }
+
+    @State var hexEdit = ""
+    @FocusState var hexFocus: Bool
+
+    // changed whenever we copy-paste a hex or select a color-grid item;
+    // manual control of re-rendering
+    @State var sliderId = UUID()
+
+    var hextTextField: some View {
+        TextField(chosenColor.asHexDisplay,
+                  text: self.$hexEdit)
+            //            .focused($hexFocus) // not needed?
+        
+        .focusedValue(\.focusedField, .textInput(fieldCoordinate))
+        
+            .onSubmit {
+                //                log("StitchColorPickerView: onSubmit: self.hexEdit: \(self.hexEdit)")
+                // invalid edits are coerced to "white"
+                //                self.chosenColor = Color.init(hex: self.hexEdit)
+                self.chosenColor = ColorConversionUtils.hexToColor(self.hexEdit) ?? .black
+                self.sliderId = .init()
+            }
+            .background(Color.gray.opacity(0.5))
+            .frame(width: 90)
+            .fixedSize(horizontal: true, vertical: false)
+    }
+
+    // -- MARK: HSLA SLIDERS
+
+    var sliders: some View {
+        HStack(alignment: .center) {
+            HueSliderView(chosenColor: $chosenColor,
+                          graph: graph)
+            Spacer()
+            SaturationSliderView(chosenColor: $chosenColor,
+                                 graph: graph)
+            Spacer()
+            LightnessSliderView(chosenColor: $chosenColor,
+                                graph: graph)
+
+            // Do not allow alpha adjustments for preview window's background color
+            if !isForPreviewWindowBackgroundPicker {
+                Spacer()
+                AlphaSliderView(chosenColor: $chosenColor,
+                                graph: graph)
+            }
+            //            Spacer()
+            //            AlphaSliderView(chosenColor: $chosenColor)
+        }
+        .frame(width: 150)
+        .id(sliderId)
+    }
+
+    // -- MARK: COLOR CIRCLE GRID
+
+    // https://developer.apple.com/documentation/swiftui/grid
+
+    func suggestedColorsArray() -> [Color] {
+        [
+            .red, .orange, .yellow
+            , .green, .cyan, .blue
+            , .teal, .indigo, .purple
+            , .black, .gray, .white
+        ]
+
+        ////  Alternatively, adjusting current hue's alpha:
+        //        let rgba = self.currentColor.asRGBA
+        //        var colors = [Color]()
+        //        (0..<9).forEach { index in
+        //            let alpha = rgba.alpha * CGFloat((Double(index) * 0.1))
+        //            let color = Color.init(
+        //                rgba: .init(red: rgba.red,
+        //                            green: rgba.green,
+        //                            blue: rgba.blue,
+        //                            alpha: alpha))
+        //            colors.append(color)
+        //        }
+        //        return colors
+
+    }
+
+    @MainActor
+    func colorGridItem(_ color: Color) -> some View {
+        Circle().fill(color)
+            //            .stroke(.black)
+            .frame(width: 50)
+            .modifier(ColorOrbWrapperModifier())
+            .onTapGesture {
+
+                // When user manually clicks a pre-selected color,
+                // we should persist that change.
+                if let rowId = rowId,
+                   self.chosenColor.asHexDisplay != color.asHexDisplay {
+                    dispatch(PickerOptionSelected(
+                        input: rowId,
+                        choice: .color(color),
+                        isFieldInsideLayerInspector: isFieldInsideLayerInspector,
+                        // Lots of small changes so don't persist everything
+                        isPersistence: true))
+                }
+
+                self.chosenColor = color
+                self.hexEdit = color.asHexDisplay
+                self.sliderId = .init()
+            }
+    }
+
+    @MainActor
+    var colorGrid: some View {
+
+        let colors = suggestedColorsArray()
+
+        return Grid(alignment: .center) {
+
+            GridRow(alignment: .center) {
+                ForEach(0..<4) {
+                    colorGridItem(colors[$0])
+                }
+            }
+            GridRow(alignment: .center) {
+                ForEach(4..<8) {
+                    colorGridItem(colors[$0])
+                }
+            }
+
+            GridRow(alignment: .center) {
+                ForEach(8..<12) {
+                    colorGridItem(colors[$0])
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves issue where our color picker's SwiftUI .popover in the SwiftUI Inspector would be cut off, despite `.frame`, `.fixedSize` etc.

We now use a flyout for color picker on iPad instead.