### PR TITLE
Components support for inputs, outputs and eval

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -62,6 +62,7 @@
 		B51C67512C6441A5002F83D1 /* UnpackedValueCoercer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51C67502C6441A5002F83D1 /* UnpackedValueCoercer.swift */; };
 		B51D8809298CA7A000CEBA98 /* AsyncMediaValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51D8808298CA7A000CEBA98 /* AsyncMediaValue.swift */; };
 		B51D8A022CD13D420016CCDA /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = B51D8A012CD13D420016CCDA /* StitchEngine */; };
+		B51D8A052CD2A5ED0016CCDA /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = B51D8A042CD2A5ED0016CCDA /* StitchEngine */; };
 		B521489A2C837CA6009AD42C /* DelayOneNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52148992C837CA6009AD42C /* DelayOneNode.swift */; };
 		B523698C29F9E5E800240395 /* NodeRowObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B523698B29F9E5E800240395 /* NodeRowObserver.swift */; };
 		B525BB482C18AFC300A98EB4 /* FileDropHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = B525BB472C18AFC300A98EB4 /* FileDropHandling.swift */; };
@@ -1855,6 +1856,7 @@
 				B5386FB02C9A929B00AD8065 /* StitchEngine in Frameworks */,
 				B56EA8A62C409898003D39E2 /* StitchEngine in Frameworks */,
 				EC39E75C26822ACA00674841 /* AudioKit in Frameworks */,
+				B51D8A052CD2A5ED0016CCDA /* StitchEngine in Frameworks */,
 				EC53F3C3287E27250021095B /* Numerics in Frameworks */,
 				EC15E42A2602A08B006F2E08 /* CloudKit.framework in Frameworks */,
 				201953DA25B25D3300D5296C /* Tagged in Frameworks */,
@@ -4468,6 +4470,7 @@
 				E463E7EE2C6FC7090008E318 /* StitchSchemaKit */,
 				B5386FAF2C9A929B00AD8065 /* StitchEngine */,
 				B51D8A012CD13D420016CCDA /* StitchEngine */,
+				B51D8A042CD2A5ED0016CCDA /* StitchEngine */,
 			);
 			productName = prototype;
 			productReference = 200BD857254F66EB00692903 /* Stitch.app */;
@@ -4553,7 +4556,7 @@
 				B50F41662C1EB4320082262F /* XCRemoteSwiftPackageReference "StitchViewKit" */,
 				B5FBE3C22C4195B3006DA0A7 /* XCRemoteSwiftPackageReference "DirectoryWatcher" */,
 				E463E7ED2C6FC7090008E318 /* XCRemoteSwiftPackageReference "StitchSchemaKit" */,
-				B51D8A002CD13D420016CCDA /* XCLocalSwiftPackageReference "../StitchEngineClosedSource" */,
+				B51D8A032CD2A5ED0016CCDA /* XCRemoteSwiftPackageReference "StitchEngine" */,
 			);
 			productRefGroup = 200BD858254F66EB00692903 /* Products */;
 			projectDirPath = "";
@@ -6292,13 +6295,6 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCLocalSwiftPackageReference section */
-		B51D8A002CD13D420016CCDA /* XCLocalSwiftPackageReference "../StitchEngineClosedSource" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../StitchEngineClosedSource;
-		};
-/* End XCLocalSwiftPackageReference section */
-
 /* Begin XCRemoteSwiftPackageReference section */
 		201953D825B25D3300D5296C /* XCRemoteSwiftPackageReference "swift-tagged" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -6338,6 +6334,14 @@
 			requirement = {
 				kind = revision;
 				revision = 199b6a329cfc35c1554e2f46b9ab3daac021f2e3;
+			};
+		};
+		B51D8A032CD2A5ED0016CCDA /* XCRemoteSwiftPackageReference "StitchEngine" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/StitchDesign/StitchEngine";
+			requirement = {
+				kind = revision;
+				revision = 5f747788e65190946b05329dba68cc7f3af7a956;
 			};
 		};
 		B5FBE3C22C4195B3006DA0A7 /* XCRemoteSwiftPackageReference "DirectoryWatcher" */ = {
@@ -6450,6 +6454,11 @@
 		};
 		B51D8A012CD13D420016CCDA /* StitchEngine */ = {
 			isa = XCSwiftPackageProductDependency;
+			productName = StitchEngine;
+		};
+		B51D8A042CD2A5ED0016CCDA /* StitchEngine */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B51D8A032CD2A5ED0016CCDA /* XCRemoteSwiftPackageReference "StitchEngine" */;
 			productName = StitchEngine;
 		};
 		B5386FAF2C9A929B00AD8065 /* StitchEngine */ = {

--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -61,6 +61,7 @@
 		B51C3B8C29A9462A00043089 /* ARAnchorNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51C3B8B29A9462A00043089 /* ARAnchorNode.swift */; };
 		B51C67512C6441A5002F83D1 /* UnpackedValueCoercer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51C67502C6441A5002F83D1 /* UnpackedValueCoercer.swift */; };
 		B51D8809298CA7A000CEBA98 /* AsyncMediaValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51D8808298CA7A000CEBA98 /* AsyncMediaValue.swift */; };
+		B51D8A022CD13D420016CCDA /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = B51D8A012CD13D420016CCDA /* StitchEngine */; };
 		B521489A2C837CA6009AD42C /* DelayOneNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52148992C837CA6009AD42C /* DelayOneNode.swift */; };
 		B523698C29F9E5E800240395 /* NodeRowObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B523698B29F9E5E800240395 /* NodeRowObserver.swift */; };
 		B525BB482C18AFC300A98EB4 /* FileDropHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = B525BB472C18AFC300A98EB4 /* FileDropHandling.swift */; };
@@ -131,7 +132,6 @@
 		B55501072C1BCAD60081C3F1 /* SidebarListItemActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55501062C1BCAD50081C3F1 /* SidebarListItemActions.swift */; };
 		B555010D2C1BD0E10081C3F1 /* SidebarVisibilityUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B555010C2C1BD0E10081C3F1 /* SidebarVisibilityUtils.swift */; };
 		B55501342C1C00EB0081C3F1 /* GraphStepIncrementer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55501332C1C00EB0081C3F1 /* GraphStepIncrementer.swift */; };
-		B55780612CAF5D9500907BA8 /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = B55780602CAF5D9500907BA8 /* StitchEngine */; };
 		B55780632CAF667900907BA8 /* StitchClipboardContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55780622CAF667700907BA8 /* StitchClipboardContent.swift */; };
 		B55780652CAF66D900907BA8 /* StitchComponentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55780642CAF66D600907BA8 /* StitchComponentable.swift */; };
 		B55780692CB043B600907BA8 /* StitchComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55780682CB043AF00907BA8 /* StitchComponentViewModel.swift */; };
@@ -1849,7 +1849,7 @@
 				EC7784CF27053D9700B662DD /* ZIPFoundation in Frameworks */,
 				B50F41682C1EB4320082262F /* StitchViewKit in Frameworks */,
 				EC1137382719F9B400ADCA72 /* OrderedCollections in Frameworks */,
-				B55780612CAF5D9500907BA8 /* StitchEngine in Frameworks */,
+				B51D8A022CD13D420016CCDA /* StitchEngine in Frameworks */,
 				EC91034A29109DF3007C548E /* SoulverCore in Frameworks */,
 				EC17DF0928F626660042BF4F /* MathParser in Frameworks */,
 				B5386FB02C9A929B00AD8065 /* StitchEngine in Frameworks */,
@@ -4467,7 +4467,7 @@
 				B5FBE3C32C4195B3006DA0A7 /* DirectoryWatcher */,
 				E463E7EE2C6FC7090008E318 /* StitchSchemaKit */,
 				B5386FAF2C9A929B00AD8065 /* StitchEngine */,
-				B55780602CAF5D9500907BA8 /* StitchEngine */,
+				B51D8A012CD13D420016CCDA /* StitchEngine */,
 			);
 			productName = prototype;
 			productReference = 200BD857254F66EB00692903 /* Stitch.app */;
@@ -4553,7 +4553,7 @@
 				B50F41662C1EB4320082262F /* XCRemoteSwiftPackageReference "StitchViewKit" */,
 				B5FBE3C22C4195B3006DA0A7 /* XCRemoteSwiftPackageReference "DirectoryWatcher" */,
 				E463E7ED2C6FC7090008E318 /* XCRemoteSwiftPackageReference "StitchSchemaKit" */,
-				B557805F2CAF5D9500907BA8 /* XCRemoteSwiftPackageReference "StitchEngine" */,
+				B51D8A002CD13D420016CCDA /* XCLocalSwiftPackageReference "../StitchEngineClosedSource" */,
 			);
 			productRefGroup = 200BD858254F66EB00692903 /* Products */;
 			projectDirPath = "";
@@ -6292,6 +6292,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		B51D8A002CD13D420016CCDA /* XCLocalSwiftPackageReference "../StitchEngineClosedSource" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../StitchEngineClosedSource;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		201953D825B25D3300D5296C /* XCRemoteSwiftPackageReference "swift-tagged" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -6331,14 +6338,6 @@
 			requirement = {
 				kind = revision;
 				revision = 199b6a329cfc35c1554e2f46b9ab3daac021f2e3;
-			};
-		};
-		B557805F2CAF5D9500907BA8 /* XCRemoteSwiftPackageReference "StitchEngine" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/StitchDesign/StitchEngine";
-			requirement = {
-				kind = revision;
-				revision = 7b68361244834a2b4df9ad44ae267b41b15b1de6;
 			};
 		};
 		B5FBE3C22C4195B3006DA0A7 /* XCRemoteSwiftPackageReference "DirectoryWatcher" */ = {
@@ -6449,13 +6448,12 @@
 			package = B50F41662C1EB4320082262F /* XCRemoteSwiftPackageReference "StitchViewKit" */;
 			productName = StitchViewKit;
 		};
-		B5386FAF2C9A929B00AD8065 /* StitchEngine */ = {
+		B51D8A012CD13D420016CCDA /* StitchEngine */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = StitchEngine;
 		};
-		B55780602CAF5D9500907BA8 /* StitchEngine */ = {
+		B5386FAF2C9A929B00AD8065 /* StitchEngine */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = B557805F2CAF5D9500907BA8 /* XCRemoteSwiftPackageReference "StitchEngine" */;
 			productName = StitchEngine;
 		};
 		B56EA8A52C409898003D39E2 /* StitchEngine */ = {

--- a/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1174c004236adf2d9c79fef631488080dd658e2818be6cd128080e63bc8bbb83",
+  "originHash" : "87be221b3fbded1c8027b1ce26671216264e4726379ed9409d52282eb1aab675",
   "pins" : [
     {
       "identity" : "audiokit",
@@ -52,6 +52,14 @@
       "state" : {
         "revision" : "ef309cda2d2f426476181ae294f3b899eac83af4",
         "version" : "2.6.3"
+      }
+    },
+    {
+      "identity" : "stitchengine",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/StitchDesign/StitchEngine",
+      "state" : {
+        "revision" : "5f747788e65190946b05329dba68cc7f3af7a956"
       }
     },
     {

--- a/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "87be221b3fbded1c8027b1ce26671216264e4726379ed9409d52282eb1aab675",
+  "originHash" : "1174c004236adf2d9c79fef631488080dd658e2818be6cd128080e63bc8bbb83",
   "pins" : [
     {
       "identity" : "audiokit",
@@ -52,14 +52,6 @@
       "state" : {
         "revision" : "ef309cda2d2f426476181ae294f3b899eac83af4",
         "version" : "2.6.3"
-      }
-    },
-    {
-      "identity" : "stitchengine",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StitchDesign/StitchEngine",
-      "state" : {
-        "revision" : "7b68361244834a2b4df9ad44ae267b41b15b1de6"
       }
     },
     {

--- a/Stitch/App/FeatureFlags.swift
+++ b/Stitch/App/FeatureFlags.swift
@@ -11,5 +11,10 @@ import StitchSchemaKit
 // Currently unused but will keep alive here.
 struct FeatureFlags {
     static let USE_COMMENT_BOX_FLAG: Bool = false
+    
+    #if STITCH_AI
+    static let USE_COMPONENTS = true
+    #else
     static let USE_COMPONENTS = false
+    #endif
 }

--- a/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
+++ b/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
@@ -294,7 +294,7 @@ extension StitchComponentViewModel {
         
         // Update outputs here after graph calculation
         zip(splitterOutputs, self.outputsObservers).forEach { splitter, output in
-            splitter.updateValues(output.allLoopedValues)
+            output.updateValues(splitter.allLoopedValues)
         }
         
         return .init(outputsValues: self.outputsObservers.map(\.allLoopedValues))

--- a/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
+++ b/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
@@ -250,32 +250,14 @@ extension StitchComponentViewModel {
 }
 
 extension StitchComponentViewModel {
-//    typealias InputRow = InputNodeRowObserver
-//    typealias OutputRow = OutputNodeRowObserver
-    
     var id: NodeId {
-        get {
-            guard let node = self.nodeDelegate else {
-                fatalErrorIfDebug()
-                return .init()
-            }
-            
-            return node.id
-        }
-        set(newValue) {
-            // This used?
+        guard let node = self.nodeDelegate else {
             fatalErrorIfDebug()
-//            self.nodeDelegate?.id = newValue
+            return .init()
         }
+        
+        return node.id
     }
-    
-//    var isGroupNode: Bool {
-//        false
-//    }
-//    
-//    var requiresOutputValuesChange: Bool {
-//        false
-//    }
     
     @MainActor func evaluate() -> EvalResult? {
         // Update splitters
@@ -305,10 +287,6 @@ extension StitchComponentViewModel {
         }
         
         return .init(outputsValues: self.outputsObservers.map(\.allLoopedValues))
-    }
-    
-    @MainActor func outputsUpdated(evalResult: EvalResult) {
-        fatalError()
     }
     
     @MainActor func getInputRowObserver(for id: NodeIOPortType) -> InputNodeRowObserver? {

--- a/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
+++ b/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
@@ -146,15 +146,21 @@ extension StitchComponentViewModel: NodeCalculatable {
     }
     
     @MainActor func getAllInputsObservers() -> [InputNodeRowObserver] {
-        []
+        self.graph.visibleNodesViewModel.getSplitterInputRowObservers(for: nil)
     }
     
     @MainActor func getAllOutputsObservers() -> [OutputNodeRowObserver] {
-        []
+        self.graph.visibleNodesViewModel.getSplitterOutputRowObservers(for: nil)
     }
     
     @MainActor func getInputRowObserver(for id: NodeIOPortType) -> InputNodeRowObserver? {
-        fatalError()
+        guard let portId = id.portId,
+              let input = self.getAllInputsObservers()[safe: portId] else {
+            fatalErrorIfDebug()
+            return nil
+        }
+        
+        return input
     }
     
     @MainActor var inputsValuesList: PortValuesList {

--- a/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
+++ b/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
@@ -78,7 +78,7 @@ extension StitchComponentViewModel {
     }
     
     @MainActor func createSchema() -> ComponentEntity {
-        let inputs = self.getAllInputsObservers()
+        let inputs = self.inputsObservers
             .map { $0.createSchema().portData }
         
         return .init(componentId: self.componentId,
@@ -145,17 +145,23 @@ extension StitchComponentViewModel: NodeCalculatable {
         fatalError()
     }
     
-    @MainActor func getAllInputsObservers() -> [InputNodeRowObserver] {
-        self.graph.visibleNodesViewModel.getSplitterInputRowObservers(for: nil)
+    @MainActor var inputsObservers: [InputNodeRowObserver] {
+        get {
+            self.graph.visibleNodesViewModel.getSplitterInputRowObservers(for: nil)
+        }
+        set { }
     }
     
-    @MainActor func getAllOutputsObservers() -> [OutputNodeRowObserver] {
-        self.graph.visibleNodesViewModel.getSplitterOutputRowObservers(for: nil)
+    @MainActor var outputsObservers: [OutputNodeRowObserver] {
+        get {
+            self.graph.visibleNodesViewModel.getSplitterOutputRowObservers(for: nil)
+        }
+        set { }
     }
     
     @MainActor func getInputRowObserver(for id: NodeIOPortType) -> InputNodeRowObserver? {
         guard let portId = id.portId,
-              let input = self.getAllInputsObservers()[safe: portId] else {
+              let input = self.inputsObservers[safe: portId] else {
             fatalErrorIfDebug()
             return nil
         }
@@ -164,6 +170,6 @@ extension StitchComponentViewModel: NodeCalculatable {
     }
     
     @MainActor var inputsValuesList: PortValuesList {
-        self.getAllInputsObservers().map { $0.allLoopedValues }
+        self.inputsObservers.map { $0.allLoopedValues }
     }
 }

--- a/Stitch/Graph/Node/Eval/ImpureEvaluation.swift
+++ b/Stitch/Graph/Node/Eval/ImpureEvaluation.swift
@@ -63,7 +63,7 @@ struct ImpureEvalResult {
 
     // this might also have to be a list, eg. for delay node?
     // or is there a single
-    var effects = SideEffects()
+//    var effects = SideEffects()
 
     // Determines if media objects changed in a manner which should trigger downstream nodes
     var didMediaObjectChange = false

--- a/Stitch/Graph/Node/Eval/ImpureEvaluation.swift
+++ b/Stitch/Graph/Node/Eval/ImpureEvaluation.swift
@@ -68,17 +68,18 @@ struct ImpureEvalResult {
     // Determines if media objects changed in a manner which should trigger downstream nodes
     var didMediaObjectChange = false
 
+    // TODO: remove
     func toEvalResult() -> EvalResult {
         let result = self
 
-        var effects = SideEffects()
-
-        result.effects.forEach { (effect: @escaping Effect) in
-            effects.append(effect)
-        }
+//        var effects = SideEffects()
+//
+//        result.effects.forEach { (effect: @escaping Effect) in
+//            effects.append(effect)
+//        }
 
         return EvalResult(outputsValues: result.outputsValues,
-                          effects: effects,
+//                          effects: effects,
                           runAgain: result.runAgain,
                           didMediaObjectChange: didMediaObjectChange)
     }

--- a/Stitch/Graph/Node/Eval/ImpureEvaluation.swift
+++ b/Stitch/Graph/Node/Eval/ImpureEvaluation.swift
@@ -11,79 +11,47 @@ import StitchSchemaKit
 // produces new outputs,
 // but may also update inputs, create a side effect, cause node to run again, etc.
 
-typealias ImpureNodeEval = (PatchNode) -> ImpureEvalResult
-
-// SAME PATTERN: (PatchNode, T) -> ImpureEvalResult
-typealias ImpureGraphEval = (PatchNode, GraphDelegate) -> ImpureEvalResult
-typealias ImpureGraphStepEval = (PatchNode, GraphStepState) -> ImpureEvalResult
-
-// (PatchNode, T, K, J) -> ImpureEvalResult
-typealias ImpureGraphStateAndGraphStep = (PatchNode, GraphDelegate, GraphStepState) -> ImpureEvalResult
-
-enum ImpureEvals {
-    case node(ImpureNodeEval)
-    case graph(ImpureGraphEval)
-    case graphStep(ImpureGraphStepEval)
-    case graphAndGraphStep(ImpureGraphStateAndGraphStep)
-
-    @MainActor
-    func runEvaluation(node: PatchNode) -> ImpureEvalResult {
-        guard let graphState = node.graphDelegate else {
-            fatalErrorIfDebug()
-            return .init(outputsValues: node.defaultOutputsList)
-        }
-        
-        let graphStepState = graphState.graphStepState
-        
-        switch self {
-        case .node(let impureNodeEval):
-            return impureNodeEval(node)
-        case .graph(let impureGraphEval):
-            return impureGraphEval(node, graphState)
-        case .graphStep(let impureGraphStepEval):
-            return impureGraphStepEval(node, graphStepState)
-        case .graphAndGraphStep(let impureMediaAndGraphAndStepAndComputed):
-            return impureMediaAndGraphAndStepAndComputed(node,
-                                                         graphState,
-                                                         graphStepState)
-        }
-    }
-}
-
-struct ImpureEvalResult {
-    var outputsValues: PortValuesList
-
-    // TODO: here and UI need updates to use specific indices rather than entire loop/port
-    //    var pulsedIndices: PulsedIndices = []
-    // ^^ maybe instead of a loop, still use a set, but a set of indices?
-    //
-    //    var pulsedOutputs
-
-    var runAgain = false
-
-    // this might also have to be a list, eg. for delay node?
-    // or is there a single
-//    var effects = SideEffects()
-
-    // Determines if media objects changed in a manner which should trigger downstream nodes
-    var didMediaObjectChange = false
-
-    // TODO: remove
-    func toEvalResult() -> EvalResult {
-        let result = self
-
-//        var effects = SideEffects()
+//typealias ImpureNodeEval = (PatchNode) -> ImpureEvalResult
 //
-//        result.effects.forEach { (effect: @escaping Effect) in
-//            effects.append(effect)
+//// SAME PATTERN: (PatchNode, T) -> ImpureEvalResult
+//typealias ImpureGraphEval = (PatchNode, GraphDelegate) -> ImpureEvalResult
+//typealias ImpureGraphStepEval = (PatchNode, GraphStepState) -> ImpureEvalResult
+//
+//// (PatchNode, T, K, J) -> ImpureEvalResult
+//typealias ImpureGraphStateAndGraphStep = (PatchNode, GraphDelegate, GraphStepState) -> ImpureEvalResult
+//
+//enum ImpureEvals {
+//    case node(ImpureNodeEval)
+//    case graph(ImpureGraphEval)
+//    case graphStep(ImpureGraphStepEval)
+//    case graphAndGraphStep(ImpureGraphStateAndGraphStep)
+//
+//    @MainActor
+//    func runEvaluation(node: PatchNode) -> ImpureEvalResult {
+//        guard let graphState = node.graphDelegate else {
+//            fatalErrorIfDebug()
+//            return .init(outputsValues: node.defaultOutputsList)
 //        }
+//        
+//        let graphStepState = graphState.graphStepState
+//        
+//        switch self {
+//        case .node(let impureNodeEval):
+//            return impureNodeEval(node)
+//        case .graph(let impureGraphEval):
+//            return impureGraphEval(node, graphState)
+//        case .graphStep(let impureGraphStepEval):
+//            return impureGraphStepEval(node, graphStepState)
+//        case .graphAndGraphStep(let impureMediaAndGraphAndStepAndComputed):
+//            return impureMediaAndGraphAndStepAndComputed(node,
+//                                                         graphState,
+//                                                         graphStepState)
+//        }
+//    }
+//}
 
-        return EvalResult(outputsValues: result.outputsValues,
-//                          effects: effects,
-                          runAgain: result.runAgain,
-                          didMediaObjectChange: didMediaObjectChange)
-    }
-}
+// TODO: tech debt to remove ImpureEvalResult
+typealias ImpureEvalResult = EvalResult
 
 extension ImpureEvalResult {
 

--- a/Stitch/Graph/Node/Eval/ImpureEvaluation.swift
+++ b/Stitch/Graph/Node/Eval/ImpureEvaluation.swift
@@ -8,48 +8,6 @@
 import Foundation
 import StitchSchemaKit
 
-// produces new outputs,
-// but may also update inputs, create a side effect, cause node to run again, etc.
-
-//typealias ImpureNodeEval = (PatchNode) -> ImpureEvalResult
-//
-//// SAME PATTERN: (PatchNode, T) -> ImpureEvalResult
-//typealias ImpureGraphEval = (PatchNode, GraphDelegate) -> ImpureEvalResult
-//typealias ImpureGraphStepEval = (PatchNode, GraphStepState) -> ImpureEvalResult
-//
-//// (PatchNode, T, K, J) -> ImpureEvalResult
-//typealias ImpureGraphStateAndGraphStep = (PatchNode, GraphDelegate, GraphStepState) -> ImpureEvalResult
-//
-//enum ImpureEvals {
-//    case node(ImpureNodeEval)
-//    case graph(ImpureGraphEval)
-//    case graphStep(ImpureGraphStepEval)
-//    case graphAndGraphStep(ImpureGraphStateAndGraphStep)
-//
-//    @MainActor
-//    func runEvaluation(node: PatchNode) -> ImpureEvalResult {
-//        guard let graphState = node.graphDelegate else {
-//            fatalErrorIfDebug()
-//            return .init(outputsValues: node.defaultOutputsList)
-//        }
-//        
-//        let graphStepState = graphState.graphStepState
-//        
-//        switch self {
-//        case .node(let impureNodeEval):
-//            return impureNodeEval(node)
-//        case .graph(let impureGraphEval):
-//            return impureGraphEval(node, graphState)
-//        case .graphStep(let impureGraphStepEval):
-//            return impureGraphStepEval(node, graphStepState)
-//        case .graphAndGraphStep(let impureMediaAndGraphAndStepAndComputed):
-//            return impureMediaAndGraphAndStepAndComputed(node,
-//                                                         graphState,
-//                                                         graphStepState)
-//        }
-//    }
-//}
-
 // TODO: tech debt to remove ImpureEvalResult
 typealias ImpureEvalResult = EvalResult
 

--- a/Stitch/Graph/Node/Eval/PatchEvaluateExtensions.swift
+++ b/Stitch/Graph/Node/Eval/PatchEvaluateExtensions.swift
@@ -11,331 +11,331 @@ import StitchSchemaKit
 
 extension Patch {
     @MainActor
-    var evaluate: EvaluationStyle {
+    var evaluate: PureEvals {
         switch self {
         case
             // wireless nodes are just splitter nodes with covered up edges and invisible edges
             .wirelessReceiver, .wirelessBroadcaster:
-            return .pure(.node(outputsOnlyEval(identityEvaluation)))
+            return .node(outputsOnlyEval(identityEvaluation))
         case .splitter:
             // .impure(.impure because of pulse nodeType)
-            return .impure(.graphStep(splitterEval))
+            return .graphStep(splitterEval)
         case .imageImport:
-            return .pure(.node(imageImportEval))
+            return .node(imageImportEval)
         case .add:
-            return .pure(.node(arithmeticNodeTypeEval(addEval)))
+            return .node(arithmeticNodeTypeEval(addEval))
         case .convertPosition:
-            return .pure(.graph(outputsOnlyGraphStateEval(convertPositionEval)))
+            return .graph(outputsOnlyGraphStateEval(convertPositionEval))
         case .multiply:
-            return .pure(.node(mathNodeTypeEval(multiplyEval)))
+            return .node(mathNodeTypeEval(multiplyEval))
         case .divide:
-            return .pure(.node(mathNodeTypeEval(divideEval)))
+            return .node(mathNodeTypeEval(divideEval))
         // Scroll interaction is a little different because scroll does animation stuff
         case .pressInteraction:
             // DOES NOT USE graph step
-            return .impure(.graphAndGraphStep(pressInteractionEval))
+            return .graph(pressInteractionEval)
         case .dragInteraction:
             // DOES use GraphStep
-            return .impure(.graphAndGraphStep(dragInteractionEval))
+            return .graph(dragInteractionEval)
         case .cameraFeed:
-            return .impure(.graph(cameraFeedEval))
+            return .graph(cameraFeedEval)
         case .loop:
-            return .pure(.node(outputsOnlyEval(loopStartEval)))
+            return .node(outputsOnlyEval(loopStartEval))
         case .counter:
-            return .impure(.graphStep(counterEval))
+            return .graphStep(counterEval)
         case .repeatingPulse:
-            return .impure(.graph(repeatingPulseEval))
+            return .graph(repeatingPulseEval)
         //        case .soundKit:
         //            // technically has no outputs and is side-effect only...
-        //            return .impure(.computed(soundKitEval))
+        //            return .computed(soundKitEval)
         case .time:
-            return .pure(.graphStep(timeEvalWrapper))
+            return .graphStep(timeEvalWrapper)
         case .deviceTime:
-            return .pure(.node(deviceTimeEval))
+            return .node(deviceTimeEval)
         case .location:
-            return .impure(.graph(locationEval))
+            return .graph(locationEval)
         case .random:
-            return .impure(.graphStep(randomEval))
+            return .graphStep(randomEval)
         case .hslColor:
-            return .pure(.node(outputsOnlyEval(hslColorEval)))
+            return .node(outputsOnlyEval(hslColorEval))
         case .optionPicker:
-            return .pure(.node(outputsOnlyEval(optionPickerEval)))
+            return .node(outputsOnlyEval(optionPickerEval))
         case .pack:
-            return .pure(.node(outputsOnlyEval(packEval)))
+            return .node(outputsOnlyEval(packEval))
         case .unpack:
-            return .pure(.node(outputsOnlyEval(unpackEval)))
+            return .node(outputsOnlyEval(unpackEval))
         case .or:
-            return .pure(.node(outputsOnlyEval(orEval)))
+            return .node(outputsOnlyEval(orEval))
         case .and:
-            return .pure(.node(outputsOnlyEval(andEval)))
+            return .node(outputsOnlyEval(andEval))
         case .restartPrototype:
-            return .impure(.graphStep(restartPrototypeEval))
+            return .graphStep(restartPrototypeEval)
         case .flipSwitch:
-            return .impure(.graphStep(switchEval))
+            return .graphStep(switchEval)
         case .optionSwitch:
-            return .impure(.graphStep(optionSwitchEval))
+            return .graphStep(optionSwitchEval)
         case .pulseOnChange:
-            return .impure(.graphStep(pulseOnChangeEval))
+            return .graphStep(pulseOnChangeEval)
         case .pulse:
-            return .impure(.graphStep(pulseNodeEval))
+            return .graphStep(pulseNodeEval)
         case .springAnimation:
-            return .impure(.graphStep(springAnimationEval))
+            return .graphStep(springAnimationEval)
         case .popAnimation:
-            return .impure(.graphStep(popAnimationEval))
+            return .graphStep(popAnimationEval)
         case .bouncyConverter:
-            return .pure(.node(outputsOnlyEval(bouncyConverterEval)))
+            return .node(outputsOnlyEval(bouncyConverterEval))
         case .classicAnimation:
-            return .impure(.graphStep(classicAnimationEval))
+            return .graphStep(classicAnimationEval)
         case .curve:
-            return .pure(.node(outputsOnlyEval(curveEval)))
+            return .node(outputsOnlyEval(curveEval))
         case .cubicBezierAnimation:
-            return .impure(.graphStep(cubicBezierAnimationEval))
+            return .graphStep(cubicBezierAnimationEval)
         case .cubicBezierCurve:
-            return .pure(.node(outputsOnlyEval(cubicBezierCurveEval)))
+            return .node(outputsOnlyEval(cubicBezierCurveEval))
         case .repeatingAnimation:
-            return .impure(.graphStep(repeatingAnimationEval))
+            return .graphStep(repeatingAnimationEval)
         case .loopBuilder:
-            return .impure(.graphStep(loopBuilderEval))
+            return .graphStep(loopBuilderEval)
         case .loopInsert:
-            return .impure(.graphStep(loopInsertEval))
+            return .graphStep(loopInsertEval)
         case .delay:
-            return .pure(.node(delayEval))
+            return .node(delayEval)
         case .coreMLClassify:
-            return .pure(.node(coreMLClassifyEval))
+            return .node(coreMLClassifyEval)
         case .coreMLDetection:
-            return .pure(.node(coreMLDetectionEval))
+            return .node(coreMLDetectionEval)
         case .not:
-            return .pure(.node(outputsOnlyEval(notEval)))
+            return .node(outputsOnlyEval(notEval))
         case .transition:
-            return .pure(.node(outputsOnlyEval(transitionEval)))
+            return .node(outputsOnlyEval(transitionEval))
         case .scrollInteraction:
-            return .impure(.graphAndGraphStep(scrollInteractionEval))
+            return .graph(scrollInteractionEval)
         case .sampleAndHold:
-            return .impure(.graphStep(sampleAndHoldEval))
+            return .graphStep(sampleAndHoldEval)
         case .grayscale:
-            return .pure(.node(grayscaleEval))
+            return .node(grayscaleEval)
         case .loopSelect:
-            return .pure(.node(outputsOnlyEval(loopSelectEval)))
+            return .node(outputsOnlyEval(loopSelectEval))
         case .videoImport:
-            return .pure(.node(videoImportEval))
+            return .node(videoImportEval)
         case .sampleRange:
-            return .impure(.graphAndGraphStep(sampleRangeEval))
+            return .graph(sampleRangeEval)
         case .soundImport:
-            return .pure(.node(soundImportEval))
+            return .node(soundImportEval)
         case .speaker:
-            return .pure(.node(speakerEval))
+            return .node(speakerEval)
         case .microphone:
-            return .pure(.node(microphoneEval))
+            return .node(microphoneEval)
         case .networkRequest:
-            return .impure(.graphStep(networkRequestEval))
+            return .graphStep(networkRequestEval)
         case .valueForKey:
-            return .pure(.graphStep(valueForKeyEval))
+            return .graphStep(valueForKeyEval)
         case .valueAtIndex:
-            return .pure(.graphStep((valueAtIndexEval)))
+            return .graphStep((valueAtIndexEval))
         case .loopOverArray:
-            return .pure(.node(outputsOnlyEval(loopOverArrayEval)))
+            return .node(outputsOnlyEval(loopOverArrayEval))
         case .setValueForKey:
-            return .pure(.node(setValueForKeyEval))
+            return .node(setValueForKeyEval)
         case .jsonObject:
-            return .pure(.node(jsonObjectEval))
+            return .node(jsonObjectEval)
         case .jsonArray:
-            return .pure(.node(jsonArrayEval))
+            return .node(jsonArrayEval)
         case .arrayAppend:
-            return .pure(.node(arrayAppendEval))
+            return .node(arrayAppendEval)
         case .arrayCount:
-            return .pure(.node(outputsOnlyEval(arrayCountEval)))
+            return .node(outputsOnlyEval(arrayCountEval))
         case . arrayJoin:
-            return .pure(.node(outputsOnlyEval(arrayJoinEval)))
+            return .node(outputsOnlyEval(arrayJoinEval))
         case .arrayReverse:
-            return .pure(.node(outputsOnlyEval(arrayReverseEval)))
+            return .node(outputsOnlyEval(arrayReverseEval))
         case .arraySort:
-            return .pure(.node(outputsOnlyEval(arraySortEval)))
+            return .node(outputsOnlyEval(arraySortEval))
         case .getKeys:
-            return .pure(.node(outputsOnlyEval(getKeysEval)))
+            return .node(outputsOnlyEval(getKeysEval))
         case .indexOf:
-            return .pure(.node(outputsOnlyEval(indexOfEval)))
+            return .node(outputsOnlyEval(indexOfEval))
         case .subarray:
-            return .pure(.node(outputsOnlyEval(subarrayEval)))
+            return .node(outputsOnlyEval(subarrayEval))
         case . valueAtPath:
-            return .pure(.graphStep(valueAtPathEval))
+            return .graphStep(valueAtPathEval)
         case .deviceMotion:
-            return .pure(.graph(deviceMotionEval))
+            return .graph(deviceMotionEval)
         case .deviceInfo:
-            return .pure(.graph(deviceInfoEval))
+            return .graph(deviceInfoEval)
         case .velocity:
-            return .pure(.node(velocityEval))
+            return .node(velocityEval)
         case .smoothValue:
-            return .impure(.graphStep(smoothValueEval))
+            return .graphStep(smoothValueEval)
         case .clip:
-            return .pure(.node(outputsOnlyEval(clipEval)))
+            return .node(outputsOnlyEval(clipEval))
         case .max:
-            return .pure(.node(outputsOnlyEval(maxEval)))
+            return .node(outputsOnlyEval(maxEval))
         case .mod:
-            return .pure(.node(outputsOnlyEval(modEval)))
+            return .node(outputsOnlyEval(modEval))
         case .round:
-            return .pure(.node(outputsOnlyEval(roundEval)))
+            return .node(outputsOnlyEval(roundEval))
         case .absoluteValue:
-            return .pure(.node(outputsOnlyEval(absoluteValueEval)))
+            return .node(outputsOnlyEval(absoluteValueEval))
         case .progress:
-            return .pure(.node(outputsOnlyEval(progressEval)))
+            return .node(outputsOnlyEval(progressEval))
         case .reverseProgress:
-            return .pure(.node(outputsOnlyEval(reverseProgressEval)))
+            return .node(outputsOnlyEval(reverseProgressEval))
         case .rgba:
-            return .pure(.node(outputsOnlyEval(rgbaEval)))
+            return .node(outputsOnlyEval(rgbaEval))
         case .arcTan2:
-            return .pure(.node(outputsOnlyEval(arcTan2Eval)))
+            return .node(outputsOnlyEval(arcTan2Eval))
         case .sine:
-            return .pure(.node(outputsOnlyEval(sineEval)))
+            return .node(outputsOnlyEval(sineEval))
         case .cosine:
-            return .pure(.node(outputsOnlyEval(cosineEval)))
+            return .node(outputsOnlyEval(cosineEval))
         case .hapticFeedback:
-            return .impure(.graphStep(hapticFeedbackEval))
+            return .graphStep(hapticFeedbackEval)
         case .imageToBase64String:
-            return .pure(.node(imageToBase64StringEval))
+            return .node(imageToBase64StringEval)
         case .base64StringToImage:
-            return .pure(.node(base64StringToImageEval))
+            return .node(base64StringToImageEval)
         case .whenPrototypeStarts:
-            return  .impure(.graphStep(whenPrototypeStartsEval))
+            return .graphStep(whenPrototypeStartsEval)
         case .soulver:
-            return .pure(.node(outputsOnlyEval(soulverEval)))
+            return .node(outputsOnlyEval(soulverEval))
         case .optionEquals:
-            return .pure(.node(outputsOnlyEval(optionEqualsEval)))
+            return .node(outputsOnlyEval(optionEqualsEval))
         case .subtract:
-            return .pure(.node(mathNodeTypeEval(subtractEval)))
+            return .node(mathNodeTypeEval(subtractEval))
         case .squareRoot:
-            return .pure(.node(mathNodeTypeEval(squareRootEval)))
+            return .node(mathNodeTypeEval(squareRootEval))
         case .length:
-            return .pure(.node(arithmeticNodeTypeEval(lengthEval)))
+            return .node(arithmeticNodeTypeEval(lengthEval))
         case .min:
-            return .pure(.node(outputsOnlyEval(minEval)))
+            return .node(outputsOnlyEval(minEval))
         case .power:
-            return .pure(.node(mathNodeTypeEval(powerEval)))
+            return .node(mathNodeTypeEval(powerEval))
         case .equals:
-            return .pure(.node(outputsOnlyEval(equalsEval)))
+            return .node(outputsOnlyEval(equalsEval))
         case .equalsExactly:
-            return .pure(.node(pureNodeEval(equalsExactlyEval)))
+            return .node(pureNodeEval(equalsExactlyEval))
         case .greaterThan:
-            return .pure(.node(pureNodeEval(greaterThanEval)))
+            return .node(pureNodeEval(greaterThanEval))
         case .greaterOrEqual:
-            return.pure(.node(pureNodeEval(greaterOrEqualEval)))
+            return .node(pureNodeEval(greaterOrEqualEval))
         case .lessThan:
-            return .pure(.node(pureNodeEval(lessThanEval)))
+            return .node(pureNodeEval(lessThanEval))
         case .lessThanOrEqual:
-            return .pure(.node(pureNodeEval(lessThanOrEqualEval)))
+            return .node(pureNodeEval(lessThanOrEqualEval))
         case .colorToHSL:
-            return .pure(.node(outputsOnlyEval(colorToHSLEval)))
+            return .node(outputsOnlyEval(colorToHSLEval))
         case .colorToHex:
-            return .pure(.node(outputsOnlyEval(colorToHexEval)))
+            return .node(outputsOnlyEval(colorToHexEval))
         case .colorToRGB:
-            return .pure(.node(outputsOnlyEval(colorToRGBAEval)))
+            return .node(outputsOnlyEval(colorToRGBAEval))
         case .hexColor:
-            return .pure(.node(outputsOnlyEval(hexEval)))
+            return .node(outputsOnlyEval(hexEval))
         case .splitText:
-            return .pure(.node(outputsOnlyEval(splitTextEval)))
+            return .node(outputsOnlyEval(splitTextEval))
         case .textEndsWith:
-            return .pure(.node(outputsOnlyEval(textEndsWithEval)))
+            return .node(outputsOnlyEval(textEndsWithEval))
         case .textLength:
-            return .pure(.node(outputsOnlyEval(textLengthEval)))
+            return .node(outputsOnlyEval(textLengthEval))
         case .textReplace:
-            return .pure(.node(outputsOnlyEval(textReplaceEval)))
+            return .node(outputsOnlyEval(textReplaceEval))
         case .textStartsWith:
-            return .pure(.node(outputsOnlyEval(textStartsWithEval)))
+            return .node(outputsOnlyEval(textStartsWithEval))
         case .trimText:
-            return .pure(.node(outputsOnlyEval(trimTextEval)))
+            return .node(outputsOnlyEval(trimTextEval))
         case .textTransform:
-            return .pure(.node(outputsOnlyEval(textTransformEval)))
+            return .node(outputsOnlyEval(textTransformEval))
         case .dateAndTimeFormatter:
-            return .pure(.node(outputsOnlyEval(dateAndTimeFormatterEval)))
+            return .node(outputsOnlyEval(dateAndTimeFormatterEval))
         case .stopwatch:
-            return .pure(.graphStep(stopwatchEval))
+            return .graphStep(stopwatchEval)
         case .optionSender:
-            return .pure(.node(outputsOnlyEval(optionSenderEval)))
+            return .node(outputsOnlyEval(optionSenderEval))
         case .any:
-            return .pure(.node(outputsOnlyEval(anyEval)))
+            return .node(outputsOnlyEval(anyEval))
         case .loopCount:
-            return .pure(.node(outputsOnlyEval(loopCountEval)))
+            return .node(outputsOnlyEval(loopCountEval))
         case .loopDedupe:
-            return .pure(.node(outputsOnlyEval(loopDedupeEval)))
+            return .node(outputsOnlyEval(loopDedupeEval))
         case .loopOptionSwitch:
-            return .impure(.graphStep(loopOptionSwitchEval))
+            return .graphStep(loopOptionSwitchEval)
         case .loopRemove:
-            return .pure(.graphStep(loopRemoveEval))
+            return .graphStep(loopRemoveEval)
         case .loopReverse:
-            return .pure(.node(outputsOnlyEval(loopReverseEval)))
+            return .node(outputsOnlyEval(loopReverseEval))
         case .loopShuffle:
-            return .pure(.graphStep(loopShuffleEval))
+            return .graphStep(loopShuffleEval)
         case .loopSum:
-            return .pure(.node(outputsOnlyEval(loopSumEval)))
+            return .node(outputsOnlyEval(loopSumEval))
         case .loopToArray:
-            return .pure(.node(loopToArrayEval))
+            return .node(loopToArrayEval)
         case .runningTotal:
-            return .pure(.node(outputsOnlyEval(runningTotalEval)))
+            return .node(outputsOnlyEval(runningTotalEval))
         case .loopFilter:
-            return .pure(.node(outputsOnlyEval(loopFilterEval)))
+            return .node(outputsOnlyEval(loopFilterEval))
         case .layerInfo:
-            return .pure(.graph(layerInfoEval))
+            return .graph(layerInfoEval)
         case .triangleShape:
-            return .pure(.node(outputsOnlyEval(triangleShapeEval)))
+            return .node(outputsOnlyEval(triangleShapeEval))
         case .ovalShape:
-            return .pure(.node(outputsOnlyEval(ovalShapeEval)))
+            return .node(outputsOnlyEval(ovalShapeEval))
         case .circleShape:
-            return .pure(.node(outputsOnlyEval(circleShapeEval)))
+            return .node(outputsOnlyEval(circleShapeEval))
         case .roundedRectangleShape:
-            return .pure(.node(outputsOnlyEval(roundedRectangleShapeEval)))
+            return .node(outputsOnlyEval(roundedRectangleShapeEval))
         case .union:
-            return .pure(.node(outputsOnlyEval(unionEval)))
+            return .node(outputsOnlyEval(unionEval))
         case .model3DImport:
-            return .pure(.node(model3DImportEval))
+            return .node(model3DImportEval)
         case .arRaycasting:
-            return .pure(.node(arRayCastingEval))
+            return .node(arRayCastingEval)
         case .keyboard:
-            return .pure(.graph(keyboardEval))
+            return .graph(keyboardEval)
         case .jsonToShape:
-            return .pure(.node(outputsOnlyEval(jsonToShapeEval)))
+            return .node(outputsOnlyEval(jsonToShapeEval))
         case .arAnchor:
-            return .pure(.node(arAnchorEval))
+            return .node(arAnchorEval)
         case .shapeToCommands:
-            return .pure(.node(outputsOnlyEval(shapeToCommandsEval)))
+            return .node(outputsOnlyEval(shapeToCommandsEval))
         case .commandsToShape:
-            return .pure(.node(outputsOnlyEval(commandsToShapeEval)))
+            return .node(outputsOnlyEval(commandsToShapeEval))
         case .mouse:
-            return .pure(.node(outputsOnlyEval(mouseEval)))
+            return .node(outputsOnlyEval(mouseEval))
         case .sizePack:
-            return .pure(.node(outputsOnlyEval(sizePackEval)))
+            return .node(outputsOnlyEval(sizePackEval))
         case .sizeUnpack:
-            return .pure(.node(outputsOnlyEval(sizeUnpackEval)))
+            return .node(outputsOnlyEval(sizeUnpackEval))
         case .positionPack:
-            return .pure(.node(outputsOnlyEval(positionPackEval)))
+            return .node(outputsOnlyEval(positionPackEval))
         case .positionUnpack:
-            return .pure(.node(outputsOnlyEval(positionUnpackEval)))
+            return .node(outputsOnlyEval(positionUnpackEval))
         case .point3DPack:
-            return .pure(.node(outputsOnlyEval(point3DPackEval)))
+            return .node(outputsOnlyEval(point3DPackEval))
         case .point3DUnpack:
-            return .pure(.node(outputsOnlyEval(point3DUnpackEval)))
+            return .node(outputsOnlyEval(point3DUnpackEval))
         case .point4DPack:
-            return .pure(.node(outputsOnlyEval(point4DPackEval)))
+            return .node(outputsOnlyEval(point4DPackEval))
         case .point4DUnpack:
-            return .pure(.node(outputsOnlyEval(point4DUnpackEval)))
+            return .node(outputsOnlyEval(point4DUnpackEval))
         case .transformPack:
-            return .pure(.node(outputsOnlyEval(transformPackEval)))
+            return .node(outputsOnlyEval(transformPackEval))
         case .transformUnpack:
-            return .pure(.node(outputsOnlyEval(transformUnpackEval)))
+            return .node(outputsOnlyEval(transformUnpackEval))
         case .closePath:
-            return .pure(.node(outputsOnlyEval(identityEvaluation)))
+            return .node(outputsOnlyEval(identityEvaluation))
         case .moveToPack:
-            return .pure(.node(outputsOnlyEval(moveToPackEval)))
+            return .node(outputsOnlyEval(moveToPackEval))
         case .lineToPack:
-            return .pure(.node(outputsOnlyEval(lineToPackEval)))
+            return .node(outputsOnlyEval(lineToPackEval))
         case .curveToPack:
-            return .pure(.node(outputsOnlyEval(curveToPackEval)))
+            return .node(outputsOnlyEval(curveToPackEval))
         case .curveToUnpack:
-            return .pure(.node(outputsOnlyEval(curveToUnpackEval)))
+            return .node(outputsOnlyEval(curveToUnpackEval))
         case .mathExpression:
-            return .pure(.node(mathExpressionEval))
+            return .node(mathExpressionEval)
         case .qrCodeDetection:
-            return .pure(.node(qrCodeDetectionEval))
+            return .node(qrCodeDetectionEval)
         case .delayOne:
-            return .pure(.node(DelayOneNode.eval))
+            return .node(DelayOneNode.eval)
         }
     }
 }

--- a/Stitch/Graph/Node/Eval/PatchEvaluation.swift
+++ b/Stitch/Graph/Node/Eval/PatchEvaluation.swift
@@ -44,8 +44,3 @@ extension EvalResult {
         self.outputsValues = []
     }
 }
-
-//enum EvaluationStyle {
-//    case pure(PureEvals),
-//         impure(ImpureEvals)
-//}

--- a/Stitch/Graph/Node/Eval/PatchEvaluation.swift
+++ b/Stitch/Graph/Node/Eval/PatchEvaluation.swift
@@ -32,7 +32,6 @@ struct EvalResult: NodeEvalResult, Sendable {
     
     
     var outputsValues: PortValuesList
-    var effects = SideEffects()
     var runAgain = false
 
     // Determines if media objects changed in a manner which should trigger downstream nodes

--- a/Stitch/Graph/Node/Eval/PatchEvaluation.swift
+++ b/Stitch/Graph/Node/Eval/PatchEvaluation.swift
@@ -45,7 +45,7 @@ extension EvalResult {
     }
 }
 
-enum EvaluationStyle {
-    case pure(PureEvals),
-         impure(ImpureEvals)
-}
+//enum EvaluationStyle {
+//    case pure(PureEvals),
+//         impure(ImpureEvals)
+//}

--- a/Stitch/Graph/Node/Eval/PatchEvaluation.swift
+++ b/Stitch/Graph/Node/Eval/PatchEvaluation.swift
@@ -11,6 +11,14 @@ import StitchSchemaKit
 import StitchEngine
 
 struct EvalResult: NodeEvalResult, Sendable {
+    var outputsValues: PortValuesList
+    var runAgain = false
+
+    // Determines if media objects changed in a manner which should trigger downstream nodes
+    var didMediaObjectChange = false
+}
+
+extension EvalResult {
     // TODO: clean up properties below?
     var willEvalAgain: Bool {
         get {
@@ -30,15 +38,6 @@ struct EvalResult: NodeEvalResult, Sendable {
         }
     }
     
-    
-    var outputsValues: PortValuesList
-    var runAgain = false
-
-    // Determines if media objects changed in a manner which should trigger downstream nodes
-    var didMediaObjectChange = false
-}
-
-extension EvalResult {
     /// Failure state initializer.
     init() {
         self.outputsValues = []

--- a/Stitch/Graph/Node/Layer/Util/LayerEvalExtensions.swift
+++ b/Stitch/Graph/Node/Layer/Util/LayerEvalExtensions.swift
@@ -10,16 +10,14 @@ import StitchSchemaKit
 
 extension Layer {
     @MainActor
-    var evaluate: EvaluationStyle? {
+    var evaluate: PureEvals? {
         switch self {
         case .canvasSketch:
-            return .pure(.node(canvasSketchEval))
+            return .node(canvasSketchEval)
         case .textField:
-            return .pure(.node(textFieldLayerEval))
+            return .node(textFieldLayerEval)
         case .switchLayer:
-            return .pure(.graphStep(switchLayerEval))
-        case .oval, .rectangle, .image, .group, .video, .realityView, .shape, .colorFill, .hitArea, .map:
-            return nil
+            return .graphStep(switchLayerEval)
         default:
             return nil
         }

--- a/Stitch/Graph/Node/Patch/Type/Data/NetworkRequestNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Data/NetworkRequestNode.swift
@@ -224,9 +224,10 @@ func networkRequestEval(node: PatchNode,
         newErrorOutputs,
         newHeaderOutputs
     ]
+    
+    newEffects.processEffects()
 
-    return ImpureEvalResult(outputsValues: allNewOutputs,
-                            effects: newEffects)
+    return ImpureEvalResult(outputsValues: allNewOutputs)
 }
 
 func getNetworkRequestOpSideEffect(nodeId: NodeId,

--- a/Stitch/Graph/Node/Patch/Type/Interaction/DragInteractionPatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/DragInteractionPatchNode.swift
@@ -104,8 +104,7 @@ extension DragInteractionNodeState {
  */
 @MainActor
 func dragInteractionEval(node: PatchNode,
-                         graphState: GraphDelegate,
-                         graphStepState: GraphStepState) -> ImpureEvalResult {
+                         graphState: GraphDelegate) -> ImpureEvalResult {
 
     return node.loopedEval(DragInteractionNodeState.self,
                            graphState: graphState) { values, dragState, interactiveLayer, loopIndex in
@@ -114,8 +113,8 @@ func dragInteractionEval(node: PatchNode,
             loopIndex: loopIndex,
             interactiveLayer: interactiveLayer,
             state: dragState,
-            graphTime: graphStepState.graphTime,
-            fps: graphStepState.estimatedFPS)
+            graphTime: graphState.graphStepState.graphTime,
+            fps: graphState.graphStepState.estimatedFPS)
     }
                            .toImpureEvalResult()
 }

--- a/Stitch/Graph/Node/Patch/Type/Interaction/PressInteractionPatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/PressInteractionPatchNode.swift
@@ -101,8 +101,7 @@ actor PressInteractionActor {
 // Need to update to be more like scroll animation eval
 @MainActor
 func pressInteractionEval(node: NodeViewModel,
-                          graph: GraphDelegate,
-                          graphStep: GraphStepState) -> ImpureEvalResult {
+                          graph: GraphDelegate) -> ImpureEvalResult {
     node.loopedEval(PressInteractionNodeObserver.self,
                     graphState: graph) { values, evalObserver, interactiveLayer, loopIndex in
         pressInteractionOp(

--- a/Stitch/Graph/Node/Patch/Type/Interaction/Scroll/ScrollInteractionNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/Scroll/ScrollInteractionNode.swift
@@ -141,8 +141,7 @@ struct ScrollInteractionNode: PatchNodeDefinition {
 
 @MainActor
 func scrollInteractionEval(node: NodeViewModel,
-                           graphState: GraphDelegate,
-                           graphStepState: GraphStepState) -> ImpureEvalResult {
+                           graphState: GraphDelegate) -> ImpureEvalResult {
     
     node.loopedEval(ScrollInteractionState.self,
                     graphState: graphState) { values, scrollState, interactiveLayer, _ in
@@ -160,7 +159,7 @@ func scrollInteractionEval(node: NodeViewModel,
             return totalScrollInteractionEvalOp(values: values,
                                                 scrollState: scrollState,
                                                 interactiveLayer: interactiveLayer,
-                                                graphTime: graphStepState.graphTime)
+                                                graphTime: graphState.graphStepState.graphTime)
         }
         // Normal drag--no rubberbanding yet
         else {

--- a/Stitch/Graph/Node/Patch/Type/Media/SampleRangeNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Media/SampleRangeNode.swift
@@ -44,8 +44,7 @@ struct SampleRangeNode: PatchNodeDefinition {
 
 @MainActor
 func sampleRangeEval(node: PatchNode,
-                     graphState: GraphDelegate,
-                     graphStepState: GraphStepState) -> ImpureEvalResult {
+                     graphState: GraphDelegate) -> ImpureEvalResult {
     // MARK: Currently disabled
     return .init(outputsValues: node.defaultOutputsList)
     

--- a/Stitch/Graph/Node/Patch/Type/Pulse/RestartPrototypeNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Pulse/RestartPrototypeNode.swift
@@ -55,15 +55,10 @@ func restartPrototypeEval(node: PatchNode,
     }
 
     log("restartPrototypeEval: had pulse")
-    let effect: Effect = { PrototypeRestartEffect() }
-    return ImpureEvalResult(
-        outputsValues: [],
-        effects: [effect])
-}
-
-// Hack for effect above
-struct PrototypeRestartEffect: GraphEvent {
-    func handle(state: GraphState) {
+    Task { @MainActor in
         dispatch(PrototypeRestartedAction())
     }
+    
+    return ImpureEvalResult(
+        outputsValues: [])
 }

--- a/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
+++ b/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
@@ -263,6 +263,7 @@ extension PatchNodeViewModel {
                                                  unpackedPortIndex: nil)
     }
     
+    // TODO: can we remove
     @MainActor
     func portCountShortened(to length: Int, nodeIO: NodeIO) {
         switch nodeIO {

--- a/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
+++ b/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
@@ -262,17 +262,6 @@ extension PatchNodeViewModel {
                                                  unpackedPortParentFieldGroupType: nil,
                                                  unpackedPortIndex: nil)
     }
-    
-    // TODO: can we remove
-    @MainActor
-    func portCountShortened(to length: Int, nodeIO: NodeIO) {
-        switch nodeIO {
-        case .input:
-            self.inputsObservers = Array(self.inputsObservers[0..<length])
-        case .output:
-            self.outputsObservers = Array(self.outputsObservers[0..<length])
-        }
-    }
 }
 
 extension NodeViewModel {

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
@@ -334,8 +334,9 @@ extension GraphState {
             node.outputs.enumerated().forEach { index, values in
                 changedDownstreamNodes = changedDownstreamNodes.union(
                     graph.updateDownstreamInputs(
-                    flowValues: values,
-                    outputCoordinate: .init(portId: index, nodeId: node.id))
+                        sourceNode: node,
+                        flowValues: values,
+                        outputCoordinate: .init(portId: index, nodeId: node.id))
                 )
             }
             

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
@@ -314,8 +314,7 @@ extension GraphState {
             
             // portValuesList is the full outputs etc.;
             // set new outputs in node
-            node.updateOutputsObservers(newValuesList: portValuesList,
-                                        activeIndex: graph.activeIndex)
+            node.updateOutputsObservers(newValuesList: portValuesList)
             
             effects += portValuesList
                 .getPulseReversionEffects(nodeId: nodeId,

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/NetworkRequest/NetworkRequestHandleResponse.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/NetworkRequest/NetworkRequestHandleResponse.swift
@@ -283,8 +283,7 @@ func handleSuccessfulNetworkRequest(index: Int,
         headersLoop
     ]
 
-    node.updateOutputsObservers(newValuesList: newValues,
-                                activeIndex: state.activeIndex)
+    node.updateOutputsObservers(newValuesList: newValues)
 }
 
 @MainActor
@@ -347,8 +346,7 @@ extension GraphState {
         ]
 
         // SEE NOTE IN `handleSuccessfulNetworkRequest` about `node.outputsObservers.updateAllValues` vs `node.outputs`
-        node.updateOutputsObservers(newOutputsValues: newValues,
-                                    activeIndex: self.activeIndex)
+        node.updateOutputsObservers(newValuesList: newValues)
 
         //        node.outputs = [
         //            loadingLoop,

--- a/Stitch/Graph/Node/Port/Util/PulseActions.swift
+++ b/Stitch/Graph/Node/Port/Util/PulseActions.swift
@@ -105,7 +105,8 @@ struct ReversePulseCoercion: GraphEvent {
         
         // Reverse the values in the downstream inputs
         let changedDownstreamNodeIds = state
-            .updateDownstreamInputs(flowValues: currentOutputs,
+            .updateDownstreamInputs(sourceNode: node,
+                                    flowValues: currentOutputs,
                                     outputCoordinate: pulsedOutput)
         
         // Run the downstream inputs' node evals

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -33,7 +33,7 @@ protocol NodeRowObserver: AnyObject, Observable, Identifiable, Sendable, NodeRow
     
     var hasEdge: Bool { get }
     
-    @MainActor var containsUpstreamConnection: Bool { get }
+//    @MainActor var containsUpstreamConnection: Bool { get }
     
     init(values: PortValues,
          nodeKind: NodeKind,
@@ -183,9 +183,9 @@ extension InputNodeRowObserver {
         self.upstreamOutputObserver?.containsDownstreamConnection = true
     }
     
-    @MainActor var containsUpstreamConnection: Bool {
-        self.upstreamOutputObserver.isDefined
-    }
+//    @MainActor var containsUpstreamConnection: Bool {
+//        self.upstreamOutputObserver.isDefined
+//    }
     
     /// Values for import dropdowns don't hold media directly, so we need to find it.
     @MainActor var importedMediaObject: StitchMediaObject? {
@@ -528,4 +528,4 @@ extension NodeRowObserver {
     }
 }
 
-extension InputNodeRowObserver: NodeRowCalculatable { }
+//extension InputNodeRowObserver: InputNodeRowCalculatable { }

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -33,8 +33,6 @@ protocol NodeRowObserver: AnyObject, Observable, Identifiable, Sendable, NodeRow
     
     var hasEdge: Bool { get }
     
-//    @MainActor var containsUpstreamConnection: Bool { get }
-    
     init(values: PortValues,
          nodeKind: NodeKind,
          userVisibleType: UserVisibleType?,
@@ -182,11 +180,7 @@ extension InputNodeRowObserver {
         // Update that upstream observer of new edge
         self.upstreamOutputObserver?.containsDownstreamConnection = true
     }
-    
-//    @MainActor var containsUpstreamConnection: Bool {
-//        self.upstreamOutputObserver.isDefined
-//    }
-    
+
     /// Values for import dropdowns don't hold media directly, so we need to find it.
     @MainActor var importedMediaObject: StitchMediaObject? {
         guard self.id.portId == 0,
@@ -527,5 +521,3 @@ extension NodeRowObserver {
         }
     }
 }
-
-//extension InputNodeRowObserver: InputNodeRowCalculatable { }

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
@@ -228,12 +228,15 @@ extension Array where Element: NodeRowObserver {
     }
     
     @MainActor
-    func updateAllValues(_ newValuesList: PortValuesList,
-                         nodeId: NodeId,
-                         nodeKind: NodeKind,
-                         userVisibleType: UserVisibleType?,
-                         nodeDelegate: NodeDelegate,
-                         activeIndex: ActiveIndex) {
+    func updateAllValues(_ newValuesList: PortValuesList) {
+        guard let nodeDelegate = self.first?.nodeDelegate else {
+            fatalErrorIfDebug()
+            return
+        }
+        
+        let nodeKind = nodeDelegate.kind
+        let userVisibleType = nodeDelegate.userVisibleType
+        let nodeId = nodeDelegate.id
         
         let oldValues = self.values
         let oldLongestPortLength = oldValues.count

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
@@ -221,50 +221,46 @@ extension NodeRowObserver {
 }
 
 extension Array where Element: NodeRowObserver {
-    var values: PortValuesList {
-        self.map {
-            $0.allLoopedValues
-        }
-    }
+//    var values: PortValuesList {
+//        self.map {
+//            $0.allLoopedValues
+//        }
+//    }
     
-    @MainActor
-    func updateAllValues(_ newValuesList: PortValuesList) {
-        guard let nodeDelegate = self.first?.nodeDelegate else {
-            fatalErrorIfDebug()
-            return
-        }
-        
-        let nodeKind = nodeDelegate.kind
-        let userVisibleType = nodeDelegate.userVisibleType
-        let nodeId = nodeDelegate.id
-        
-        let oldValues = self.values
-        let oldLongestPortLength = oldValues.count
-        let newLongestPortLength = newValuesList.count
-        let currentObserverCount = self.count
-
-        // Remove view models if loop count decreased
-        if newLongestPortLength < oldLongestPortLength {
-            // Sub-array can't exceed its current bounds or we get index-out-of-bounds
-            // Helpers below will create any missing observers
-            let arrayBoundary = Swift.min(newLongestPortLength, currentObserverCount)
-
-            nodeDelegate.patchNodeViewModel?.portCountShortened(to: arrayBoundary,
-                                                                nodeIO: .input)
-        }
-
-        newValuesList.enumerated().forEach { portId, values in
-            guard let observer = self[safe: portId] else {
-                fatalErrorIfDebug()
-                return
-            }
-
-            // Only update values if there's no upstream connection
-            if !observer.containsUpstreamConnection {
-                observer.updateValues(values)
-            }
-        }
-    }
+//    @MainActor
+//    func updateAllValues(_ newValuesList: PortValuesList) {
+//        guard let nodeDelegate = self.first?.nodeDelegate else {
+//            fatalErrorIfDebug()
+//            return
+//        }
+//        
+//        let oldValues = self.values
+//        let oldLongestPortLength = oldValues.count
+//        let newLongestPortLength = newValuesList.count
+//        let currentObserverCount = self.count
+//
+//        // Remove view models if loop count decreased
+//        if newLongestPortLength < oldLongestPortLength {
+//            // Sub-array can't exceed its current bounds or we get index-out-of-bounds
+//            // Helpers below will create any missing observers
+//            let arrayBoundary = Swift.min(newLongestPortLength, currentObserverCount)
+//
+//            nodeDelegate.patchNodeViewModel?.portCountShortened(to: arrayBoundary,
+//                                                                nodeIO: .input)
+//        }
+//
+//        newValuesList.enumerated().forEach { portId, values in
+//            guard let observer = self[safe: portId] else {
+//                fatalErrorIfDebug()
+//                return
+//            }
+//
+//            // Only update values if there's no upstream connection
+//            if !observer.containsUpstreamConnection {
+//                observer.updateValues(values)
+//            }
+//        }
+//    }
 }
 
 extension [InputNodeRowObserver] {

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
@@ -220,49 +220,6 @@ extension NodeRowObserver {
     }
 }
 
-extension Array where Element: NodeRowObserver {
-//    var values: PortValuesList {
-//        self.map {
-//            $0.allLoopedValues
-//        }
-//    }
-    
-//    @MainActor
-//    func updateAllValues(_ newValuesList: PortValuesList) {
-//        guard let nodeDelegate = self.first?.nodeDelegate else {
-//            fatalErrorIfDebug()
-//            return
-//        }
-//        
-//        let oldValues = self.values
-//        let oldLongestPortLength = oldValues.count
-//        let newLongestPortLength = newValuesList.count
-//        let currentObserverCount = self.count
-//
-//        // Remove view models if loop count decreased
-//        if newLongestPortLength < oldLongestPortLength {
-//            // Sub-array can't exceed its current bounds or we get index-out-of-bounds
-//            // Helpers below will create any missing observers
-//            let arrayBoundary = Swift.min(newLongestPortLength, currentObserverCount)
-//
-//            nodeDelegate.patchNodeViewModel?.portCountShortened(to: arrayBoundary,
-//                                                                nodeIO: .input)
-//        }
-//
-//        newValuesList.enumerated().forEach { portId, values in
-//            guard let observer = self[safe: portId] else {
-//                fatalErrorIfDebug()
-//                return
-//            }
-//
-//            // Only update values if there's no upstream connection
-//            if !observer.containsUpstreamConnection {
-//                observer.updateValues(values)
-//            }
-//        }
-//    }
-}
-
 extension [InputNodeRowObserver] {
     @MainActor
     init(values: PortValuesList,

--- a/Stitch/Graph/Node/Title/View/MathExpressionSubmenuButtonView.swift
+++ b/Stitch/Graph/Node/Title/View/MathExpressionSubmenuButtonView.swift
@@ -19,7 +19,7 @@ struct FatalErrorIfDebugView: View {
 }
 
 func fatalErrorIfDebug(_ message: String = "") {
-#if DEBUG || DEV_DEBUG
+#if DEBUG || DEV_DEBUG || STITCH_AI
     fatalError(message)
 #else
     log(message)
@@ -27,7 +27,7 @@ func fatalErrorIfDebug(_ message: String = "") {
 }
 
 func assertInDebug(_ conditional: Bool) {
-#if DEBUG || DEV_DEBUG
+#if DEBUG || DEV_DEBUG || STITCH_AI
     assert(conditional)
 #endif
 }

--- a/Stitch/Graph/Node/View/NodeTag/NodeTagMenuButtonsView.swift
+++ b/Stitch/Graph/Node/View/NodeTag/NodeTagMenuButtonsView.swift
@@ -20,7 +20,7 @@ struct NodeTagMenuButtonsView: View {
 
     let canvasItemId: CanvasItemId // id for Node or LayerInputOnGraph
     
-    var activeGroupId: NodeId?
+    var activeGroupId: GroupNodeType?
     var nodeTypeChoices: [UserVisibleType] = []
     
     // Always false for Layer Nodes;

--- a/Stitch/Graph/Node/View/NodeView.swift
+++ b/Stitch/Graph/Node/View/NodeView.swift
@@ -16,7 +16,7 @@ struct NodeView<InputsViews: View, OutputsViews: View>: View {
     @Bindable var graph: GraphState
     let isSelected: Bool
     let atleastOneCommentBoxSelected: Bool
-    let activeGroupId: NodeId?
+    let activeGroupId: GroupNodeType?
     let canAddInput: Bool
     let canRemoveInput: Bool
 

--- a/Stitch/Graph/Node/View/NodeViewType.swift
+++ b/Stitch/Graph/Node/View/NodeViewType.swift
@@ -19,7 +19,7 @@ struct NodeTypeView: View {
     @Bindable var canvasNode: CanvasItemViewModel
     let atleastOneCommentBoxSelected: Bool
     let activeIndex: ActiveIndex
-    let groupNodeFocused: NodeId?
+    let groupNodeFocused: GroupNodeType?
     let adjustmentBarSessionId: AdjustmentBarSessionId
 
     var boundsReaderDisabled: Bool = false

--- a/Stitch/Graph/Node/View/NodeViewType.swift
+++ b/Stitch/Graph/Node/View/NodeViewType.swift
@@ -76,7 +76,6 @@ struct NodeTypeView: View {
     
     @ViewBuilder @MainActor
     func inputsViews() -> some View {
-        
         VStack(alignment: .leading,
                spacing: SPACING_BETWEEN_NODE_ROWS) {
             if self.node.patch == .wirelessReceiver {

--- a/Stitch/Graph/Node/View/NodesOnlyView.swift
+++ b/Stitch/Graph/Node/View/NodesOnlyView.swift
@@ -47,7 +47,7 @@ struct NodesOnlyView: View {
                     canvasNode: canvasNode,
                     atleastOneCommentBoxSelected: selection.selectedCommentBoxes.count >= 1,
                     activeIndex: activeIndex,
-                    groupNodeFocused: graphUI.groupNodeFocused?.groupNodeId,
+                    groupNodeFocused: graphUI.groupNodeFocused,
                     adjustmentBarSessionId: adjustmentBarSessionId,
                     isHiddenDuringAnimation: insertNodeMenuHiddenNode
                         .map { $0 == node.id } ?? false

--- a/Stitch/Graph/Node/ViewModel/NodeDelegate.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeDelegate.swift
@@ -71,8 +71,7 @@ protocol NodeDelegate: AnyObject {
     
     @MainActor func updateOutputPortViewModels(activeIndex: ActiveIndex)
     
-    @MainActor func updateOutputsObservers(newOutputsValues: PortValuesList,
-                                           activeIndex: ActiveIndex)
+//    @MainActor func updateOutputsObservers(newOutputsValues: PortValuesList)
         
     @MainActor func calculate()
 }

--- a/Stitch/Graph/Node/ViewModel/NodeDelegate.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeDelegate.swift
@@ -48,8 +48,6 @@ protocol NodeDelegate: AnyObject {
     
     var ephemeralObservers: [any NodeEphemeralObservable]? { get }
     
-    @MainActor func portCountShortened(to length: Int, nodeIO: NodeIO)
-    
     // TODO: why is this a function? is it the id of the node represented by the `NodeObserverDelegate`, or is it actually an accessor on GraphState?
     @MainActor func getNode(_ id: NodeId) -> NodeViewModel?
         
@@ -70,8 +68,6 @@ protocol NodeDelegate: AnyObject {
     @MainActor func updateInputPortViewModels(activeIndex: ActiveIndex)
     
     @MainActor func updateOutputPortViewModels(activeIndex: ActiveIndex)
-    
-//    @MainActor func updateOutputsObservers(newOutputsValues: PortValuesList)
         
     @MainActor func calculate()
 }

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
@@ -110,6 +110,11 @@ extension NodeViewModel: NodeCalculatable {
         }
     }
     
+    var isComponentOutputSplitter: Bool {
+        let isNodeInComponent = self.graphDelegate?.saveLocation.isEmpty ?? false
+        return self.splitterType == .output && isNodeInComponent
+    }
+    
     var requiresOutputValuesChange: Bool {
         self.kind.getPatch == .pressInteraction
     }

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
@@ -373,8 +373,9 @@ extension NodeViewModel {
     func getInputRowObserver(for portType: NodeIOPortType) -> InputNodeRowObserver? {
         switch portType {
         case .portIndex(let portId):
-            // Assumes patch node for port ID
-            return self.patchNode?.inputsObservers[safe: portId]
+            // Assumes patch node or component for port ID
+            return self.patchNode?.inputsObservers[safe: portId] ??
+            self.nodeType.componentNode?.inputsObservers[safe: portId]
 
         case .keyPath(let keyPath):
             guard let layerNode = self.layerNode else {

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
@@ -179,21 +179,22 @@ extension NodeViewModel: NodeCalculatable {
                                         id: self.id)
     }
     
-    @MainActor func outputsUpdated(evalResult: EvalResult) {
-        self.updateOutputsObservers(newOutputsValues: evalResult.outputsValues,
-                                    activeIndex: graphDelegate?.activeIndex ?? .init(.zero))
-        
-        // `state.flashes` is for pulses' UI-effects
-        var effects = evalResult.effects
-        
-        // Reverse any fired output pulses
-        effects += evalResult
-            .outputsValues
-            .getPulseReversionEffects(nodeId: self.id,
-                                      graphTime: graphDelegate?.graphStepState.graphTime ?? .zero)
-
-        effects.processEffects()
-    }
+//    // TODO: remove
+//    @MainActor func outputsUpdated(evalResult: EvalResult) {
+//        self.updateOutputsObservers(newOutputsValues: evalResult.outputsValues,
+//                                    activeIndex: graphDelegate?.activeIndex ?? .init(.zero))
+//        
+//        // `state.flashes` is for pulses' UI-effects
+//        var effects = evalResult.effects
+//        
+//        // Reverse any fired output pulses
+//        effects += evalResult
+//            .outputsValues
+//            .getPulseReversionEffects(nodeId: self.id,
+//                                      graphTime: graphDelegate?.graphStepState.graphTime ?? .zero)
+//
+//        effects.processEffects()
+//    }
     
     var isGroupNode: Bool {
         self.kind == .group
@@ -731,17 +732,16 @@ extension NodeViewModel {
         self.getAllOutputsObservers()[safe: portId]?.updateValues(values)
     }
 
-    @MainActor
-    func updateOutputsObservers(newOutputsValues: PortValuesList,
-                                activeIndex: ActiveIndex) {
-        self.getAllOutputsObservers()
-            .updateAllValues(newOutputsValues,
-                             nodeId: self.id,
-                             nodeKind: self.kind,
-                             userVisibleType: self.userVisibleType,
-                             nodeDelegate: self,
-                             activeIndex: activeIndex)
-    }
+//    // TODO: remove
+//    @MainActor
+//    func updateOutputsObservers(newOutputsValues: PortValuesList) {
+//        self.getAllOutputsObservers()
+//            .updateAllValues(newOutputsValues,
+//                             nodeId: self.id,
+//                             nodeKind: self.kind,
+//                             userVisibleType: self.userVisibleType,
+//                             nodeDelegate: self)
+//    }
     
     // don't worry about making the input a loop or not --
     // the extension will happen at eval-time

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
@@ -198,23 +198,6 @@ extension NodeViewModel: NodeCalculatable {
                                         id: self.id)
     }
     
-//    // TODO: remove
-//    @MainActor func outputsUpdated(evalResult: EvalResult) {
-//        self.updateOutputsObservers(newOutputsValues: evalResult.outputsValues,
-//                                    activeIndex: graphDelegate?.activeIndex ?? .init(.zero))
-//        
-//        // `state.flashes` is for pulses' UI-effects
-//        var effects = evalResult.effects
-//        
-//        // Reverse any fired output pulses
-//        effects += evalResult
-//            .outputsValues
-//            .getPulseReversionEffects(nodeId: self.id,
-//                                      graphTime: graphDelegate?.graphStepState.graphTime ?? .zero)
-//
-//        effects.processEffects()
-//    }
-    
     var isGroupNode: Bool {
         self.kind == .group
     }
@@ -563,12 +546,7 @@ extension NodeViewModel {
     }
 }
 
-extension NodeViewModel: NodeDelegate {    
-    func portCountShortened(to length: Int, nodeIO: NodeIO) {
-        self.patchNodeViewModel?.portCountShortened(to: length,
-                                                    nodeIO: nodeIO)
-    }
-    
+extension NodeViewModel: NodeDelegate {
     var inputsRowCount: Int {
         self.getAllParentInputsObservers().count
     }
@@ -749,17 +727,6 @@ extension NodeViewModel {
 
         self.getAllOutputsObservers()[safe: portId]?.updateValues(values)
     }
-
-//    // TODO: remove
-//    @MainActor
-//    func updateOutputsObservers(newOutputsValues: PortValuesList) {
-//        self.getAllOutputsObservers()
-//            .updateAllValues(newOutputsValues,
-//                             nodeId: self.id,
-//                             nodeKind: self.kind,
-//                             userVisibleType: self.userVisibleType,
-//                             nodeDelegate: self)
-//    }
     
     // don't worry about making the input a loop or not --
     // the extension will happen at eval-time

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
@@ -791,20 +791,22 @@ extension NodeViewModel {
                                                     userVisibleType: self.userVisibleType,
                                                     id: newInputCoordinate,
                                                     upstreamOutputCoordinate: nil)
-        newInputObserver.initializeDelegate(self)
         
         let newInputViewModel = InputNodeRowViewModel(id: .init(graphItemType: .node(patchNode.canvasObserver.id),
                                                                 nodeId: newInputCoordinate.nodeId,
                                                                 portId: allInputsObservers.count),
                                                       rowDelegate: newInputObserver,
                                                       canvasItemDelegate: patchNode.canvasObserver)
+        
+        patchNode.inputsObservers.append(newInputObserver)
+        patchNode.canvasObserver.inputViewModels.append(newInputViewModel)
+        
+        // Assign delegates once view models are assigned to node
+        newInputObserver.initializeDelegate(self)
         newInputViewModel.initializeDelegate(self,
                                              // Only relevant for layer nodes, which cannot have an input added or removed
                                              unpackedPortParentFieldGroupType: nil,
                                              unpackedPortIndex: nil)
-        
-        patchNode.inputsObservers.append(newInputObserver)
-        patchNode.canvasObserver.inputViewModels.append(newInputViewModel)
     }
 
     @MainActor

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
@@ -91,7 +91,25 @@ final class NodeViewModel: Sendable {
     }
 }
 
-extension NodeViewModel: NodeCalculatable {    
+extension NodeViewModel: NodeCalculatable {
+    var inputsObservers: [InputNodeRowObserver] {
+        get {
+            self.getAllInputsObservers()
+        }
+        set(newValue) {
+            self.patchNode?.inputsObservers = newValue
+        }
+    }
+    
+    var outputsObservers: [OutputNodeRowObserver] {
+        get {
+            self.getAllOutputsObservers()
+        }
+        set(newValue) {
+            self.patchNode?.outputsObservers = newValue
+        }
+    }
+    
     var requiresOutputValuesChange: Bool {
         self.kind.getPatch == .pressInteraction
     }
@@ -100,6 +118,7 @@ extension NodeViewModel: NodeCalculatable {
         self.getAllInputsObservers()
     }
     
+    @MainActor
     var inputsValuesList: PortValuesList {
         switch self.nodeType {
         case .patch(let patch):

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
@@ -373,8 +373,7 @@ extension NodeViewModel {
     }
     
     @MainActor
-    func updateOutputsObservers(newValuesList: PortValuesList? = nil,
-                                activeIndex: ActiveIndex) {
+    func updateOutputsObservers(newValuesList: PortValuesList? = nil) {
         let outputsObservers = self.getAllOutputsObservers()
         
         if let newValuesList = newValuesList {

--- a/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
@@ -37,16 +37,8 @@ extension NodeViewModelType {
                                 unpackedPortParentFieldGroupType: nil,
                                 unpackedPortIndex: nil))
         case .component(let component):
-            let componentCanvas = CanvasItemViewModel(from: component.canvasEntity,
-                                                      id: .node(nodeId),
-                                                      // Initialize as empty since splitter row observers might not have yet been created
-                                                      inputRowObservers: [],
-                                                      outputRowObservers: [],
-                                                      unpackedPortParentFieldGroupType: nil,
-                                                      unpackedPortIndex: nil)
-            
-            self = .component(.init(componentId: component.componentId,
-                                    canvas: componentCanvas,
+            self = .component(.init(nodeId: nodeId,
+                                    componentEntity: component,
                                     
                                     // TODO: thie gets a new reference later
                                     graph: .createEmpty()))
@@ -69,14 +61,6 @@ extension NodeViewModelType {
                 fatalError()
             }
             
-            let componentCanvas = CanvasItemViewModel(from: componentEntity.canvasEntity,
-                                                      id: .node(nodeId),
-                                                      // Initialize as empty since splitter row observers might not have yet been created
-                                                      inputRowObservers: [],
-                                                      outputRowObservers: [],
-                                                      unpackedPortParentFieldGroupType: nil,
-                                                      unpackedPortIndex: nil)
-            
             guard let masterComponent = components.get(componentEntity.componentId) else {
                 fatalErrorIfDebug()
                 self = .component(.createEmpty())
@@ -84,9 +68,9 @@ extension NodeViewModelType {
             }
             
             let component = await StitchComponentViewModel(
-                componentId: componentEntity.componentId,
-                componentEntity: masterComponent.lastEncodedDocument,
-                canvas: componentCanvas,
+                nodeId: nodeId,
+                componentEntity: componentEntity,
+                encodedComponent: masterComponent.lastEncodedDocument,
                 parentGraphPath: parentGraphPath,
                 componentEncoder: masterComponent.encoder)
             self = .component(component)

--- a/Stitch/Graph/Util/GraphEvaluationUtil.swift
+++ b/Stitch/Graph/Util/GraphEvaluationUtil.swift
@@ -43,13 +43,6 @@ extension NodeViewModel {
         self.graphDelegate?.calculate(self.id)
     }
 }
-//
-//extension EvaluationStyle {
-//    @MainActor
-//    func runEvaluation(node: NodeViewModel) -> EvalResult {
-//        return pureEval.runEvaluation(node: node)
-//    }
-//}
 
 // Recalculates graph from a specific node
 struct RecalculateGraphFromNode: GraphEvent {

--- a/Stitch/Graph/Util/GraphEvaluationUtil.swift
+++ b/Stitch/Graph/Util/GraphEvaluationUtil.swift
@@ -43,24 +43,13 @@ extension NodeViewModel {
         self.graphDelegate?.calculate(self.id)
     }
 }
-
-extension EvaluationStyle {
-    @MainActor
-    func runEvaluation(node: NodeViewModel) -> EvalResult {
-
-        switch self {
-
-        case .pure(let pureEval):
-            return pureEval
-                .runEvaluation(node: node)
-
-        case .impure(let impureEval):
-            return impureEval
-                .runEvaluation(node: node)
-                .toEvalResult()
-        }
-    }
-}
+//
+//extension EvaluationStyle {
+//    @MainActor
+//    func runEvaluation(node: NodeViewModel) -> EvalResult {
+//        return pureEval.runEvaluation(node: node)
+//    }
+//}
 
 // Recalculates graph from a specific node
 struct RecalculateGraphFromNode: GraphEvent {

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -239,7 +239,13 @@ extension GraphState: GraphDelegate {
     
     /// Syncs visible nodes and topological data when persistence actions take place.
     @MainActor
-    func updateGraphData() {        
+    func updateGraphData() {
+        // Update parent graphs first if this graph is a component
+        // Order here needed so parent components know if there are input/output changes
+        if let parentGraph = self.parentGraph {
+            parentGraph.updateGraphData()
+        }
+        
         if let document = self.documentDelegate,
            let encoderDelegate = self.documentEncoderDelegate {
             self.initializeDelegate(document: document,

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -717,8 +717,7 @@ extension GraphState {
             nodeIdsToRecalculate = nodeIdsToRecalculate.union(changedNodeIds)
         } // (portId, newOutputValue) in portValues.enumerated()
      
-        node.updateOutputsObservers(newOutputsValues: outputsToUpdate,
-                                    activeIndex: self.activeIndex)
+        node.updateOutputsObservers(newValuesList: outputsToUpdate)
         
         // Must also run pulse reversion effects
         node.outputs

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -654,17 +654,11 @@ extension GraphState {
     @MainActor
     func getInputCoordinate(from viewData: InputPortViewData) -> NodeIOCoordinate? {
         guard let node = self.getCanvasItem(viewData.canvasId),
-              let sourceInputRow = node.inputViewModels[safe: viewData.portId]?.rowDelegate else {
+              let inputRow = node.inputViewModels[safe: viewData.portId]?.rowDelegate else {
             return nil
         }
         
-//        guard node.nodeDelegate?.nodeType.componentNode == nil else {
-//            // Component case, keep original node ID as we don't want to use a different graph state's node ID
-//            return .init(portId: viewData.portId,
-//                         nodeId: node.id.nodeId)
-//        }
-        
-        return sourceInputRow.id
+        return inputRow.id
     }
     
     @MainActor

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -648,11 +648,17 @@ extension GraphState {
     @MainActor
     func getInputCoordinate(from viewData: InputPortViewData) -> NodeIOCoordinate? {
         guard let node = self.getCanvasItem(viewData.canvasId),
-              let inputRow = node.inputViewModels[safe: viewData.portId]?.rowDelegate else {
+              let sourceInputRow = node.inputViewModels[safe: viewData.portId]?.rowDelegate else {
             return nil
         }
         
-        return inputRow.id
+//        guard node.nodeDelegate?.nodeType.componentNode == nil else {
+//            // Component case, keep original node ID as we don't want to use a different graph state's node ID
+//            return .init(portId: viewData.portId,
+//                         nodeId: node.id.nodeId)
+//        }
+        
+        return sourceInputRow.id
     }
     
     @MainActor

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -717,6 +717,7 @@ extension GraphState {
             
             // Update downstream node's inputs
             let changedNodeIds = self.updateDownstreamInputs(
+                sourceNode: node,
                 flowValues: outputToUpdate,
                 outputCoordinate: outputCoordinate)
             

--- a/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
+++ b/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
@@ -122,27 +122,33 @@ extension VisibleNodesViewModel {
                                                unpackedPortIndex: nil)
                 
             case .component(let componentViewModel):
-                // Create port view models for group nodes once row observers have been established
-                // MARK: similar to group nodes but we use nil group ID given new top-level graph state
-                let inputRowObservers = componentViewModel.graph.visibleNodesViewModel
-                    .getSplitterInputRowObservers(for: nil)
-                let outputRowObservers = componentViewModel.graph.visibleNodesViewModel
-                    .getSplitterOutputRowObservers(for: nil)
-                componentViewModel.canvas.syncRowViewModels(inputRowObservers: inputRowObservers,
-                                                            outputRowObservers: outputRowObservers,
-                                                            // Not relevant
+                // TODO: abstract with patch node logic above
+                componentViewModel.canvas.syncRowViewModels(inputRowObservers: componentViewModel.inputsObservers,
+                                                            outputRowObservers: componentViewModel.outputsObservers,
                                                             unpackedPortParentFieldGroupType: nil,
                                                             unpackedPortIndex: nil)
                 
-                // Initializes view models for canvas
-                guard let node = componentViewModel.nodeDelegate else {
-                    fatalErrorIfDebug()
-                    return
-                }
-                
-                componentViewModel.canvas.initializeDelegate(node,
-                                                             unpackedPortParentFieldGroupType: nil,
-                                                             unpackedPortIndex: nil)
+//                // Create port view models for group nodes once row observers have been established
+//                // MARK: similar to group nodes but we use nil group ID given new top-level graph state
+//                let inputRowObservers = componentViewModel.graph.visibleNodesViewModel
+//                    .getSplitterInputRowObservers(for: nil)
+//                let outputRowObservers = componentViewModel.graph.visibleNodesViewModel
+//                    .getSplitterOutputRowObservers(for: nil)
+//                componentViewModel.canvas.syncRowViewModels(inputRowObservers: inputRowObservers,
+//                                                            outputRowObservers: outputRowObservers,
+//                                                            // Not relevant
+//                                                            unpackedPortParentFieldGroupType: nil,
+//                                                            unpackedPortIndex: nil)
+//                
+//                // Initializes view models for canvas
+//                guard let node = componentViewModel.nodeDelegate else {
+//                    fatalErrorIfDebug()
+//                    return
+//                }
+//                
+//                componentViewModel.canvas.initializeDelegate(node,
+//                                                             unpackedPortParentFieldGroupType: nil,
+//                                                             unpackedPortIndex: nil)
                 
             default:
                 return

--- a/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
+++ b/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
@@ -122,34 +122,12 @@ extension VisibleNodesViewModel {
                                                unpackedPortIndex: nil)
                 
             case .component(let componentViewModel):
-                // TODO: abstract with patch node logic above
+                // Similar logic to patch nodes, where we have inputs/outputs observers stored directly in component
                 componentViewModel.canvas.syncRowViewModels(inputRowObservers: componentViewModel.inputsObservers,
                                                             outputRowObservers: componentViewModel.outputsObservers,
                                                             unpackedPortParentFieldGroupType: nil,
                                                             unpackedPortIndex: nil)
-                
-//                // Create port view models for group nodes once row observers have been established
-//                // MARK: similar to group nodes but we use nil group ID given new top-level graph state
-//                let inputRowObservers = componentViewModel.graph.visibleNodesViewModel
-//                    .getSplitterInputRowObservers(for: nil)
-//                let outputRowObservers = componentViewModel.graph.visibleNodesViewModel
-//                    .getSplitterOutputRowObservers(for: nil)
-//                componentViewModel.canvas.syncRowViewModels(inputRowObservers: inputRowObservers,
-//                                                            outputRowObservers: outputRowObservers,
-//                                                            // Not relevant
-//                                                            unpackedPortParentFieldGroupType: nil,
-//                                                            unpackedPortIndex: nil)
-//                
-//                // Initializes view models for canvas
-//                guard let node = componentViewModel.nodeDelegate else {
-//                    fatalErrorIfDebug()
-//                    return
-//                }
-//                
-//                componentViewModel.canvas.initializeDelegate(node,
-//                                                             unpackedPortParentFieldGroupType: nil,
-//                                                             unpackedPortIndex: nil)
-                
+
             default:
                 return
             }

--- a/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
+++ b/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
@@ -120,6 +120,30 @@ extension VisibleNodesViewModel {
                 canvasGroup.initializeDelegate(node,
                                                unpackedPortParentFieldGroupType: nil,
                                                unpackedPortIndex: nil)
+                
+            case .component(let componentViewModel):
+                // Create port view models for group nodes once row observers have been established
+                // MARK: similar to group nodes but we use nil group ID given new top-level graph state
+                let inputRowObservers = componentViewModel.graph.visibleNodesViewModel
+                    .getSplitterInputRowObservers(for: nil)
+                let outputRowObservers = componentViewModel.graph.visibleNodesViewModel
+                    .getSplitterOutputRowObservers(for: nil)
+                componentViewModel.canvas.syncRowViewModels(inputRowObservers: inputRowObservers,
+                                                            outputRowObservers: outputRowObservers,
+                                                            // Not relevant
+                                                            unpackedPortParentFieldGroupType: nil,
+                                                            unpackedPortIndex: nil)
+                
+                // Initializes view models for canvas
+                guard let node = componentViewModel.nodeDelegate else {
+                    fatalErrorIfDebug()
+                    return
+                }
+                
+                componentViewModel.canvas.initializeDelegate(node,
+                                                             unpackedPortParentFieldGroupType: nil,
+                                                             unpackedPortIndex: nil)
+                
             default:
                 return
             }

--- a/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
+++ b/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
@@ -214,7 +214,7 @@ extension VisibleNodesViewModel {
 
     /// Obtains input row observers directly from splitter patch nodes given its parent group node.
     @MainActor
-    func getSplitterInputRowObservers(for groupNodeId: NodeId) -> [InputNodeRowObserver] {
+    func getSplitterInputRowObservers(for groupNodeId: NodeId?) -> [InputNodeRowObserver] {
         // find splitters inside this group node
         let allSplitterNodes: [PatchNodeViewModel] = self.nodes.values
             .compactMap { $0.patchNode }
@@ -253,7 +253,7 @@ extension VisibleNodesViewModel {
     
     /// Obtains output row observers directly from splitter patch nodes given its parent group node.
     @MainActor
-    func getSplitterOutputRowObservers(for groupNodeId: NodeId) -> [OutputNodeRowObserver] {
+    func getSplitterOutputRowObservers(for groupNodeId: NodeId?) -> [OutputNodeRowObserver] {
         // find splitters inside this group node
         let allSplitterNodes: [PatchNodeViewModel] = self.nodes.values
             .compactMap { $0.patchNode }


### PR DESCRIPTION
This PR makes components functionally complete for layer-less scenarios by supporting inputs and outputs ports. Changes were needed in StitchEngine to better support eval scenarios here.

Additionally we've simplified the graph eval process by removing the `ImpureEval` result type given that most node's effects were already processed in the eval directly.