### PR TITLE
Improved perf by replacing encoded sidebar getter

### DIFF
--- a/Stitch/Graph/Node/Model/GraphCopyable.swift
+++ b/Stitch/Graph/Node/Model/GraphCopyable.swift
@@ -426,7 +426,8 @@ extension GraphState {
                 return node
             }
         
-        let selectedSidebarLayers = self.orderedSidebarLayers
+        let selectedSidebarLayers = self.layersSidebarViewModel
+            .createdOrderedEncodedData()
             .getSubset(from: selectedNodes.map { $0.id }.toSet)
         
         let copiedComponentData: [StitchComponent] = selectedNodes

--- a/Stitch/Graph/Sidebar/Util/LayerGrouping/SidebarLayerData.swift
+++ b/Stitch/Graph/Sidebar/Util/LayerGrouping/SidebarLayerData.swift
@@ -15,15 +15,15 @@ typealias SidebarLayerList = [SidebarLayerData]
 
 typealias OrderedSidebarLayers = SidebarLayerList
 
-extension SidebarLayerList {
+extension Array where Element: StitchNestedListElement {
     /// Returns ids just at a single hierarchy without recursively gathering other ids.
-    var idsAtHierarchy: NodeIdSet {
+    var idsAtHierarchy: Set<Element.ID> {
         self.map { $0.id }
             .toSet
     }
 
     /// Gets flattened list of IDs recursively.
-    func getIds() -> NodeIdList {
+    func getIds() -> [Element.ID] {
         self.flatMap {
             [$0.id] + ($0.children?.getIds() ?? [])
         }

--- a/Stitch/Graph/ViewModel/GraphDelegate.swift
+++ b/Stitch/Graph/ViewModel/GraphDelegate.swift
@@ -75,7 +75,7 @@ protocol GraphDelegate: AnyObject, Sendable {
     
     var layersSidebarViewModel: LayersSidebarViewModel { get }
     
-    var orderedSidebarLayers: OrderedSidebarLayers { get }
+    var orderedSidebarLayers: [SidebarItemGestureViewModel] { get }
 
     @MainActor func updateGraphData()
     

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -96,8 +96,8 @@ final class GraphState: Sendable {
 
 extension GraphState {
     @MainActor
-    var orderedSidebarLayers: SidebarLayerList {
-        self.layersSidebarViewModel.createdOrderedEncodedData()
+    var orderedSidebarLayers: [SidebarItemGestureViewModel] {
+        self.layersSidebarViewModel.items
     }
     
     convenience init(from schema: GraphEntity,
@@ -279,7 +279,7 @@ extension GraphState {
         let graph = GraphEntity(id: self.projectId,
                                 name: self.name,
                                 nodes: nodes,
-                                orderedSidebarLayers: self.orderedSidebarLayers,
+                                orderedSidebarLayers: self.layersSidebarViewModel.createdOrderedEncodedData(),
                                 commentBoxes: commentBoxes)
         return graph
     }

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -221,7 +221,7 @@ extension GraphState: GraphCalculatable {
         let flattenedPinMap = self.getFlattenedPinMap()
         let rootPinMap = self.getRootPinMap(pinMap: flattenedPinMap)
         
-        let previewLayers = self.recursivePreviewLayers(sidebarLayersGlobal: self.orderedSidebarLayers,
+        let previewLayers = self.recursivePreviewLayers(sidebarLayersGlobal: self.layersSidebarViewModel.createdOrderedEncodedData(),
                                                         pinMap: rootPinMap)
         
         self.cachedOrderedPreviewLayers = previewLayers


### PR DESCRIPTION
`GraphDelegate.orderedSidebarLayers` used to have to be a complicated getter for getting nested sidebar data. Because the sidebar now uses nested view model data we don't need to use the old logic for many locations.