### PR TITLE
Only focus sidebar when sidebar layer tapped or dragged

### DIFF
--- a/Stitch/Graph/Sidebar/Model/Gesture/SidebarSelectionState.swift
+++ b/Stitch/Graph/Sidebar/Model/Gesture/SidebarSelectionState.swift
@@ -16,7 +16,9 @@ extension ProjectSidebarObservable {
     }
     
     func resetEditModeSelections() {
-        self.graphDelegate?.graphUI.isSidebarFocused = true
+        // DO NOT 'focus the sidebar' here; resetting primary selections is NOT the same thing as tapping or dragging a layer
+//        self.graphDelegate?.graphUI.isSidebarFocused = true
+        
         self.primary = .init()
     }
 }

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
@@ -35,6 +35,9 @@ extension ProjectSidebarObservable {
         
         let originalSelections = self.selectionState.primary
         
+        // Set sidebar to be focused:
+        self.graphDelegate?.graphUI.isSidebarFocused = true
+        
         log("sidebarItemTapped: originalSelections: \(originalSelections)")
         
         if shiftHeld, originalSelections.isEmpty {

--- a/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
+++ b/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
@@ -31,9 +31,9 @@ extension StitchDocumentViewModel {
         }
         
         // TODO: `graph` vs `visibleGraph` ?
-        let activelySelectedLayers = state.visibleGraph.sidebarSelectionState.primary
+        let activelySelectedLayers = state.visibleGraph.isSidebarFocused
         
-        if !activelySelectedLayers.isEmpty {
+        if activelySelectedLayers {
             state.visibleGraph.sidebarSelectedItemsDuplicated()
         } else {
             let copiedComponentResult = state.visibleGraph.createCopiedComponent(
@@ -181,6 +181,7 @@ extension GraphState {
         newNodes
             .forEach { nodeEntity in
                 switch nodeEntity.nodeTypeEntity {
+                    
                 case .layer(let layerNode):
                     
                     // Actively-select the new layer node


### PR DESCRIPTION
Fixes a regression from the way we changed sidebar-focus. 

1. Cmd+A now looks at sidebar-focus
2. sidebar-focus set true when layer tapped, not when primary-selections reset