### PR TITLE
Apply .rotation after .shadow on LayerGroup

### DIFF
--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
@@ -156,15 +156,7 @@ struct PreviewGroupLayer: View {
                 nodeId: interactiveLayer.id.layerNodeId,
                 highlightedSidebarLayers: document.graphUI.highlightedSidebarLayers,
                 scale: scale))
-                
-            .modifier(PreviewLayerRotationModifier(
-                graph: graph,
-                viewModel: layerViewModel,
-                isPinnedViewRendering: isPinnedViewRendering,
-                rotationX: rotationX,
-                rotationY: rotationY,
-                rotationZ: rotationZ))
-        
+                        
         // .clipped modifier should come before the offset/position modifier,
         // so that it's affected by the offset/position modifier
             .modifier(ClippedModifier(isClipped: isClipped,
@@ -212,6 +204,15 @@ struct PreviewGroupLayer: View {
                         shadowRadius: shadowRadius,
                         shadowOffset: shadowOffset))
             }
+        
+        // moved here, so that .rotation affects .shadow
+            .modifier(PreviewLayerRotationModifier(
+                graph: graph,
+                viewModel: layerViewModel,
+                isPinnedViewRendering: isPinnedViewRendering,
+                rotationX: rotationX,
+                rotationY: rotationY,
+                rotationZ: rotationZ))
         
             .opacity(opacity) // opacity on group and all its contents
         

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
@@ -10,21 +10,6 @@ import StitchSchemaKit
 import SwiftUI
 import OrderedCollections
 
-// Sidebar layer 'tapped' while not in
-struct SidebarItemTapped: GraphEvent {
-    
-    let id: LayerNodeId
-    let shiftHeld: Bool
-    let commandHeld: Bool
-    
-    func handle(state: GraphState) {
-        state.layersSidebarViewModel
-            .sidebarItemTapped(id: id.asItemId,
-                               shiftHeld: shiftHeld,
-                               commandHeld: commandHeld)
-    }
-}
-
 extension ProjectSidebarObservable {
     @MainActor
     func sidebarItemTapped(id: Self.ItemID,


### PR DESCRIPTION
Otherwise layer group background (additional one applied for .shadow) does not rotate.