### PR TITLE
Place node menu above sidebar

### DIFF
--- a/Stitch/App/View/StitchRootView.swift
+++ b/Stitch/App/View/StitchRootView.swift
@@ -56,10 +56,6 @@ struct StitchRootView: View {
          return document.graphUI.insertNodeMenuState.menuAnimatingToNode ||
          document.graphUI.insertNodeMenuState.show
      }
-
-     // For now,
-    @State private var menuHeight: CGFloat = INSERT_NODE_MENU_MAX_HEIGHT
-    @State private var screenSize: CGSize = .zero
     
     var body: some View {
         Group {
@@ -102,16 +98,10 @@ struct StitchRootView: View {
                                 }
                             } // if document.graphUI
 #endif
-                            
                             if showMenu {
                                 InsertNodeMenuWrapper(document: document,
-                                                      graphUI: document.graphUI,
-                                                      menuHeight: self.$menuHeight,
-                                                      screenSize: .constant(document.graphUI.frame.size)
-//                                                      screenSize: self.$screenSize
-                                )
+                                                      graphUI: document.graphUI)
                             }
-                            
                         } // if let document
                     } // .overlay
             }

--- a/Stitch/App/View/StitchRootView.swift
+++ b/Stitch/App/View/StitchRootView.swift
@@ -48,44 +48,77 @@ struct StitchRootView: View {
     // Handled manually by user; but synced with GraphUIState.leftSide
     @State var columnVisibility: NavigationSplitViewVisibility = .detailOnly
             
+    var showMenu: Bool {
+         guard let document = store.currentDocument else {
+             return false
+         }
+
+         return document.graphUI.insertNodeMenuState.menuAnimatingToNode ||
+         document.graphUI.insertNodeMenuState.show
+     }
+
+     // For now,
+    @State private var menuHeight: CGFloat = INSERT_NODE_MENU_MAX_HEIGHT
+//    @State private var screenSize: CGSize = .zero
+    
     var body: some View {
         Group {
             if isPhoneDevice() {
                 iPhoneBody
             } else {
                 splitView
-#if targetEnvironment(macCatalyst)
+//#if targetEnvironment(macCatalyst)
                     .overlay(alignment: .center) {
-                        if let document = store.currentDocument,
-                           document.graphUI.showCatalystProjectTitleModal {
-                            logInView("will show modal view at top level")
-                            ZStack {
-                                
-                                MODAL_BACKGROUND_COLOR
-                                    .ignoresSafeArea([.all, .keyboard])
-                                    .onTapGesture {
-                                        dispatch(CatalystProjectTitleModalClosed())
-                                    }
-                                
-                                VStack(alignment: .leading) {
-                                    StitchTextView(string: "Edit Project Title")
-                                    CatalystProjectTitleModalView(graph: document.visibleGraph)
-                                }
-                                .padding()
-//                                .frame(width: 260, alignment: .leading)
-                                .frame(width: 360, alignment: .leading)
-                                .background(
-                                    Color(uiColor: .systemGray5)
-                                    // NOTE: strangely we need `[.all, .keyboard]` on BOTH the background color AND the StitchHostingControllerView
+                        
+
+                        if let document = store.currentDocument {
+
+#if targetEnvironment(macCatalyst)
+                            if document.graphUI.showCatalystProjectTitleModal {
+                                logInView("will show modal view at top level")
+                                ZStack {
+                                    
+                                    MODAL_BACKGROUND_COLOR
                                         .ignoresSafeArea([.all, .keyboard])
-                                        .cornerRadius(4)
-                                )
-                                
-                                
-                            }
-                        } // if let document
-                    } // .overlay
+                                        .onTapGesture {
+                                            dispatch(CatalystProjectTitleModalClosed())
+                                        }
+                                    
+                                    VStack(alignment: .leading) {
+                                        StitchTextView(string: "Edit Project Title")
+                                        CatalystProjectTitleModalView(graph: document.visibleGraph)
+                                    }
+                                    .padding()
+                                    //                                .frame(width: 260, alignment: .leading)
+                                    .frame(width: 360, alignment: .leading)
+                                    .background(
+                                        Color(uiColor: .systemGray5)
+                                        // NOTE: strangely we need `[.all, .keyboard]` on BOTH the background color AND the StitchHostingControllerView
+                                            .ignoresSafeArea([.all, .keyboard])
+                                            .cornerRadius(4)
+                                    )
+                                    
+                                    
+                                }
+                            } // if document.graphUI
 #endif
+                            
+                            
+                            if showMenu {
+                                InsertNodeMenuWrapper(document: document,
+                                                      graphUI: document.graphUI,
+                                                      menuHeight: self.$menuHeight,
+                                                      screenSize: .constant(document.graphUI.frame.size))
+                            }
+                            
+                            
+                        } // if let document
+
+                        
+                        
+                        
+                    } // .overlay
+//#endif
             }
         }
 //        .coordinateSpace(name: Self.STITCH_ROOT_VIEW_COORDINATE_SPACE)

--- a/Stitch/App/View/StitchRootView.swift
+++ b/Stitch/App/View/StitchRootView.swift
@@ -59,7 +59,7 @@ struct StitchRootView: View {
 
      // For now,
     @State private var menuHeight: CGFloat = INSERT_NODE_MENU_MAX_HEIGHT
-//    @State private var screenSize: CGSize = .zero
+    @State private var screenSize: CGSize = .zero
     
     var body: some View {
         Group {
@@ -103,22 +103,17 @@ struct StitchRootView: View {
                             } // if document.graphUI
 #endif
                             
-                            
                             if showMenu {
                                 InsertNodeMenuWrapper(document: document,
                                                       graphUI: document.graphUI,
                                                       menuHeight: self.$menuHeight,
-                                                      screenSize: .constant(document.graphUI.frame.size))
+                                                      screenSize: .constant(document.graphUI.frame.size)
+//                                                      screenSize: self.$screenSize
+                                )
                             }
                             
-                            
                         } // if let document
-
-                        
-                        
-                        
                     } // .overlay
-//#endif
             }
         }
 //        .coordinateSpace(name: Self.STITCH_ROOT_VIEW_COORDINATE_SPACE)

--- a/Stitch/Graph/Gesture/Util/GraphUITappedActions.swift
+++ b/Stitch/Graph/Gesture/Util/GraphUITappedActions.swift
@@ -28,8 +28,8 @@ struct GraphDoubleTappedAction: StitchDocumentEvent {
         state.graphUI.toggleInsertNodeMenu()
         
 //        if !state.llmRecording.isRecording {
-//            // Do not set double-tap location if we're actively recording
-//            state.graphUI.doubleTapLocation = location
+        // Do not set double-tap location if we're actively recording
+        state.graphUI.doubleTapLocation = location
 //        }
         
         // log("GraphDoubleTappedAction: state.doubleTapLocation is now: \(state.doubleTapLocation)")

--- a/Stitch/Graph/Menu/InsertNodeMenu/Util/InsertNodeMenuActions.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/Util/InsertNodeMenuActions.swift
@@ -59,7 +59,7 @@ extension GraphUIState {
         
         // `withAnimation` still seems to cause view to scroll
         
-        withAnimation {
+        withAnimation(.INSERT_NODE_MENU_TOGGLE_ANIMATION) {
             self.insertNodeMenuState.show = showMenu
 
             // whenever we toggle (open or close) the menu,
@@ -69,13 +69,17 @@ extension GraphUIState {
     }
 }
 
+extension Animation {
+    static let INSERT_NODE_MENU_TOGGLE_ANIMATION = Self.spring(duration: 0.2)
+}
+
 /// Resets all state include hiding the menu and the node selection.
 struct CloseAndResetInsertNodeMenu: GraphUIEvent {
     func handle(state: GraphUIState) {
         // log("CloseAndResetInsertNodeMenu called")
 
         if !state.insertNodeMenuState.menuAnimatingToNode {
-            withAnimation {
+            withAnimation(.INSERT_NODE_MENU_TOGGLE_ANIMATION) {
                 state.insertNodeMenuState = InsertNodeMenuState()
             }
         }

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenu.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenu.swift
@@ -15,7 +15,7 @@ let INSERT_NODE_MENU_WIDTH: CGFloat = 639
 // TODO: put menu ABOVE navbar, so that we don't have to shrink for iPad's fullscreen keyboard?
 // TODO: if still shrinking, determine the min height dynamically by the diff screen's regular vs height with fullscreen keyboard
 // let INSERT_NODE_MENU_MIN_HEIGHT: CGFloat = 220 // previously
-//let INSERT_NODE_MENU_MIN_HEIGHT: CGFloat = 232 // acceptable for iPad Mini
+// let INSERT_NODE_MENU_MIN_HEIGHT: CGFloat = 232 // acceptable for iPad Mini
 // let INSERT_NODE_MENU_MIN_HEIGHT: CGFloat = 240 // too big for iPad Mini
 // let INSERT_NODE_MENU_MIN_HEIGHT: CGFloat = 260
 let INSERT_NODE_MENU_MIN_HEIGHT: CGFloat = 280 // okay now that node menu sits above sidebar

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenu.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenu.swift
@@ -15,9 +15,10 @@ let INSERT_NODE_MENU_WIDTH: CGFloat = 639
 // TODO: put menu ABOVE navbar, so that we don't have to shrink for iPad's fullscreen keyboard?
 // TODO: if still shrinking, determine the min height dynamically by the diff screen's regular vs height with fullscreen keyboard
 // let INSERT_NODE_MENU_MIN_HEIGHT: CGFloat = 220 // previously
-let INSERT_NODE_MENU_MIN_HEIGHT: CGFloat = 232 // acceptable for iPad Mini
+//let INSERT_NODE_MENU_MIN_HEIGHT: CGFloat = 232 // acceptable for iPad Mini
 // let INSERT_NODE_MENU_MIN_HEIGHT: CGFloat = 240 // too big for iPad Mini
 // let INSERT_NODE_MENU_MIN_HEIGHT: CGFloat = 260
+let INSERT_NODE_MENU_MIN_HEIGHT: CGFloat = 280 // okay now that node menu sits above sidebar
 
 // let INSERT_NODE_MENU_MAX_HEIGHT: CGFloat = 500
 let INSERT_NODE_MENU_MAX_HEIGHT: CGFloat = 366

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWrapper.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWrapper.swift
@@ -42,8 +42,13 @@ struct InsertNodeMenuWrapper: View {
 
     @Bindable var document: StitchDocumentViewModel
     @Bindable var graphUI: GraphUIState
-    @Binding var menuHeight: CGFloat
-    @Binding var screenSize: CGSize
+    
+    var menuHeight: CGFloat {
+        graphUI.nodeMenuHeight
+    }
+    
+    // TODO: add back or fully remove when we reintroduce
+    //    @Binding var screenSize: CGSize
     
     var graphScale: CGFloat {
         graphMovement.zoomData.zoom
@@ -56,13 +61,13 @@ struct InsertNodeMenuWrapper: View {
     }
 
     var screenWidth: CGFloat {
-        // graphUI.frame.width
-        self.screenSize.width
+         graphUI.frame.width
+//        self.screenSize.width
     }
 
     var screenHeight: CGFloat {
-        // graphUI.frame.height
-        self.screenSize.height
+         graphUI.frame.height
+//        self.screenSize.height
     }
     
     private var graphMovement: GraphMovementObserver {
@@ -140,7 +145,8 @@ struct InsertNodeMenuWrapper: View {
         self.nodePosition = self.getAdjustedMenuOrigin() // menuOrigin
 
         if setHeightToMax {
-            self.menuHeight = INSERT_NODE_MENU_MAX_HEIGHT
+//            self.menuHeight = INSERT_NODE_MENU_MAX_HEIGHT
+            dispatch(NodeMenuHeightSet(newHeight: INSERT_NODE_MENU_MAX_HEIGHT))
         }
     }
     
@@ -300,7 +306,7 @@ struct InsertNodeMenuWrapper: View {
             animatingNodeOpacity: self.nodeOpacity)
         
             // scale first, THEN position
-            .scaleEffect(x: menuScaleX, y: menuScaleY)
+//            .scaleEffect(x: menuScaleX, y: menuScaleY)
             // use .position modifier to match node's use of .position modifier
 //            .position(menuPosition)
 //            .offset(x: -sidebarHalfWidth)
@@ -364,13 +370,13 @@ struct InsertNodeMenuWrapper: View {
                 prepareHiddenMenu(setHeightToMax: false)
             }
         }
-        .onChange(of: self.screenSize, initial: true) { _, _ in
-            //            log("ContentView: onChange of self.screenSize: oldValue: \(oldValue)")
-            //            log("ContentView: onChange of self.screenSize: newValue: \(newValue)")
-            if !graphUI.insertNodeMenuState.menuAnimatingToNode {
-                prepareHiddenMenu(setHeightToMax: false)
-            }
-        }
+//        .onChange(of: self.screenSize, initial: true) { _, _ in
+//            //            log("ContentView: onChange of self.screenSize: oldValue: \(oldValue)")
+//            //            log("ContentView: onChange of self.screenSize: newValue: \(newValue)")
+//            if !graphUI.insertNodeMenuState.menuAnimatingToNode {
+//                prepareHiddenMenu(setHeightToMax: false)
+//            }
+//        }
         .onChange(of: graphUI.insertNodeMenuState.menuAnimatingToNode, initial: true) { _, newValue in
             // log("ContentView: onChange of menuAnimatingToNode: oldValue: \(oldValue)")
             // log("ContentView: onChange of menuAnimatingToNode: newValue: \(newValue)")

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWrapper.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWrapper.swift
@@ -298,6 +298,7 @@ struct InsertNodeMenuWrapper: View {
             showMenu: insertNodeMenuState.show,
             menuHeight: menuHeight,
             animatingNodeOpacity: self.nodeOpacity)
+        
             // scale first, THEN position
             .scaleEffect(x: menuScaleX, y: menuScaleY)
             // use .position modifier to match node's use of .position modifier
@@ -312,29 +313,26 @@ struct InsertNodeMenuWrapper: View {
     
     var body: some View {
         ZStack {
-//            MODAL_BACKGROUND_COLOR
-//                .ignoresSafeArea()
-//                .frame(maxWidth: .infinity, maxHeight: .infinity)
-//                .opacity(showModalBackground ? 1 : 0)
-//                .onTapGesture {
-//                    dispatch(CloseAndResetInsertNodeMenu())
-//                }
-//            // IMPORTANT: keep `nodeSizeReadingView` in an .overlay, so that the changing of the node during insert-node-menu query-typing does not
-//                .overlay {
-//                    // NodeView used only for reading the size of the insert node menu's active selection;
-//                    // its size does not change becasue it is not animated.
-//                    
-//                    // Only use node-size-reading view when not actively animating
-//                    if !graphUI.insertNodeMenuState.menuAnimatingToNode {
-//                        sizeReadingNodeView.opacity(0)
-//                    }
-//                }
+
+            
+#if DEV_DEBUG || DEBUG
+            let pseudoPopoverBackgroundOpacity = 0.1
+#else
+            let pseudoPopoverBackgroundOpacity = 0.001
+#endif
+            
+            ModalBackgroundGestureRecognizer(dismissalCallback: { dispatch(CloseAndResetInsertNodeMenu()) }) {
+//                Color.blue.opacity(pseudoPopoverBackgroundOpacity)
+                Color.clear
+            }
+//            .opacity(showModalBackground ? 1 : 0)
             
             // Insert Node Menu view
             if graphUI.insertNodeMenuState.show {
                 menuView
-                    .shadow(radius: 4)
-                    .shadow(radius: 8, x: 4, y: 2)
+                .shadow(radius: 4)
+                .shadow(radius: 8, x: 4, y: 2)
+                    .animation(.default, value: graphUI.insertNodeMenuState.show)
             }
                         
 //            // NodeView used only for animation; does not read size,

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWrapper.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWrapper.swift
@@ -312,27 +312,28 @@ struct InsertNodeMenuWrapper: View {
     
     var body: some View {
         ZStack {
-            MODAL_BACKGROUND_COLOR
-                .ignoresSafeArea()
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .opacity(showModalBackground ? 1 : 0)
-                .onTapGesture {
-                    dispatch(CloseAndResetInsertNodeMenu())
-                }
-            // IMPORTANT: keep `nodeSizeReadingView` in an .overlay, so that the changing of the node during insert-node-menu query-typing does not
-                .overlay {
-                    // NodeView used only for reading the size of the insert node menu's active selection;
-                    // its size does not change becasue it is not animated.
-                    
-                    // Only use node-size-reading view when not actively animating
-                    if !graphUI.insertNodeMenuState.menuAnimatingToNode {
-                        sizeReadingNodeView.opacity(0)
-                    }
-                }
+//            MODAL_BACKGROUND_COLOR
+//                .ignoresSafeArea()
+//                .frame(maxWidth: .infinity, maxHeight: .infinity)
+//                .opacity(showModalBackground ? 1 : 0)
+//                .onTapGesture {
+//                    dispatch(CloseAndResetInsertNodeMenu())
+//                }
+//            // IMPORTANT: keep `nodeSizeReadingView` in an .overlay, so that the changing of the node during insert-node-menu query-typing does not
+//                .overlay {
+//                    // NodeView used only for reading the size of the insert node menu's active selection;
+//                    // its size does not change becasue it is not animated.
+//                    
+//                    // Only use node-size-reading view when not actively animating
+//                    if !graphUI.insertNodeMenuState.menuAnimatingToNode {
+//                        sizeReadingNodeView.opacity(0)
+//                    }
+//                }
             
             // Insert Node Menu view
             if graphUI.insertNodeMenuState.show {
                 menuView
+                    .shadow(radius: 10, x: 10, y: 10)
             }
                         
 //            // NodeView used only for animation; does not read size,

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWrapper.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWrapper.swift
@@ -104,7 +104,7 @@ struct InsertNodeMenuWrapper: View {
             document.visibleGraph.localPosition,
             graphScale: self.graphScale)
         
-        let sidebarAdjustment = (self.sidebarHalfWidth * 1/self.graphScale)
+        let sidebarAdjustment = 0.0 //(self.sidebarHalfWidth * 1/self.graphScale)
         
 //        if document.llmRecording.isRecording {
 //            return defaultCenter
@@ -301,14 +301,14 @@ struct InsertNodeMenuWrapper: View {
             // scale first, THEN position
             .scaleEffect(x: menuScaleX, y: menuScaleY)
             // use .position modifier to match node's use of .position modifier
-            .position(menuPosition)
-            .offset(x: -sidebarHalfWidth)
+//            .position(menuPosition)
+//            .offset(x: -sidebarHalfWidth)
     }
     
     // should be subtracted
-    var sidebarHalfWidth: CGFloat {
-        graphUI.sidebarWidth/2
-    }
+//    var sidebarHalfWidth: CGFloat {
+//        graphUI.sidebarWidth/2
+//    }
     
     var body: some View {
         ZStack {
@@ -335,19 +335,19 @@ struct InsertNodeMenuWrapper: View {
                 menuView
             }
                         
-            // NodeView used only for animation; does not read size,
-            // since its size changes during animation.
-            // Note: don't render this NodeView until we have committed our choice.
-            if graphUI.insertNodeMenuState.menuAnimatingToNode {
-                animatedNodeView
-                    .opacity(graphUI.insertNodeMenuState.show ? 1 : 0)
-                    .onChange(of: graphUI.insertNodeMenuState.show) {
-                        // Surfacing the menu may cause the responder chain to break, causing key modifiers
-                        // to lose tracking for end state
-                        dispatch(KeyModifierReset())
-                    }
-                    .offset(x: -sidebarHalfWidth)
-            }
+//            // NodeView used only for animation; does not read size,
+//            // since its size changes during animation.
+//            // Note: don't render this NodeView until we have committed our choice.
+//            if graphUI.insertNodeMenuState.menuAnimatingToNode {
+//                animatedNodeView
+//                    .opacity(graphUI.insertNodeMenuState.show ? 1 : 0)
+//                    .onChange(of: graphUI.insertNodeMenuState.show) {
+//                        // Surfacing the menu may cause the responder chain to break, causing key modifiers
+//                        // to lose tracking for end state
+//                        dispatch(KeyModifierReset())
+//                    }
+////                    .offset(x: -sidebarHalfWidth)
+//            }
         }
         .onAppear {
             //            log("onAppear")

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWrapper.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWrapper.swift
@@ -333,7 +333,8 @@ struct InsertNodeMenuWrapper: View {
             // Insert Node Menu view
             if graphUI.insertNodeMenuState.show {
                 menuView
-                    .shadow(radius: 10, x: 10, y: 10)
+                    .shadow(radius: 4)
+                    .shadow(radius: 8, x: 4, y: 2)
             }
                         
 //            // NodeView used only for animation; does not read size,

--- a/Stitch/Graph/View/ContentView.swift
+++ b/Stitch/Graph/View/ContentView.swift
@@ -67,6 +67,9 @@ struct ContentView: View, KeyboardReadable {
 
     var body: some View {
         ZStack {
+            
+            // probably the best location for listening to how iPad's on-screen keyboard reduces available height for node menu ?
+            
             // Must respect keyboard safe-area
             ProjectWindowSizeReader(previewWindowSizing: previewWindowSizing,
                                     previewWindowSize: document.previewWindowSize,

--- a/Stitch/Graph/View/ContentView.swift
+++ b/Stitch/Graph/View/ContentView.swift
@@ -56,12 +56,12 @@ struct ContentView: View, KeyboardReadable {
                 contentView // the graph
             }
             
-            if showMenu {
-                InsertNodeMenuWrapper(document: document,
-                                      graphUI: graphUI,
-                                      menuHeight: $menuHeight,
-                                      screenSize: $screenSize) // node menu + other animating views
-            }
+//            if showMenu {
+//                InsertNodeMenuWrapper(document: document,
+//                                      graphUI: graphUI,
+//                                      menuHeight: $menuHeight,
+//                                      screenSize: $screenSize) // node menu + other animating views
+//            }
         }
     }
 

--- a/Stitch/Graph/View/ContentView.swift
+++ b/Stitch/Graph/View/ContentView.swift
@@ -77,8 +77,9 @@ struct ContentView: View, KeyboardReadable {
                                     isFullScreen: graphUI.isFullScreenMode,
                                     showFullScreenAnimateCompleted: $showFullScreenAnimateCompleted,
                                     showFullScreenObserver: showFullScreen,
-                                    menuHeight: $menuHeight,
-                                    screenSize: $screenSize,
+//                                    menuHeight: $menuHeight,
+                                    menuHeight: menuHeight,
+//                                    screenSize: $screenSize,
                                     menuAnimatingToNode: graphUI.insertNodeMenuState.menuAnimatingToNode)
 
             // Must IGNORE keyboard safe-area

--- a/Stitch/Graph/View/ContentView.swift
+++ b/Stitch/Graph/View/ContentView.swift
@@ -70,6 +70,7 @@ struct ContentView: View, KeyboardReadable {
             
             // probably the best location for listening to how iPad's on-screen keyboard reduces available height for node menu ?
             
+            
             // Must respect keyboard safe-area
             ProjectWindowSizeReader(previewWindowSizing: previewWindowSizing,
                                     previewWindowSize: document.previewWindowSize,

--- a/Stitch/Graph/View/GraphBaseView.swift
+++ b/Stitch/Graph/View/GraphBaseView.swift
@@ -141,11 +141,11 @@ struct GraphBaseView: View {
             GeometryReader { geometry in
                 Color.clear
                     .onChange(of: geometry.frame(in: .local), initial: true) { oldValue, newValue in
-                        // log("GraphBaseView: local frame: newValue: \(newValue)")
+                        log("SIZE READING: GraphBaseView: local frame: newValue: \(newValue)")
                         dispatch(SetDeviceScreenSize(frame: newValue))
                     }
                     .onChange(of: geometry.frame(in: .global), initial: true) { oldValue, newValue in
-                        // log("GraphBaseView: global frame: newValue: \(newValue)")
+                         log("SIZE READING: GraphBaseView: global frame: newValue: \(newValue)")
                         dispatch(SetGraphYPosition(graphYPosition: newValue.origin.y))
                         dispatch(SetSidebarWidth(frame: newValue))
                     }

--- a/Stitch/Graph/View/GraphBaseView.swift
+++ b/Stitch/Graph/View/GraphBaseView.swift
@@ -141,11 +141,11 @@ struct GraphBaseView: View {
             GeometryReader { geometry in
                 Color.clear
                     .onChange(of: geometry.frame(in: .local), initial: true) { oldValue, newValue in
-                        log("SIZE READING: GraphBaseView: local frame: newValue: \(newValue)")
+                       // log("SIZE READING: GraphBaseView: local frame: newValue: \(newValue)")
                         dispatch(SetDeviceScreenSize(frame: newValue))
                     }
                     .onChange(of: geometry.frame(in: .global), initial: true) { oldValue, newValue in
-                         log("SIZE READING: GraphBaseView: global frame: newValue: \(newValue)")
+                        // log("SIZE READING: GraphBaseView: global frame: newValue: \(newValue)")
                         dispatch(SetGraphYPosition(graphYPosition: newValue.origin.y))
                         dispatch(SetSidebarWidth(frame: newValue))
                     }

--- a/Stitch/Graph/View/Util/ProjectWindowSizeReader.swift
+++ b/Stitch/Graph/View/Util/ProjectWindowSizeReader.swift
@@ -9,6 +9,15 @@ import Foundation
 import SwiftUI
 import StitchSchemaKit
 
+
+struct NodeMenuHeightSet: GraphUIEvent {
+    let newHeight: CGFloat
+    
+    func handle(state: GraphUIState) {
+        state.nodeMenuHeight = newHeight
+    }
+}
+
 import GameController
 
 /// Uses `GeometryReader` to process screen size changes for the prototype preview window.
@@ -19,8 +28,9 @@ struct ProjectWindowSizeReader: View {
     @Binding var showFullScreenAnimateCompleted: Bool
     let showFullScreenObserver: AnimatableBool
 
-    @Binding var menuHeight: CGFloat
-    @Binding var screenSize: CGSize
+//    @Binding var menuHeight: CGFloat
+    let menuHeight: CGFloat
+//    @Binding var screenSize: CGSize
 
     let menuAnimatingToNode: Bool
 
@@ -33,7 +43,7 @@ struct ProjectWindowSizeReader: View {
 
                      log("SIZE READING: ProjectWindowSizeReader: onAppear: geometry.size: \(geometry.size)")
 
-                    screenSize = geometry.size
+//                    screenSize = geometry.size
 
                     if geometry.size.isLandscape {
                         self.defaultLandscapeSize = geometry.size
@@ -71,7 +81,7 @@ struct ProjectWindowSizeReader: View {
                     }
 
                     // TODO: ignore geometry changes when magic keyboard attached, so that we don't "slightly move up" the insert node menu?
-                    screenSize = geometry.size
+//                    screenSize = geometry.size
 
                     if !self.defaultLandscapeSize.isDefined,
                        geometry.size.isLandscape {
@@ -111,24 +121,30 @@ struct ProjectWindowSizeReader: View {
                         // TODO: test on iPad Mini etc.
                         // TODO: why were we getting 299 vs 300 vs ... ?
                         //                        if heightDiff.magnitude > 300 {
+                        
+                        let heightDiffMag = heightDiff.magnitude
+                        
                         if heightDiff.magnitude > 295 {
-                            // log("ProjectWindowSizeReader: onChange of: geometry.size: setting to min height")
-                            menuHeight = INSERT_NODE_MENU_MIN_HEIGHT
+                             log("ProjectWindowSizeReader: onChange of: geometry.size: setting to min height")
+                            //menuHeight = INSERT_NODE_MENU_MIN_HEIGHT
+                            dispatch(NodeMenuHeightSet(newHeight: INSERT_NODE_MENU_MIN_HEIGHT))
 
                             // TODO: only adjust screen size if geometry changed enough to change the menu's height? Be careful about e.g. maybe us wanting to move up the menu when in portrait mode.
                             // screenHeight = geometry.size.height
 
                         } else {
-                            // log("ProjectWindowSizeReader: onChange of: geometry.size: diff not big enough")
-                            menuHeight = INSERT_NODE_MENU_MAX_HEIGHT
+                             log("ProjectWindowSizeReader: onChange of: geometry.size: diff not big enough")
+                            //menuHeight = INSERT_NODE_MENU_MAX_HEIGHT
+                            dispatch(NodeMenuHeightSet(newHeight: INSERT_NODE_MENU_MAX_HEIGHT))
                         }
                     }
 
                     // Needed when e.g. keyboard dimissed?
                     // or we rotate the device, e.g. into portrait mode?
                     else {
-                        // log("ProjectWindowSizeReader: onChange of: geometry.size: setting to max height again")
-                        menuHeight = INSERT_NODE_MENU_MAX_HEIGHT
+                         log("ProjectWindowSizeReader: onChange of: geometry.size: setting to max height again")
+//                        menuHeight = INSERT_NODE_MENU_MAX_HEIGHT
+                        dispatch(NodeMenuHeightSet(newHeight: INSERT_NODE_MENU_MAX_HEIGHT))
                     }
                 }
             // TODO: why does this logic live here? we're changing some ephemeral parts of preview-window data (size etc.) in a reader that's mostly about user-device-screen changes (e.g. keyboard, rotation) ?

--- a/Stitch/Graph/View/Util/ProjectWindowSizeReader.swift
+++ b/Stitch/Graph/View/Util/ProjectWindowSizeReader.swift
@@ -31,7 +31,7 @@ struct ProjectWindowSizeReader: View {
             Color.clear
                 .onAppear {
 
-                    // log("ProjectWindowSizeReader: onAppear: geometry.size: \(geometry.size)")
+                     log("SIZE READING: ProjectWindowSizeReader: onAppear: geometry.size: \(geometry.size)")
 
                     screenSize = geometry.size
 
@@ -53,11 +53,11 @@ struct ProjectWindowSizeReader: View {
 
                 // TODO: if we want to resize the prototype window when Mac app window or iOS device orientation changes, decide how to coorindate that with user's manual-drag changes of prototype window size.
                 // Listener here needed for repainting the view after a device orientation change
-                .onChange(of: geometry.size) { _, _ in
+                .onChange(of: geometry.size) { oldValue, newValue in
 
                     // log("ProjectWindowSizeReader: onChange of: geometry.size: \(geometry.size)")
-                    // log("ProjectWindowSizeReader: onChange of: oldValue: \(oldValue)")
-                    // log("ProjectWindowSizeReader: onChange of: newValue: \(newValue)")
+                     log("SIZE READING: ProjectWindowSizeReader: onChange of: oldValue: \(oldValue)")
+                     log("SIZE READING: ProjectWindowSizeReader: onChange of: newValue: \(newValue)")
 
                     if isFullScreen {
                         // log("ProjectWindowSizeReader: onChange of: geometry.size: we are fullscreen, so will update previewWindowSizing")

--- a/Stitch/Graph/View/Util/ProjectWindowSizeReader.swift
+++ b/Stitch/Graph/View/Util/ProjectWindowSizeReader.swift
@@ -41,7 +41,7 @@ struct ProjectWindowSizeReader: View {
             Color.clear
                 .onAppear {
 
-                     log("SIZE READING: ProjectWindowSizeReader: onAppear: geometry.size: \(geometry.size)")
+                    // log("SIZE READING: ProjectWindowSizeReader: onAppear: geometry.size: \(geometry.size)")
 
 //                    screenSize = geometry.size
 
@@ -65,9 +65,9 @@ struct ProjectWindowSizeReader: View {
                 // Listener here needed for repainting the view after a device orientation change
                 .onChange(of: geometry.size) { oldValue, newValue in
 
-                    // log("ProjectWindowSizeReader: onChange of: geometry.size: \(geometry.size)")
-                     log("SIZE READING: ProjectWindowSizeReader: onChange of: oldValue: \(oldValue)")
-                     log("SIZE READING: ProjectWindowSizeReader: onChange of: newValue: \(newValue)")
+                    //// log("ProjectWindowSizeReader: onChange of: geometry.size: \(geometry.size)")
+                    // log("SIZE READING: ProjectWindowSizeReader: onChange of: oldValue: \(oldValue)")
+                    // log("SIZE READING: ProjectWindowSizeReader: onChange of: newValue: \(newValue)")
 
                     if isFullScreen {
                         // log("ProjectWindowSizeReader: onChange of: geometry.size: we are fullscreen, so will update previewWindowSizing")
@@ -125,7 +125,7 @@ struct ProjectWindowSizeReader: View {
                         let heightDiffMag = heightDiff.magnitude
                         
                         if heightDiff.magnitude > 295 {
-                             log("ProjectWindowSizeReader: onChange of: geometry.size: setting to min height")
+                             // log("ProjectWindowSizeReader: onChange of: geometry.size: setting to min height")
                             //menuHeight = INSERT_NODE_MENU_MIN_HEIGHT
                             dispatch(NodeMenuHeightSet(newHeight: INSERT_NODE_MENU_MIN_HEIGHT))
 
@@ -133,7 +133,7 @@ struct ProjectWindowSizeReader: View {
                             // screenHeight = geometry.size.height
 
                         } else {
-                             log("ProjectWindowSizeReader: onChange of: geometry.size: diff not big enough")
+                             // log("ProjectWindowSizeReader: onChange of: geometry.size: diff not big enough")
                             //menuHeight = INSERT_NODE_MENU_MAX_HEIGHT
                             dispatch(NodeMenuHeightSet(newHeight: INSERT_NODE_MENU_MAX_HEIGHT))
                         }
@@ -142,7 +142,7 @@ struct ProjectWindowSizeReader: View {
                     // Needed when e.g. keyboard dimissed?
                     // or we rotate the device, e.g. into portrait mode?
                     else {
-                         log("ProjectWindowSizeReader: onChange of: geometry.size: setting to max height again")
+                         // log("ProjectWindowSizeReader: onChange of: geometry.size: setting to max height again")
 //                        menuHeight = INSERT_NODE_MENU_MAX_HEIGHT
                         dispatch(NodeMenuHeightSet(newHeight: INSERT_NODE_MENU_MAX_HEIGHT))
                     }

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -304,7 +304,11 @@ extension GraphState {
         self.graphUI.selection = GraphUISelectionState()
         self.resetSelectedCanvasItems()
         self.graphUI.insertNodeMenuState.searchResults = InsertNodeMenuState.allSearchOptions
-        self.graphUI.insertNodeMenuState.show = false
+        
+        withAnimation(.INSERT_NODE_MENU_TOGGLE_ANIMATION) {
+            self.graphUI.insertNodeMenuState.show = false
+        }
+        
         self.graphUI.isFullScreenMode = false
 
         self.graphUI.activelyEditedCommentBoxTitle = nil

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -31,6 +31,8 @@ struct ActiveDragInteractionNodeVelocityData: Equatable, Hashable {
 @Observable
 final class GraphUIState {
     
+    var nodeMenuHeight: CGFloat = INSERT_NODE_MENU_MAX_HEIGHT
+    
     var sidebarWidth: CGFloat = .zero // i.e. origin of graph from .global frame
 
     var showCatalystProjectTitleModal: Bool = false


### PR DESCRIPTION
Also: add drop shadow to menu. Menu is dismissed when we scroll or tap outside. 

Notes:
- We have already disabled the node insertion animation for now; can re-introduce it later.
- We still correctly shrink the menu height on smaller devices like iPad Mini



https://github.com/user-attachments/assets/63f7acde-5989-4a33-ab30-ad4a477b051f

