### PR TITLE
Focus newly created layer nodes (including groups) in inspector

### DIFF
--- a/Stitch/Graph/Node/Util/NodeCreatedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeCreatedAction.swift
@@ -148,10 +148,17 @@ extension StitchDocumentViewModel {
                 return nil
             }
             
+            // Update sidebar data
             let sidebarLayerData = SidebarLayerData(id: layerNode.id)
             var newSidebarData = self.visibleGraph.layersSidebarViewModel.createdOrderedEncodedData()
             newSidebarData.insert(sidebarLayerData, at: 0)
             self.visibleGraph.layersSidebarViewModel.update(from: newSidebarData)
+            
+            // Focus this, and only this, layer node in inspector
+            self.visibleGraph.layersSidebarViewModel.resetEditModeSelections()
+            self.visibleGraph.layersSidebarViewModel.sidebarItemSelectedViaEditMode(sidebarLayerData.id)
+            self.visibleGraph.layersSidebarViewModel.selectionState.lastFocused = sidebarLayerData.id
+            self.visibleGraph.deselectAllCanvasItems()
             
             return layerNode
 

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarGroupCreated.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarGroupCreated.swift
@@ -57,7 +57,12 @@ extension LayersSidebarViewModel {
             // Reset selections
             self.selectionState.resetEditModeSelections()
         }
-
+        
+        // Focus this, and only this, layer node in inspector
+        self.selectionState.resetEditModeSelections()
+        self.sidebarItemSelectedViaEditMode(newNode.id)
+        self.selectionState.lastFocused = newNode.id
+        self.graphDelegate?.deselectAllCanvasItems()
         
         // NOTE: must do this AFTER children have been assigned to the new layer node; else we return preview window size
         


### PR DESCRIPTION
Note: no changes to duplication / copy-paste.

### new layer
https://github.com/user-attachments/assets/bc757280-a385-4437-a245-a56103e61683

### new layer group
https://github.com/user-attachments/assets/8d783caf-ed62-46b1-bc57-29a4ea4018a1


