### PR TITLE
Fixed math expression node edge locations

### DIFF
--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowViewModel.swift
@@ -127,7 +127,7 @@ extension NodeRowViewModel {
         let ioAdjustment: CGFloat = 10
         let standardHeightAdjustment: CGFloat = 69
         let ioConstraint: CGFloat = Self.nodeIO == .input ? ioAdjustment : -ioAdjustment
-        let titleHeightOffset: CGFloat = node.getValidCustomTitle().isDefined ? 23 : 0
+        let titleHeightOffset: CGFloat = node.hasLargeCanvasTitleSpace ? 23 : 0
         
         // Offsets needed because node position uses its center location
         let offsetX: CGFloat = canvas.position.x + ioConstraint - size.width / 2

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
@@ -356,6 +356,17 @@ extension NodeViewModel {
         return defaultTitle
     }
     
+    @MainActor var hasLargeCanvasTitleSpace: Bool {
+        let hasMathFormula = !(self.patchNode?.mathExpression?.isEmpty ?? true)
+        
+        // Math Expression nodes only adjust height for math formula, not custom title
+        if self.kind == .patch(.mathExpression) {
+            return hasMathFormula
+        }
+        
+        return self.getValidCustomTitle().isDefined
+    }
+    
     @MainActor
     func updateOutputsObservers(newValuesList: PortValuesList? = nil) {
         let outputsObservers = self.getAllOutputsObservers()


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/6690

Issue was incorrect title height logic specifically for the math expression node.