### PR TITLE
Parent padding shrinks available space for child to fill

### DIFF
--- a/Stitch/Graph/Node/Port/View/Field/ValueButton/StitchColorPicker/StitchColorPickerView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/ValueButton/StitchColorPicker/StitchColorPickerView.swift
@@ -88,6 +88,7 @@ struct StitchColorPickerView: View {
                                  isMultiselectInspectorInputWithHeterogenousValues: isMultiselectInspectorInputWithHeterogenousValues)
                 .popover(isPresented: $show, content: {
                     colorPopover.padding()
+                    
                 })
                 .onTapGesture {
                     show.toggle()

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonSizeModifier.swift
@@ -145,6 +145,10 @@ struct PreviewCommonSizeModifier: ViewModifier {
         }
     }
     
+    var widthIsFill: Bool {
+        width == .fill
+    }
+    
     var finalHeight: CGFloat? {
         if usesParentPercentForHeight && (finalMinHeight.isDefined || finalMaxHeight.isDefined) {
             return nil
@@ -155,6 +159,9 @@ struct PreviewCommonSizeModifier: ViewModifier {
         }
     }
     
+    var heightIsFill: Bool {
+        height == .fill
+    }
     
     func body(content: Content) -> some View {
         switch sizingScenario {
@@ -170,6 +177,8 @@ struct PreviewCommonSizeModifier: ViewModifier {
                     alignment: frameAlignment,
                     usesParentPercentForWidth: usesParentPercentForWidth,
                     usesParentPercentForHeight: usesParentPercentForHeight,
+                    usesFillForWidth: widthIsFill,
+                    usesFillForHeight: heightIsFill,
                     width: finalWidth,
                     height: finalHeight,
                     minWidth: finalMinWidth,
@@ -200,6 +209,8 @@ struct PreviewCommonSizeModifier: ViewModifier {
                     alignment: frameAlignment,
                     usesParentPercentForWidth: usesParentPercentForWidth,
                     usesParentPercentForHeight: usesParentPercentForHeight,
+                    usesFillForWidth: widthIsFill,
+                    usesFillForHeight: heightIsFill,
                     width: finalWidth,
                     height: nil,
                     minWidth: finalMinWidth,
@@ -227,6 +238,8 @@ struct PreviewCommonSizeModifier: ViewModifier {
                     alignment: frameAlignment,
                     usesParentPercentForWidth: usesParentPercentForWidth,
                     usesParentPercentForHeight: usesParentPercentForHeight,
+                    usesFillForWidth: widthIsFill,
+                    usesFillForHeight: heightIsFill,
                     width: nil,
                     height: finalHeight,
                     minWidth: nil,

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
@@ -150,7 +150,7 @@ struct LayerSizeModifier: ViewModifier {
             
             // If we are using width = fill, then passed-in width will actually be parent-length,
             // and we should supply `.frame(width = nil)` but `.frame(maxWidth = passed-in-width)`
-                .frame(maxWidth: finalMaxWidth)
+                .frame(maxWidth: finalMaxWidth, alignment: alignment)
                 .frame(width: usesFillForWidth ? nil : width,
                        alignment: alignment)
                 
@@ -164,8 +164,8 @@ struct LayerSizeModifier: ViewModifier {
             logInView("LayerSizeModifier: defined height but not width")
                 
             content
-                .frame(minHeight: usesParentPercentForHeight ? minHeight : nil)
-                .frame(maxHeight: finalMaxHeight)
+                .frame(minHeight: usesParentPercentForHeight ? minHeight : nil, alignment: alignment)
+                .frame(maxHeight: finalMaxHeight, alignment: alignment)
             
                 .frame(height: usesFillForHeight ? nil : height,
                        alignment: alignment)
@@ -190,14 +190,14 @@ struct LayerSizeModifier: ViewModifier {
             } else {
                 
                 content
-                    .frame(minWidth: usesParentPercentForWidth ? minWidth : nil)
-                    .frame(maxWidth: finalMaxWidth)
+                    .frame(minWidth: usesParentPercentForWidth ? minWidth : nil, alignment: alignment)
+                    .frame(maxWidth: finalMaxWidth, alignment: alignment)
                     
                     .frame(width: usesFillForWidth ? nil : width,
                            alignment: alignment)
                     
-                    .frame(minHeight: usesParentPercentForHeight ? minHeight : nil)
-                    .frame(maxHeight: finalMaxHeight)
+                    .frame(minHeight: usesParentPercentForHeight ? minHeight : nil, alignment: alignment)
+                    .frame(maxHeight: finalMaxHeight, alignment: alignment)
                     
                     .frame(height: usesFillForHeight ? nil : height,
                            alignment: alignment)

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
@@ -111,19 +111,27 @@ struct LayerSizeModifier: ViewModifier {
     }
     
     func body(content: Content) -> some View {
+        logInView("LayerSizeModifier: BODY")
         logInView("LayerSizeModifier: alignment: \(alignment)")
-        //
+        
         logInView("LayerSizeModifier: usesParentPercentForWidth: \(usesParentPercentForWidth)")
         logInView("LayerSizeModifier: usesParentPercentForHeight: \(usesParentPercentForHeight)")
-        //
+        
+        
+        logInView("LayerSizeModifier: usesFillForWidth: \(usesFillForWidth)")
+        logInView("LayerSizeModifier: usesFillForHeight: \(usesFillForHeight)")
+        
         logInView("LayerSizeModifier: width: \(width)")
         logInView("LayerSizeModifier: height: \(height)")
-        //
+        
         logInView("LayerSizeModifier: minWidth: \(minWidth)")
         logInView("LayerSizeModifier: maxWidth: \(maxWidth)")
         logInView("LayerSizeModifier: minHeight: \(minHeight)")
         logInView("LayerSizeModifier: maxHeight: \(maxHeight)")
-        //
+                
+        logInView("LayerSizeModifier: finalMaxHeight: \(finalMaxHeight)")
+        logInView("LayerSizeModifier: finalMaxWidth: \(finalMaxWidth)")
+        
                
         // TODO: the below conditionals can be simplified, but are currently evolving; will be cleaned up after final iterations on conditional input logic
         
@@ -179,16 +187,20 @@ struct LayerSizeModifier: ViewModifier {
         else if let width = width, let height = height {
             logInView("LayerSizeModifier: defined width and height")
             
-            // TODO: get rid of this branch
-            // If we have a static width and height, and we're not using an parent-percents,
-            // then we can use the SwiftUI API with the specified alignment
-            if !usesParentPercentForWidth && !usesParentPercentForHeight {
-                logInView("LayerSizeModifier: defined width and height and not using parent percent for width or height")
-                content.frame(width: width,
-                              height: height,
-                              alignment: alignment)
-            } else {
-                
+//            // TODO: get rid of this branch
+//            // If we have a static width and height, and we're not using an parent-percents,
+//            // then we can use the SwiftUI API with the specified alignment
+////            if !usesParentPercentForWidth && !usesParentPercentForHeight {
+//            if !usesParentPercentForWidth,
+//               !usesParentPercentForHeight,
+//               !usesFillForWidth,
+//               !usesFillForHeight {
+//                logInView("LayerSizeModifier: defined width and height and not using parent percent for width or height")
+//                content.frame(width: width,
+//                              height: height,
+//                              alignment: alignment)
+//            } else {
+//                
                 content
                     .frame(minWidth: usesParentPercentForWidth ? minWidth : nil, alignment: alignment)
                     .frame(maxWidth: finalMaxWidth, alignment: alignment)
@@ -201,7 +213,7 @@ struct LayerSizeModifier: ViewModifier {
                     
                     .frame(height: usesFillForHeight ? nil : height,
                            alignment: alignment)
-            }
+//            }
         }
         
         // Both height and width are auto, so use min/max height and width

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
@@ -111,26 +111,27 @@ struct LayerSizeModifier: ViewModifier {
     }
     
     func body(content: Content) -> some View {
-        logInView("LayerSizeModifier: BODY")
-        logInView("LayerSizeModifier: alignment: \(alignment)")
         
-        logInView("LayerSizeModifier: usesParentPercentForWidth: \(usesParentPercentForWidth)")
-        logInView("LayerSizeModifier: usesParentPercentForHeight: \(usesParentPercentForHeight)")
-        
-        
-        logInView("LayerSizeModifier: usesFillForWidth: \(usesFillForWidth)")
-        logInView("LayerSizeModifier: usesFillForHeight: \(usesFillForHeight)")
-        
-        logInView("LayerSizeModifier: width: \(width)")
-        logInView("LayerSizeModifier: height: \(height)")
-        
-        logInView("LayerSizeModifier: minWidth: \(minWidth)")
-        logInView("LayerSizeModifier: maxWidth: \(maxWidth)")
-        logInView("LayerSizeModifier: minHeight: \(minHeight)")
-        logInView("LayerSizeModifier: maxHeight: \(maxHeight)")
-                
-        logInView("LayerSizeModifier: finalMaxHeight: \(finalMaxHeight)")
-        logInView("LayerSizeModifier: finalMaxWidth: \(finalMaxWidth)")
+        // TODO: remove once this view is cleaned up; but very helpful for debugging atm
+        //        logInView("LayerSizeModifier: BODY")
+        //        logInView("LayerSizeModifier: alignment: \(alignment)")
+        //
+        //        logInView("LayerSizeModifier: usesParentPercentForWidth: \(usesParentPercentForWidth)")
+        //        logInView("LayerSizeModifier: usesParentPercentForHeight: \(usesParentPercentForHeight)")
+        //
+        //        logInView("LayerSizeModifier: usesFillForWidth: \(usesFillForWidth)")
+        //        logInView("LayerSizeModifier: usesFillForHeight: \(usesFillForHeight)")
+        //
+        //        logInView("LayerSizeModifier: width: \(width)")
+        //        logInView("LayerSizeModifier: height: \(height)")
+        //
+        //        logInView("LayerSizeModifier: minWidth: \(minWidth)")
+        //        logInView("LayerSizeModifier: maxWidth: \(maxWidth)")
+        //        logInView("LayerSizeModifier: minHeight: \(minHeight)")
+        //        logInView("LayerSizeModifier: maxHeight: \(maxHeight)")
+        //
+        //        logInView("LayerSizeModifier: finalMaxHeight: \(finalMaxHeight)")
+        //        logInView("LayerSizeModifier: finalMaxWidth: \(finalMaxWidth)")
         
                
         // TODO: the below conditionals can be simplified, but are currently evolving; will be cleaned up after final iterations on conditional input logic
@@ -139,7 +140,7 @@ struct LayerSizeModifier: ViewModifier {
         
         
         if isPinnedViewRendering && (viewModel.isPinned.getBool ?? false) {
-            logInView("LayerSizeModifier: will use pinned size for layer \(viewModel.layer), pinnedSize: \(viewModel.pinnedSize)")
+            // logInView("LayerSizeModifier: will use pinned size for layer \(viewModel.layer), pinnedSize: \(viewModel.pinnedSize)")
               // If this is the "PinnedView" for View A,
               // then View A's "GhostView" will already have read the appropriate size etc. for View A.
               // So we can just use the layer view model's pinnedSize
@@ -150,7 +151,7 @@ struct LayerSizeModifier: ViewModifier {
         
         // Width is pt, but height is auto (so can use min/max height)
         else if let width = width, !height.isDefined {
-            logInView("LayerSizeModifier: defined width but not height")
+            // logInView("LayerSizeModifier: defined width but not height")
             
             content
             // Note: parent-percentage supports min/max along a dimension
@@ -169,7 +170,7 @@ struct LayerSizeModifier: ViewModifier {
         
         // Height is pt, but width is auto (so can use min/max width)
         else if let height = height, !width.isDefined {
-            logInView("LayerSizeModifier: defined height but not width")
+            // logInView("LayerSizeModifier: defined height but not width")
                 
             content
                 .frame(minHeight: usesParentPercentForHeight ? minHeight : nil, alignment: alignment)
@@ -185,40 +186,24 @@ struct LayerSizeModifier: ViewModifier {
         
         // Both height and width are pt (so no min/max size at all)
         else if let width = width, let height = height {
-            logInView("LayerSizeModifier: defined width and height")
+            // logInView("LayerSizeModifier: defined width and height")
+            content
+                .frame(minWidth: usesParentPercentForWidth ? minWidth : nil, alignment: alignment)
+                .frame(maxWidth: finalMaxWidth, alignment: alignment)
             
-//            // TODO: get rid of this branch
-//            // If we have a static width and height, and we're not using an parent-percents,
-//            // then we can use the SwiftUI API with the specified alignment
-////            if !usesParentPercentForWidth && !usesParentPercentForHeight {
-//            if !usesParentPercentForWidth,
-//               !usesParentPercentForHeight,
-//               !usesFillForWidth,
-//               !usesFillForHeight {
-//                logInView("LayerSizeModifier: defined width and height and not using parent percent for width or height")
-//                content.frame(width: width,
-//                              height: height,
-//                              alignment: alignment)
-//            } else {
-//                
-                content
-                    .frame(minWidth: usesParentPercentForWidth ? minWidth : nil, alignment: alignment)
-                    .frame(maxWidth: finalMaxWidth, alignment: alignment)
-                    
-                    .frame(width: usesFillForWidth ? nil : width,
-                           alignment: alignment)
-                    
-                    .frame(minHeight: usesParentPercentForHeight ? minHeight : nil, alignment: alignment)
-                    .frame(maxHeight: finalMaxHeight, alignment: alignment)
-                    
-                    .frame(height: usesFillForHeight ? nil : height,
-                           alignment: alignment)
-//            }
+                .frame(width: usesFillForWidth ? nil : width,
+                       alignment: alignment)
+            
+                .frame(minHeight: usesParentPercentForHeight ? minHeight : nil, alignment: alignment)
+                .frame(maxHeight: finalMaxHeight, alignment: alignment)
+            
+                .frame(height: usesFillForHeight ? nil : height,
+                       alignment: alignment)
         }
         
         // Both height and width are auto, so use min/max height and width
         else if someMinMaxDefined {
-            logInView("LayerSizeModifier: defined min-max")
+            // logInView("LayerSizeModifier: defined min-max")
             content.frame(minWidth: minWidth,
                           maxWidth: finalMaxWidth,
                           minHeight: minHeight,
@@ -228,7 +213,7 @@ struct LayerSizeModifier: ViewModifier {
         
         // Default
         else {
-            logInView("LayerSizeModifier: default")
+            // logInView("LayerSizeModifier: default")
             content.frame(width: width,
                           height: height,
                           alignment: alignment)

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewLayerSizeModifier.swift
@@ -65,6 +65,9 @@ struct LayerSizeModifier: ViewModifier {
     let usesParentPercentForWidth: Bool
     let usesParentPercentForHeight: Bool
     
+    let usesFillForWidth: Bool
+    let usesFillForHeight: Bool
+    
     // nil = dimension is unspecified
     let width: CGFloat?
     let height: CGFloat?
@@ -86,27 +89,49 @@ struct LayerSizeModifier: ViewModifier {
         minHeight.isDefined || maxHeight.isDefined
     }
     
-   
+   // If we are using `fill`, our `width` will actually be our
+    var finalMaxWidth: CGFloat? {
+        if usesFillForWidth {
+            return width
+        } else if usesParentPercentForWidth {
+            return maxWidth
+        } else {
+            return nil
+        }
+    }
+    
+    var finalMaxHeight: CGFloat? {
+        if usesFillForHeight {
+            return height
+        } else if usesParentPercentForHeight {
+            return maxHeight
+        } else {
+            return nil
+        }
+    }
+    
     func body(content: Content) -> some View {
-        //        logInView("LayerSizeModifier: alignment: \(alignment)")
+        logInView("LayerSizeModifier: alignment: \(alignment)")
         //
-        //        logInView("LayerSizeModifier: usesParentPercentForWidth: \(usesParentPercentForWidth)")
-        //        logInView("LayerSizeModifier: usesParentPercentForHeight: \(usesParentPercentForHeight)")
+        logInView("LayerSizeModifier: usesParentPercentForWidth: \(usesParentPercentForWidth)")
+        logInView("LayerSizeModifier: usesParentPercentForHeight: \(usesParentPercentForHeight)")
         //
-        //        logInView("LayerSizeModifier: width: \(width)")
-        //        logInView("LayerSizeModifier: height: \(height)")
+        logInView("LayerSizeModifier: width: \(width)")
+        logInView("LayerSizeModifier: height: \(height)")
         //
-        //        logInView("LayerSizeModifier: minWidth: \(minWidth)")
-        //        logInView("LayerSizeModifier: maxWidth: \(maxWidth)")
-        //        logInView("LayerSizeModifier: minHeight: \(minHeight)")
-        //        logInView("LayerSizeModifier: maxHeight: \(maxHeight)")
+        logInView("LayerSizeModifier: minWidth: \(minWidth)")
+        logInView("LayerSizeModifier: maxWidth: \(maxWidth)")
+        logInView("LayerSizeModifier: minHeight: \(minHeight)")
+        logInView("LayerSizeModifier: maxHeight: \(maxHeight)")
         //
                
         // TODO: the below conditionals can be simplified, but are currently evolving; will be cleaned up after final iterations on conditional input logic
         
+        // TODO: we can break a `.frame(width:height,alignment:)` modifier into into separate `.frame(width:alignment:)`, `.frame(height:alignment:)` modifiers and `alignment` will still work.
+        
         
         if isPinnedViewRendering && (viewModel.isPinned.getBool ?? false) {
-              // logInView("LayerSizeModifier: will use pinned size for layer \(viewModel.layer), pinnedSize: \(viewModel.pinnedSize)")
+            logInView("LayerSizeModifier: will use pinned size for layer \(viewModel.layer), pinnedSize: \(viewModel.pinnedSize)")
               // If this is the "PinnedView" for View A,
               // then View A's "GhostView" will already have read the appropriate size etc. for View A.
               // So we can just use the layer view model's pinnedSize
@@ -117,14 +142,18 @@ struct LayerSizeModifier: ViewModifier {
         
         // Width is pt, but height is auto (so can use min/max height)
         else if let width = width, !height.isDefined {
-            //             logInView("LayerSizeModifier: defined width but not height")
+            logInView("LayerSizeModifier: defined width but not height")
             
             content
             // Note: parent-percentage supports min/max along a dimension
                 .frame(minWidth: usesParentPercentForWidth ? minWidth : nil)
-                .frame(maxWidth: usesParentPercentForWidth ? maxWidth : nil)
-                .frame(width: width, 
+            
+            // If we are using width = fill, then passed-in width will actually be parent-length,
+            // and we should supply `.frame(width = nil)` but `.frame(maxWidth = passed-in-width)`
+                .frame(maxWidth: finalMaxWidth)
+                .frame(width: usesFillForWidth ? nil : width,
                        alignment: alignment)
+                
                 .frame(minHeight: minHeight,
                        maxHeight: maxHeight,
                        alignment: alignment)
@@ -132,25 +161,29 @@ struct LayerSizeModifier: ViewModifier {
         
         // Height is pt, but width is auto (so can use min/max width)
         else if let height = height, !width.isDefined {
-            //             logInView("LayerSizeModifier: defined height but not width")
+            logInView("LayerSizeModifier: defined height but not width")
                 
             content
                 .frame(minHeight: usesParentPercentForHeight ? minHeight : nil)
-                .frame(maxHeight: usesParentPercentForHeight ? maxHeight : nil)
-                .frame(height: height, 
+                .frame(maxHeight: finalMaxHeight)
+            
+                .frame(height: usesFillForHeight ? nil : height,
                        alignment: alignment)
+            
                 .frame(minWidth: minWidth,
-                       maxWidth: maxWidth,
+                       maxWidth: finalMaxWidth,
                        alignment: alignment)
         }
         
         // Both height and width are pt (so no min/max size at all)
         else if let width = width, let height = height {
-            // logInView("LayerSizeModifier: defined width and height")
+            logInView("LayerSizeModifier: defined width and height")
+            
+            // TODO: get rid of this branch
             // If we have a static width and height, and we're not using an parent-percents,
             // then we can use the SwiftUI API with the specified alignment
             if !usesParentPercentForWidth && !usesParentPercentForHeight {
-                // logInView("LayerSizeModifier: defined width and height and not using parent percent for width or height")
+                logInView("LayerSizeModifier: defined width and height and not using parent percent for width or height")
                 content.frame(width: width,
                               height: height,
                               alignment: alignment)
@@ -158,27 +191,32 @@ struct LayerSizeModifier: ViewModifier {
                 
                 content
                     .frame(minWidth: usesParentPercentForWidth ? minWidth : nil)
-                    .frame(maxWidth: usesParentPercentForWidth ? maxWidth : nil)
-                    .frame(width: width, alignment: alignment)
+                    .frame(maxWidth: finalMaxWidth)
+                    
+                    .frame(width: usesFillForWidth ? nil : width,
+                           alignment: alignment)
+                    
                     .frame(minHeight: usesParentPercentForHeight ? minHeight : nil)
-                    .frame(maxHeight: usesParentPercentForHeight ? maxHeight : nil)
-                    .frame(height: height, alignment: alignment)
+                    .frame(maxHeight: finalMaxHeight)
+                    
+                    .frame(height: usesFillForHeight ? nil : height,
+                           alignment: alignment)
             }
         }
         
         // Both height and width are auto, so use min/max height and width
         else if someMinMaxDefined {
-            // logInView("LayerSizeModifier: defined min-max")
+            logInView("LayerSizeModifier: defined min-max")
             content.frame(minWidth: minWidth,
-                          maxWidth: maxWidth,
+                          maxWidth: finalMaxWidth,
                           minHeight: minHeight,
-                          maxHeight: maxHeight,
+                          maxHeight: finalMaxHeight,
                           alignment: alignment)
         } 
         
         // Default
         else {
-            // logInView("LayerSizeModifier: default")
+            logInView("LayerSizeModifier: default")
             content.frame(width: width,
                           height: height,
                           alignment: alignment)


### PR DESCRIPTION
We use e.g. `.frame(maxWidth: .parentPercent(100))` and `.frame(width: nil)` when a child's width = fill, so that parent's padding can squeeze the child smaller. 

Also: LayerInfo patch accurately detects the shrinkage:

### Parent’s padding = 40 on each side subtracted 80 from child’s width and height: 
<img width="1440" alt="Screenshot 2024-10-24 at 6 43 44 PM" src="https://github.com/user-attachments/assets/212a7cf8-9ca2-4414-b90f-3059bc727225">

### similarly on Text layer: 
 
<img width="1440" alt="Screenshot 2024-10-24 at 6 48 43 PM" src="https://github.com/user-attachments/assets/c83d917d-9059-4745-bb58-4eae1801dafe">


### Stitch group size = 300x300, padding = 20

<img width="1440" alt="Screenshot 2024-10-24 at 10 59 11 AM" src="https://github.com/user-attachments/assets/fc073d5a-0050-41fb-a00e-19061daa2671">

### Origami group size = 300x300, padding = 20

<img width="1337" alt="Screenshot 2024-10-24 at 10 56 47 AM" src="https://github.com/user-attachments/assets/916b3ce6-57ad-405d-a00c-aad413713cf2">

### Note: padding on ZStack's children is messed up, probably from SwiftUI .position modifier 

<img width="1440" alt="Screenshot 2024-10-24 at 6 26 40 PM" src="https://github.com/user-attachments/assets/89f3e025-14b4-4bc7-adc1-a397d3e55548">
