### PR TITLE
Fixed pulse reversion effects regression

### DIFF
--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
@@ -275,7 +275,6 @@ extension GraphState {
         let graph = self
         let outputValues = outputValues
         var nodeIdsToRecalculate = NodeIdSet()
-//        var effects = SideEffects()
         
         guard let node = graph.getNodeViewModel(nodeId) else {
             log("recalculateGraph: AsyncMediaImpureEvalOpResult: could not retrieve node \(nodeId)")
@@ -301,24 +300,12 @@ extension GraphState {
                                 node: node,
                                 portValues: portValues)
             
-//            effects += portValues.enumerated().flatMap { portId, value in
-//                value.getPulseReversionEffects(nodeId: nodeId,
-//                                               portId: portId,
-//                                               graphTime: graph.graphStepState.graphTime)
-//            }
-            
-//            effects.processEffects()
-            
         case .all(let portValuesList):
             var changedDownstreamNodes = NodeIdSet()
             
             // portValuesList is the full outputs etc.;
             // set new outputs in node
             node.updateOutputsObservers(newValuesList: portValuesList)
-            
-//            effects += portValuesList
-//                .getPulseReversionEffects(nodeId: nodeId,
-//                                          graphTime: graph.graphStepState.graphTime)
             
             // We just manually set new outputs on the media node.
             // Now we need to flow those new outputs to any downstream nodes,
@@ -343,8 +330,6 @@ extension GraphState {
             
             // Recalculate downstream patch nodes after values are updated
             self.calculate(changedDownstreamNodes)
-            
-//            effects.processEffects()
         }
     }
 }

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
@@ -275,7 +275,7 @@ extension GraphState {
         let graph = self
         let outputValues = outputValues
         var nodeIdsToRecalculate = NodeIdSet()
-        var effects = SideEffects()
+//        var effects = SideEffects()
         
         guard let node = graph.getNodeViewModel(nodeId) else {
             log("recalculateGraph: AsyncMediaImpureEvalOpResult: could not retrieve node \(nodeId)")
@@ -301,13 +301,13 @@ extension GraphState {
                                 node: node,
                                 portValues: portValues)
             
-            effects += portValues.enumerated().flatMap { portId, value in
-                value.getPulseReversionEffects(nodeId: nodeId,
-                                               portId: portId,
-                                               graphTime: graph.graphStepState.graphTime)
-            }
+//            effects += portValues.enumerated().flatMap { portId, value in
+//                value.getPulseReversionEffects(nodeId: nodeId,
+//                                               portId: portId,
+//                                               graphTime: graph.graphStepState.graphTime)
+//            }
             
-            effects.processEffects()
+//            effects.processEffects()
             
         case .all(let portValuesList):
             var changedDownstreamNodes = NodeIdSet()
@@ -316,9 +316,9 @@ extension GraphState {
             // set new outputs in node
             node.updateOutputsObservers(newValuesList: portValuesList)
             
-            effects += portValuesList
-                .getPulseReversionEffects(nodeId: nodeId,
-                                          graphTime: graph.graphStepState.graphTime)
+//            effects += portValuesList
+//                .getPulseReversionEffects(nodeId: nodeId,
+//                                          graphTime: graph.graphStepState.graphTime)
             
             // We just manually set new outputs on the media node.
             // Now we need to flow those new outputs to any downstream nodes,
@@ -344,7 +344,7 @@ extension GraphState {
             // Recalculate downstream patch nodes after values are updated
             self.calculate(changedDownstreamNodes)
             
-            effects.processEffects()
+//            effects.processEffects()
         }
     }
 }

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Pulse/PulseReversionUtils.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Pulse/PulseReversionUtils.swift
@@ -8,18 +8,6 @@
 import Foundation
 import StitchSchemaKit
 
-//extension PortValuesList {
-//    func getPulseReversionEffects(nodeId: NodeId,
-//                                  graphTime: TimeInterval) -> SideEffects {
-//        self.enumerated()
-//            .flatMap { portId, values in
-//                values.getPulseReversionEffects(nodeId: nodeId,
-//                                                portId: portId,
-//                                                graphTime: graphTime)
-//            }
-//    }
-//}
-
 extension PortValues {
     func getPulseReversionEffects(id: NodeIOCoordinate,
                                   graphTime: TimeInterval) -> SideEffects {

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Pulse/PulseReversionUtils.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Pulse/PulseReversionUtils.swift
@@ -8,39 +8,34 @@
 import Foundation
 import StitchSchemaKit
 
-extension PortValuesList {
-    func getPulseReversionEffects(nodeId: NodeId,
-                                  graphTime: TimeInterval) -> SideEffects {
-        self.enumerated()
-            .flatMap { portId, values in
-                values.getPulseReversionEffects(nodeId: nodeId,
-                                                portId: portId,
-                                                graphTime: graphTime)
-            }
-    }
-}
+//extension PortValuesList {
+//    func getPulseReversionEffects(nodeId: NodeId,
+//                                  graphTime: TimeInterval) -> SideEffects {
+//        self.enumerated()
+//            .flatMap { portId, values in
+//                values.getPulseReversionEffects(nodeId: nodeId,
+//                                                portId: portId,
+//                                                graphTime: graphTime)
+//            }
+//    }
+//}
 
 extension PortValues {
-    func getPulseReversionEffects(nodeId: NodeId,
-                                  portId: Int,
+    func getPulseReversionEffects(id: NodeIOCoordinate,
                                   graphTime: TimeInterval) -> SideEffects {
         self.flatMap {
-            $0.getPulseReversionEffects(nodeId: nodeId,
-                                        portId: portId,
+            $0.getPulseReversionEffects(id: id,
                                         graphTime: graphTime)
         }
     }
 }
 
 extension PortValue {
-    func getPulseReversionEffects(nodeId: NodeId,
-                                  portId: Int,
+    func getPulseReversionEffects(id: NodeIOCoordinate,
                                   graphTime: TimeInterval) -> SideEffects {
         if let lastTimePulsed = self.getPulse,
            lastTimePulsed.shouldPulse(graphTime) {
-            let pulsedIndex = NodeIOCoordinate(portId: portId,
-                                               nodeId: nodeId)
-            return getPostPulseEffects(.output(pulsedIndex))
+            return getPostPulseEffects(.output(id))
         }
         
         return []

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
@@ -43,6 +43,8 @@ extension NodeRowObserver {
         }
         
         self.postProcessing(oldValues: oldValues, newValues: newValues)
+        
+        self.didValuesUpdate()
     }
     
     @MainActor

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -732,12 +732,6 @@ extension GraphState {
      
         node.updateOutputsObservers(newValuesList: outputsToUpdate)
         
-        // Must also run pulse reversion effects
-        node.outputs
-            .getPulseReversionEffects(nodeId: nodeId,
-                                      graphTime: graphTime)
-            .processEffects()
-        
         // Recalculate graph
         self.calculate(nodeIdsToRecalculate)
     }


### PR DESCRIPTION
Logic moved to a new helper for row outputs observers which now processes each change for pulses.