### PR TITLE
Regression Fixed: `Delete` shortcut on layer-input-on-graph no longer deletes layer too

### DIFF
--- a/Stitch/App/Shortcut/ProjectsHomeCommands.swift
+++ b/Stitch/App/Shortcut/ProjectsHomeCommands.swift
@@ -20,8 +20,8 @@ struct ProjectsHomeCommands: Commands {
         store.currentDocument.isDefined
     }
         
-    var layersActivelySelected: Bool {
-        self.graph?.hasActivelySelectedLayers ?? false
+    var isSidebarFocused: Bool {
+        self.graph?.graphUI.isSidebarFocused ?? false
     }
     
     var graph: GraphState? {
@@ -287,7 +287,7 @@ struct ProjectsHomeCommands: Commands {
                 SwiftUIShortcutView(title: "Group Layers",
                                     key: GROUP_LAYERS_SHORTCUT,
                                     // Disabled if no layers are actively selected
-                                    disabled: !layersActivelySelected || !groupButtonEnabled) {
+                                    disabled: !isSidebarFocused || !groupButtonEnabled) {
                     // deletes both selected nodes and selected comments
                     self.graph?.layersSidebarViewModel.sidebarGroupCreated()
                 }
@@ -296,8 +296,8 @@ struct ProjectsHomeCommands: Commands {
                                     key: DELETE_SELECTED_NODES_SHORTCUT,
                                     eventModifiers: [.command],
                                     // Disabled if no layers are actively selected
-                                    disabled: !layersActivelySelected || !ungroupButtonEnabled) {
-//                                    disabled: !layersActivelySelected) {
+                                    disabled: !isSidebarFocused || !ungroupButtonEnabled) {
+//                                    disabled: !isSidebarFocused) {
                     // deletes both selected nodes and selected comments
                     self.graph?.layersSidebarViewModel.sidebarGroupUncreated()
                 }

--- a/Stitch/Graph/Node/Util/NodeDeletedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeDeletedAction.swift
@@ -9,19 +9,13 @@ import Foundation
 import SwiftUI
 import StitchSchemaKit
 
-extension GraphState {
-    var hasActivelySelectedLayers: Bool {
-        !self.sidebarSelectionState.primary.isEmpty
-    }
-}
-
 // Used for Delete key shortcut
 struct DeleteShortcutKeyPressed: GraphEventWithResponse {
     
     func handle(state: GraphState) -> GraphResponse {
 
         // Check which we have focused: layers or canvas items
-        if state.hasActivelySelectedLayers {
+        if state.graphUI.isSidebarFocused {
             state.layersSidebarViewModel.deleteSelectedItems()
             state.updateInspectorFocusedLayers()
         }

--- a/Stitch/Graph/Util/NodeSelection/NodeSelectionUtil.swift
+++ b/Stitch/Graph/Util/NodeSelection/NodeSelectionUtil.swift
@@ -92,7 +92,7 @@ struct SelectAllShortcutKeyPressed: GraphEvent {
         
         // If we have at least one actively selected sidebar layers,
         // then select all layers, not canvas items.
-        if state.hasActivelySelectedLayers {            
+        if state.graphUI.isSidebarFocused {            
             let allLayers = state.orderedSidebarLayers.flattenedItems.map(\.id).toSet
             state.sidebarSelectionState.primary = state.sidebarSelectionState.primary.union(allLayers)
             


### PR DESCRIPTION
Look at `GraphUI.isSidebarFocused` instead of just whether we have primary selections. 

Regressed because `hasActiveSelections` changed from data that distinguished between 'sidebar focused or not.' 
Quick fix.