### PR TITLE
Fixed document persistence regression

### DIFF
--- a/Stitch/App/Serialization/DocumentLoading/DocumentEncodable.swift
+++ b/Stitch/App/Serialization/DocumentLoading/DocumentEncodable.swift
@@ -97,10 +97,14 @@ extension DocumentEncodable {
             saveUndoHistory(delegate, oldSchema, newSchema)
         }
         
-        Task(priority: .background) {
-            await self.encodeProject(newSchema,
-                                     willUpdateUndoHistory: willUpdateUndoHistory,
-                                     temporaryURL: temporaryUrl)
+        Task(priority: .background) { [weak self] in
+            guard let encoder = self else {
+                return
+            }
+            
+            let _ = await encoder.encodeProject(newSchema,
+                                                willUpdateUndoHistory: willUpdateUndoHistory,
+                                                temporaryURL: temporaryUrl)
         }
     }
     

--- a/Stitch/App/Serialization/DocumentLoading/DocumentLoader.swift
+++ b/Stitch/App/Serialization/DocumentLoading/DocumentLoader.swift
@@ -100,6 +100,7 @@ actor DocumentLoader {
             // thumbnail loading not needed for import
             let thumbnail = isImport ? nil : DocumentEncoder.getProjectThumbnailImage(rootUrl: url)
             
+            
             return .loaded(document, thumbnail)
         } catch {
             log("DocumentLoader.loadDocument error: \(error)")
@@ -111,7 +112,14 @@ actor DocumentLoader {
                                   isImport: Bool = false) async {
         let newLoading = await self.loadDocument(from: projectLoader.url, isImport: isImport)
 
+        
         await MainActor.run { [weak projectLoader] in
+            // Create an encoder if not yet created
+            if projectLoader?.encoder == nil,
+                let document = newLoading.document {
+                projectLoader?.encoder = DocumentEncoder(document: document)
+            }
+    
             projectLoader?.loadingDocument = newLoading
         }
     }

--- a/Stitch/App/Serialization/DocumentLoading/ProjectLoader.swift
+++ b/Stitch/App/Serialization/DocumentLoading/ProjectLoader.swift
@@ -11,6 +11,8 @@ import SwiftUI
 /// Passed into view to property sort URLs by modified date and forces a new render cycle when the date changes.
 @Observable
 final class ProjectLoader: Sendable {
+    var encoder: DocumentEncoder?
+    
     var modifiedDate: Date
     var url: URL
     var loadingDocument: DocumentLoadingStatus = .initialized

--- a/Stitch/Graph/Node/Util/NodeCreatedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeCreatedAction.swift
@@ -71,8 +71,6 @@ extension StitchDocumentViewModel {
     func nodeCreated(node: NodeViewModel) {
 
         let choice = node.kind
-        var undoEvents = Actions()
-        let nodeId = node.id
 
         // Note: DO NOT RESET THE ACTIVE NODE MENU SELECTION UNTIL ANIMATION HAS COMPLETED
         // Reset selection for insert node menu


### PR DESCRIPTION
Issue was caused by new encoder logic which moved encoders inside `StitchDocumentViewModel`. This meant when the document tears down, the encoder does as well, creating race conditions with persistence.

The fix was moving encoders to the project home screen so they always exist.