### PR TITLE
TAB between eligible nodes during edit mode

### DIFF
--- a/Stitch/App/View/Component/StitchButton.swift
+++ b/Stitch/App/View/Component/StitchButton.swift
@@ -87,7 +87,7 @@ struct UIKitTappableWrapper<T: View>: UIViewControllerRepresentable {
             rootView: view(),
             ignoresSafeArea: false,
             ignoreKeyCommands: true,
-            name: "UIKitTappableWrapper")
+            name: .uiKitTappableWrapper)
         let delegate = context.coordinator
 
         let tapGesture = UITapGestureRecognizer(target: delegate,

--- a/Stitch/App/View/Component/StitchSheet.swift
+++ b/Stitch/App/View/Component/StitchSheet.swift
@@ -48,7 +48,7 @@ struct SheetViewModifier<T: View>: ViewModifier {
         content
             .sheet(isPresented: isPresentedBinding) {
                 StitchHostingControllerView(ignoreKeyCommands: false,
-                                            name: "SheetViewModifier") {
+                                            name: .sheetView) {
                     VStack(alignment: .leading) {
                         titleView
                         sheetBody

--- a/Stitch/App/View/ViewUtil/StitchHostingController.swift
+++ b/Stitch/App/View/ViewUtil/StitchHostingController.swift
@@ -68,7 +68,7 @@ class StitchHostingController<T: View>: UIHostingController<T> {
     @MainActor
     override func pressesBegan(_ presses: Set<UIPress>,
                                with event: UIPressesEvent?) {
-        // log("KEY: StitchHostingController: name: \(name): pressesBegan: presses.first?.key: \(presses.first?.key)")
+        log("KEY: StitchHostingController: name: \(name): pressesBegan: presses.first?.key: \(presses.first?.key)")
         presses.first?.key.map(keyPressed)
         //        super.pressesBegan(presses, with: event)
         
@@ -94,7 +94,7 @@ class StitchHostingController<T: View>: UIHostingController<T> {
     @MainActor
     override func pressesEnded(_ presses: Set<UIPress>,
                                with event: UIPressesEvent?) {
-        // log("KEY: StitchHostingController: name: \(name): pressesEnded: presses.first?.key: \(presses.first?.key)")
+        log("KEY: StitchHostingController: name: \(name): pressesEnded: presses.first?.key: \(presses.first?.key)")
         presses.first?.key.map(keyReleased)
         super.pressesEnded(presses, with: event)
     }
@@ -102,14 +102,14 @@ class StitchHostingController<T: View>: UIHostingController<T> {
     @MainActor
     override func pressesCancelled(_ presses: Set<UIPress>,
                                    with event: UIPressesEvent?) {
-        // log("KEY: StitchHostingController: name: \(name): pressesCancelled: presses.first?.key: \(presses.first?.key)")
+        log("KEY: StitchHostingController: name: \(name): pressesCancelled: presses.first?.key: \(presses.first?.key)")
         presses.first?.key.map(keyReleased)
         super.pressesCancelled(presses, with: event)
     }
 
     @MainActor
     func keyPressed(_ key: UIKey) {
-        // log("KEY: StitchHostingController: name: \(name): keyPressed: key: \(key)")
+        log("KEY: StitchHostingController: name: \(name): keyPressed: key: \(key)")
         
         // TODO: key-modifiers (Tab, Shift etc.) and key-characters are not exclusive
         if let modifiers = key.asStitchKeyModifiers {
@@ -121,7 +121,7 @@ class StitchHostingController<T: View>: UIHostingController<T> {
 
     @MainActor
     func keyReleased(_ key: UIKey) {
-        // log("KEY: StitchHostingController: name: \(name): keyReleased: key: \(key)")
+        log("KEY: StitchHostingController: name: \(name): keyReleased: key: \(key)")
         if let modifiers = key.asStitchKeyModifiers {
             dispatch(KeyModifierPressEnded(modifiers: modifiers))
         } else if let keyPress = key.characters.first {

--- a/Stitch/App/View/ViewUtil/StitchHostingController.swift
+++ b/Stitch/App/View/ViewUtil/StitchHostingController.swift
@@ -9,18 +9,61 @@ import Foundation
 import SwiftUI
 import UIKit
 
+/*
+ We use UIHostingController key-listening when:
+ 
+ 1. listening for any key press, e.g. graph listening for TABs on the graph or in a field (node field, inspector field etc.) or for a keyboard patch node
+ 2. listening only for specific keys, e.g. arrow keys in the insert node menu searchbar).
+ 3. listening only in specific UI situations, e.g. listening to TAB presses when preview window fullscreen (NOTE: No longer relevant?)
+ 
+ 
+ We use UIHostingController more generally to:
+ 
+ 1. apply UIKit gestures
+ 2. solve certain bugs, e.g. UIKitWrapper around preview window
+ 
+
+ Current challenges / undesired behavior:
+ 
+ 1. key-released events firing before a key-pressed event and/or fired while key still held down
+ 2. multiple key listeners responding to certain key modifiers but not others (e.g. `TAB` but not `Option`)
+ 
+
+ Current solutions / workarounds:
+ 
+ 1. rely on UIKit gestures for detecting `Option`, `Shift` during a tap or drag etc. (NOTE: relying on UITapGestureRecognizer for sidebar items has seemed to make tap less reliable?)
+ 
+ 
+ Multiple ways to solve this:
+ 
+ 1. be smarter about when and where we use key listening; e.g. maybe we need a UIHostingController on PreviewContent to solve a gesture bug, but that controlelr doesn't need to listen to gestures
+ 2. handle conflicting key-listening logic at the redux level; helpful for more complicated scenarios where we need to look at other state to determine how to handle a key
+ 
+ 
+ Note: `ignoresKeyCommands = true` does not prevent us from listening to key modifier presses like TAB.
+ */
+enum KeyListenerName: String, Equatable {
+    case previewWindow, // PreviewContent
+         insertNodeMenuSearchbar, // InsertNodeMenuSearchBar
+         mainGraph, // ContentView i.e. "nodeAndMenu"
+         sheetView,
+         fullScreenGestureRecognzer, // full screen preview window
+         uiKitTappableWrapper, // variety of use cases?
+         sidebarListItem // "SidebarListItemGestureRecognizerView"
+}
+
 /// Used by various SwiftUI views to inject a view into a view controller
 class StitchHostingController<T: View>: UIHostingController<T> {
     let ignoresSafeArea: Bool
     let ignoreKeyCommands: Bool
     var usesArrowKeyBindings: Bool = false
-    let name: String
+    let name: KeyListenerName
 
     init(rootView: T,
          ignoresSafeArea: Bool,
          ignoreKeyCommands: Bool,
          usesArrowKeyBindings: Bool = false,
-         name: String) {
+         name: KeyListenerName) {
         self.ignoresSafeArea = ignoresSafeArea
         self.ignoreKeyCommands = ignoreKeyCommands
         self.usesArrowKeyBindings = usesArrowKeyBindings
@@ -234,7 +277,7 @@ class StitchHostingController<T: View>: UIHostingController<T> {
 struct StitchHostingControllerView<T: View>: View {
     let ignoreKeyCommands: Bool
     var usesArrowKeyBindings: Bool = false
-    let name: String
+    let name: KeyListenerName
     @ViewBuilder var view: () -> T
 
     var body: some View {
@@ -251,7 +294,7 @@ struct StitchHostingControllerViewRepresentable<T: View>: UIViewControllerRepres
     let view: T
     let ignoreKeyCommands: Bool
     var usesArrowKeyBindings: Bool = false
-    let name: String
+    let name: KeyListenerName
 
     func makeUIViewController(context: Context) -> StitchHostingController<T> {
         StitchHostingController(rootView: view,

--- a/Stitch/App/View/ViewUtil/StitchHostingController.swift
+++ b/Stitch/App/View/ViewUtil/StitchHostingController.swift
@@ -156,7 +156,7 @@ class StitchHostingController<T: View>: UIHostingController<T> {
         
         // TODO: key-modifiers (Tab, Shift etc.) and key-characters are not exclusive
         if let modifiers = key.asStitchKeyModifiers {
-            dispatch(KeyModifierPressBegan(modifiers: modifiers))
+            dispatch(KeyModifierPressBegan(name: self.name, modifiers: modifiers))
         } else if let keyPress = key.characters.first {
             dispatch(KeyCharacterPressBegan(char: keyPress))
         }

--- a/Stitch/App/View/ViewUtil/UIKitWrapper.swift
+++ b/Stitch/App/View/ViewUtil/UIKitWrapper.swift
@@ -13,7 +13,7 @@ import StitchSchemaKit
 // a SwiftUI view that accepts another SwiftUI view T, and which wraps T in a UIKit view
 struct UIKitWrapper<T: View>: UIViewControllerRepresentable {
     let ignoresKeyCommands: Bool
-    let name: String
+    let name: KeyListenerName
     @ViewBuilder var content: () -> T
 
     // called when first made

--- a/Stitch/Graph/Edge/Model/EdgeEditingState.swift
+++ b/Stitch/Graph/Edge/Model/EdgeEditingState.swift
@@ -49,8 +49,9 @@ struct EdgeEditingState {
     // with closest closest canvas item at index = 0
     var eastNodesFromClosestToFarthest: EligibleEasternNodes
 
+    // Modified by `canvasItemIndexChanged`
     var nearbyCanvasItemIndex: Int // = Self.defaultNearbyCanvasItemIndex
-    
+        
     var possibleEdges: PossibleEdgeSet
 
     /// Are we showing the edge-edit mode labels in front of inputs?
@@ -86,4 +87,62 @@ struct EdgeEditingState {
         animationInProgressIds.contains(possibleEdgeId)
     }
     
+}
+
+extension EdgeEditingState {
+    
+    // TODO: make EdgeEditingState an @Observable if perf problems encountered; but perf should be fine given that this is done via a user-button press
+    @MainActor
+    func canvasItemIndexChanged(edgeEditState: EdgeEditingState,
+                                graph: GraphState,
+                                wasIncremented: Bool) -> Self {
+        
+        var edgeEditState = edgeEditState._indexChanged(
+            edgeEditState: edgeEditState,
+            wasIncremented: wasIncremented)
+                
+        // Immediately show labels
+        edgeEditState.labelsShown = true
+        
+        // Update possible edges etc.
+        guard let newNearbyNode = graph.getCanvasItem(edgeEditState.nearbyCanvasItem) else {
+            fatalErrorIfDebug()
+            return edgeEditState
+        }
+        
+        let (alreadyShownEdges,
+             possibleEdges) = graph.getShownAndPossibleEdges(
+            nearbyNode: newNearbyNode,
+            outputCoordinate: edgeEditState.originOutput)
+        
+        edgeEditState.shownIds = alreadyShownEdges
+        edgeEditState.possibleEdges = possibleEdges
+        
+        return edgeEditState
+    }
+    
+    private func _indexChanged(edgeEditState: EdgeEditingState,
+                               wasIncremented: Bool) -> Self {
+        
+        var edgeEditState = edgeEditState
+        
+        let eastNodeCount = edgeEditState.eastNodesFromClosestToFarthest.count
+        
+        if wasIncremented {
+            if (edgeEditState.nearbyCanvasItemIndex + 1) >= eastNodeCount {
+                // If we incremented past the end, jump back to the start.
+                edgeEditState.nearbyCanvasItemIndex = 0
+            } else {
+                edgeEditState.nearbyCanvasItemIndex += 1
+            }
+        } else {
+            if (edgeEditState.nearbyCanvasItemIndex - 1) < 0 {
+                edgeEditState.nearbyCanvasItemIndex = eastNodeCount - 1
+            } else {
+                edgeEditState.nearbyCanvasItemIndex -= 1
+            }
+        }
+                
+        return edgeEditState
+    }
 }

--- a/Stitch/Graph/Edge/Model/EdgeEditingState.swift
+++ b/Stitch/Graph/Edge/Model/EdgeEditingState.swift
@@ -7,6 +7,7 @@
 
 import StitchSchemaKit
 import SwiftUI
+import NonEmpty
 
 typealias PossibleEdgeId = InputPortViewData
 
@@ -29,14 +30,27 @@ extension PossibleEdge {
 
 typealias PossibleEdgeSet = Set<PossibleEdge>
 
-struct EdgeEditingState {
+typealias EligibleEasternNodes = NonEmptyArray<CanvasItemId>
 
+struct EdgeEditingState {
+    
+    static let defaultNearbyCanvasItemIndex = 0
+    
     // currently hovered-over output
     var originOutput: OutputPortViewData
-
+    
     // the node that is east of, and the shortest distance from, the origin node
-    var nearbyCanvasItem: CanvasItemId
+    //    var nearbyCanvasItem: CanvasItemId
+    var nearbyCanvasItem: CanvasItemId {
+        self.eastNodesFromClosestToFarthest[safeIndex: self.nearbyCanvasItemIndex] ?? self.eastNodesFromClosestToFarthest.first
+    }
+    
+    // Canvas items east of the hovered output,
+    // with closest closest canvas item at index = 0
+    var eastNodesFromClosestToFarthest: EligibleEasternNodes
 
+    var nearbyCanvasItemIndex: Int // = Self.defaultNearbyCanvasItemIndex
+    
     var possibleEdges: PossibleEdgeSet
 
     /// Are we showing the edge-edit mode labels in front of inputs?
@@ -71,4 +85,5 @@ struct EdgeEditingState {
     func isAnimating(_ possibleEdgeId: PossibleEdgeId) -> Bool {
         animationInProgressIds.contains(possibleEdgeId)
     }
+    
 }

--- a/Stitch/Graph/Edge/Util/EdgeEditingActions.swift
+++ b/Stitch/Graph/Edge/Util/EdgeEditingActions.swift
@@ -16,9 +16,15 @@ struct OutputHoveredLongEnough: GraphUIEvent {
     }
 }
 
+
+
 extension GraphState {
+//    @MainActor
+//    func createEdgeEditingState()
+    
     @MainActor
     func outputHovered(outputCoordinate: OutputPortViewData) {
+        log("outputHovered fired")
         
         if self.edgeDrawingObserver.drawingGesture != nil {
             log("OutputHovered called during edge drawing gesture; exiting")
@@ -34,27 +40,103 @@ extension GraphState {
             return
         }
         
-        guard let nearbyNodeId = self.getEligibleNearbyNode(eastOf: outputCoordinate.canvasId) else {
-            log("OutputHovered: no nearby node")
+//        guard let nearbyNodeId = self.getEligibleNearbyNode(eastOf: outputCoordinate.canvasId) else {
+//            log("OutputHovered: no nearby node")
+//            return
+//        }
+        
+        guard let nodesEastOfOutput = self.getNodesToTheEastFromClosestToFarthest(eastOf: outputCoordinate.canvasId) else {
+            log("OutputHovered: no nodes to the east of this hovered output")
             return
         }
         
+        guard let nearbyNodeId = nodesEastOfOutput[safeIndex: EdgeEditingState.defaultNearbyCanvasItemIndex] else {
+            log("OutputHovered: could not retrieve closest nearby-node")
+            return
+        }
+                
         guard let nearbyNode = self.getCanvasItem(nearbyNodeId) else {
             log("OutputHovered: could not retrieve nearby node \(nearbyNodeId)")
             return
         }
         
         // log("OutputHovered: nearbyNodeId: \(nearbyNodeId)")
+        let (alreadyShownEdges,
+             possibleEdges) = getShownAndPossibleEdges(nearbyNode: nearbyNode,
+                                                       outputCoordinate: outputCoordinate)
         
+//        var alreadyShownEdges = Set<PossibleEdgeId>()
+//        
+//        let possibleEdges: PossibleEdgeSet = nearbyNode
+//            .edgeFriendlyInputCoordinates(from: self.visibleNodesViewModel,
+//                                          focusedGroupId: self.groupNodeFocused)
+//            .reduce(into: PossibleEdgeSet()) { partialResult, inputCoordinate in
+//                
+//                let edgeUI = PortEdgeUI(from: outputCoordinate,
+//                                        to: inputCoordinate)
+//                
+//                guard let edgeData = PortEdgeData(viewData: edgeUI, graph: self) else {
+//                    return
+//                }
+//                
+//                /*
+//                 If there's already an edge to this input,
+//                 then start out with the possible-edge committed.
+//                 Note: `graphSchema.connections.hasEdge` checks whether the input has any edges, not this specific edge
+//                 */
+//                let isCommitted = self.edgeExists(edgeData)
+//                
+//                let possibleEdge = PossibleEdge(
+//                    edge: edgeUI,
+//                    isCommitted: isCommitted)
+//                
+//                if isCommitted {
+//                    alreadyShownEdges.insert(possibleEdge.id)
+//                }
+//                
+//                partialResult.insert(possibleEdge)
+//            }
+//        
+        log("OutputHovered: possibleEdges: \(possibleEdges)")
+        log("OutputHovered: alreadyShownEdges: \(alreadyShownEdges)")
+        
+        self.graphUI.edgeAnimationEnabled = true
+        
+//        self.graphUI.edgeEditingState = .init(
+//            originOutput: outputCoordinate,
+//            nearbyCanvasItem: nearbyNodeId,
+//            possibleEdges: possibleEdges,
+//            shownIds: alreadyShownEdges)
+        
+        self.graphUI.edgeEditingState = .init(
+            originOutput: outputCoordinate,
+            eastNodesFromClosestToFarthest: nodesEastOfOutput,
+            nearbyCanvasItemIndex: EdgeEditingState.defaultNearbyCanvasItemIndex,
+            possibleEdges: possibleEdges,
+            shownIds: alreadyShownEdges)
+    }
+    
+    @MainActor
+    func getShownAndPossibleEdges(nearbyNode: CanvasItemViewModel,
+                                  outputCoordinate: OutputPortViewData) -> (shownEdges: Set<PossibleEdgeId>,
+                                            possibleEdges: PossibleEdgeSet) {
         var alreadyShownEdges = Set<PossibleEdgeId>()
         
+        log("getShownAndPossibleEdges: nearbyNode.id: \(nearbyNode.id)")
+        
         let possibleEdges: PossibleEdgeSet = nearbyNode
+        
             .edgeFriendlyInputCoordinates(from: self.visibleNodesViewModel,
                                           focusedGroupId: self.groupNodeFocused)
+        
             .reduce(into: PossibleEdgeSet()) { partialResult, inputCoordinate in
+                log("getShownAndPossibleEdges: on inputCoordinate: \(inputCoordinate)")
+                
+                //
                 
                 let edgeUI = PortEdgeUI(from: outputCoordinate,
                                         to: inputCoordinate)
+                
                 guard let edgeData = PortEdgeData(viewData: edgeUI, graph: self) else {
                     return
                 }
@@ -77,18 +159,14 @@ extension GraphState {
                 partialResult.insert(possibleEdge)
             }
         
-        // log("OutputHovered: possibleEdges: \(possibleEdges)")
-        // log("OutputHovered: alreadyShownEdges: \(alreadyShownEdges)")
+        log("getShownAndPossibleEdges: alreadyShownEdges: \(alreadyShownEdges)")
+        log("getShownAndPossibleEdges: possibleEdges: \(possibleEdges)")
         
-        self.graphUI.edgeAnimationEnabled = true
-        
-        self.graphUI.edgeEditingState = .init(
-            originOutput: outputCoordinate,
-            nearbyCanvasItem: nearbyNodeId,
-            possibleEdges: possibleEdges,
-            shownIds: alreadyShownEdges)
+        return (shownEdges: alreadyShownEdges,
+                possibleEdges: possibleEdges)
     }
 }
+
 
 extension CanvasItemViewModel {
     
@@ -98,8 +176,19 @@ extension CanvasItemViewModel {
     @MainActor
     func edgeFriendlyInputCoordinates(from nodes: VisibleNodesViewModel,
                                       focusedGroupId: NodeId?) -> [InputPortViewData] {
+        
+        // this looks at ALL nodes' inputs -- need to look only at
+        
         nodes.getVisibleCanvasItems(at: focusedGroupId)
-            .flatMap { canvasItem in
+            .flatMap { canvasItem -> [InputPortViewData] in
+                
+                guard let nodeId = self.nodeDelegate?.id,
+                      let canvasItemNodeId = canvasItem.nodeDelegate?.id,
+                      nodeId == canvasItemNodeId else {
+                    log("edgeFriendlyInputCoordinates: canvas item was not for this node")
+                    return .init()
+                }
+                
                 let inputsCount = canvasItem.inputViewModels.count
                 return (0..<inputsCount).map {
                     InputPortViewData(portId: $0, canvasId: canvasItem.id)
@@ -165,6 +254,57 @@ struct PossibleEdgeDecommitmentCompleted: GraphEvent {
 extension GraphState {
     
     @MainActor
+//    func getNodesToTheEastFromClosestToFarthest(eastOf originOutputNodeId: CanvasItemId) -> [CanvasItemId]? {
+    func getNodesToTheEastFromClosestToFarthest(eastOf originOutputNodeId: CanvasItemId) -> EligibleEasternNodes? {
+        
+        guard let originOutputNode = self.getCanvasItem(originOutputNodeId) else {
+            log("GraphState.closesNodeEast: node not found: \(originOutputNodeId)")
+            return nil
+        }
+                
+        let nodes = self.visibleNodesViewModel
+            .getVisibleCanvasItems(at: self.graphUI.groupNodeFocused?.asNodeId)
+        
+        // "Nearby node" for edge-edit mode can never be a wireless receiver node
+            .filter { $0.nodeDelegate?.kind.getPatch != .wirelessReceiver }
+        
+        // Note: we compare the origin node's output against the other nodes' inputs.
+        // The *input* must be east of the output.
+        let nodesEast = nodes.filter { node in
+            /*
+             Note: although SwiftUI's .position modifier is from top-left corner, we actually adjust the node's `position: CGPoint`, such that position = center of node.
+             
+             So:
+             `node.center.x - node.width/2` = east face, where inputs are.
+             the `node.center.x + node.width/2` = west face, where outputs are.
+             */
+            let adjustedOrigin = originOutputNode.position.x + originOutputNode.sizeByLocalBounds.width/2
+            let adjustedInput = node.position.x - node.sizeByLocalBounds.width/2
+            return adjustedInput > adjustedOrigin
+        }
+        
+        guard !nodesEast.isEmpty else {
+            log("GraphState.closesNodeEast: no nodes to the east of this output")
+            return nil
+        }
+        
+        let sortedNodes = nodesEast.sorted { n1, n2 in
+            let distance1 = originOutputNode.position.distance(to: n1.position)
+            let distance2 = originOutputNode.position.distance(to: n2.position)
+            return distance1 < distance2
+        }.map(\.id)
+        
+        log("sortedNodes: \(sortedNodes)")
+        
+        guard let result = EligibleEasternNodes(sortedNodes) else {
+            log("GraphState.closesNodeEast: could not create non-empty array")
+            return nil
+        }
+        
+        return result
+    }
+    
+    @MainActor
     func getEligibleNearbyNode(eastOf originOutputNodeId: CanvasItemId) -> CanvasItemId? {
         
         guard let originOutputNode = self.getCanvasItem(originOutputNodeId) else {
@@ -172,9 +312,10 @@ extension GraphState {
             return nil
         }
         
-        let groupNodeFouced = self.graphUI.groupNodeFocused?.asNodeId
+        let groupNodeFocused = self.graphUI.groupNodeFocused?.asNodeId
         let nodes = self.visibleNodesViewModel
-            .getVisibleCanvasItems(at: groupNodeFouced)
+            .getVisibleCanvasItems(at: groupNodeFocused)
+        
         // "Nearby node" for edge-edit mode can never be a wireless receiver node
             .filter { $0.nodeDelegate?.kind.getPatch != .wirelessReceiver }
         

--- a/Stitch/Graph/Edge/Util/EdgeEditingActions.swift
+++ b/Stitch/Graph/Edge/Util/EdgeEditingActions.swift
@@ -101,13 +101,7 @@ extension GraphState {
         log("OutputHovered: alreadyShownEdges: \(alreadyShownEdges)")
         
         self.graphUI.edgeAnimationEnabled = true
-        
-//        self.graphUI.edgeEditingState = .init(
-//            originOutput: outputCoordinate,
-//            nearbyCanvasItem: nearbyNodeId,
-//            possibleEdges: possibleEdges,
-//            shownIds: alreadyShownEdges)
-        
+                
         self.graphUI.edgeEditingState = .init(
             originOutput: outputCoordinate,
             eastNodesFromClosestToFarthest: nodesEastOfOutput,

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuSearchBar.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuSearchBar.swift
@@ -95,7 +95,7 @@ struct InsertNodeMenuSearchBar: View {
         // this is also the main key-press listener for the app, since the insert node menu is always on-screen
         StitchHostingControllerView(ignoreKeyCommands: false,
                                     usesArrowKeyBindings: true,
-                                    name: "InsertNodeMenuSearchBar") {
+                                    name: .insertNodeMenuSearchbar) {
             searchInput
         }
         .height(INSERT_NODE_MENU_SEARCH_BAR_HEIGHT) // need to set height again

--- a/Stitch/Graph/Node/Patch/Type/Interaction/Keyboard/KeyPressActions.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/Keyboard/KeyPressActions.swift
@@ -14,7 +14,7 @@ struct KeyModifierPressEnded: StitchDocumentEvent {
 
     @MainActor
     func handle(state: StitchDocumentViewModel) {
-        // log("KeyModifierPressEnded: modifiers: \(modifiers)")
+        log("KeyModifierPressEnded: modifiers: \(modifiers)")
         for modifier in modifiers {
             state.keypressState.modifiers.remove(modifier)
         }

--- a/Stitch/Graph/Node/Patch/Type/Interaction/Keyboard/KeyPressActions.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/Keyboard/KeyPressActions.swift
@@ -26,7 +26,7 @@ struct KeyModifierPressBegan: StitchDocumentEvent {
 
     @MainActor
     func handle(state: StitchDocumentViewModel) {
-        // log("KeyModifierPressBegan: modifiers: \(modifiers)")
+         log("KeyModifierPressBegan: modifiers: \(modifiers)")
         
         state.keypressState.modifiers = state.keypressState.modifiers.union(modifiers)
         
@@ -37,10 +37,31 @@ struct KeyModifierPressBegan: StitchDocumentEvent {
         let shiftTabPressed = shiftHeld && tabPressed
         
         // log("KeyModifierPressBegan: shiftHeld: \(shiftHeld)")
-        // log("KeyModifierPressBegan: tabPressed: \(tabPressed)")
-        // log("KeyModifierPressBegan: shiftTabPressed: \(shiftTabPressed)")
+         log("KeyModifierPressBegan: tabPressed: \(tabPressed)")
+         log("KeyModifierPressBegan: shiftTabPressed: \(shiftTabPressed)")
         
         let focusedField = state.graphUI.reduxFocusedField
+        
+        // When we tab, we change the edge editing state's nearbyNode, labelsShown, and possible and shown edges
+        // but hovered output and nodest-to-the-east stays the same
+        if let edgeEditingState = state.graphUI.edgeEditingState,
+            tabPressed {
+            log("tabbed with edge editing state: edgeEditingState.possibleEdges was: \(edgeEditingState.possibleEdges)")
+            state.graphUI.edgeEditingState!.nearbyCanvasItemIndex += 1
+            state.graphUI.edgeEditingState!.labelsShown = true // immediately show labels
+            if let newNearbyNode = state.graph.getCanvasItem(state.graphUI.edgeEditingState!.nearbyCanvasItem) {
+                let (alreadyShownEdges, possibleEdges) = state.graph.getShownAndPossibleEdges(
+                    nearbyNode: newNearbyNode,
+                    outputCoordinate: edgeEditingState.originOutput)
+                state.graphUI.edgeEditingState!.shownIds = alreadyShownEdges
+                state.graphUI.edgeEditingState!.possibleEdges = possibleEdges
+                log("tabbed with edge editing state: edgeEditingState.possibleEdges is now: \(edgeEditingState.possibleEdges)")
+            } else {
+                log("tabbed with edge editing state: could not get new nearby node")
+            }
+            
+            return
+        }
         
         // Tabbing between inputs project setting's preview window dimensions fields
         if focusedField == .previewWindowSettingsWidth, tabPressed {

--- a/Stitch/Graph/Node/Patch/Type/Interaction/Keyboard/KeyPressActions.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/Keyboard/KeyPressActions.swift
@@ -22,11 +22,12 @@ struct KeyModifierPressEnded: StitchDocumentEvent {
 }
 
 struct KeyModifierPressBegan: StitchDocumentEvent {
+    let name: KeyListenerName
     let modifiers: Set<StitchKeyModifier>
 
     @MainActor
     func handle(state: StitchDocumentViewModel) {
-         log("KeyModifierPressBegan: modifiers: \(modifiers)")
+         log("KeyModifierPressBegan: listener \(name) had modifiers: \(modifiers)")
         
         state.keypressState.modifiers = state.keypressState.modifiers.union(modifiers)
         
@@ -45,20 +46,15 @@ struct KeyModifierPressBegan: StitchDocumentEvent {
         // When we tab, we change the edge editing state's nearbyNode, labelsShown, and possible and shown edges
         // but hovered output and nodest-to-the-east stays the same
         if let edgeEditingState = state.graphUI.edgeEditingState,
-            tabPressed {
+           name == .mainGraph,
+           tabPressed {
+            
             log("tabbed with edge editing state: edgeEditingState.possibleEdges was: \(edgeEditingState.possibleEdges)")
-            state.graphUI.edgeEditingState!.nearbyCanvasItemIndex += 1
-            state.graphUI.edgeEditingState!.labelsShown = true // immediately show labels
-            if let newNearbyNode = state.graph.getCanvasItem(state.graphUI.edgeEditingState!.nearbyCanvasItem) {
-                let (alreadyShownEdges, possibleEdges) = state.graph.getShownAndPossibleEdges(
-                    nearbyNode: newNearbyNode,
-                    outputCoordinate: edgeEditingState.originOutput)
-                state.graphUI.edgeEditingState!.shownIds = alreadyShownEdges
-                state.graphUI.edgeEditingState!.possibleEdges = possibleEdges
-                log("tabbed with edge editing state: edgeEditingState.possibleEdges is now: \(edgeEditingState.possibleEdges)")
-            } else {
-                log("tabbed with edge editing state: could not get new nearby node")
-            }
+            
+            state.graphUI.edgeEditingState = edgeEditingState.canvasItemIndexChanged(
+                edgeEditState: edgeEditingState,
+                graph: state.graph,
+                wasIncremented: shiftTabPressed ? false : true)
             
             return
         }

--- a/Stitch/Graph/PrototypePreview/Frame/View/FullScreenGestureRecognizerView.swift
+++ b/Stitch/Graph/PrototypePreview/Frame/View/FullScreenGestureRecognizerView.swift
@@ -26,7 +26,7 @@ struct FullScreenGestureRecognizerView<Content: View>: UIViewControllerRepresent
             rootView: content(),
             ignoresSafeArea: ignoresSafeArea,
             ignoreKeyCommands: true,
-            name: "FullScreenGestureRecognizerView")
+            name: .fullScreenGestureRecognzer)
         vc.delegate = delegate
 
         // three-finger tap gesture opens action sheet

--- a/Stitch/Graph/PrototypePreview/Frame/View/PreviewContent.swift
+++ b/Stitch/Graph/PrototypePreview/Frame/View/PreviewContent.swift
@@ -56,7 +56,12 @@ struct PreviewContent: View {
         
         let generatedPreview = GeneratePreview(document: document)
         
-        UIKitWrapper(ignoresKeyCommands: false, name: "PreviewContent") {
+        // TODO: still needed to contain gestures?
+//        UIKitWrapper(ignoresKeyCommands: false, name: "PreviewContent") {
+        
+        // Even when `ignoresKeyCommands: true` and 
+        UIKitWrapper(ignoresKeyCommands: true, name: "PreviewContent") {
+//        NoKeyPressHostingController(name: "PreviewContent") {
             generatedPreview
                 .frame(finalSize)
                 .coordinateSpace(name: Self.prototypeCoordinateSpace)

--- a/Stitch/Graph/PrototypePreview/Frame/View/PreviewContent.swift
+++ b/Stitch/Graph/PrototypePreview/Frame/View/PreviewContent.swift
@@ -60,7 +60,7 @@ struct PreviewContent: View {
 //        UIKitWrapper(ignoresKeyCommands: false, name: "PreviewContent") {
         
         // Even when `ignoresKeyCommands: true` and 
-        UIKitWrapper(ignoresKeyCommands: true, name: "PreviewContent") {
+        UIKitWrapper(ignoresKeyCommands: true, name: .previewWindow) {
 //        NoKeyPressHostingController(name: "PreviewContent") {
             generatedPreview
                 .frame(finalSize)

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
@@ -43,7 +43,7 @@ struct SidebarListItemGestureRecognizerView<T: View,
             rootView: view,
             ignoresSafeArea: false,
             ignoreKeyCommands: true,
-            name: "SidebarListItemGestureRecognizerView")
+            name: .sidebarListItem)
 
         let delegate = context.coordinator
 

--- a/Stitch/Graph/View/ContentView.swift
+++ b/Stitch/Graph/View/ContentView.swift
@@ -52,7 +52,7 @@ struct ContentView: View, KeyboardReadable {
         ZStack {
             
             // Best place to listen for TAB key for flyout
-            UIKitWrapper(ignoresKeyCommands: true, name: "nodeAndMenu") {
+            UIKitWrapper(ignoresKeyCommands: true, name: .mainGraph) {
                 contentView // the graph
             }
             


### PR DESCRIPTION
Vastly extends usefulness of edge-edit-mode. Was also a feature requested by Jay.

https://github.com/user-attachments/assets/bc35f23d-1e1f-4a4b-89b2-5101808c6dae

