### PR TITLE
Improved sidebar drag perf

### DIFF
--- a/Stitch/Graph/LayerInspector/LayerMultiselect.swift
+++ b/Stitch/Graph/LayerInspector/LayerMultiselect.swift
@@ -79,7 +79,7 @@ extension LayerInputPort {
     @MainActor
     func multiselectObservers(_ graph: GraphDelegate) -> [LayerInputObserver] {
                 
-        let selectedLayers = graph.sidebarSelectionState.all
+        let selectedLayers = graph.sidebarSelectionState.primary
         
         let observers: [LayerInputObserver] = selectedLayers.compactMap {
             if let layerNode = graph.getNodeViewModel($0)?.layerNode {


### PR DESCRIPTION
`sidebarSelectionState.all` is a computed property that gets updated when secondarily selected items update. Here we only need primary selections.