### PR TITLE
Do not use `fatalError` if DocumentDelegate not yet assigned in GraphStepManager

### DIFF
--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -369,7 +369,8 @@ extension GraphState {
     
     var graphStepManager: GraphStepManager {
         guard let document = self.documentDelegate else {
-            fatalErrorIfDebug()
+//            fatalErrorIfDebug()
+            log("graphStepManager: did not have a document delegate")
             return .init()
         }
         


### PR DESCRIPTION
Was causing intermittent crashes when e.g. opening a project with media layers. Returning the empty GraphStepManager seems fine.

Why does this race condition arise?

<img width="1440" alt="Screenshot 2024-10-28 at 10 49 04 AM" src="https://github.com/user-attachments/assets/fbfbd252-ac7c-4769-b91c-29388af237d2">
<img width="1440" alt="Screenshot 2024-10-28 at 10 48 25 AM" src="https://github.com/user-attachments/assets/f029c2b5-9c9c-4c6f-91b4-539e43a0d8c7">
