### PR TITLE
Improve preview window position changes when sidebar and inspector opened

### DIFF
--- a/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
+++ b/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
@@ -215,7 +215,9 @@ struct CatalystTopBarGraphButtons: View {
 struct LayerInspectorToggled: GraphUIEvent {
     func handle(state: GraphUIState) {
         
-        state.showsLayerInspector.toggle()
+        withAnimation {
+            state.showsLayerInspector.toggle()
+        }
         
         // reset selected inspector-row when inspector panel toggled
         state.propertySidebar.selectedProperty = nil

--- a/Stitch/Graph/Util/GraphUIActions.swift
+++ b/Stitch/Graph/Util/GraphUIActions.swift
@@ -124,12 +124,14 @@ struct ToggleSidebars: GraphEvent {
         let inspectorOpen = state.graphUI.showsLayerInspector
         let layerSidebarOpen = state.graphUI.leftSidebarOpen
         
-        if !inspectorOpen && !layerSidebarOpen {
-            state.graphUI.showsLayerInspector = true
-            state.graphUI.leftSidebarOpen = true
-        } else {
-            state.graphUI.showsLayerInspector = false
-            state.graphUI.leftSidebarOpen = false
+        withAnimation {
+            if !inspectorOpen && !layerSidebarOpen {
+                state.graphUI.showsLayerInspector = true
+                state.graphUI.leftSidebarOpen = true
+            } else {
+                state.graphUI.showsLayerInspector = false
+                state.graphUI.leftSidebarOpen = false
+            }
         }
     }
 }


### PR DESCRIPTION
We now 'animate' sidebar, inspector toggling.


https://github.com/user-attachments/assets/d73fffa6-4c16-41c0-af59-8e607e5b565c

