### PR TITLE
Catalyst: Edit project title via modal

### DIFF
--- a/Stitch/App/View/StitchRootView.swift
+++ b/Stitch/App/View/StitchRootView.swift
@@ -62,11 +62,11 @@ struct StitchRootView: View {
                             ZStack {
                                 
                                 MODAL_BACKGROUND_COLOR
-                                //                                    .ignoresSafeArea()
                                     .ignoresSafeArea([.all, .keyboard])
                                     .onTapGesture {
                                         dispatch(CatalystProjectTitleModalClosed())
                                     }
+                                
                                 VStack(alignment: .leading) {
                                     StitchTextView(string: "Edit Project Title")
                                     CatalystProjectTitleModalView(graph: document.visibleGraph)

--- a/Stitch/App/View/StitchRootView.swift
+++ b/Stitch/App/View/StitchRootView.swift
@@ -54,6 +54,37 @@ struct StitchRootView: View {
                 iPhoneBody
             } else {
                 splitView
+#if targetEnvironment(macCatalyst)
+                    .overlay(alignment: .center) {
+                        if let document = store.currentDocument,
+                           document.graphUI.showCatalystProjectTitleModal {
+                            logInView("will show modal view at top level")
+                            ZStack {
+                                
+                                MODAL_BACKGROUND_COLOR
+                                //                                    .ignoresSafeArea()
+                                    .ignoresSafeArea([.all, .keyboard])
+                                    .onTapGesture {
+                                        dispatch(CatalystProjectTitleModalClosed())
+                                    }
+                                VStack(alignment: .leading) {
+                                    StitchTextView(string: "Edit Project Title")
+                                    CatalystProjectTitleModalView(graph: document.visibleGraph)
+                                }
+                                .padding()
+                                .frame(width: 260, alignment: .leading)
+                                .background(
+                                    Color(uiColor: .systemGray5)
+                                    // NOTE: strangely we need `[.all, .keyboard]` on BOTH the background color AND the StitchHostingControllerView
+                                        .ignoresSafeArea([.all, .keyboard])
+                                        .cornerRadius(4)
+                                )
+                                
+                                
+                            }
+                        }
+                    }
+#endif
             }
         }
 //        .coordinateSpace(name: Self.STITCH_ROOT_VIEW_COORDINATE_SPACE)

--- a/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
+++ b/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
@@ -8,10 +8,25 @@
 import SwiftUI
 import StitchSchemaKit
 
-// Imitates the .navigationTitle($someBinding) edit experience on iPad
-struct CatalystNavBarTitleEditField: View {
-    @Bindable var graph: GraphState
+struct CatalystProjectTitleModalOpened: GraphUIEvent {
+    func handle(state: GraphUIState) {
+        // log("CatalystProjectTitleModalOpened")
+        state.showCatalystProjectTitleModal = true
+        state.reduxFieldFocused(focusedField: .projectTitle)
+    }
+}
 
+struct CatalystProjectTitleModalClosed: GraphUIEvent {
+    func handle(state: GraphUIState) {
+        // log("CatalystProjectTitleModalClosed")
+        state.showCatalystProjectTitleModal = false
+        state.reduxFieldDefocused(focusedField: .projectTitle)
+    }
+}
+
+struct CatalystProjectTitleModalView: View {
+    
+    @Bindable var graph: GraphState
     @FocusState var focus: Bool
     
     var body: some View {
@@ -20,46 +35,52 @@ struct CatalystNavBarTitleEditField: View {
             .autocorrectionDisabled()
             .modifier(SelectAllTextViewModifier())
             .modifier(NavigationTitleFontViewModifier())
-            .padding(6)
-        
-            // worked well with Sonoma 14.3 and earlier
-            // .frame(minWidth: self.focus ? 260 : 30, maxWidth: 400)
-            
-            // fix for issue with Sonoma 14.4
-            // .frame(minWidth: 260, maxWidth: 400)
-        
-            // Padding alone does not prevent text field from sliding to the left and covering the back-button etc. ...
-            // .padding(.trailing, 64)
-        
-            // ... setting an explicit width seems necessary to prevent the text field from covering the back-button during a long title edit
-            .width(260)
-        
-            .overlay { fieldHighlight }
-            .onChange(of: self.focus) { oldValue, newValue in
-                log("CatalystNavBarTitleEditField: .onChange(of: self.focus): oldValue: \(oldValue)")
-                log("CatalystNavBarTitleEditField: .onChange(of: self.focus): newValue: \(newValue)")
-                withAnimation(.easeOut(duration: 0.2)) {
-                    self.focus = newValue
+            .onAppear {
+                // log("CatalystProjectTitleModalView: onAppear")
+                self.focus = true
+            }
+            .onChange(of: self.graph.graphUI.reduxFocusedField == .projectTitle, initial: true) { oldValue, newValue in
+                // log("CatalystProjectTitleModalView: .onChange(of: self.graph.graphUI.reduxFocusedField): oldValue: \(oldValue)")
+                // log("CatalystProjectTitleModalView: .onChange(of: self.graph.graphUI.reduxFocusedField): newValue: \(newValue)")
+                if !newValue {
+                    // log("CatalystProjectTitleModalView: .onChange(of: self.graph.graphUI.reduxFocusedField): will set focus false")
+                    self.focus = false
+                } else {
+                    // log("CatalystProjectTitleModalView: .onChange(of: self.graph.graphUI.reduxFocusedField): will set focus true")
+                    self.focus = true
                 }
-
+            }
+        // Do not use `initial: true`
+            .onChange(of: self.focus) { oldValue, newValue in
+                // log("CatalystProjectTitleModalView: .onChange(of: self.focus): oldValue: \(oldValue)")
+                // log("CatalystProjectTitleModalView: .onChange(of: self.focus): newValue: \(newValue)")
                 if newValue {
                     dispatch(ReduxFieldFocused(focusedField: .projectTitle))
                 } else {
                     // log("CatalystNavBarTitleEditField: defocused, so will commit")
                     graph.name = graph.name.validateProjectTitle()
                     dispatch(ReduxFieldDefocused(focusedField: .projectTitle))
+                    dispatch(CatalystProjectTitleModalClosed())
                     // Commit project name to disk
                     graph.encodeProjectInBackground()
-                    
                 }
             }
     }
+}
+
+// Imitates the .navigationTitle($someBinding) edit experience on iPad
+struct CatalystNavBarProjectTitleDisplayView: View {
+    @Bindable var graph: GraphState
     
-    var fieldHighlight: some View {
-        RoundedRectangle(cornerRadius: 8)
-            .stroke(Color.accentColor,
-                    lineWidth: self.focus ? 2 : 0)
-    }
+    var body: some View {
+        Text(graph.name)
+            .modifier(NavigationTitleFontViewModifier())
+            .padding(6)
+            .frame(width: 260, height: 16, alignment: .leading)
+            .onTapGesture {
+                dispatch(CatalystProjectTitleModalOpened())
+            }
+    }    
 }
 
 struct NavigationTitleFontViewModifier: ViewModifier {

--- a/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
+++ b/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
@@ -11,7 +11,9 @@ import StitchSchemaKit
 struct CatalystProjectTitleModalOpened: GraphUIEvent {
     func handle(state: GraphUIState) {
         // log("CatalystProjectTitleModalOpened")
-        state.showCatalystProjectTitleModal = true
+        withAnimation {
+            state.showCatalystProjectTitleModal = true
+        }
         state.reduxFieldFocused(focusedField: .projectTitle)
     }
 }
@@ -19,7 +21,9 @@ struct CatalystProjectTitleModalOpened: GraphUIEvent {
 struct CatalystProjectTitleModalClosed: GraphUIEvent {
     func handle(state: GraphUIState) {
         // log("CatalystProjectTitleModalClosed")
-        state.showCatalystProjectTitleModal = false
+        withAnimation {
+            state.showCatalystProjectTitleModal = false
+        }
         state.reduxFieldDefocused(focusedField: .projectTitle)
     }
 }

--- a/Stitch/Graph/View/ProjectToolbar.swift
+++ b/Stitch/Graph/View/ProjectToolbar.swift
@@ -97,7 +97,7 @@ struct ProjectToolbarViewModifier: ViewModifier {
                 #else
                 // on Mac, show project title name
                 ToolbarItem(placement: .navigationBarLeading) {
-                    CatalystNavBarTitleEditField(graph: graph)
+                    CatalystNavBarProjectTitleDisplayView(graph: graph)
                 }
 
                 // Catalyst and iPad have same button layout,

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -31,6 +31,8 @@ struct ActiveDragInteractionNodeVelocityData: Equatable, Hashable {
 @Observable
 final class GraphUIState {
 
+    var showCatalystProjectTitleModal: Bool = false
+    
     // Only for node cursor selection box done when shift held
     var nodesAlreadySelectedAtStartOfShiftNodeCursorBoxDrag: CanvasItemIdSet? = nil
     
@@ -292,6 +294,8 @@ extension GraphState {
         // Wipe any redux-controlled focus field
         // (For now, just used with TextField layers)
         self.graphUI.reduxFocusedField = nil
+        
+        self.graphUI.showCatalystProjectTitleModal = false
         
         self.graphUI.isSidebarFocused = false
     }

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -295,7 +295,9 @@ extension GraphState {
         // (For now, just used with TextField layers)
         self.graphUI.reduxFocusedField = nil
         
-        self.graphUI.showCatalystProjectTitleModal = false
+        withAnimation {
+            self.graphUI.showCatalystProjectTitleModal = false
+        }
         
         self.graphUI.isSidebarFocused = false
     }


### PR DESCRIPTION
Several bugs (double character entry, state render cycles ignored, etc.) with TextField in NavigationStack's Toolbar on Catalyst with the "Optimize for Mac" build. 

Using a modal as a workaround.

https://github.com/user-attachments/assets/b1f22b2c-32b5-451a-ac36-36fe98978d5c

https://github.com/user-attachments/assets/9ac02339-dc3b-422b-a8c1-7b2e378e3d21
