### PR TITLE
Completely hide wireless edges

### DIFF
--- a/Stitch/Graph/Node/View/NodesView.swift
+++ b/Stitch/Graph/Node/View/NodesView.swift
@@ -56,8 +56,12 @@ struct NodesView: View {
                         canvasItem.inputViewModels
                     }
                 
-                let connectedInputs = allInputs
-                    .filter { $0.rowDelegate?.containsUpstreamConnection ?? false }
+                let connectedInputs = allInputs.filter { input in
+                    guard input.nodeDelegate?.patchNodeViewModel?.patch != .wirelessReceiver else {
+                        return false
+                    }
+                    return input.rowDelegate?.containsUpstreamConnection ?? false
+                }
                 
                 // Including "possible" inputs enables edge animation
                 let candidateInputs: [InputNodeRowViewModel] = graphUI.edgeEditingState?.possibleEdges.compactMap {


### PR DESCRIPTION
Filter out wireless receiver inputs from 'connected inputs for edges'

Hat tip Elliot for the debugging help here. 

Issue was us drawing an edge "from 0,0 to 0,0" for the wireless broadcaster -> wireless receiver. 

All wireless edges should instead be hidden.

![Screenshot 2024-10-30 at 12 11 00 PM](https://github.com/user-attachments/assets/9ae8105d-3404-47bc-a1c4-8b128ce682c6)
