### PR TITLE
Do not delete a layer node when deleting a GroupNode containing one of the layer's inputs

### DIFF
--- a/Stitch/Graph/Node/Group/GroupNodeDestructionActions.swift
+++ b/Stitch/Graph/Node/Group/GroupNodeDestructionActions.swift
@@ -19,7 +19,8 @@ struct GroupNodeDeletedAction: ProjectEnvironmentEvent {
                 environment: StitchEnvironment) -> GraphResponse {
         log("GroupNodeDeletedAction called: groupNodeId: \(groupNodeId)")
 
-        graphState.deleteNode(id: groupNodeId.asNodeId)
+//        graphState.deleteNode(id: groupNodeId.asNodeId)
+        graphState.deleteCanvasItem(.node(groupNodeId.asNodeId))
         graphState.updateGraphData()
         return .persistenceResponse
     }

--- a/Stitch/Graph/Node/Util/NodeDeletedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeDeletedAction.swift
@@ -144,9 +144,10 @@ extension GraphState {
             }
             
         case .group:
-            let groupChildren = self.getGroupChildren(for: id)
+            let groupChildren = self.getGroupNodeChildren(for: id)
             groupChildren.forEach {
-                self.deleteNode(id: $0)
+//                self.deleteNode(id: $0)
+                self.deleteCanvasItem($0)
             }
             
         default:

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -653,15 +653,18 @@ extension GraphState {
             .toSet
     }
     
+    // The children of a ui group node are better described as 'canvas items',
+    // since a ui group node is really a grouping of canvas items (patch nodes + layer inputs on graph) rather than nodes (patch nodes + full layer nodes)
     @MainActor
-    func getGroupChildren(for groupId: NodeId) -> NodeIdSet {
+    func getGroupNodeChildren(for groupId: NodeId) -> CanvasItemIdSet {
         self.nodes.values
             .flatMap { $0.getAllCanvasObservers() }
             .filter { $0.parentGroupNodeId == groupId }
-            .compactMap { $0.nodeDelegate?.id }
+            .map(\.id)
             .toSet
     }
     
+   
     @MainActor
     func getInputCoordinate(from viewData: InputPortViewData) -> NodeIOCoordinate? {
         guard let node = self.getCanvasItem(viewData.canvasId),


### PR DESCRIPTION
Notes: 
1. deleting a GroupNode is deleting a canvas item
2. the children of a GroupNode are canvas items as well (e.g. layer inputs, never a full layer node itself)


https://github.com/user-attachments/assets/63abda1e-d64b-4c15-a93c-02717865634f

