### PR TITLE
Fixed adjustment bar undo regression

### DIFF
--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWrapper.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWrapper.swift
@@ -254,6 +254,7 @@ struct InsertNodeMenuWrapper: View {
                          atleastOneCommentBoxSelected: false,
                          activeIndex: .init(1),
                          groupNodeFocused: nil,
+                         adjustmentBarSessionId: .fakeId,
                          boundsReaderDisabled: boundsDisabled,
                          // fake node does NOT use position handler
                          usePositionHandler: false,

--- a/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
@@ -136,6 +136,10 @@ struct InputValueView: View {
         viewModel.fieldValue
     }
 
+    @MainActor var adjustmentBarSessionId: AdjustmentBarSessionId {
+        self.graph.graphUI.adjustmentBarSessionId
+    }
+
     var isFieldInsideLayerInspector: Bool {
         viewModel.isFieldInsideLayerInspector
     }
@@ -159,6 +163,7 @@ struct InputValueView: View {
                                      fieldCoordinate: fieldCoordinate,
                                      isCanvasItemSelected: isCanvasItemSelected,
                                      choices: nil,
+                                     adjustmentBarSessionId: adjustmentBarSessionId,
                                      forPropertySidebar: forPropertySidebar,
                                      propertyIsAlreadyOnGraph: propertyIsAlreadyOnGraph,
                                      isFieldInMultifieldInput: isFieldInMultifieldInput,
@@ -176,6 +181,7 @@ struct InputValueView: View {
                                  rowObserverCoordinate: rowObserverId,
                                  isCanvasItemSelected: isCanvasItemSelected,
                                  choices: nil,
+                                 adjustmentBarSessionId: adjustmentBarSessionId,
                                  forPropertySidebar: forPropertySidebar,
                                  propertyIsAlreadyOnGraph: propertyIsAlreadyOnGraph,
                                  isFieldInMultifieldInput: isFieldInMultifieldInput,
@@ -197,6 +203,7 @@ struct InputValueView: View {
                                                                                  nodeKind: nodeKind,
                                                                                  layerInputObserver: layerInputObserver)
                                     .map(\.rawValue),
+                                 adjustmentBarSessionId: adjustmentBarSessionId,
                                  forPropertySidebar: forPropertySidebar,
                                  propertyIsAlreadyOnGraph: propertyIsAlreadyOnGraph,
                                  isFieldInMultifieldInput: isFieldInMultifieldInput,
@@ -215,6 +222,7 @@ struct InputValueView: View {
                                  rowObserverCoordinate: rowObserverId,
                                  isCanvasItemSelected: isCanvasItemSelected,
                                  choices: StitchSpacing.choices,
+                                 adjustmentBarSessionId: adjustmentBarSessionId,
                                  forPropertySidebar: forPropertySidebar,
                                  propertyIsAlreadyOnGraph: propertyIsAlreadyOnGraph,
                                  isFieldInMultifieldInput: isFieldInMultifieldInput,

--- a/Stitch/Graph/Node/Port/View/Field/InputView/CommonEditingViewWrapper.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/CommonEditingViewWrapper.swift
@@ -17,6 +17,7 @@ struct CommonEditingViewWrapper: View {
     let fieldCoordinate: FieldCoordinate
     let isCanvasItemSelected: Bool
     let choices: [String]?
+    let adjustmentBarSessionId: AdjustmentBarSessionId
     let forPropertySidebar: Bool
     let propertyIsAlreadyOnGraph: Bool
     let isFieldInMultifieldInput: Bool

--- a/Stitch/Graph/Node/Port/View/Field/InputView/FieldValueNumberView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/FieldValueNumberView.swift
@@ -20,6 +20,7 @@ struct FieldValueNumberView: View {
     let rowObserverCoordinate: NodeIOCoordinate
     let isCanvasItemSelected: Bool
     let choices: [String]?
+    let adjustmentBarSessionId: AdjustmentBarSessionId
     let forPropertySidebar: Bool
     let propertyIsAlreadyOnGraph: Bool
     let isFieldInMultifieldInput: Bool
@@ -67,6 +68,7 @@ struct FieldValueNumberView: View {
                                       fieldCoordinate: fieldCoordinate,
                                       rowObserverCoordinate: rowObserverCoordinate,
                                       fieldValueNumberType: fieldValueNumberType,
+                                      adjustmentBarSessionId: adjustmentBarSessionId,
                                       isFieldInsideLayerInspector: fieldViewModel.isFieldInsideLayerInspector, 
                                       isSelectedInspectorRow: isSelectedInspectorRow,
                                       isPressed: $isButtonPressed)
@@ -79,6 +81,7 @@ struct FieldValueNumberView: View {
                                      fieldCoordinate: fieldCoordinate,
                                      isCanvasItemSelected: isCanvasItemSelected,
                                      choices: choices,
+                                     adjustmentBarSessionId: adjustmentBarSessionId,
                                      forPropertySidebar: forPropertySidebar,
                                      propertyIsAlreadyOnGraph: propertyIsAlreadyOnGraph,
                                      isFieldInMultifieldInput: isFieldInMultifieldInput,

--- a/Stitch/Graph/Node/Port/View/Field/ValueButton/NumberValueButtonView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/ValueButton/NumberValueButtonView.swift
@@ -25,6 +25,8 @@ struct FieldButtonImage: View {
     }
 }
 
+typealias AdjustmentBarSessionId = UUID
+
 struct NumberValueButtonView: View {
     
     @Bindable var graph: GraphState
@@ -32,6 +34,7 @@ struct NumberValueButtonView: View {
     let fieldCoordinate: FieldCoordinate
     let rowObserverCoordinate: NodeIOCoordinate
     let fieldValueNumberType: FieldValueNumberType
+    let adjustmentBarSessionId: AdjustmentBarSessionId
     let isFieldInsideLayerInspector: Bool
     let isSelectedInspectorRow: Bool
     
@@ -44,6 +47,10 @@ struct NumberValueButtonView: View {
             .rotationEffect(Angle(degrees: 90))
             .onTapGesture {
                 self.isPressed = true
+            }
+            .onChange(of: self.adjustmentBarSessionId) { _, _ in
+                // `AdjustmentBarSessionId` is changed just when
+                self.isPressed = false
             }
             // TODO: add attachment anchor as well?
             .modifier(AdjustmentBarViewModifier(

--- a/Stitch/Graph/Node/View/NodeViewType.swift
+++ b/Stitch/Graph/Node/View/NodeViewType.swift
@@ -20,6 +20,7 @@ struct NodeTypeView: View {
     let atleastOneCommentBoxSelected: Bool
     let activeIndex: ActiveIndex
     let groupNodeFocused: GroupNodeType?
+    let adjustmentBarSessionId: AdjustmentBarSessionId
 
     var boundsReaderDisabled: Bool = false
     var usePositionHandler: Bool = true
@@ -84,7 +85,8 @@ struct NodeTypeView: View {
                 DefaultNodeInputView(graph: graph,
                                      node: node,
                                      canvas: canvasNode,
-                                     isNodeSelected: isSelected)
+                                     isNodeSelected: isSelected,
+                                     adjustmentBarSessionId: adjustmentBarSessionId)
             }
         }
     }
@@ -101,7 +103,8 @@ struct NodeTypeView: View {
                 DefaultNodeOutputView(graph: graph,
                                       node: node,
                                       canvas: canvasNode,
-                                      isNodeSelected: isSelected)
+                                      isNodeSelected: isSelected,
+                                      adjustmentBarSessionId: adjustmentBarSessionId)
             }
         }
     }
@@ -112,12 +115,14 @@ struct DefaultNodeInputView: View {
     @Bindable var node: NodeViewModel
     @Bindable var canvas: CanvasItemViewModel
     let isNodeSelected: Bool
+    let adjustmentBarSessionId: AdjustmentBarSessionId
     
     var body: some View {
         DefaultNodeRowView(graph: graph,
                            node: node,
                            rowViewModels: canvas.inputViewModels,
-                           nodeIO: .input) { rowObserver, rowViewModel in
+                           nodeIO: .input,
+                           adjustmentBarSessionId: adjustmentBarSessionId) { rowObserver, rowViewModel in
                         
             let layerInputObserver: LayerInputObserver? = rowObserver.id.layerInput
                 .flatMap { node.layerNode?.getLayerInputObserver($0.layerInput) }
@@ -146,12 +151,14 @@ struct DefaultNodeOutputView: View {
     @Bindable var node: NodeViewModel
     @Bindable var canvas: CanvasItemViewModel
     let isNodeSelected: Bool
+    let adjustmentBarSessionId: AdjustmentBarSessionId
     
     var body: some View {
         DefaultNodeRowView(graph: graph,
                            node: node,
                            rowViewModels: canvas.outputViewModels,
-                           nodeIO: .output) { rowObserver, rowViewModel in
+                           nodeIO: .output,
+                           adjustmentBarSessionId: adjustmentBarSessionId) { rowObserver, rowViewModel in
             NodeOutputView(graph: graph,
                            rowObserver: rowObserver,
                            rowViewModel: rowViewModel,
@@ -171,6 +178,7 @@ struct DefaultNodeRowView<RowViewModel, RowView>: View where RowViewModel: NodeR
     @Bindable var node: NodeViewModel
     let rowViewModels: [RowViewModel]
     let nodeIO: NodeIO
+    let adjustmentBarSessionId: AdjustmentBarSessionId
     @ViewBuilder var rowView: (RowViewModel.RowObserver, RowViewModel) -> RowView
 
     var id: NodeId {

--- a/Stitch/Graph/Node/View/NodesOnlyView.swift
+++ b/Stitch/Graph/Node/View/NodesOnlyView.swift
@@ -24,6 +24,10 @@ struct NodesOnlyView: View {
     var activeIndex: ActiveIndex {
         graphUI.activeIndex
     }
+    
+    var adjustmentBarSessionId: AdjustmentBarSessionId {
+        graphUI.adjustmentBarSessionId
+    }
         
     var body: some View {
         // HACK for when no nodes present
@@ -44,6 +48,7 @@ struct NodesOnlyView: View {
                     atleastOneCommentBoxSelected: selection.selectedCommentBoxes.count >= 1,
                     activeIndex: activeIndex,
                     groupNodeFocused: graphUI.groupNodeFocused,
+                    adjustmentBarSessionId: adjustmentBarSessionId,
                     isHiddenDuringAnimation: insertNodeMenuHiddenNode
                         .map { $0 == node.id } ?? false
                 )

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -53,6 +53,10 @@ final class GraphUIState {
     // nil = no field focused
     var reduxFocusedField: FocusedUserEditField?
 
+    // Hack: to differentiate state updates that came from undo/redo (and which close the adjustment bar popover),
+    // vs those that came from user manipulation of adjustment bar (which do not close the adjustment bar popover).
+    var adjustmentBarSessionId: UUID = .init()
+
     var activelyEditedCommentBoxTitle: CommentBoxId?
 
     var commentBoxBoundsDict = CommentBoxBoundsDict()


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/6628

A recent PR removed the adjustment bar ID hack, which at the time was doing nothing but used to fix a bug where undo changes should close adjustment bar popovers. This was to resolve an issue where the popover becomes out of sync with the field.

The fix here reverts a recent commit and adds logic to undo to close the adjustment bar.