### PR TITLE
Open 'wireless broadcaster choice' menu by clicking node title

### DIFF
--- a/Stitch/Graph/Node/Title/View/CanvasItemTitleView.swift
+++ b/Stitch/Graph/Node/Title/View/CanvasItemTitleView.swift
@@ -32,20 +32,31 @@ struct CanvasItemTitleView: View {
     var name: String {
         node.displayTitle
     }
-        
+    
+    @State private var showMenu = false
+            
     var body: some View {
 //        logInView("NodeTitleView body \(id)")
         
-        // A Wireless Receiver node's title is not directly editable by a
+        // A Wireless Receiver node's title is not directly editable
         if node.patch == .wirelessReceiver {
             // logInView("NodeTitleView body isWirelessReceiver \(id)")
             let _title = node.currentBroadcastChoiceId.flatMap { graph.getNodeViewModel($0)?.displayTitle } ?? name
+                        
+            Menu {
+                let choice = node.currentBroadcastChoice
+                NodeWirelessBroadcastSubmenuView(graph: graph,
+                                                 currentBroadcastChoice: choice ?? nilBroadcastChoice,
+//                                                 assignedBroadcaster: choice,
+                                                 nodeId: nodeId,
+                                                 forNodeTitle: true)
+            } label: {
+                StitchTextView(string: _title)
+            }
+            .buttonStyle(.plain)
+            .foregroundColor(STITCH_TITLE_FONT_COLOR)
+            .menuIndicator(.hidden)
             
-            #if DEV_DEBUG
-            StitchTextView(string: _title + " " + nodeId.debugFriendlyId)
-            #else
-            StitchTextView(string: _title)
-            #endif
         } else {
             editableTitle
                 .font(STITCH_FONT)

--- a/Stitch/Graph/Node/Util/NodeViewModelUtils.swift
+++ b/Stitch/Graph/Node/Util/NodeViewModelUtils.swift
@@ -120,6 +120,15 @@ extension NodeViewModel {
     var currentBroadcastChoiceId: NodeId? {
         self.getInputRowObserver(0)?.currentBroadcastChoiceId
     }
+    
+    @MainActor
+    var currentBroadcastChoice: BroadcastChoice? {
+        if let currentBroadcastChoiceId = currentBroadcastChoiceId {
+            return .init(title: self.displayTitle, id: currentBroadcastChoiceId)
+        }
+        return nilBroadcastChoice
+        
+    }
 
     @MainActor
     static var mock: NodeViewModel {

--- a/Stitch/Graph/Node/View/NodeTag/NodeTagMenuButtonsView.swift
+++ b/Stitch/Graph/Node/View/NodeTag/NodeTagMenuButtonsView.swift
@@ -167,10 +167,13 @@ struct NodeTagMenuButtonsView: View {
                                  loopIndices)
             }
 
-            if isWirelessReceiver {
-                NodeWirelessBroadcastSubmenuView(graph: graph,
-                                                 nodeId: node.id)
-            }
+//            if isWirelessReceiver {
+//                let choice = node.currentBroadcastChoice
+//                NodeWirelessBroadcastSubmenuView(graph: graph,
+//                                                 currentBroadcastChoice: choice ?? nilBroadcastChoice,
+//                                                 assignedBroadcaster: choice,
+//                                                 nodeId: node.id)
+//            }
             
             jumpToAssignedBroadcasterButton
             

--- a/Stitch/Graph/Node/View/NodeTag/NodeWirelessBroadcastSubmenuView.swift
+++ b/Stitch/Graph/Node/View/NodeTag/NodeWirelessBroadcastSubmenuView.swift
@@ -18,23 +18,27 @@ let nilBroadcastChoice = BroadcastChoice(
     title: "None",
     id: .fakeNodeId)
 
-// TODO: why does moving the node (or something else?) reset the Picker's selection to None even when there's still an assigned broadcaster? Keeping around the commented out code to help debug that in the future
 struct NodeWirelessBroadcastSubmenuView: View {
 
     @Bindable var graph: GraphState
     
-    @State var currentBroadcastChoice: BroadcastChoice = nilBroadcastChoice
-    
+    @State var currentBroadcastChoice: BroadcastChoice
+        
     let nodeId: NodeId // wireless receiver node id
-    // let currentAssignedBroadcaster: NodeId?
     
-    //    var currentAssignedBroadcasterTitle: String {
-    //        if let currentAssignedBroadcaster = currentAssignedBroadcaster {
-    //            return choices.first { $0.id == currentAssignedBroadcaster }?.title ?? "No"
-    //
-    //        }
-    //        return nilBroadcastChoice.title
-    //    }
+    var forNodeTitle: Bool = false
+
+    // TODO: Picker's selection state (the checkmark) is incorrect; and .onChange for a manually passed in input value completely breaks Picker's selection state; and this explicit `init` does not help either
+    init(graph: GraphState,
+         currentBroadcastChoice: BroadcastChoice,
+         nodeId: NodeId,
+         forNodeTitle: Bool = false) {
+        self.graph = graph
+        self.currentBroadcastChoice = currentBroadcastChoice
+        self.nodeId = nodeId
+        self.forNodeTitle = forNodeTitle
+    }
+    
     
     // nilChoice id is created afresh everytime
     @MainActor
@@ -66,7 +70,9 @@ struct NodeWirelessBroadcastSubmenuView: View {
                 }
             }
         }
-        .pickerStyle(.menu)
+        .pickerStyle(.inline)
+//        .modifier(PickerStyleModifierView(forNodeTitle: forNodeTitle))
+        
         //        .onChange(of: self.currentAssignedBroadcaster, initial: true) { oldValue, newValue in
         //            log("NodeBroadcastSubmenuView: onChange self.currentAssignedBroadcaster: oldValue: \(oldValue)")
         //            log("NodeBroadcastSubmenuView: onChange self.currentAssignedBroadcaster: newValue: \(newValue)")
@@ -83,3 +89,19 @@ struct NodeWirelessBroadcastSubmenuView: View {
         }
     }
 }
+
+// TODO: support in the node tag menu again?
+//struct PickerStyleModifierView: ViewModifier {
+//    
+//    let forNodeTitle: Bool
+//    
+//    func body(content: Content) -> some View {
+//        if forNodeTitle {
+//            // .inline = create this Picker at the same hierarchy level as the current view, don't nest etc.
+//            content.pickerStyle(.inline)
+//        } else {
+//            // Default to .menu, which manifests as 'submenu' when used with another menu
+//            content.pickerStyle(.menu)
+//        }
+//    }
+//}


### PR DESCRIPTION
Note: we no longer show "choose broadcaster" in the node tag menu. 

Easier UX and avoids several issues with SwiftUI native Picker selection state (can't be set by passed in value).

https://github.com/user-attachments/assets/832395c3-f5f7-470a-8189-e6360a6fe956

