### PR TITLE
Use 2x2 grid for layer padding and margin inputs in inspector

### DIFF
--- a/Stitch/Graph/LayerInspector/FlyoutUtils.swift
+++ b/Stitch/Graph/LayerInspector/FlyoutUtils.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 extension LayerInputPort {
     
-    // Note: msot cases are just "is this multifield?", with exception of shadow inputs)
+    // Note: most cases are just "is this multifield?", with exception of shadow inputs)
     var usesFlyout: Bool {
         switch self {
             
@@ -29,49 +29,8 @@ extension LayerInputPort {
             
             return false
         }
-
-        
-//        if self.usesPaddingFlyout {
-//            return true
-//        }
-//        
-//        if self.usesTwoFieldFlyout {
-//            return true
-//        }
-//        
-//        switch self {
-//        case .padding, .layerMargin, .layerPadding,
-//                .shadowColor, .shadowOffset, .shadowRadius, .shadowOpacity:
-//            return true
-//        default:
-//            return false
-//        }
-        
-        
     }
-        
-//    // TODO: COMPARE INPUT'S VALUES, NOT INPUT TYPE
-//    var usesTwoFieldFlyout: Bool {
-//        switch self {
-//        case .size, .position, .offsetInGroup, .maxSize, .minSize:
-//            return true
-//        default:
-//            return false
-//        }
-//    }
-    
-//    // TODO: better?: compare against the actual value in the input, rather than on the input's keyword
-//    // But in some contexts we don't have access to the input?
-    // TODO: handle padding same as
-//    var usesPaddingFlyout: Bool {
-//        switch self {
-//        case .padding, .layerPadding, .layerMargin:
-//            return true
-//        default:
-//            return false
-//        }
-//    }
-        
+                
     func usesTextFields(_ layer: Layer) -> Bool {
         self.getDefaultValue(for: layer)
             .getNodeRowType(nodeIO: .input)

--- a/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
@@ -73,6 +73,7 @@ struct GenericFlyoutView: View {
             fieldValueTypes: fieldValueTypes,
             nodeId: nodeId,
             forPropertySidebar: true,
+            forFlyout: true,
             blockedFields: layerInputObserver.blockedFields) { inputFieldViewModel, isMultifield in
                 GenericFlyoutRowView(
                     graph: graph,

--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -139,15 +139,27 @@ struct LayerInspectorPortView<RowView>: View where RowView: View {
         canvasItemId.isDefined
     }
     
+    var isPaddingPortValueTypeRow: Bool {
+        layerInputObserver?.port == .layerMargin || layerInputObserver?.port == .layerPadding
+    }
+    
+    var hstackAlignment: VerticalAlignment {
+        return isPaddingPortValueTypeRow ? .firstTextBaseline : .center
+    }
+    
     var body: some View {
-        HStack {
+        HStack(alignment: hstackAlignment) {
             LayerInspectorRowButton(layerInputObserver: layerInputObserver,
                                     layerInspectorRowId: layerInspectorRowId,
                                     coordinate: coordinate,
                                     canvasItemId: canvasItemId,
                                     isPortSelected: propertyRowIsSelected,
                                     isHovered: isHovered)
-            
+            // TODO: `.firstTextBaseline` doesn't align symbols and text in quite the way we want;
+            // Really, we want the center of the symbol and the center of the input's label text to align
+            // Alternatively, we want the height of the row-buton to be the same as the height of the input-row's label, e.g. specify a height in `LabelDisplayView`
+            .offset(y: isPaddingPortValueTypeRow ? INSPECTOR_LIST_ROW_TOP_AND_BOTTOM_INSET : 0)
+                        
             rowView(propertyRowIsSelected)
         }
         .listRowBackground(Color.clear)

--- a/Stitch/Graph/LayerInspector/LayerMultiselect.swift
+++ b/Stitch/Graph/LayerInspector/LayerMultiselect.swift
@@ -26,6 +26,12 @@ extension InputFieldViewModel {
     }
 }
 
+extension FieldGroupTypeViewModel {
+    var layerInput: LayerInputPort? {
+        self.id.rowId.portType.keyPath?.layerInput
+    }
+}
+
 /*
  Suppose:
  

--- a/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
+++ b/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
@@ -217,6 +217,7 @@ struct NodeInputView: View {
                     fieldValueTypes: fieldValueTypes,
                     nodeId: nodeId,
                     forPropertySidebar: forPropertySidebar,
+                    forFlyout: forFlyout,
                     blockedFields: layerInputObserver?.blockedFields,
                     valueEntryView: valueEntryView)
             }
@@ -325,6 +326,7 @@ struct NodeOutputView: View {
                     fieldValueTypes: rowViewModel.fieldValueTypes,
                     nodeId: nodeId,
                     forPropertySidebar: forPropertySidebar,
+                    forFlyout: false, // Outputs do not use flyouts
                     blockedFields: nil, // Always nil for output fields
                     valueEntryView: valueEntryView)
             }
@@ -360,6 +362,7 @@ struct FieldsListView<PortType, ValueEntryView>: View where PortType: NodeRowVie
     var fieldValueTypes: [FieldGroupTypeViewModel<PortType.FieldType>]
     let nodeId: NodeId
     let forPropertySidebar: Bool
+    let forFlyout: Bool
     let blockedFields: LayerPortTypeSet?
 
     @ViewBuilder var valueEntryView: (PortType.FieldType, Bool) -> ValueEntryView
@@ -380,6 +383,7 @@ struct FieldsListView<PortType, ValueEntryView>: View where PortType: NodeRowVie
                            nodeId: nodeId,
                            isMultiField: isMultiField,
                            forPropertySidebar: forPropertySidebar,
+                           forFlyout: forFlyout,
                            blockedFields: blockedFields,
                            valueEntryView: valueEntryView)
         }


### PR DESCRIPTION
Gives more space in the inspector. 

<img width="304" alt="Screenshot 2024-10-29 at 12 11 16 PM" src="https://github.com/user-attachments/assets/02dd6585-e63b-41e6-9bca-ad3c51b6eb4a">
