### PR TITLE
Support specific outputs on ConnectionAdded action

### DIFF
--- a/Stitch/Graph/Edge/Util/EdgeEditingActions.swift
+++ b/Stitch/Graph/Edge/Util/EdgeEditingActions.swift
@@ -138,7 +138,7 @@ extension CanvasItemViewModel {
                 guard let nodeId = self.nodeDelegate?.id,
                       let canvasItemNodeId = canvasItem.nodeDelegate?.id,
                       nodeId == canvasItemNodeId else {
-                    log("edgeFriendlyInputCoordinates: canvas item was not for this node")
+                    // log("edgeFriendlyInputCoordinates: canvas item was not for this node")
                     return .init()
                 }
                 

--- a/Stitch/Graph/Edge/Util/PortActions.swift
+++ b/Stitch/Graph/Edge/Util/PortActions.swift
@@ -130,7 +130,9 @@ extension GraphState {
         self.calculate(edge.from.nodeId)
         
         //we need the port here
-        self.documentDelegate?.maybeCreateLLMStepEdgeAdded(fromNodeId: edge.from.nodeId.uuidString, toNodeId: edge.to.nodeId.uuidString, input: edge.to)
+        self.documentDelegate?.maybeCreateLLMStepConnectionAdded(
+            input: edge.to,
+            output: edge.from)
     }
     
     @MainActor

--- a/Stitch/Graph/StitchAI/GraphPrompting/API/StitchAIConstants.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/StitchAIConstants.swift
@@ -191,10 +191,10 @@ let VISUAL_PROGRAMMING_ACTIONS = """
             { "type": "integer" },
             { "$ref": "#/$defs/LayerPorts" }
           ],
-          "description": "The port to use for the connection. Patch nodes use integers; Layer nodes use LayerPorts values."
+        "from_port": { "type": "integer", "description": "The port used for an outgoing node. Both Patch nodes and Layer nodes use integer values for their outputs." } ,
         }
       },
-      "required": ["step_type", "from_node_id", "to_node_id", "port"]
+      "required": ["step_type", "from_node_id", "to_node_id", "port", "from_port"]
     },
     "ChangeNodeTypeAction": {
       "type": "object",

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StateChangeToStepAction.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StateChangeToStepAction.swift
@@ -55,10 +55,15 @@ extension StitchDocumentViewModel {
     }
     
     @MainActor
-    func maybeCreateLLMStepEdgeAdded(fromNodeId: String,
-                                     toNodeId: String, input: InputCoordinate) {
+    func maybeCreateLLMStepConnectionAdded(input: InputCoordinate,
+                                           output: OutputCoordinate) {
+            
         if self.llmRecording.isRecording {
-            let step = createLLMStepEdgeAdded(input: input, fromNodeId, toNodeId: toNodeId)
+            
+            let step = createLLMStepConnectionAdded(
+                input: input,
+                output: output)
+            
             self.llmRecording.actions.append(step)
         }
     }
@@ -151,15 +156,20 @@ extension InputCoordinate {
 
 //need to feed in port id's as well
 //pass in the input coordinate
-func createLLMStepEdgeAdded(input: InputCoordinate,
-                            _ fromNodeId: String,
-                            toNodeId: String) -> LLMStepAction {
+func createLLMStepConnectionAdded(input: InputCoordinate,
+                                  output: OutputCoordinate) -> LLMStepAction {
     //actually create the action with the input coordiante using
     //asLLMStepPort()
-    LLMStepAction(stepType: StepType.connectNodes.rawValue,
-                  port: .init(value: input.asLLMStepPort()),
-                  fromNodeId: fromNodeId,
-                  toNodeId: toNodeId)
+    
+    var fromPort = output.portId
+    assertInDebug(fromPort.isDefined)
+    
+    return LLMStepAction(
+        stepType: StepType.connectNodes.rawValue,
+        port: .init(value: input.asLLMStepPort()),
+        fromPort: output.asLLMStepPort(),
+        fromNodeId: output.nodeId.uuidString,
+        toNodeId: input.nodeId.uuidString)
 }
 
 

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StitchAIDataModel.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StitchAIDataModel.swift
@@ -46,7 +46,9 @@ struct Step: Equatable, Codable {
     
     // NOTE: this is currently ALWAYS the input port (for edge-connection, for set-input etc.)
     // We currently assume that an edge goes out from a patch's first output.
-    var port: StringOrNumber?  // Updated to handle String or Int
+    var port: StringOrNumber?
+    
+    var fromPort: String?
     
     var fromNodeId: String?
     var toNodeId: String?
@@ -58,6 +60,7 @@ struct Step: Equatable, Codable {
         case nodeId = "node_id"
         case nodeName = "node_name"
         case port
+        case fromPort = "from_port"
         case fromNodeId = "from_node_id"
         case toNodeId = "to_node_id"
         case value


### PR DESCRIPTION
Example json:

```json

[
  {
    "node_name" : "time || Patch",
    "node_id" : "75350181-A3D3-44EC-B8EA-64C36C737846",
    "step_type" : "add_node"
  },
  {
    "node_name" : "oval || Layer",
    "node_id" : "2607544C-8521-47BA-99C1-EE6F300826E4",
    "step_type" : "add_node"
  },
  {
    "step_type" : "set_input",
    "value" : "[\"height\": 200.0, \"width\": 100.0]",
    "port" : "Size",
    "node_id" : "2607544C-8521-47BA-99C1-EE6F300826E4",
    "node_type" : "size"
  },
  {
    "port" : "Rotation Z",
    "node_id" : "2607544C-8521-47BA-99C1-EE6F300826E4",
    "step_type" : "add_layer_input"
  },
  {
    "from_node_id" : "75350181-A3D3-44EC-B8EA-64C36C737846",
    "step_type" : "connect_nodes",
    "port" : "Rotation Z",
    "from_port" : "1",
    "to_node_id" : "2607544C-8521-47BA-99C1-EE6F300826E4"
  }
]
```