### PR TITLE
Rely on sidebar data for a layer's parent

### DIFF
--- a/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
@@ -13,7 +13,6 @@ let HEIGHT_FIELD_INDEX = 1
 
 struct LayerGroupIdChanged: GraphEvent {
     let layerNodeId: LayerNodeId
-    let layerGroupParentId: NodeId?
     
     func handle(state: GraphState) {
         
@@ -23,16 +22,20 @@ struct LayerGroupIdChanged: GraphEvent {
             return
         }
         
-        if layerGroupParentId.isDefined {
+        // Use offset rather than position inputs if parent uses non-ZStack orientation.
+        // NOTE: complication: the parent's layout-orientation could vary by loop-index, but blocking/unblocking fields and the inspector-view are currently unaware of loop-index.
+        if let parentId = layerNode.layerGroupId,
+           let parentLayerNodeViewModel = state.getLayerNode(id: parentId)?.layerNode,
+           let parentLayerViewModel = parentLayerNodeViewModel.previewLayerViewModels[safe: state.activeIndex.adjustedIndex(parentLayerNodeViewModel.previewLayerViewModels.count)] ?? parentLayerNodeViewModel.previewLayerViewModels.first,
+           parentLayerViewModel.orientation.getOrientation != StitchOrientation.none {
+            
             layerNode.blockPositionInput()
             layerNode.unblockOffsetInput()
         } else {
             layerNode.unblockPositionInput()
             layerNode.blockOffsetInput()
         }
-        
     }
-    
 }
 
 // TODO: we also need to block or unblock the inputs of the row on the canvas as well

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarGroupCreated.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarGroupCreated.swift
@@ -49,17 +49,7 @@ extension LayersSidebarViewModel {
         // Update sidebar state
         self.items.insertGroup(group: newGroupData,
                                selections: primarilySelectedLayers)
-        
-        newNode.layerNode?.layerGroupId = candidateGroup.parentId
-        
-        // Iterate through primarly selected layers,
-        // assigning new LG as their layerGoupId.
-        primarilySelectedLayers.forEach { layerId in
-            if let layerNode = graph.getLayerNode(id: layerId)?.layerNode {
-                layerNode.layerGroupId = newNode.id
-            }
-        }
-        
+   
         self.items.updateSidebarIndices()
         
         // Only reset edit mode selections if we're explicitly in edit mode (i.e. on iPad)

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarGroupUncreated.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarGroupUncreated.swift
@@ -50,17 +50,9 @@ extension LayersSidebarViewModel {
             fatalErrorIfDebug()
             return
         }
-        
-        let newParentId = graph.getNodeViewModel(groupId)?.layerNode?.layerGroupId
 
-        // find each child of the group, set its layer group id to the parent of the selected group
-        children.forEach { child in
-            if let layerNode = graph.getNodeViewModel(child) {
-                layerNode.layerNode?.layerGroupId = newParentId
-            }
-        }
-
-        // finally, delete layer group node itself (but not its children)
+        // Delete layer group node itself (but not its children)
+        // Note: the uncreated-group's children's new parent (nil or the next closest ancestor) is handled automatically?
         graph.deleteNode(id: groupId, willDeleteLayerGroupChildren: false)
 
         // update legacy sidebar data

--- a/Stitch/Graph/Sidebar/ViewModel/SidebarItemGestureViewModel.swift
+++ b/Stitch/Graph/Sidebar/ViewModel/SidebarItemGestureViewModel.swift
@@ -44,7 +44,17 @@ final class SidebarItemGestureViewModel: SidebarItemSwipable {
     internal var previousSwipeX: CGFloat = 0
     
     weak var sidebarDelegate: LayersSidebarViewModel?
-    weak var parentDelegate: SidebarItemGestureViewModel?
+    
+    weak var parentDelegate: SidebarItemGestureViewModel? {
+        didSet {
+            DispatchQueue.main.async { [weak self] in
+                if let sidebarItem = self {
+                    dispatch(AssignedLayerUpdated(changedLayerNode: sidebarItem.id.asLayerNodeId))
+                    dispatch(LayerGroupIdChanged(layerNodeId: sidebarItem.id.asLayerNodeId))
+                }
+            }
+        }
+    }
 
     init(data: SidebarLayerData,
          parentDelegate: SidebarItemGestureViewModel?,


### PR DESCRIPTION
Fixes regression. 

We now derive a layer node view model's layer group parent from sidebar items.

TODO: remove `layerGroupId` from schema ?

https://github.com/user-attachments/assets/4864f93b-fed6-4b29-b392-ff36ecf457a5

