### PR TITLE
Support wider variety of PortValue types in StitchAI Step actions

### DIFF
--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/JSON/JSONUtils.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/JSON/JSONUtils.swift
@@ -575,6 +575,12 @@ extension JSON {
     }
 }
 
+enum StitchAIValue: Equatable {
+    case number(Double)
+    case string(String)
+    case dictionary
+}
+
 //enum JSONFriendlyFormat: Encodable, Equatable {
 
 // Represents a PortValue in a way that displays "naturally" in a JSON.
@@ -592,7 +598,7 @@ enum JSONFriendlyFormat: Encodable, Decodable, Equatable {
     var jsonWrapper: JSON {
         self.setInJSON(JSON(["a"]), index: 0)
     }
-
+            
     /*
      How would you really decode this?
      You have no keys etc. -- you just get a string or number or dictionary etc. back.
@@ -610,15 +616,24 @@ enum JSONFriendlyFormat: Encodable, Decodable, Equatable {
         if let s = try? container.decode(String.self) {
             self = .string(s)
         }
+        
         else if let n = try? container.decode(Double.self) {
             self = .number(n)
-        } else if let d = try? container.decode([String: Double].self) {
+        }
+        
+        else if let d = try? container.decode([String: Double].self) {
             self = .dictionary(d)
-        } else if let ld = try? container.decode([String: String].self) {
+        }
+        
+        else if let ld = try? container.decode([String: String].self) {
             self = .layerSizeDictionary(ld)
-        } else if let j = try? container.decode(JSON.self) {
+        }
+        
+        else if let j = try? container.decode(JSON.self) {
             self = .json(j)
-        } else {
+        }
+        
+        else {
             fatalErrorIfDebug()
             self = .string("Decoding Failed")
         }
@@ -641,9 +656,6 @@ enum JSONFriendlyFormat: Encodable, Decodable, Equatable {
         }
     }
 }
-
-//extension LayerSize: Codable { }
-
 
 extension JSONFriendlyFormat {
     

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/JSON/JSONUtils.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/JSON/JSONUtils.swift
@@ -750,6 +750,13 @@ extension JSONFriendlyFormat {
                 }
                 return nil
                 
+            case .size:
+                // TODO: remove this once we have taught LLM Model t
+                if let size = self.jsonWrapper.first?.1.toSize {
+                    return .size(size)
+                }
+                return nil
+                
             default:
                 fatalErrorIfDebug()
                 return nil

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/JSON/JSONUtils.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/JSON/JSONUtils.swift
@@ -547,9 +547,17 @@ extension JSON {
         return nil
     }
 
+    var getWidth: LayerDimension? {
+        self[WIDTH].string?.asLayerDimension ?? self[WIDTH].double.map { LayerDimension.number($0) }
+    }
+    
+    var getHeight: LayerDimension? {
+        self[HEIGHT].string?.asLayerDimension ?? self[HEIGHT].double.map { LayerDimension.number($0) }
+    }
+    
     var toSize: LayerSize? {
-        if let width = self[WIDTH].string?.asLayerDimension,
-           let height = self[HEIGHT].string?.asLayerDimension {
+        if let width = self.getWidth,
+           let height = self.getHeight {
             return .init(width: width, height: height)
         }
         return nil

--- a/Stitch/Graph/Node/Port/Util/PortValue/PortValueDisplay.swift
+++ b/Stitch/Graph/Node/Port/Util/PortValue/PortValueDisplay.swift
@@ -136,7 +136,8 @@ extension PortValue {
         case  .cameraDirection(let x):
             return x.display
         case .assignedLayer(let x):
-            return x?.id.description ?? "No Layers" // Doesn't seem correct?
+//            return x?.id.description ?? "No Layers" // Doesn't seem correct?
+            return x?.id.description ?? "None" // Doesn't seem correct?
         case .pinTo(let x):
             return x.display
         case .scrollMode(let x):

--- a/Stitch/Graph/StitchAI/GraphPrompting/API/OpenAIRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/OpenAIRequest.swift
@@ -187,7 +187,7 @@ extension Stitch.Step: CustomStringConvertible {
             port: \(port?.value ?? "nil"),
             fromNodeId: \(fromNodeId ?? "nil"),
             toNodeId: \(toNodeId ?? "nil"),
-            value: \(value?.value ?? "nil"),
+            value: \(value),
             nodeType: \(nodeType ?? "nil")
         )
         """

--- a/Stitch/Graph/StitchAI/GraphPrompting/API/StitchAIConstants.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/StitchAIConstants.swift
@@ -382,7 +382,12 @@ let VISUAL_PROGRAMMING_ACTIONS = """
       "enum": [
         "number",
         "text",
-        "boolean"
+        "boolean", 
+        "size",
+        "position",
+        "point3D",
+        "padding",
+        "assignedLayer"
       ],
       "title": "NodeType",
       "type": "string"

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StateChangeToStepAction.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StateChangeToStepAction.swift
@@ -134,6 +134,7 @@ extension NodeViewModel {
                       // Note: `.asLLMValue: JSONFriendlyFormat` is needed for handling more complex values like `LayerDimension`
                       // value: value.asLLMValue,
                       value: .init(value: value.display),
+//                      value: .init(value: JSONFriendlyFormat(value: value)),
                       
                       // For disambiguating between e.g. a string "2" and the number 2
                       nodeType: value.toNodeType.asLLMStepNodeType)

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StateChangeToStepAction.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StateChangeToStepAction.swift
@@ -97,44 +97,17 @@ extension NodeViewModel {
                       nodeType: newNodeType.asLLMStepNodeType)
     }
     
+    @MainActor
     func createLLMStepSetInput(input: InputCoordinate,
                                value: PortValue) -> LLMStepAction {
-        /*
-         RELEVANT SECTION OF OUR OPEN-AI SCHEMA:
-         
-         "SetInputAction": {
-           "type": "object",
-           "properties": {
-             "step_type": { "const": "set_input" },
-             "node_id": { "type": "string", "description": "ID of the node receiving the input", "format": "uuid" },
-             "value": {
-               "anyOf": [
-                 { "type": "number" },
-                 { "type": "string" },
-                 { "type": "boolean" }
-               ],
-               "description": "Value to set for the input"
-             },
-             "port": {
-               "anyOf": [
-                 { "type": "integer" },
-                 { "$ref": "#/$defs/LayerPorts" }
-               ],
-               "description": "The port to which the value is set. Patch nodes use integers; Layer nodes use LayerPorts."
-             },
-             "node_type": { "$ref": "#/$defs/NodeType", "description": "The type of node to use." }
-           },
-           "required": ["step_type", "node_id", "port", "value", "node_type"]
-         },
-         */
         LLMStepAction(stepType: StepType.setInput.rawValue,
                       nodeId: self.id.description,
                       port: .init(value: input.asLLMStepPort()),
                       
                       // Note: `.asLLMValue: JSONFriendlyFormat` is needed for handling more complex values like `LayerDimension`
                       // value: value.asLLMValue,
-                      value: .init(value: value.display),
-//                      value: .init(value: JSONFriendlyFormat(value: value)),
+//                      value: .init(value: value.display),
+                      value: JSONFriendlyFormat(value: value),
                       
                       // For disambiguating between e.g. a string "2" and the number 2
                       nodeType: value.toNodeType.asLLMStepNodeType)

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StateChangeToStepAction.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StateChangeToStepAction.swift
@@ -128,6 +128,19 @@ extension InputCoordinate {
     }
 }
 
+extension OutputCoordinate {
+    func asLLMStepFromPort() -> Int {
+        switch self.portType {
+        case .keyPath(let x):
+            fatalErrorIfDebug()
+            return 0
+        case .portIndex(let x):
+            // an integer
+            return x
+        }
+    }
+}
+
 //need to feed in port id's as well
 //pass in the input coordinate
 func createLLMStepConnectionAdded(input: InputCoordinate,
@@ -141,7 +154,7 @@ func createLLMStepConnectionAdded(input: InputCoordinate,
     return LLMStepAction(
         stepType: StepType.connectNodes.rawValue,
         port: .init(value: input.asLLMStepPort()),
-        fromPort: output.asLLMStepPort(),
+        fromPort: output.asLLMStepFromPort(),
         fromNodeId: output.nodeId.uuidString,
         toNodeId: input.nodeId.uuidString)
 }

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StepActionToStateChange.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StepActionToStateChange.swift
@@ -229,21 +229,15 @@ extension LLMStepAction {
     }
     
     func parseFromPort() -> Int? {
-        guard let fromPort: String = self.fromPort else {
+        
+        guard let fromPort: Int = self.fromPort else {
             log("fromPort was not defined")
             // For legacy reasons, assume 0
 //            return nil
             return 0
         }
           
-        if let portId = Int(fromPort) {
-            return portId
-        } else if let portId = Double(fromPort) {
-            return Int(portId)
-        } else {
-            log("could not parse LLMStepAction's fromPort: \(fromPort)")
-            return nil
-        }
+        return fromPort
     }
     
     // See note in `NodeType.asLLMStepNodeType`

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StepActionToStateChange.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StepActionToStateChange.swift
@@ -175,18 +175,73 @@ enum PatchOrLayer: Equatable, Codable {
 
 extension LLMStepAction {
     
+    // TODO: smarter 
     func parseValue(_ nodeType: NodeType) -> PortValue? {
         guard let value: StringOrNumber = self.value else {
             log("value was not defined")
             return nil
         }
         
-        // TODO: to support a wider range of values, use `JSONFriendlyFormat` instead of `StringOrNumber` and follow older LLMAction-style parsing of LLMSetInput
-        if let number = Double(value.value) {
-            return .number(number)
-        } else {
+        log("LLMStepAction: parseValue: had node type \(nodeType) and value \(value)")
+        
+        let valueAsJSON = parseJSON(value.value)
+        
+        log("LLMStepAction: parseValue: valueAsJSON \(valueAsJSON)")
+        
+        // parsing what the model can create; but not the same as what LLM "recording mode" creates
+        
+        switch nodeType {
+                        
+        case .position:
+            if let json = parseJSON(value.value),
+               let x = json["x"].double,
+               let y = json["y"].double {
+                
+                log("LLMStepAction: parseValue: position \(x), \(y)")
+                return .position(.init(x: x, y: y))
+            } else {
+                log("LLMStepAction: parseValue: position: could not create position")
+                return nil
+            }
+        
+        case .size:
+            if let json = parseJSON(value.value),
+               let width = json["width"].double,
+               let height = json["height"].double {
+                
+                log("LLMStepAction: parseValue: size \(width), \(height)")
+                return .size(.init(width: width, height: height))
+            } else {
+                log("LLMStepAction: parseValue: size: could not create size")
+                return nil
+            }
+        
+        case .number:
+            return Double(value.value).map(PortValue.number)
+            
+        case .interactionId:
+            if let uuid = UUID(uuidString: value.value) {
+                log("LLMStepAction: parseValue: interactionId: had assigned layer \(uuid)")
+                return .assignedLayer(.init(uuid))
+            } else if value.value == PortValue.assignedLayer(nil).display {
+                log("LLMStepAction: parseValue: interactionId: had assigned nil layer")
+                return .assignedLayer(nil)
+            } else {
+                log("LLMStepAction: parseValue: interactionId: could not create assigned layer")
+                return nil
+            }
+        
+        default:
+            log("LLMStepAction: parseValue: node type \(nodeType) defaulting for value \(value)")
             return .string(.init(value.value))
         }
+        
+        // TODO: to support a wider range of values, use `JSONFriendlyFormat` instead of `StringOrNumber` and follow older LLMAction-style parsing of LLMSetInput
+//        if let number = Double(value.value) {
+//            return .number(number)
+//        } else {
+//            return .string(.init(value.value))
+//        }
     }
     
     // TODO: `LLMStepAction`'s `port` parameter does not yet properly distinguish between input vs output?

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StitchAIDataModel.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StitchAIDataModel.swift
@@ -55,7 +55,7 @@ struct Step: Equatable, Codable {
     var toNodeId: String?
     
 //    var value: StringOrNumber?  // Updated to handle String or Int
-    var value: JSONFriendlyFormat
+    var value: JSONFriendlyFormat?
     
     var nodeType: String?
     

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StitchAIDataModel.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StitchAIDataModel.swift
@@ -49,7 +49,7 @@ struct Step: Equatable, Codable {
     // We currently assume that an edge goes out from a patch's first output.
     var port: StringOrNumber?
     
-    var fromPort: String?
+    var fromPort: Int?
     
     var fromNodeId: String?
     var toNodeId: String?

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StitchAIDataModel.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StitchAIDataModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftyJSON
 
 struct OpenAIResponse: Codable {
     var choices: [Choice]
@@ -52,7 +53,10 @@ struct Step: Equatable, Codable {
     
     var fromNodeId: String?
     var toNodeId: String?
-    var value: StringOrNumber?  // Updated to handle String or Int
+    
+//    var value: StringOrNumber?  // Updated to handle String or Int
+    var value: JSONFriendlyFormat
+    
     var nodeType: String?
     
     enum CodingKeys: String, CodingKey {
@@ -93,7 +97,12 @@ extension StringOrNumber: Codable {
         } else if let stringValue = try? container.decode(String.self) {
             log("StringOrNumber: Decoder: tried string")
             self.value = stringValue
-        } else {
+        } else if let jsonValue = try? container.decode(JSON.self) {
+            log("StringOrNumber: Decoder: had json \(jsonValue)")
+            // escaped string?
+            self.value = jsonValue.description
+        }
+        else {
             throw DecodingError.typeMismatch(String.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected String, Int, or Double"))
         }
     }


### PR DESCRIPTION
We now encode and decode values as `JSONFriendlyFormat`, so we theoretically support all PortValue types but we need to extend the node_types listed in the OpenAI schema. 

(Also fixes bug with creating connections from OpenAI-generated data.)

In practice the non-fine-tuned model can get the following prompts right about 50% of them:
- Create a value node, change its node type to Size, then change its input to be width = 300 and height = 200
- Create a value node, change its node type to Position, then change its input to be x = 300 and y = 200

^^ when we get e.g. "width = 300, height = 300" on a node as the final result, it's because the model created two separate `SetInput` steps, each which has `.number(300)`; i.e. the model is creating incorrect information; our action-parsing logic seems to be fine.

This fails horribly though: 
- Create an Oval layer, then create a Drag Interaction patch node, and assign the Oval layer to the Drag Interaction patch node

https://github.com/user-attachments/assets/ef3fa442-af81-4430-bb1c-12c8a3b8dfa7

https://github.com/user-attachments/assets/e6f7e5d3-fd44-4c94-9bbb-4ed4a516f9df


