### PR TITLE
Reality node support for Mac

### DIFF
--- a/Stitch/Graph/Node/Layer/Type/Media/RealityView/PreviewRealityLayer.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/RealityView/PreviewRealityLayer.swift
@@ -19,7 +19,6 @@ struct PreviewRealityLayer: View {
     let parentDisablesPosition: Bool
     
     var body: some View {
-//        let nodeId = self.viewModel.id.layerNodeId.id
         let position = viewModel.position.getPosition ?? .zero
         let rotationX = viewModel.rotationX.asCGFloat
         let rotationY = viewModel.rotationY.asCGFloat
@@ -29,64 +28,50 @@ struct PreviewRealityLayer: View {
         let anchoring = viewModel.anchoring.getAnchoring ?? .defaultAnchoring
         let scale = viewModel.scale.asCGFloat
         
-//        switch document.cameraFeedManager {
-//        case .loaded(let cameraFeedManager):
-            if let node = document.visibleGraph.getNodeViewModel(viewModel.id.layerNodeId.asNodeId) {
-                @Bindable var node = node
-                
-                RealityLayerView(document: document,
-                                 graph: graph,
-                                 node: node,
-                                 layerViewModel: viewModel,
-                                 cameraFeedManager: document.cameraFeedManager?.loadedInstance?.cameraFeedManager,
-                                 isPinnedViewRendering: isPinnedViewRendering,
-                                 interactiveLayer: self.viewModel.interactiveLayer,
-                                 allAnchors: viewModel.allAnchors.compactMap { $0.asyncMedia },
-                                 position: position,
-                                 rotationX: rotationX,
-                                 rotationY: rotationY,
-                                 rotationZ: rotationZ,
-                                 size: size,
-                                 layerSize: layerSize,
-                                 scale: scale,
-                                 opacity: viewModel.opacity.asCGFloat,
-                                 anchoring: anchoring,
-                                 isCameraFeedEnabled: viewModel.isCameraEnabled.getBool ?? false,
-                                 isShadowsEnabled: viewModel.isShadowsEnabled.getBool ?? false,
-                                 blurRadius: viewModel.blurRadius.getNumber ?? .zero,
-                                 blendMode: viewModel.blendMode.getBlendMode ?? .defaultBlendMode,
-                                 brightness: viewModel.brightness.getNumber ?? .defaultBrightnessForLayerEffect,
-                                 colorInvert: viewModel.colorInvert.getBool ?? .defaultColorInvertForLayerEffect,
-                                 contrast: viewModel.contrast.getNumber ?? .defaultContrastForLayerEffect,
-                                 hueRotation: viewModel.hueRotation.getNumber ?? .defaultHueRotationForLayerEffect,
-                                 saturation: viewModel.saturation.getNumber ?? .defaultSaturationForLayerEffect,
-                                 pivot: viewModel.pivot.getAnchoring ?? .defaultPivot,
-                                 shadowColor: viewModel.shadowColor.getColor ?? .defaultShadowColor,
-                                 shadowOpacity: viewModel.shadowOpacity.getNumber ?? .defaultShadowOpacity,
-                                 shadowRadius: viewModel.shadowRadius.getNumber ?? .defaultShadowOpacity,
-                                 shadowOffset: viewModel.shadowOffset.getPosition ?? .defaultShadowOffset,
-                                 parentSize: parentSize,
-                                 parentDisablesPosition: parentDisablesPosition)
-            } else {
-                EmptyView()
-                    .onAppear {
+        if let node = document.visibleGraph.getNodeViewModel(viewModel.id.layerNodeId.asNodeId) {
+            @Bindable var node = node
+            
+            RealityLayerView(document: document,
+                             graph: graph,
+                             node: node,
+                             layerViewModel: viewModel,
+                             cameraFeedManager: document.cameraFeedManager?.loadedInstance?.cameraFeedManager,
+                             isPinnedViewRendering: isPinnedViewRendering,
+                             interactiveLayer: self.viewModel.interactiveLayer,
+                             allAnchors: viewModel.allAnchors.compactMap { $0.asyncMedia },
+                             position: position,
+                             rotationX: rotationX,
+                             rotationY: rotationY,
+                             rotationZ: rotationZ,
+                             size: size,
+                             layerSize: layerSize,
+                             scale: scale,
+                             opacity: viewModel.opacity.asCGFloat,
+                             anchoring: anchoring,
+                             isCameraFeedEnabled: viewModel.isCameraEnabled.getBool ?? false,
+                             isShadowsEnabled: viewModel.isShadowsEnabled.getBool ?? false,
+                             blurRadius: viewModel.blurRadius.getNumber ?? .zero,
+                             blendMode: viewModel.blendMode.getBlendMode ?? .defaultBlendMode,
+                             brightness: viewModel.brightness.getNumber ?? .defaultBrightnessForLayerEffect,
+                             colorInvert: viewModel.colorInvert.getBool ?? .defaultColorInvertForLayerEffect,
+                             contrast: viewModel.contrast.getNumber ?? .defaultContrastForLayerEffect,
+                             hueRotation: viewModel.hueRotation.getNumber ?? .defaultHueRotationForLayerEffect,
+                             saturation: viewModel.saturation.getNumber ?? .defaultSaturationForLayerEffect,
+                             pivot: viewModel.pivot.getAnchoring ?? .defaultPivot,
+                             shadowColor: viewModel.shadowColor.getColor ?? .defaultShadowColor,
+                             shadowOpacity: viewModel.shadowOpacity.getNumber ?? .defaultShadowOpacity,
+                             shadowRadius: viewModel.shadowRadius.getNumber ?? .defaultShadowOpacity,
+                             shadowOffset: viewModel.shadowOffset.getPosition ?? .defaultShadowOffset,
+                             parentSize: parentSize,
+                             parentDisablesPosition: parentDisablesPosition)
+        } else {
+            EmptyView()
+                .onAppear {
 #if DEBUG
-                        fatalError()
+                    fatalError()
 #endif
-                    }
-            }
-//            
-//        case .loading, .failed:
-//            EmptyView()
-//            
-//        case .none:
-//            // Note that EmptyView won't trigger the onApppear closure
-//            Color.clear
-//                .onAppear {
-//                    document.realityViewCreatedWithoutCamera(graph: graph,
-//                                                             nodeId: nodeId)
-//                }
-//        }
+                }
+        }
     }
 }
 
@@ -158,7 +143,6 @@ struct RealityLayerView: View {
                             // Update list of node Ids using camera
                             graph.enabledCameraNodeIds.insert(node.id)
                         }
-                        //                                      anchors: allAnchors)
                         .onChange(of: allAnchors, initial: true) { _, newAnchors in
                             let mediaList = newAnchors.map { $0.mediaObject }
                             

--- a/Stitch/Graph/Node/Layer/Type/Media/RealityView/PreviewRealityLayer.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/RealityView/PreviewRealityLayer.swift
@@ -150,13 +150,16 @@ struct RealityLayerView: View {
     
     var body: some View {
         Group {
-            if _isCameraEnabled {
+            // Can't run multiple reality views
+            if !isPinnedViewRendering || document.isGeneratingProjectThumbnail {
+                Color.clear
+            }
+            
+            else if _isCameraEnabled {
                 switch document.cameraFeedManager {
                 case .loaded(let cameraFeedManager):
                     if let cameraFeedManager = cameraFeedManager.cameraFeedManager,
-                       let arView = cameraFeedManager.arView,
-                       isPinnedViewRendering, // Can't run multiple reality views
-                       !document.isGeneratingProjectThumbnail {
+                       let arView = cameraFeedManager.arView {
                         CameraRealityView(arView: arView,
                                           size: layerSize,
                                           scale: scale,
@@ -182,10 +185,6 @@ struct RealityLayerView: View {
                     Color.clear
 #if !targetEnvironment(macCatalyst)
                         .onAppear {
-                            guard document.cameraFeedManager == nil else {
-                                // This somehow happens despite the switch statement!
-                                return
-                            }
                             let nodeId = self.layerViewModel.id.layerNodeId.id
                             document.realityViewCreatedWithoutCamera(graph: graph,
                                                                      nodeId: nodeId)
@@ -193,12 +192,14 @@ struct RealityLayerView: View {
 #endif
                     
                 }
-            } else {
-                NonCameraRealityViewWrapper(size: layerSize,
-                                            scale: scale,
-                                            opacity: opacity,
-                                            isShadowsEnabled: isShadowsEnabled,
-                                            anchors: allAnchors)
+            }
+            
+            else {
+                NonCameraRealityView(size: layerSize,
+                                     scale: scale,
+                                     opacity: opacity,
+                                     isShadowsEnabled: isShadowsEnabled,
+                                     anchors: allAnchors)
             }
         }
         .modifier(PreviewCommonModifier(

--- a/Stitch/Graph/Node/Layer/Type/Media/RealityView/PreviewRealityLayer.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/RealityView/PreviewRealityLayer.swift
@@ -194,11 +194,11 @@ struct RealityLayerView: View {
                     
                 }
             } else {
-                NonCameraRealityView(size: layerSize,
-                                     scale: scale,
-                                     opacity: opacity,
-                                     isShadowsEnabled: isShadowsEnabled,
-                                     anchors: allAnchors)
+                NonCameraRealityViewWrapper(size: layerSize,
+                                            scale: scale,
+                                            opacity: opacity,
+                                            isShadowsEnabled: isShadowsEnabled,
+                                            anchors: allAnchors)
             }
         }
         .modifier(PreviewCommonModifier(

--- a/Stitch/Graph/Node/Layer/Type/Media/RealityView/PreviewRealityLayer.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/RealityView/PreviewRealityLayer.swift
@@ -67,17 +67,6 @@ struct PreviewRealityLayer: View {
                                  shadowOffset: viewModel.shadowOffset.getPosition ?? .defaultShadowOffset,
                                  parentSize: parentSize,
                                  parentDisablesPosition: parentDisablesPosition)
-//#if !targetEnvironment(macCatalyst)
-//                .onAppear {
-//                    if document.cameraFeedManager?.loadedInstance?.cameraFeedManager == nil {
-//                        document.realityViewCreatedWithoutCamera(graph: graph,
-//                                                                 nodeId: nodeId)
-//                    }
-//                    
-//                    // Update list of node Ids using camera
-//                    graph.enabledCameraNodeIds.insert(nodeId)
-//                }
-//#endif
             } else {
                 EmptyView()
                     .onAppear {

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/AR/RealityView.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/AR/RealityView.swift
@@ -10,29 +10,41 @@ import RealityKit
 import SwiftUI
 import StitchSchemaKit
 
-struct RealityView: UIViewRepresentable {
+struct CameraRealityView: UIViewRepresentable {
     // AR view must already be created in media manager
-//    let arView: StitchARView
+    let arView: StitchARView
     let size: LayerSize
     let scale: Double
     let opacity: Double
-    let isCameraEnabled: Bool
+    let isShadowsEnabled: Bool
+//    let anchors: [GraphMediaValue]
+    
+    func makeUIView(context: Context) -> StitchARView {
+        arView.environment.background = .cameraFeed()
+        arView.cameraMode = .ar
+        arView.renderOptions = isShadowsEnabled ? [] : [.disableGroundingShadows]
+        return arView
+    }
+
+    func updateUIView(_ uiView: StitchARView, context: Context) {
+        uiView.frame.size = size.asAlgebraicCGSize
+        uiView.alpha = opacity
+        uiView.transform = CGAffineTransform(scaleX: scale, y: scale)
+        uiView.renderOptions = isShadowsEnabled ? [] : [.disableGroundingShadows]
+    }
+}
+
+struct NonCameraRealityView: UIViewRepresentable {
+    let size: LayerSize
+    let scale: Double
+    let opacity: Double
     let isShadowsEnabled: Bool
     let anchors: [GraphMediaValue]
     
-    // Override camera setting on Mac
-    var _isCameraEnabled: Bool {
-#if targetEnvironment(macCatalyst)
-        return false
-#else
-        return isCameraEnabled
-#endif
-    }
-    
     func makeUIView(context: Context) -> StitchARView {
         let arView = StitchARView(cameraMode: .nonAR)
-        arView.environment.background = _isCameraEnabled ? .cameraFeed() : .color(.blue)
-        arView.cameraMode = _isCameraEnabled ? .ar : .nonAR
+        arView.environment.background = .color(.blue)
+        arView.cameraMode = .nonAR
         arView.renderOptions = isShadowsEnabled ? [] : [.disableGroundingShadows]
         return arView
     }
@@ -42,9 +54,6 @@ struct RealityView: UIViewRepresentable {
         
         // Update entities in ar view
         uiView.updateAnchors(mediaList: mediaList)
-        
-        uiView.cameraMode = _isCameraEnabled ? .ar : .nonAR
-        uiView.environment.background = _isCameraEnabled ? .cameraFeed() : .color(.blue)
         uiView.frame.size = size.asAlgebraicCGSize
         uiView.alpha = opacity
         uiView.transform = CGAffineTransform(scaleX: scale, y: scale)

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/AR/RealityView.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/AR/RealityView.swift
@@ -34,26 +34,45 @@ struct CameraRealityView: UIViewRepresentable {
     }
 }
 
-struct NonCameraRealityView: UIViewRepresentable {
+struct NonCameraRealityViewWrapper: View {
+    let arView = StitchARView(cameraMode: .nonAR)
     let size: LayerSize
     let scale: Double
     let opacity: Double
     let isShadowsEnabled: Bool
     let anchors: [GraphMediaValue]
+ 
+    var body: some View {
+        NonCameraRealityView(arView: arView,
+                             size: size,
+                             scale: scale,
+                             opacity: opacity,
+                             isShadowsEnabled: isShadowsEnabled)
+        .onChange(of: anchors, initial: true) {
+            let mediaList = anchors.map { $0.mediaObject }
+            
+            // Update entities in ar view
+            arView.updateAnchors(mediaList: mediaList)
+        }
+    }
+}
+
+struct NonCameraRealityView: UIViewRepresentable {
+    let arView: StitchARView
+    let size: LayerSize
+    let scale: Double
+    let opacity: Double
+    let isShadowsEnabled: Bool
     
     func makeUIView(context: Context) -> StitchARView {
-        let arView = StitchARView(cameraMode: .nonAR)
-        arView.environment.background = .color(.blue)
+//        let arView = StitchARView(cameraMode: .nonAR)
+        arView.environment.background = .color(.purple)
         arView.cameraMode = .nonAR
         arView.renderOptions = isShadowsEnabled ? [] : [.disableGroundingShadows]
         return arView
     }
 
     func updateUIView(_ uiView: StitchARView, context: Context) {
-        let mediaList = anchors.map { $0.mediaObject }
-        
-        // Update entities in ar view
-        uiView.updateAnchors(mediaList: mediaList)
         uiView.frame.size = size.asAlgebraicCGSize
         uiView.alpha = opacity
         uiView.transform = CGAffineTransform(scaleX: scale, y: scale)

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/AR/RealityView.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/AR/RealityView.swift
@@ -17,7 +17,6 @@ struct CameraRealityView: UIViewRepresentable {
     let scale: Double
     let opacity: Double
     let isShadowsEnabled: Bool
-//    let anchors: [GraphMediaValue]
     
     func makeUIView(context: Context) -> StitchARView {
         arView.environment.background = .cameraFeed()
@@ -34,45 +33,28 @@ struct CameraRealityView: UIViewRepresentable {
     }
 }
 
-struct NonCameraRealityViewWrapper: View {
-    let arView = StitchARView(cameraMode: .nonAR)
+struct NonCameraRealityView: UIViewRepresentable {
     let size: LayerSize
     let scale: Double
     let opacity: Double
     let isShadowsEnabled: Bool
     let anchors: [GraphMediaValue]
- 
-    var body: some View {
-        NonCameraRealityView(arView: arView,
-                             size: size,
-                             scale: scale,
-                             opacity: opacity,
-                             isShadowsEnabled: isShadowsEnabled)
-        .onChange(of: anchors, initial: true) {
-            let mediaList = anchors.map { $0.mediaObject }
-            
-            // Update entities in ar view
-            arView.updateAnchors(mediaList: mediaList)
-        }
-    }
-}
-
-struct NonCameraRealityView: UIViewRepresentable {
-    let arView: StitchARView
-    let size: LayerSize
-    let scale: Double
-    let opacity: Double
-    let isShadowsEnabled: Bool
     
     func makeUIView(context: Context) -> StitchARView {
-//        let arView = StitchARView(cameraMode: .nonAR)
-        arView.environment.background = .color(.purple)
+        let arView = StitchARView(cameraMode: .nonAR)
+        arView.environment.background = .color(.clear)
         arView.cameraMode = .nonAR
         arView.renderOptions = isShadowsEnabled ? [] : [.disableGroundingShadows]
         return arView
     }
 
     func updateUIView(_ uiView: StitchARView, context: Context) {
+        // MARK: must update anchors in update view
+        let mediaList = anchors.map { $0.mediaObject }
+        
+        // Update entities in ar view
+        uiView.updateAnchors(mediaList: mediaList)
+        
         uiView.frame.size = size.asAlgebraicCGSize
         uiView.alpha = opacity
         uiView.transform = CGAffineTransform(scaleX: scale, y: scale)

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/AR/RealityView.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/AR/RealityView.swift
@@ -12,26 +12,42 @@ import StitchSchemaKit
 
 struct RealityView: UIViewRepresentable {
     // AR view must already be created in media manager
-    let arView: StitchARView
+//    let arView: StitchARView
     let size: LayerSize
     let scale: Double
     let opacity: Double
     let isCameraEnabled: Bool
     let isShadowsEnabled: Bool
-
+    let anchors: [GraphMediaValue]
+    
+    // Override camera setting on Mac
+    var _isCameraEnabled: Bool {
+#if targetEnvironment(macCatalyst)
+        return false
+#else
+        return isCameraEnabled
+#endif
+    }
+    
     func makeUIView(context: Context) -> StitchARView {
-        let view = arView
-        arView.environment.background = .cameraFeed()
-        arView.cameraMode = isCameraEnabled ? .ar : .nonAR
+        let arView = StitchARView(cameraMode: .nonAR)
+        arView.environment.background = _isCameraEnabled ? .cameraFeed() : .color(.blue)
+        arView.cameraMode = _isCameraEnabled ? .ar : .nonAR
         arView.renderOptions = isShadowsEnabled ? [] : [.disableGroundingShadows]
-        return view
+        return arView
     }
 
     func updateUIView(_ uiView: StitchARView, context: Context) {
-        uiView.cameraMode = isCameraEnabled ? .ar : .nonAR
+        let mediaList = anchors.map { $0.mediaObject }
+        
+        // Update entities in ar view
+        uiView.updateAnchors(mediaList: mediaList)
+        
+        uiView.cameraMode = _isCameraEnabled ? .ar : .nonAR
+        uiView.environment.background = _isCameraEnabled ? .cameraFeed() : .color(.blue)
         uiView.frame.size = size.asAlgebraicCGSize
         uiView.alpha = opacity
         uiView.transform = CGAffineTransform(scaleX: scale, y: scale)
-        arView.renderOptions = isShadowsEnabled ? [] : [.disableGroundingShadows]
+        uiView.renderOptions = isShadowsEnabled ? [] : [.disableGroundingShadows]
     }
 }

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/CameraFeed/Util/CameraUtil.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/CameraFeed/Util/CameraUtil.swift
@@ -114,7 +114,9 @@ extension StitchDocumentViewModel {
         }
 
         // Reset camera
-        self.deactivateCamera()
+        if self.cameraFeedManager != nil {
+            self.deactivateCamera()
+        }
 
         let cameraFeed = CameraFeedManager(cameraSettings: self.cameraSettings,
                                            isEnabled: true,


### PR DESCRIPTION
This PR supports a camera-less version of the reality layer node, allowing users to add 3D objects to a blank background.