### PR TITLE
Better support masking when the masked and masking views have different loop length

### DIFF
--- a/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
+++ b/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
@@ -25,12 +25,7 @@ final class LayerNodeViewModel {
     var layer: Layer
 
     // View models for layers in prototype window
-    var previewLayerViewModels: [LayerViewModel] = [] {
-        didSet {
-            let ids = previewLayerViewModels.map(\.id.loopIndex)
-            log("LayerNodeViewModel: previewLayerViewModels: didSet: ids: \(ids)")
-        }
-    }
+    var previewLayerViewModels: [LayerViewModel] = [] 
  
     // Some layer nodes contain outputs
     var outputPorts: [OutputLayerNodeRowData] = []

--- a/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
+++ b/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
@@ -25,7 +25,12 @@ final class LayerNodeViewModel {
     var layer: Layer
 
     // View models for layers in prototype window
-    var previewLayerViewModels: [LayerViewModel] = []
+    var previewLayerViewModels: [LayerViewModel] = [] {
+        didSet {
+            let ids = previewLayerViewModels.map(\.id.loopIndex)
+            log("LayerNodeViewModel: previewLayerViewModels: didSet: ids: \(ids)")
+        }
+    }
  
     // Some layer nodes contain outputs
     var outputPorts: [OutputLayerNodeRowData] = []

--- a/Stitch/Graph/PrototypePreview/Frame/View/PreviewWindowElementUIKitGestures.swift
+++ b/Stitch/Graph/PrototypePreview/Frame/View/PreviewWindowElementUIKitGestures.swift
@@ -56,7 +56,7 @@ struct PreviewWindowElementSwiftUIGestures: ViewModifier {
     var dragGesture: some Gesture {
         DragGesture(minimumDistance: minimumDragDistance)
             .onChanged {
-                 log("PreviewWindowElementGestures: DragGesture: onChanged: id: \(interactiveLayer.id)")
+                 // log("PreviewWindowElementGestures: DragGesture: onChanged: id: \(interactiveLayer.id)")
                 
                 // TODO: come up with a better, more accurate velocity calculation
                 // (average vs momentaneous velocity?)

--- a/Stitch/Graph/PrototypePreview/Frame/View/PreviewWindowElementUIKitGestures.swift
+++ b/Stitch/Graph/PrototypePreview/Frame/View/PreviewWindowElementUIKitGestures.swift
@@ -56,7 +56,7 @@ struct PreviewWindowElementSwiftUIGestures: ViewModifier {
     var dragGesture: some Gesture {
         DragGesture(minimumDistance: minimumDragDistance)
             .onChanged {
-                // log("PreviewWindowElementGestures: DragGesture: id: \(interactiveLayer.id) onChanged: \($0)")
+                 log("PreviewWindowElementGestures: DragGesture: onChanged: id: \(interactiveLayer.id)")
                 
                 // TODO: come up with a better, more accurate velocity calculation
                 // (average vs momentaneous velocity?)
@@ -67,7 +67,8 @@ struct PreviewWindowElementSwiftUIGestures: ViewModifier {
                 // Factor out anchoring (i.e. position + size/2 + anchoring)
                 let location = CGPoint(x: $0.location.x - pos.x,
                                        y: $0.location.y - pos.y)
-                                
+                     
+            
                 graph.layerDragged(interactiveLayer: interactiveLayer,
                                    location: location, // // PRESS NODE ONLY
                                    translation: $0.translation,

--- a/Stitch/Graph/PrototypePreview/Layer/Model/LayerData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/LayerData.swift
@@ -20,7 +20,6 @@ indirect enum LayerType: Equatable, Hashable {
     
     // TODO: theoretically could just use `[LayerType]` but need to update recursion logic
     // TODO: should be also NonEmpty, i.e. guaranteed to have at least one masked view and one masker view
-    // NOTE: THIS IS AN ORDERED SET
     case mask(masked: LayerTypeSet, masker: LayerTypeSet)
 }
 
@@ -49,32 +48,32 @@ struct LayerGroupData: Equatable, Hashable {
 extension LayerType {
     
     // Only used for pinning?
-//    var id: PreviewCoordinate {
-//        switch self {
-//        case .nongroup(let data, _):
-//            return data.id
-//        case .group(let data, _):
-//            return data.id
-//        case .mask(masked: let masked, masker: _):
-//            // TODO: what is the the layer-node-id of a LayerType in a masking situation? Really, it's nil, there's no single LayerNode
-//            // return masked.id
-//            return masked.first!.id
-//        }
-//    }
+    var id: PreviewCoordinate {
+        switch self {
+        case .nongroup(let data, _):
+            return data.id
+        case .group(let data, _):
+            return data.id
+        case .mask(masked: let masked, masker: _):
+            // TODO: what is the the layer-node-id of a LayerType in a masking situation? Really, it's nil, there's no single LayerNode
+            // return masked.id
+            return masked.first!.id
+        }
+    }
 
-//    // DEBUG ONLY?
-//    var layer: Layer {
-//        switch self {
-//        case .nongroup(let data, _):
-//            return data.layer
-//        case .group(let data, _):
-//            return data.layer
-//        case .mask(masked: let masked, masker: _):
-//            // TODO: what is the the layer-node-id of a LayerType in a masking situation? Really, it's nil, there's no single LayerNode
-//            // return masked.id
-//            return masked.first!.layer
-//        }
-//    }
+    // DEBUG ONLY?
+    var layer: Layer {
+        switch self {
+        case .nongroup(let data, _):
+            return data.layer
+        case .group(let data, _):
+            return data.layer
+        case .mask(masked: let masked, masker: _):
+            // TODO: what is the the layer-node-id of a LayerType in a masking situation? Really, it's nil, there's no single LayerNode
+            // return masked.id
+            return masked.first!.layer
+        }
+    }
     
     var isGroup: Bool {
         switch self {
@@ -86,17 +85,16 @@ extension LayerType {
     }
     
     var isPinnedView: Bool {
-        return false
-//        switch self {
-//        case .nongroup(_, let isPinned):
-//            return isPinned
-//        case .group(_, let isPinned):
-//            // "Is group layer itself pinned?"
-//            return isPinned
-//        case .mask(masked: let x, masker: _):
-//            // "Is first masked view pinned?" (is this correct?)
-//            return x.first?.isPinnedView ?? false
-//        }
+        switch self {
+        case .nongroup(_, let isPinned):
+            return isPinned
+        case .group(_, let isPinned):
+            // "Is group layer itself pinned?"
+            return isPinned
+        case .mask(masked: let x, masker: _):
+            // "Is first masked view pinned?" (is this correct?)
+            return x.first?.isPinnedView ?? false
+        }
     }
     
     var sidebarIndex: Int {
@@ -146,15 +144,14 @@ extension LayerData: Identifiable {
     }
 
     var isPinned: Bool {
-        return false
-//        switch self {
-//        case .nongroup(_, let isPinned):
-//            return isPinned
-//        case .group(_, _, let isPinned):
-//            return isPinned
-//        case .mask:
-//            return false
-//        }
+        switch self {
+        case .nongroup(_, let isPinned):
+            return isPinned
+        case .group(_, _, let isPinned):
+            return isPinned
+        case .mask:
+            return false
+        }
     }
         
     var layer: LayerViewModel {
@@ -165,8 +162,8 @@ extension LayerData: Identifiable {
             return layer
         case .mask(masked: let layerDataList, masker: _):
             // TODO: `layerDataList` should be NonEmpty; there's no way to gracefully fail here
-//            return layerDataList.first!.layer
-            return layerDataList.last!.layer
+            return layerDataList.first!.layer
+//            return layerDataList.last!.layer
         }
     }
     

--- a/Stitch/Graph/PrototypePreview/Layer/Model/LayerData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/LayerData.swift
@@ -163,7 +163,6 @@ extension LayerData: Identifiable {
         case .mask(masked: let layerDataList, masker: _):
             // TODO: `layerDataList` should be NonEmpty; there's no way to gracefully fail here
             return layerDataList.first!.layer
-//            return layerDataList.last!.layer
         }
     }
     

--- a/Stitch/Graph/PrototypePreview/Layer/Model/LayerData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/LayerData.swift
@@ -20,6 +20,7 @@ indirect enum LayerType: Equatable, Hashable {
     
     // TODO: theoretically could just use `[LayerType]` but need to update recursion logic
     // TODO: should be also NonEmpty, i.e. guaranteed to have at least one masked view and one masker view
+    // NOTE: THIS IS AN ORDERED SET
     case mask(masked: LayerTypeSet, masker: LayerTypeSet)
 }
 
@@ -46,32 +47,34 @@ struct LayerGroupData: Equatable, Hashable {
 }
 
 extension LayerType {
-    var id: PreviewCoordinate {
-        switch self {
-        case .nongroup(let data, _):
-            return data.id
-        case .group(let data, _):
-            return data.id
-        case .mask(masked: let masked, masker: _):
-            // TODO: what is the the layer-node-id of a LayerType in a masking situation? Really, it's nil, there's no single LayerNode
-            // return masked.id
-            return masked.first!.id
-        }
-    }
+    
+    // Only used for pinning?
+//    var id: PreviewCoordinate {
+//        switch self {
+//        case .nongroup(let data, _):
+//            return data.id
+//        case .group(let data, _):
+//            return data.id
+//        case .mask(masked: let masked, masker: _):
+//            // TODO: what is the the layer-node-id of a LayerType in a masking situation? Really, it's nil, there's no single LayerNode
+//            // return masked.id
+//            return masked.first!.id
+//        }
+//    }
 
-    // DEBUG ONLY?
-    var layer: Layer {
-        switch self {
-        case .nongroup(let data, _):
-            return data.layer
-        case .group(let data, _):
-            return data.layer
-        case .mask(masked: let masked, masker: _):
-            // TODO: what is the the layer-node-id of a LayerType in a masking situation? Really, it's nil, there's no single LayerNode
-            // return masked.id
-            return masked.first!.layer
-        }
-    }
+//    // DEBUG ONLY?
+//    var layer: Layer {
+//        switch self {
+//        case .nongroup(let data, _):
+//            return data.layer
+//        case .group(let data, _):
+//            return data.layer
+//        case .mask(masked: let masked, masker: _):
+//            // TODO: what is the the layer-node-id of a LayerType in a masking situation? Really, it's nil, there's no single LayerNode
+//            // return masked.id
+//            return masked.first!.layer
+//        }
+//    }
     
     var isGroup: Bool {
         switch self {
@@ -83,16 +86,17 @@ extension LayerType {
     }
     
     var isPinnedView: Bool {
-        switch self {
-        case .nongroup(_, let isPinned):
-            return isPinned
-        case .group(_, let isPinned):
-            // "Is group layer itself pinned?"
-            return isPinned
-        case .mask(masked: let x, masker: _):
-            // "Is first masked view pinned?" (is this correct?)
-            return x.first?.isPinnedView ?? false
-        }
+        return false
+//        switch self {
+//        case .nongroup(_, let isPinned):
+//            return isPinned
+//        case .group(_, let isPinned):
+//            // "Is group layer itself pinned?"
+//            return isPinned
+//        case .mask(masked: let x, masker: _):
+//            // "Is first masked view pinned?" (is this correct?)
+//            return x.first?.isPinnedView ?? false
+//        }
     }
     
     var sidebarIndex: Int {
@@ -142,14 +146,15 @@ extension LayerData: Identifiable {
     }
 
     var isPinned: Bool {
-        switch self {
-        case .nongroup(_, let isPinned):
-            return isPinned
-        case .group(_, _, let isPinned):
-            return isPinned
-        case .mask:
-            return false
-        }
+        return false
+//        switch self {
+//        case .nongroup(_, let isPinned):
+//            return isPinned
+//        case .group(_, _, let isPinned):
+//            return isPinned
+//        case .mask:
+//            return false
+//        }
     }
         
     var layer: LayerViewModel {
@@ -160,7 +165,8 @@ extension LayerData: Identifiable {
             return layer
         case .mask(masked: let layerDataList, masker: _):
             // TODO: `layerDataList` should be NonEmpty; there's no way to gracefully fail here
-            return layerDataList.first!.layer
+//            return layerDataList.first!.layer
+            return layerDataList.last!.layer
         }
     }
     

--- a/Stitch/Graph/PrototypePreview/Layer/Util/LayerNodesSorting.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Util/LayerNodesSorting.swift
@@ -49,34 +49,31 @@ extension GraphState {
         }
         
         // If we're at the root level, we need to also add the LayerTypes for views with `isPinned = true` and `pinToId = .root`, since those views' PinnedViews will not be handled by
-//        if isRoot,
-//           let pinnedData = pinMap.get(nil) {
-//            
-//            let layerTypesFromRootPinnedViews = getLayerTypesForPinnedViews(
-//                pinnedData: pinnedData,
-//                sidebarLayers: sidebarLayersGlobal,
-//                layerNodes: self.layerNodes,
-//                layerTypesAtThisLevel: layerTypesAtThisLevel)
-//            
-//            layerTypesAtThisLevel = layerTypesAtThisLevel.union(layerTypesFromRootPinnedViews)
-//        } // if isRoot
+        if isRoot,
+           let pinnedData = pinMap.get(nil) {
+            
+            let layerTypesFromRootPinnedViews = getLayerTypesForPinnedViews(
+                pinnedData: pinnedData,
+                sidebarLayers: sidebarLayersGlobal,
+                layerNodes: self.layerNodes,
+                layerTypesAtThisLevel: layerTypesAtThisLevel)
+            
+            layerTypesAtThisLevel = layerTypesAtThisLevel.union(layerTypesFromRootPinnedViews)
+        } // if isRoot
         
         
         // log("recursivePreviewLayers: DONE GETTING ALL LAYER TYPES: \(layerTypesAtThisLevel)")
         
-        let sortedLayerTypes = layerTypesAtThisLevel.sorted(by: { lhs, rhs in
+        var sortedLayerTypes = layerTypesAtThisLevel.sorted(by: { lhs, rhs in
             Self.layerSortingComparator(lhs: lhs,
                                         rhs: rhs,
                                         pinMap: pinMap)
         })
-        
-        log("recursivePreviewLayers: sortedLayerTypes: \(sortedLayerTypes)")
-        
+                
         // is this flipping
-//        if isInGroupOrientation {
-//            sortedLayerTypes = sortedLayerTypes.reversed()
-//            log("recursivePreviewLayers: sortedLayerTypes after reversal: \(sortedLayerTypes)")
-//        }
+        if isInGroupOrientation {
+            sortedLayerTypes = sortedLayerTypes.reversed()
+        }
         
         let sortedLayerDataList: LayerDataList = sortedLayerTypes.compactMap { (layerType: LayerType) -> LayerData? in
             self.getLayerDataFromLayerType(layerType,
@@ -84,19 +81,12 @@ extension GraphState {
                                            sidebarLayersGlobal: sidebarLayersGlobal,
                                            layerNodes: self.layerNodes)
         }
-        
-        log("recursivePreviewLayers: sortedLayerDataList: \(sortedLayerDataList)")
-        
+                
         for sortedLayerData in sortedLayerDataList {
             switch sortedLayerData {
             case .mask(let masked, let masker):
                 let maskedIndices = masked.map(\.id.loopIndex)
                 let maskerIndices = masker.map(\.id.loopIndex)
-                
-                log("recursivePreviewLayers: maskedIndices: \(maskedIndices)")
-                
-                log("recursivePreviewLayers: maskerIndices: \(maskerIndices)")
-                
             default:
                 continue
             }
@@ -119,18 +109,18 @@ extension GraphState {
         let lhsSidebarIndex = lhs.sidebarIndex
         let rhsSidebarIndex = rhs.sidebarIndex
         
-//        // If both layers are in same pinning linked list, prioritize the lower-level pin over a receiver
-//        let isPinningScenario = pinMap.areLayersInSamePinFamily(idSet: .init([lhs.id.layerNodeId, rhs.id.layerNodeId]))
-//        
-//        // Determines if a view is pinned and if so, how nested that pin is (higher value = more nesting)
-//        if isPinningScenario {
-//            let lhsPinNestedCount = pinMap.getPinnedNestedLayerCount(id: lhs.id.layerNodeId)
-//            let rhsPinNestedCount = pinMap.getPinnedNestedLayerCount(id: rhs.id.layerNodeId)
-//            
-//            if lhsPinNestedCount != rhsPinNestedCount {
-//                return rhsPinNestedCount > lhsPinNestedCount
-//            }
-//        }
+        // If both layers are in same pinning linked list, prioritize the lower-level pin over a receiver
+        let isPinningScenario = pinMap.areLayersInSamePinFamily(idSet: .init([lhs.id.layerNodeId, rhs.id.layerNodeId]))
+        
+        // Determines if a view is pinned and if so, how nested that pin is (higher value = more nesting)
+        if isPinningScenario {
+            let lhsPinNestedCount = pinMap.getPinnedNestedLayerCount(id: lhs.id.layerNodeId)
+            let rhsPinNestedCount = pinMap.getPinnedNestedLayerCount(id: rhs.id.layerNodeId)
+            
+            if lhsPinNestedCount != rhsPinNestedCount {
+                return rhsPinNestedCount > lhsPinNestedCount
+            }
+        }
         
         if lhsZIndex != rhsZIndex {
             return lhsZIndex < rhsZIndex
@@ -156,13 +146,7 @@ extension GraphState {
         switch layerType {
             
         case .mask(masked: let masked, masker: let masker):
-//            masked.map(\.id.loopIndex)
-            
-            // LayerType has id and loop index etc. but those are just debug or pinning; are not used in
-//            masked.map {
-//                $0.
-//            }
-            
+ 
             log("getLayerDataFromLayerType: masked")
             var maskedLayerData = masked.compactMap {
                 getLayerDataFromLayerType($0,
@@ -179,7 +163,6 @@ extension GraphState {
             }
             
             log("getLayerDataFromLayerType: maskedLayerData.map(.id.loopIndex) was: \(maskedLayerData.map(\.id.loopIndex))")
-            
             log("getLayerDataFromLayerType: maskerLayerData.map(.id.loopIndex) was: \(maskerLayerData.map(\.id.loopIndex))")
             
             let newMaskCount = max(maskedLayerData.count, maskerLayerData.count)
@@ -188,7 +171,6 @@ extension GraphState {
             maskerLayerData = maskerLayerData.lengthenArray(newMaskCount)
             
             log("getLayerDataFromLayerType: maskedLayerData.map(.id.loopIndex) now: \(maskedLayerData.map(\.id.loopIndex))")
-            
             log("getLayerDataFromLayerType: maskerLayerData.map(.id.loopIndex) now: \(maskerLayerData.map(\.id.loopIndex))")
             
             guard !maskedLayerData.isEmpty,
@@ -201,35 +183,15 @@ extension GraphState {
             
             // we call `getLayerDataFromLayerType` recursively, and
         case .nongroup(let data, let isPinned): // LayerData
-            
-            log("getLayerDataFromLayerType: nongroup: data.id: \(data.id)")
-            
-            //
-            let layerViewModels =  layerNodes
+                        
+            guard let previewLayer: LayerViewModel = layerNodes
                 .get(data.id.layerNodeId.id)?
                 .layerNode?
-                .previewLayerViewModels
-            
-//            layerViewModels?.forEach { (lvm: LayerViewModel) in
-//                log("getLayerDataFromLayerType: lvm.interactiveLayer.id: \(lvm.interactiveLayer.id)")
-//                log("getLayerDataFromLayerType: lvm.position.getPosition: \(lvm.position.getPosition)")
-//            }
-            
-//            log("getLayerDataFromLayerType: nongroup: layerViewModels: \(layerViewModels)")
-            
-//            guard let previewLayer: LayerViewModel = layerNodes
-//                .get(data.id.layerNodeId.id)?
-//                .layerNode?
-//                    // these layer view models are ALREADY CREATED on the layer node
-//                .previewLayerViewModels[safe: data.id.loopIndex] else {
-            
-            guard let previewLayer: LayerViewModel = layerViewModels?[safe: data.id.loopIndex] else {
-                
+                    // these layer view models are ALREADY CREATED on the layer node
+                .previewLayerViewModels[safe: data.id.loopIndex] else {
                 return nil
             }
-            
-            log("getLayerDataFromLayerType: nongroup: taking previewLayer: \(previewLayer.id)")
-            
+                        
             return .nongroup(previewLayer, isPinned)
             
         case .group(let layerGroupData, let isPinned): // LayerGroupData
@@ -292,9 +254,7 @@ func getLayerTypesFromSidebarLayerData(_ layerData: SidebarLayerData,
     // Non-group case
     else {
         let layerTypes: LayerTypeSet = layerNode.previewLayerViewModels
-        
-        //    .reversed() // Reverse loop's layer view models, for default "ZStack" case
-        
+            .reversed() // Reverse loop's layer view models, for default "ZStack" case
             .map { layerViewModel in
                     .nongroup(.init(id: layerViewModel.id,
                                     zIndex: layerViewModel.zIndex.getNumber ?? .zero,

--- a/Stitch/Graph/PrototypePreview/Layer/Util/LayerNodesSorting.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Util/LayerNodesSorting.swift
@@ -70,7 +70,6 @@ extension GraphState {
                                         pinMap: pinMap)
         })
                 
-        // is this flipping
         if isInGroupOrientation {
             sortedLayerTypes = sortedLayerTypes.reversed()
         }
@@ -80,16 +79,6 @@ extension GraphState {
                                            pinMap: pinMap,
                                            sidebarLayersGlobal: sidebarLayersGlobal,
                                            layerNodes: self.layerNodes)
-        }
-                
-        for sortedLayerData in sortedLayerDataList {
-            switch sortedLayerData {
-            case .mask(let masked, let masker):
-                let maskedIndices = masked.map(\.id.loopIndex)
-                let maskerIndices = masker.map(\.id.loopIndex)
-            default:
-                continue
-            }
         }
         
         return sortedLayerDataList
@@ -147,7 +136,6 @@ extension GraphState {
             
         case .mask(masked: let masked, masker: let masker):
  
-            log("getLayerDataFromLayerType: masked")
             var maskedLayerData = masked.compactMap {
                 getLayerDataFromLayerType($0,
                                           pinMap: pinMap,
@@ -162,16 +150,10 @@ extension GraphState {
                                           layerNodes: layerNodes)
             }
             
-            log("getLayerDataFromLayerType: maskedLayerData.map(.id.loopIndex) was: \(maskedLayerData.map(\.id.loopIndex))")
-            log("getLayerDataFromLayerType: maskerLayerData.map(.id.loopIndex) was: \(maskerLayerData.map(\.id.loopIndex))")
-            
+            // Extend the masked/masker views:
             let newMaskCount = max(maskedLayerData.count, maskerLayerData.count)
-            
             maskedLayerData = maskedLayerData.lengthenArray(newMaskCount)
             maskerLayerData = maskerLayerData.lengthenArray(newMaskCount)
-            
-            log("getLayerDataFromLayerType: maskedLayerData.map(.id.loopIndex) now: \(maskedLayerData.map(\.id.loopIndex))")
-            log("getLayerDataFromLayerType: maskerLayerData.map(.id.loopIndex) now: \(maskerLayerData.map(\.id.loopIndex))")
             
             guard !maskedLayerData.isEmpty,
                   !maskerLayerData.isEmpty else {
@@ -372,15 +354,15 @@ func handleRawSidebarLayer(sidebarIndex: Int,
             
             // "Does this layer have other views pinned to it?"
             // i.e. "Is this layer the B to some A and C?"
-//            if let pinnedViews = pinMap.get(layerData.id.asLayerNodeId) {
-//                let layerTypesFromPinnedViews = getLayerTypesForPinnedViews(
-//                    pinnedData: pinnedViews,
-//                    sidebarLayers: sidebarLayersGlobal,
-//                    layerNodes: layerNodes,
-//                    layerTypesAtThisLevel: layerTypesAtThisLevel)
-//                
-//                layerTypesAtThisLevel = layerTypesAtThisLevel.union(layerTypesFromPinnedViews)
-//            }
+            if let pinnedViews = pinMap.get(layerData.id.asLayerNodeId) {
+                let layerTypesFromPinnedViews = getLayerTypesForPinnedViews(
+                    pinnedData: pinnedViews,
+                    sidebarLayers: sidebarLayersGlobal,
+                    layerNodes: layerNodes,
+                    layerTypesAtThisLevel: layerTypesAtThisLevel)
+                
+                layerTypesAtThisLevel = layerTypesAtThisLevel.union(layerTypesFromPinnedViews)
+            }
         }
     } // else
     

--- a/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
@@ -339,7 +339,6 @@ struct NonGroupPreviewLayersView: View {
     var body: some View {
         if layerNode.hasSidebarVisibility,
            let graph = layerNode.nodeDelegate?.graphDelegate as? GraphState {
-            logInView("NonGroupPreviewLayersView: non-empty view")
             PreviewLayerView(document: document,
                              graph: graph,
                              layerViewModel: layerViewModel,
@@ -348,7 +347,6 @@ struct NonGroupPreviewLayersView: View {
                              parentSize: parentSize,
                              parentDisablesPosition: parentDisablesPosition)
         } else {
-            logInView("NonGroupPreviewLayersView: empty view")
             EmptyView()
         }
     }

--- a/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
@@ -268,99 +268,45 @@ struct LayerDataView: View {
             // For "more maskers than masked views, limit ourselves to masked (layer) view count"
         case .mask(masked: var maskedLayerDataList,
                    masker: var maskerLayerDataList):
-            
-            /*
-            If the masked count != masker count, extend either to whichever is longer.
-             
-            Note: do we need to give unique loop-indices
-            
-            Does an extended masker/masked-view need to be completely new layer view model?
-            "No" because the extended A3 is just a copy of A1, has some properties etc.
-            "Yes" because A3 can be interacted with separately from A1, e.g. can be dragged...
-             ... Ah, but the dragging would just update a patch node output -- but if the patch node is connected to the input of A1...
-             ... Hmm, I find this hard to think about. For now, will
-             
-            Note: Extending does not change layer input properites such as .position, .scale etc.
-             
-            Note: Does extending masked/masker-views change z-index sort order? By 'extending', we can have multiple layer view models whose sidebar item position is the same AND whose .zIndex property is the same.
-             */
-            
+      
             logInView("maskedLayerDataList.map(.id.loopIndex): \(maskedLayerDataList.map(\.id.loopIndex))")
-            
             logInView("maskerLayerDataList.map(.id.loopIndex): \(maskerLayerDataList.map(\.id.loopIndex))")
-//            
-//            let newMaskCount = max(maskedLayerDataList.count, maskerLayerDataList.count)
-//            
-//            maskedLayerDataList.lengthenArray(newMaskCount)
-//            maskerLayerDataList.lengthenArray(newMaskCount)
-//            
-//            logInView("maskedLayerDataList.map(.id.loopIndex) now: \(maskedLayerDataList.map(\.id.loopIndex))")
-//            
-//            logInView("maskerLayerDataList.map(.id.loopIndex) now: \(maskerLayerDataList.map(\.id.loopIndex))")
             
-            
-            // ideally: masked and masker view counts are same and so we iterate through the zipped collection
-            //
             ForEach(maskedLayerDataList) { (maskedLayerData: LayerData) in
                 
-                let maskedIndex = maskedLayerDataList.firstIndex(where: { $0.id == maskedLayerData.id })!
-                
-//                let maskedItemIsAboveMasker: Bool = maskedIndex.map {
-//                    $0 < maskerLayerDataList.endIndex
-//                } ?? false
-                
-                logInView("LayerDataView: maskedLayerData layer, id: \(maskedLayerData.layer.layer), \(maskedLayerData.id)")
-                
-                logInView("LayerDataView: maskedIndex: \(maskedIndex)")
-//                logInView("LayerDataView: maskerLayerDataList.endIndex: \(maskerLayerDataList.endIndex)")
-//                logInView("LayerDataView: maskedItemIsAboveMasker: \(maskedItemIsAboveMasker)")
-                
-//                if let maskedIndex = maskedLayerDataList.firstIndex(where: { $0.id == maskedLayerData.id }),
-//                   maskedIndex < maskerLayerDataList.endIndex {
-//                if let maskedIndex = maskedIndex,
-//                   maskedItemIsAboveMasker {
+                if let maskedIndex = maskedLayerDataList.firstIndex(where: { $0.id == maskedLayerData.id }),
+                    maskedIndex < maskerLayerDataList.endIndex, // Is this check necessary?
+                    let maskerLayerData: LayerData = maskerLayerDataList.first(where: { $0.id.loopIndex == maskedLayerData.id.loopIndex }) {
                     
-//                    logInView("LayerDataView: WILL MASK")
+                    logInView("LayerDataView: maskedLayerData layer, id: \(maskedLayerData.layer.layer), \(maskedLayerData.id)")
+                    logInView("LayerDataView: maskedIndex: \(maskedIndex)")
                     
-//                    let maskerLayerData: LayerData = maskerLayerDataList[maskedIndex]
-                
-                /*
-                  TODO: do we need to create new layer view models when we "extend" a masked-view or masker-view?
-                 
-                 "Extending" does not change the value of any inputs on the layer view model; but we may need another loop index in the preview
-                 */
-                let maskerLayerData: LayerData = maskerLayerDataList.first {
-                    $0.id.loopIndex == maskedLayerData.id.loopIndex
-                } ?? maskerLayerDataList.first!
-                
-                
-                
-                logInView("LayerDataView: creating LayerDataView for masked layer \(maskedLayerData.layer.layer), \(maskedLayerData.id)")
-                // Turn masked LayerData into a single view
-                let masked: some View = LayerDataView(
-                    document: document,
-                    layerData: maskedLayerData,
-                    parentSize: parentSize,
-                    parentDisablesPosition: parentDisablesPosition,
-                    isGhostView: isGhostView)
-                
-                logInView("LayerDataView: creating LayerDataView for masker layer \(maskerLayerData.layer.layer), \(maskerLayerData.id)")
-                
-                // Turn masker LayerData into a single view
-                let masker: some View = LayerDataView(
-                    document: document,
-                    layerData: maskerLayerData,
-                    parentSize: parentSize,
-                    parentDisablesPosition: parentDisablesPosition,
-                    isGhostView: isGhostView)
-                
-                // Return
-                masked.mask(masker)
-                //                }
-//            else {
-//                    logInView("LayerDataView: WILL NOT MASK")
-//                    EmptyView()
-//                }
+                    logInView("LayerDataView: creating LayerDataView for masked layer \(maskedLayerData.layer.layer), \(maskedLayerData.id)")
+                    
+                    // Turn masked LayerData into a single view
+                    let masked: some View = LayerDataView(
+                        document: document,
+                        layerData: maskedLayerData,
+                        parentSize: parentSize,
+                        parentDisablesPosition: parentDisablesPosition,
+                        isGhostView: isGhostView)
+                    
+                    logInView("LayerDataView: creating LayerDataView for masker layer \(maskerLayerData.layer.layer), \(maskerLayerData.id)")
+                    
+                    // Turn masker LayerData into a single view
+                    let masker: some View = LayerDataView(
+                        document: document,
+                        layerData: maskerLayerData,
+                        parentSize: parentSize,
+                        parentDisablesPosition: parentDisablesPosition,
+                        isGhostView: isGhostView)
+                    
+                    // Return
+                    masked.mask(masker)
+                } else {
+                    logInView("LayerDataView: WILL NOT MASK")
+                    EmptyView()
+                }
             }
             
         case .nongroup(let layerViewModel, _):

--- a/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
@@ -259,8 +259,6 @@ struct LayerDataView: View {
     
     var body: some View {
         
-        logInView("LayerDataView: called for layerData: \(layerData.layer.layer), \(layerData.id)")
-        
         switch layerData {
             
             // TODO: will this be accurate when e.g. masked's loop count = 3 but masker's loop count = 5? Or vice-versa?
@@ -269,19 +267,11 @@ struct LayerDataView: View {
         case .mask(masked: let maskedLayerDataList,
                    masker: let maskerLayerDataList):
       
-            logInView("maskedLayerDataList.map(.id.loopIndex): \(maskedLayerDataList.map(\.id.loopIndex))")
-            logInView("maskerLayerDataList.map(.id.loopIndex): \(maskerLayerDataList.map(\.id.loopIndex))")
-            
             ForEach(maskedLayerDataList) { (maskedLayerData: LayerData) in
                 
                 if let maskedIndex = maskedLayerDataList.firstIndex(where: { $0.id == maskedLayerData.id }),
                     maskedIndex < maskerLayerDataList.endIndex, // Is this check necessary?
                     let maskerLayerData: LayerData = maskerLayerDataList.first(where: { $0.id.loopIndex == maskedLayerData.id.loopIndex }) {
-                    
-                    logInView("LayerDataView: maskedLayerData layer, id: \(maskedLayerData.layer.layer), \(maskedLayerData.id)")
-                    logInView("LayerDataView: maskedIndex: \(maskedIndex)")
-                    
-                    logInView("LayerDataView: creating LayerDataView for masked layer \(maskedLayerData.layer.layer), \(maskedLayerData.id)")
                     
                     // Turn masked LayerData into a single view
                     let masked: some View = LayerDataView(
@@ -290,8 +280,6 @@ struct LayerDataView: View {
                         parentSize: parentSize,
                         parentDisablesPosition: parentDisablesPosition,
                         isGhostView: isGhostView)
-                    
-                    logInView("LayerDataView: creating LayerDataView for masker layer \(maskerLayerData.layer.layer), \(maskerLayerData.id)")
                     
                     // Turn masker LayerData into a single view
                     let masker: some View = LayerDataView(
@@ -310,7 +298,6 @@ struct LayerDataView: View {
             }
             
         case .nongroup(let layerViewModel, _):
-            logInView("LayerDataView: nongroup layer, id: \(layerViewModel.layer), \(layerViewModel.id)")
             if let node = document.graph.getLayerNode(id: layerViewModel.id.layerNodeId.id),
                let layerNode = node.layerNode {
                 NonGroupPreviewLayersView(document: document,

--- a/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
@@ -259,46 +259,117 @@ struct LayerDataView: View {
     
     var body: some View {
         
+        logInView("LayerDataView: called for layerData: \(layerData.layer.layer), \(layerData.id)")
+        
         switch layerData {
             
             // TODO: will this be accurate when e.g. masked's loop count = 3 but masker's loop count = 5? Or vice-versa?
             // For "more masked views than maskers, just repeat the maskers"
             // For "more maskers than masked views, limit ourselves to masked (layer) view count"
-        case .mask(masked: let maskedLayerDataList,
-                   masker: let maskerLayerDataList):
+        case .mask(masked: var maskedLayerDataList,
+                   masker: var maskerLayerDataList):
             
+            /*
+            If the masked count != masker count, extend either to whichever is longer.
+             
+            Note: do we need to give unique loop-indices
+            
+            Does an extended masker/masked-view need to be completely new layer view model?
+            "No" because the extended A3 is just a copy of A1, has some properties etc.
+            "Yes" because A3 can be interacted with separately from A1, e.g. can be dragged...
+             ... Ah, but the dragging would just update a patch node output -- but if the patch node is connected to the input of A1...
+             ... Hmm, I find this hard to think about. For now, will
+             
+            Note: Extending does not change layer input properites such as .position, .scale etc.
+             
+            Note: Does extending masked/masker-views change z-index sort order? By 'extending', we can have multiple layer view models whose sidebar item position is the same AND whose .zIndex property is the same.
+             */
+            
+            logInView("maskedLayerDataList.map(.id.loopIndex): \(maskedLayerDataList.map(\.id.loopIndex))")
+            
+            logInView("maskerLayerDataList.map(.id.loopIndex): \(maskerLayerDataList.map(\.id.loopIndex))")
+//            
+//            let newMaskCount = max(maskedLayerDataList.count, maskerLayerDataList.count)
+//            
+//            maskedLayerDataList.lengthenArray(newMaskCount)
+//            maskerLayerDataList.lengthenArray(newMaskCount)
+//            
+//            logInView("maskedLayerDataList.map(.id.loopIndex) now: \(maskedLayerDataList.map(\.id.loopIndex))")
+//            
+//            logInView("maskerLayerDataList.map(.id.loopIndex) now: \(maskerLayerDataList.map(\.id.loopIndex))")
+            
+            
+            // ideally: masked and masker view counts are same and so we iterate through the zipped collection
+            //
             ForEach(maskedLayerDataList) { (maskedLayerData: LayerData) in
                 
-                if let maskedIndex = maskedLayerDataList.firstIndex(where: { $0.id == maskedLayerData.id }),
-                   maskedIndex < maskerLayerDataList.endIndex {
-                    let maskerLayerData: LayerData = maskerLayerDataList[maskedIndex]
+                let maskedIndex = maskedLayerDataList.firstIndex(where: { $0.id == maskedLayerData.id })!
+                
+//                let maskedItemIsAboveMasker: Bool = maskedIndex.map {
+//                    $0 < maskerLayerDataList.endIndex
+//                } ?? false
+                
+                logInView("LayerDataView: maskedLayerData layer, id: \(maskedLayerData.layer.layer), \(maskedLayerData.id)")
+                
+                logInView("LayerDataView: maskedIndex: \(maskedIndex)")
+//                logInView("LayerDataView: maskerLayerDataList.endIndex: \(maskerLayerDataList.endIndex)")
+//                logInView("LayerDataView: maskedItemIsAboveMasker: \(maskedItemIsAboveMasker)")
+                
+//                if let maskedIndex = maskedLayerDataList.firstIndex(where: { $0.id == maskedLayerData.id }),
+//                   maskedIndex < maskerLayerDataList.endIndex {
+//                if let maskedIndex = maskedIndex,
+//                   maskedItemIsAboveMasker {
                     
-                    // Turn masked LayerData into a single view
-                    let masked: some View = LayerDataView(
-                        document: document,
-                        layerData: maskedLayerData,
-                        parentSize: parentSize,
-                        parentDisablesPosition: parentDisablesPosition,
-                        isGhostView: isGhostView)
+//                    logInView("LayerDataView: WILL MASK")
                     
-                    // Turn masker LayerData into a single view
-                    let masker: some View = LayerDataView(
-                        document: document,
-                        layerData: maskerLayerData,
-                        parentSize: parentSize,
-                        parentDisablesPosition: parentDisablesPosition,
-                        isGhostView: isGhostView)
-                    
-                    // Return
-                    masked.mask(masker)
-                } else {
-                    EmptyView()
-                }
+//                    let maskerLayerData: LayerData = maskerLayerDataList[maskedIndex]
+                
+                /*
+                  TODO: do we need to create new layer view models when we "extend" a masked-view or masker-view?
+                 
+                 "Extending" does not change the value of any inputs on the layer view model; but we may need another loop index in the preview
+                 */
+                let maskerLayerData: LayerData = maskerLayerDataList.first {
+                    $0.id.loopIndex == maskedLayerData.id.loopIndex
+                } ?? maskerLayerDataList.first!
+                
+                
+                
+                logInView("LayerDataView: creating LayerDataView for masked layer \(maskedLayerData.layer.layer), \(maskedLayerData.id)")
+                // Turn masked LayerData into a single view
+                let masked: some View = LayerDataView(
+                    document: document,
+                    layerData: maskedLayerData,
+                    parentSize: parentSize,
+                    parentDisablesPosition: parentDisablesPosition,
+                    isGhostView: isGhostView)
+                
+                logInView("LayerDataView: creating LayerDataView for masker layer \(maskerLayerData.layer.layer), \(maskerLayerData.id)")
+                
+                // Turn masker LayerData into a single view
+                let masker: some View = LayerDataView(
+                    document: document,
+                    layerData: maskerLayerData,
+                    parentSize: parentSize,
+                    parentDisablesPosition: parentDisablesPosition,
+                    isGhostView: isGhostView)
+                
+                // Return
+                masked.mask(masker)
+                //                }
+//            else {
+//                    logInView("LayerDataView: WILL NOT MASK")
+//                    EmptyView()
+//                }
             }
             
         case .nongroup(let layerViewModel, _):
+            
+            logInView("LayerDataView: nongroup layer, id: \(layerViewModel.layer), \(layerViewModel.id)")
+            
             if let node = document.graph.getLayerNode(id: layerViewModel.id.layerNodeId.id),
                let layerNode = node.layerNode {
+                logInView("LayerDataView: nongroup: will create view")
                 NonGroupPreviewLayersView(document: document,
                                           layerNode: layerNode,
                                           layerViewModel: layerViewModel,
@@ -306,6 +377,8 @@ struct LayerDataView: View {
                                           parentSize: parentSize,
                                           parentDisablesPosition: parentDisablesPosition)
             } else {
+                // NEVER hit; i.e. we always create the
+                logInView("LayerDataView: nongroup: will NOT create view")
                 EmptyView()
             }
                         
@@ -338,6 +411,7 @@ struct NonGroupPreviewLayersView: View {
     var body: some View {
         if layerNode.hasSidebarVisibility,
            let graph = layerNode.nodeDelegate?.graphDelegate as? GraphState {
+            logInView("NonGroupPreviewLayersView: non-empty view")
             PreviewLayerView(document: document,
                              graph: graph,
                              layerViewModel: layerViewModel,
@@ -346,6 +420,7 @@ struct NonGroupPreviewLayersView: View {
                              parentSize: parentSize,
                              parentDisablesPosition: parentDisablesPosition)
         } else {
+            logInView("NonGroupPreviewLayersView: empty view")
             EmptyView()
         }
     }

--- a/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
@@ -266,8 +266,8 @@ struct LayerDataView: View {
             // TODO: will this be accurate when e.g. masked's loop count = 3 but masker's loop count = 5? Or vice-versa?
             // For "more masked views than maskers, just repeat the maskers"
             // For "more maskers than masked views, limit ourselves to masked (layer) view count"
-        case .mask(masked: var maskedLayerDataList,
-                   masker: var maskerLayerDataList):
+        case .mask(masked: let maskedLayerDataList,
+                   masker: let maskerLayerDataList):
       
             logInView("maskedLayerDataList.map(.id.loopIndex): \(maskedLayerDataList.map(\.id.loopIndex))")
             logInView("maskerLayerDataList.map(.id.loopIndex): \(maskerLayerDataList.map(\.id.loopIndex))")
@@ -304,18 +304,15 @@ struct LayerDataView: View {
                     // Return
                     masked.mask(masker)
                 } else {
-                    logInView("LayerDataView: WILL NOT MASK")
+                    // logInView("LayerDataView: WILL NOT MASK")
                     EmptyView()
                 }
             }
             
         case .nongroup(let layerViewModel, _):
-            
             logInView("LayerDataView: nongroup layer, id: \(layerViewModel.layer), \(layerViewModel.id)")
-            
             if let node = document.graph.getLayerNode(id: layerViewModel.id.layerNodeId.id),
                let layerNode = node.layerNode {
-                logInView("LayerDataView: nongroup: will create view")
                 NonGroupPreviewLayersView(document: document,
                                           layerNode: layerNode,
                                           layerViewModel: layerViewModel,
@@ -323,8 +320,6 @@ struct LayerDataView: View {
                                           parentSize: parentSize,
                                           parentDisablesPosition: parentDisablesPosition)
             } else {
-                // NEVER hit; i.e. we always create the
-                logInView("LayerDataView: nongroup: will NOT create view")
                 EmptyView()
             }
                         

--- a/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
@@ -221,6 +221,9 @@ final class LayerViewModel {
          zIndex: PortValue = defaultNumber,
          position: PortValue = .position(.zero),
          nodeDelegate: NodeDelegate?) {
+        
+        log("LayerViewModel: init layer: \(layer), id: \(id)")
+        
         self.id = id
         self.layer = layer
         self.zIndex = zIndex

--- a/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
@@ -222,8 +222,6 @@ final class LayerViewModel {
          position: PortValue = .position(.zero),
          nodeDelegate: NodeDelegate?) {
         
-        log("LayerViewModel: init layer: \(layer), id: \(id)")
-        
         self.id = id
         self.layer = layer
         self.zIndex = zIndex

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -221,8 +221,9 @@ extension GraphState: GraphCalculatable {
         let flattenedPinMap = self.getFlattenedPinMap()
         let rootPinMap = self.getRootPinMap(pinMap: flattenedPinMap)
         
-        let previewLayers = self.recursivePreviewLayers(sidebarLayersGlobal: self.layersSidebarViewModel.createdOrderedEncodedData(),
-                                                        pinMap: rootPinMap)
+        let previewLayers: LayerDataList = self.recursivePreviewLayers(
+            sidebarLayersGlobal: self.layersSidebarViewModel.createdOrderedEncodedData(),
+            pinMap: rootPinMap)
         
         self.cachedOrderedPreviewLayers = previewLayers
         self.flattenedPinMap = flattenedPinMap


### PR DESCRIPTION
We now extend masker and masked view loops to be as the length of the longest loop. 

https://github.com/user-attachments/assets/97cb7459-7f55-4150-abb9-c0b6d7e734d5


https://github.com/user-attachments/assets/2d8dcb57-0c76-4c64-b0ba-f12d6b6d8c68

