### PR TITLE
FIxed unpacked canvas node insertion regression

### DIFF
--- a/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
@@ -283,6 +283,7 @@ struct LayerInputFieldAddedToGraph: GraphEventWithResponse {
                 unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
                 unpackedPortIndex: fieldIndex)
             
+            state.resetLayerInputsCache(layerNode: layerNode)
         } else {
             fatalErrorIfDebug("LayerInputFieldAddedToGraph: no unpacked port for fieldIndex \(fieldIndex)")
         }

--- a/Stitch/Graph/LayerInspector/LayerInspectorActions.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorActions.swift
@@ -97,10 +97,16 @@ extension GraphState {
                                     input: layerInputData,
                                     coordinate: coordinate)
         
+        resetLayerInputsCache(layerNode: layerNode)
+    }
+    
+    @MainActor
+    func resetLayerInputsCache(layerNode: LayerNodeViewModel) {
+        layerNode.resetInputCanvasItemsCache()
+
         // Reset graph cache to get new nodes to appear
         // Dispatch needed for fix
-        DispatchQueue.main.async { [weak self, weak layerNode] in
-            layerNode?.resetInputCanvasItemsCache()
+        DispatchQueue.main.async { [weak self] in
             self?.visibleNodesViewModel.resetCache()
         }
     }


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/6720.

Issue was due to not resetting the new cache used for layer inputs.