### PR TITLE
Fixed issue where media may disappear on undo

### DIFF
--- a/Stitch/App/Serialization/Util/File/StitchDocumentUtil.swift
+++ b/Stitch/App/Serialization/Util/File/StitchDocumentUtil.swift
@@ -274,7 +274,7 @@ extension StitchDocumentMigratable {
         
         graphDataUrl.stopAccessingSecurityScopedResource()
 
-        log("openDocument: returning codable doc")
+//        log("openDocument: returning codable doc")
         return codableDoc
     }
 }

--- a/Stitch/Graph/Node/Port/ViewModel/FieldGroupTypeViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/FieldGroupTypeViewModel.swift
@@ -378,9 +378,8 @@ extension NodeRowViewModel {
                                nodeIO: NodeIO,
                                unpackedPortParentFieldGroupType: FieldGroupType?,
                                unpackedPortIndex: Int?,
-                               importedMediaObject: StitchMediaObject?) {
-        
-        self.fieldValueTypes = getFieldValueTypes(
+                               importedMediaObject: StitchMediaObject?) -> [FieldGroupTypeViewModel<FieldType>] {
+        getFieldValueTypes(
             value: initialValue,
             nodeIO: nodeIO,
             unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -413,12 +413,13 @@ extension NodeRowViewModel {
         // Create new field value observers if the row type changed
         // This can happen on various input changes
         guard !nodeRowTypeChanged else {
-            self.createFieldValueTypes(initialValue: newValue,
-                                       nodeIO: nodeIO,
-                                       // Node Row Type change is only when a patch node changes its node type; can't happen for layer nodes
-                                       unpackedPortParentFieldGroupType: nil,
-                                       unpackedPortIndex: nil,
-                                       importedMediaObject: importedMediaObject)
+            self.fieldValueTypes = self.createFieldValueTypes(
+                initialValue: newValue,
+                nodeIO: nodeIO,
+                // Node Row Type change is only when a patch node changes its node type; can't happen for layer nodes
+                unpackedPortParentFieldGroupType: nil,
+                unpackedPortIndex: nil,
+                importedMediaObject: importedMediaObject)
             return
         }
         
@@ -442,13 +443,14 @@ extension NodeRowViewModel {
             let willUpdateField = newFields.count != fieldObserversCount || importedMediaObject.isDefined
             
             if willUpdateField {
-                self.createFieldValueTypes(initialValue: newValue,
-                                           nodeIO: nodeIO,
-                                           // Note: this is only for a patch node whose node-type has changed (?); does not happen with layer nodes, a layer input being packed or unpacked is irrelevant here etc.
-                                           // Not relevant?
-                                           unpackedPortParentFieldGroupType: nil,
-                                           unpackedPortIndex:  nil,
-                                           importedMediaObject: importedMediaObject)
+                self.fieldValueTypes = self.createFieldValueTypes(
+                    initialValue: newValue,
+                    nodeIO: nodeIO,
+                    // Note: this is only for a patch node whose node-type has changed (?); does not happen with layer nodes, a layer input being packed or unpacked is irrelevant here etc.
+                    // Not relevant?
+                    unpackedPortParentFieldGroupType: nil,
+                    unpackedPortIndex:  nil,
+                    importedMediaObject: importedMediaObject)
                 return
             }
             

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowViewModel.swift
@@ -152,13 +152,21 @@ extension NodeRowViewModel {
                           unpackedPortParentFieldGroupType: FieldGroupType?,
                           unpackedPortIndex: Int?,
                           initialValue: PortValue) {        
-        self.activeValue = initialValue
+        if initialValue != self.activeValue {
+            self.activeValue = initialValue
+        }
         
-        self.createFieldValueTypes(initialValue: initialValue,
-                                   nodeIO: Self.nodeIO,
-                                   unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                                   unpackedPortIndex: unpackedPortIndex,
-                                   importedMediaObject: nil)
+        let fields = self.createFieldValueTypes(initialValue: initialValue,
+                                                nodeIO: Self.nodeIO,
+                                                unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
+                                                unpackedPortIndex: unpackedPortIndex,
+                                                importedMediaObject: nil)
+        
+        let didFieldsChange = self.fieldValueTypes.isEmpty || self.fieldValueTypes.first?.type != fields.first?.type
+        
+        if didFieldsChange {
+            self.fieldValueTypes = fields
+        }
     }
     
     func didPortValuesUpdate(values: PortValues) {


### PR DESCRIPTION
Fix required being more selective on when our array of field observers gets refreshed—if nothing really changed then we don't create new objects. This creation caused source media to disappear.

The hope here is later helpers will call recalc and properly update fields anyways, esp if they changed.