### PR TITLE
Fixed regression where edge creation on output hover would fail

### DIFF
--- a/Stitch/Graph/Menu/InsertNodeMenu/Util/InsertNodeMenuActions.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/Util/InsertNodeMenuActions.swift
@@ -90,6 +90,9 @@ struct AddNodeButtonPressed: GraphEvent {
             return
         }
         
+        // Reset focused field
+        state.graphUI.reduxFocusedField = nil
+        
         // Immediately create a LayerNode; do not animate.
         if nodeKind.isLayer {
             guard let newNode = state.documentDelegate?.nodeCreated(choice: nodeKind) else {


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/6700

Issue was caused by not resetting focus field state when submitting the form for a new node.