### PR TITLE
LayerInfo starts with proper outputs upon graph open

### DIFF
--- a/Stitch/Graph/Node/Patch/Type/Shape/LayerInfoNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Shape/LayerInfoNode.swift
@@ -154,20 +154,26 @@ func layerInfoEval(node: PatchNode,
                     state: GraphDelegate) -> EvalResult {
     
     guard let assignedLayerId: LayerNodeId = node.inputs.first?.first?.getInteractionId,
-          let assignedLayerNode: LayerNodeViewModel = state.getNodeViewModel(assignedLayerId.id)?.layerNode else {
+          let assignedLayerNode = state.getNodeViewModel(assignedLayerId.id),
+          let assignedLayerNodeViewModel: LayerNodeViewModel = assignedLayerNode.layerNode else {
+        log("layerInfoEval: no assignedLayerId, assignedLayerNode and/or assignedLayerNodeViewModel")
         return .init(outputsValues: LayerInfoNodeEvalHelpers.defaultOutputs)
     }
     
-    let layerEnabled = assignedLayerNode.hasSidebarVisibility
-    let layerGroupParent = assignedLayerNode.layerGroupId?.asLayerNodeId
-    let layerViewModels = assignedLayerNode.previewLayerViewModels
+    let layerEnabled = assignedLayerNodeViewModel.hasSidebarVisibility
+    let layerGroupParent = assignedLayerNodeViewModel.layerGroupId?.asLayerNodeId
+    let layerViewModels = assignedLayerNodeViewModel.previewLayerViewModels
         
     // you want to return mm
     let evalOp: Operation8 = { values, loopIndex -> PortValueTuple8 in
         
         guard let layerViewModel = layerViewModels[safeIndex: loopIndex] else {
+            log("layerInfoEval: no layerViewModel at loopIndex \(loopIndex)")
             return LayerInfoNodeEvalHelpers.defaultOutputsAtSingleIndex
         }
+        
+        log("layerInfoEval: layerViewModel.readSize: \(layerViewModel.readSize)")
+        log("layerInfoEval: layerViewModel.anchoring.getAnchoring: \(layerViewModel.anchoring.getAnchoring)")
                         
         return (
             // Enabled (visibility hidden via sidebar or not)

--- a/Stitch/Graph/Node/Patch/Type/Shape/LayerInfoNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Shape/LayerInfoNode.swift
@@ -22,6 +22,7 @@ import StitchSchemaKit
 struct AssignedLayerUpdated: GraphEvent {
     let changedLayerNode: LayerNodeId
     
+    @MainActor
     func handle(state: GraphState) {
         for id in state.layerListeningPatchNodes(assignedTo: changedLayerNode) {
             state.calculate(id) // TODO: batch calculate?

--- a/Stitch/Graph/Node/Port/Util/PortValue/Coercers.swift
+++ b/Stitch/Graph/Node/Port/Util/PortValue/Coercers.swift
@@ -40,9 +40,7 @@ import CoreML
 // ... since boolParser just says "true" if the display string is non-empty,
 // whereas really, "0" is non-empty but falsey
 func boolCoercer(_ values: PortValues) -> PortValues {
-    return values.map { (value: PortValue) -> PortValue in
-        return .bool(value.coerceToTruthyOrFalsey())
-    }
+    values.map { .bool($0.coerceToTruthyOrFalsey()) }
 }
 
 // ie port is expected to be of type String;

--- a/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
@@ -187,12 +187,7 @@ final class LayerViewModel {
     var pinTo: PortValue
     var pinAnchor: PortValue
     var pinOffset: PortValue
-    
-    // TODO: source these from LayerNodeViewModel after SSK update
-//    var layerPadding: StitchPadding = .zero // .demoPadding // PortValue
-//    var layerMargin: StitchPadding = .zero // .demoPadding // PortValue
-//    var offsetInGroup: CGSize = .zero // .init(width: 50, height: 100)
-    
+        
     var layerPadding: PortValue
     var layerMargin: PortValue
     var offsetInGroup: PortValue
@@ -213,6 +208,7 @@ final class LayerViewModel {
     // Switch Toggle property
     var isUIToggled: Bool = false
     
+    // TODO: Why not initalize with proper values? If we need a 'default false/empty' LayerViewModel, do that view a separate function; and then pass in
     init(id: PreviewCoordinate,
          layer: Layer,
          zIndex: PortValue = defaultNumber,

--- a/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
@@ -69,12 +69,19 @@ final class LayerViewModel {
     
     // Layer's frame as read by layer's background GeometryReader,
     // see `LayerSizeReader`.
-    var readFrame: CGRect = .zero
+    @MainActor
+    var readFrame: CGRect = .zero {
+        didSet {
+            dispatch(AssignedLayerUpdated(changedLayerNode: self.id.layerNodeId))
+        }
+    }
     
+    @MainActor
     var readSize: CGSize {
         self.readFrame.size
     }
     
+    @MainActor
     var readMidPosition: CGPoint {
         self.readFrame.mid
     }


### PR DESCRIPTION
Specifically: we now evaluate LayerInfo and ConvertPosition patch nodes when layer view model's `readFrame` updated


https://github.com/user-attachments/assets/5d7538dd-3707-44a6-922c-1ddd2f7b9f08

