### PR TITLE
Fixed bottom padding regression for layer inspector

### DIFF
--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -117,12 +117,14 @@ struct LayerInspectorView: View {
                     graph: graph)
                 .padding(.horizontal)
                 .padding(.trailing, LAYER_INSPECTOR_ROW_SPACING + LAYER_INSPECTOR_ROW_ICON_LENGTH)
+                
+                // Hack to add some spacing to the bottom of the list, better than padding which hides scroll content
+                Color.clear
+                    .frame(height: 1)
+                    .listRowBackground(Color.clear)
             } // List
             .listSectionSpacing(.compact) // reduce spacing between sections
             .scrollContentBackground(.hidden)
-            
-            // TODO: better padding that doesn't cut off bottom input/output row and doesn't create a black band in Dark Mode
-            .padding(.bottom)
             
             // Note: Need to use `.plain` style so that layers with fewer sections (e.g. Linear Gradient layer, vs Text layer) do not default to a different list style;
             // And using .plain requires manually adding trailing and leading padding
@@ -260,6 +262,8 @@ struct LayerInspectorInputsSectionView: View {
                 }
             }
         }
+        
+        
     }
 }
 

--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -262,8 +262,6 @@ struct LayerInspectorInputsSectionView: View {
                 }
             }
         }
-        
-        
     }
 }
 

--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -117,11 +117,6 @@ struct LayerInspectorView: View {
                     graph: graph)
                 .padding(.horizontal)
                 .padding(.trailing, LAYER_INSPECTOR_ROW_SPACING + LAYER_INSPECTOR_ROW_ICON_LENGTH)
-                
-                // Hack to add some spacing to the bottom of the list, better than padding which hides scroll content
-                Color.clear
-                    .frame(height: 1)
-                    .listRowBackground(Color.clear)
             } // List
             .listSectionSpacing(.compact) // reduce spacing between sections
             .scrollContentBackground(.hidden)


### PR DESCRIPTION
Unfortunately we need to remove a bottom padding attempt here, as using a clear rectangle almost works but creates a visible line on iPad.