### PR TITLE
Reduce jitters when during node title edits

### DIFF
--- a/Stitch/App/View/Component/StitchTextEditingField.swift
+++ b/Stitch/App/View/Component/StitchTextEditingField.swift
@@ -18,20 +18,6 @@ struct CustomTextFieldModifier: ViewModifier {
     }
 }
 
-// Helpful when editing longer node titles;
-// but not to be used for inputs
-struct StitchTextEditingFieldFixedSize: ViewModifier {
-    let isForNodeTitle: Bool
-
-    func body(content: Content) -> some View {
-        if isForNodeTitle {
-            content.fixedSize()
-        } else {
-            content
-        }
-    }
-}
-
 /// Abstracts common logic away from `TextField`'s for the purpose of tracking which input
 /// in the app is focused.
 // TODO: remove this? No longer needed?
@@ -82,8 +68,6 @@ struct StitchTextEditingBindingField: View {
     // which can never happen in our node input use case.
     var canvasDimensionInput: String?
 
-    // .leading alignment for inputs,
-    // .center alignment for node titles etc.
     var isForNodeTitle = false
 
     var font: Font = STITCH_FONT
@@ -124,14 +108,13 @@ struct StitchTextEditingBindingField: View {
 
     var body: some View {
         TextField(isBase64 ? "base64" : "", text: $currentEdit)
-            .modifier(StitchTextEditingFieldFixedSize(isForNodeTitle: isForNodeTitle))
             .font(font)
             .foregroundColor(fontColor)
             .truncationMode(.tail)
             .lineLimit(1)
             .autocapitalization(.none)
             .autocorrectionDisabled()
-            .modifier(CustomTextFieldModifier(alignment: isForNodeTitle ? .center : .leading))
+            .modifier(CustomTextFieldModifier(alignment: .leading))
             .focused($isFocused)
             .onSubmit {
                 submitChanges()

--- a/Stitch/Graph/Node/Title/View/CanvasItemTitleView.swift
+++ b/Stitch/Graph/Node/Title/View/CanvasItemTitleView.swift
@@ -78,11 +78,7 @@ struct CanvasItemTitleView: View {
     var editableTitle: some View {
         // logInView("NodeTitleView editableTitle \(id)")
         
-        #if DEV_DEBUG
-        let label = name + " " + nodeId.debugFriendlyId
-        #else
         let label = name
-        #endif
           
         if node.patch == .mathExpression {
             
@@ -123,7 +119,6 @@ struct CanvasItemTitleView: View {
                                        label: label)
                 }
                 
-                
                 let defaultTitle = node.kind.getDisplayTitle(customName: nil)
                 let hasCustomTitle = name.trim() != defaultTitle.trim()
                 
@@ -136,7 +131,6 @@ struct CanvasItemTitleView: View {
                 }
             }
         }
-        
     }
 }
 

--- a/Stitch/Graph/Node/Title/View/NodeTitleTextField.swift
+++ b/Stitch/Graph/Node/Title/View/NodeTitleTextField.swift
@@ -16,6 +16,7 @@ struct NodeTitleTextField: View {
 
     var body: some View {
         StitchTitleTextField(graph: graph,
+                             id: id,
                              titleEditType: .canvas(id),
                              label: label,
                              font: font)
@@ -24,8 +25,8 @@ struct NodeTitleTextField: View {
     /// A wrapper view for `TextField` which renders a read-only view when the input isn't in focus. This fixes a performance
     /// issue with `TextField` which becomes exacerbated by many rendered `TextField`'s in a view.
 struct StitchTitleTextField: View {
-
     @Bindable var graph: GraphState
+    let id: CanvasItemId
     let titleEditType: StitchTitleEdit
     let label: String
     var font: Font = STITCH_FONT
@@ -35,6 +36,8 @@ struct StitchTitleTextField: View {
         graph.graphUI.reduxFocusedField?.getNodeTitleEdit == titleEditType
     }
 
+    @State var editWidth: CGFloat? = nil
+    
     var body: some View {
         Group {
             if isFocused {
@@ -49,19 +52,39 @@ struct StitchTitleTextField: View {
                                                  edit: newEdit,
                                                  isCommitting: isCommitting))
                     }
+                    // .border(.yellow)
                     .frame(height: NODE_TITLE_HEIGHT,
-                           alignment: .center)
+                           alignment: .leading)
+                    .frame(maxWidth: self.editWidth,
+                           alignment: .leading)
+                    // .border(.orange)
                 
 #if targetEnvironment(macCatalyst)
-//.offset(y: -1)  // Matches y axis for read-only string--only needed for Catalyst
+                // NOTE: arises when applying StitchFont to SwiftUI Text and TextField views
                     .offset(y: -0.5)  // Matches y axis for read-only string--only needed for Catalyst
 #endif
-//                    .border(.green)
+                    // .border(.green)
+                    .onAppear {
+                        // log("StitchTitleTextField: onAppear: editWidth: \(editWidth)")
+                        
+//                        let labelWidth = label.widthOfString(usingFont: STITCH_UIFONT)
+//                        log("StitchTitleTextField: onAppear: labelWidth: \(labelWidth)")
+//                        
+                        let canvasItemWidth = graph.getCanvasItem(id)?.bounds.localBounds.width
+//                        log("StitchTitleTextField: onAppear: canvasItemWidth: \(canvasItemWidth)")
+
+                        self.editWidth = canvasItemWidth
+                    }
+                    .onDisappear {
+                        // log("StitchTitleTextField: onDisappear: editWidth: \(editWidth)")
+                        self.editWidth = nil
+                    }
+                
             } else {
-                StitchTextView(string: label,
+                StitchTextView(string: readOnlyLabel,
                                font: font)
                     .frame(height: NODE_TITLE_HEIGHT,
-                           alignment: .center)
+                           alignment: .leading)
                    //  .border(.blue)
                 // Manually focus this field when user taps.
                 // Better as global redux-state than local view-state: only one field in entire app can be focused at a time.
@@ -73,4 +96,24 @@ struct StitchTitleTextField: View {
         }
         .frame(minWidth: 20)
     }
+    
+    var readOnlyLabel: String {
+#if DEV_DEBUG
+        return label + " " + id.nodeId.debugFriendlyId
+#else
+        return label
+#endif
+    }
 }
+
+//#if DEV_DEBUG || DEBUG
+// NOTE: Useful in some debug cases
+extension String {
+    func widthOfString(usingFont font: UIFont) -> CGFloat {
+        let fontAttributes = [NSAttributedString.Key.font: font]
+        let size = self.size(withAttributes: fontAttributes)
+        return size.width
+    }
+    
+}
+//#endif

--- a/Stitch/Graph/Node/View/CanvasItemSelectedViewModifier.swift
+++ b/Stitch/Graph/Node/View/CanvasItemSelectedViewModifier.swift
@@ -59,7 +59,7 @@ struct CanvasItemBoundsReader: ViewModifier {
                         .onChange(of: proxy.frame(in: .named(GraphBaseView.coordinateNamespace)),
                                   initial: true) { _, newBounds in
                             if !disabled {
-                                // log("will update GraphBaseView bounds for \(id)")
+                                 // log("CanvasItemBoundsReader: will update GraphBaseView bounds: \(newBounds)")
                                graph.updateGraphBaseViewBounds(
                                    for: canvasItem,
                                    newBounds: newBounds,
@@ -71,7 +71,7 @@ struct CanvasItemBoundsReader: ViewModifier {
                         .onChange(of: proxy.frame(in: .local),
                                   initial: true) { _, newBounds in
                             if !disabled {
-                                // log("will update local bounds for \(id)")
+                                // log("CanvasItemBoundsReader: will update local bounds: \(newBounds)")
 
                                 // Used only for comment box creation
                                 canvasItem.bounds.localBounds = newBounds


### PR DESCRIPTION
We use a canvas item's pre-edit width during title edits. Note that we still have some change in width and there is still occasional stutters on very large graphs, but overall this feels smoother.