### PR TITLE
Fixed bug where node type menu on iPad was unresponsive

### DIFF
--- a/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
+++ b/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
@@ -200,6 +200,7 @@ extension LayerNodeViewModel {
 }
 
 extension InputLayerNodeRowData {
+    @MainActor
     func update(from schema: LayerInputDataEntity,
                 layerInputType: LayerInputType,
                 layerNode: LayerNodeViewModel,

--- a/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
+++ b/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
@@ -104,7 +104,22 @@ extension PatchNodeViewModel: SchemaObserver {
             self.patch = schema.patch
         }
         if self.userVisibleType != schema.userVisibleType {
-            self.userVisibleType = schema.userVisibleType
+            guard let oldType = self.userVisibleType,
+                  let newType = schema.userVisibleType else {
+                fatalErrorIfDebug("PatchNodeViewModel.update: expected node type when none found.")
+                return
+            }
+            
+            self.userVisibleType = newType
+            
+            if let node = self.delegate,
+               let graph = node.graphDelegate {
+                // Ensures fields correctly update on events like undo which wouldn't otherwise
+                // call the changeType helper
+                let _ = graph.changeType(for: node,
+                                         oldType: oldType,
+                                         newType: newType)
+            }
         }
         if self.splitterNode != schema.splitterNode {
             self.splitterNode = schema.splitterNode

--- a/Stitch/Graph/Node/Port/Util/TypeChange/NodeTypeChangedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/TypeChange/NodeTypeChangedActions.swift
@@ -48,19 +48,11 @@ extension GraphState {
             return nil
         }
 
-        // TODO: no longer relevant now that classic animation node eval op can create a default animation state when necessary? ... But this may also fix an issue with Spring node?
-        node.ephemeralObservers?.forEach {
-            $0.nodeTypeChanged(
-                oldType: oldType,
-                newType: newNodeType,
-                kind: node.kind)
-        }
-
         // Change view model
         let changedNodeIds = self.changeType(
             for: node,
-            type: newNodeType,
-            graphTime: self.graphStepManager.graphTime)
+            oldType: oldType,
+            newType: newNodeType)
 
         // Recalculate the graph from each of the changed nodes' incoming edges
         let ids = changedNodeIds
@@ -75,8 +67,9 @@ extension GraphState {
     
     @MainActor
     func changeType(for node: NodeViewModel,
-                    type: UserVisibleType,
-                    graphTime: TimeInterval) -> NodeIdSet {
+                    oldType: UserVisibleType,
+                    newType: UserVisibleType) -> NodeIdSet {
+        let graphTime = self.graphStepManager.graphTime
 
         guard let patchNode = node.patchNode else {
             fatalErrorIfDebug()
@@ -88,17 +81,25 @@ extension GraphState {
             log("GraphState.changeType: type change not supported")
             return Set([node.id])
         }
+        
+        // TODO: no longer relevant now that classic animation node eval op can create a default animation state when necessary? ... But this may also fix an issue with Spring node?
+        node.ephemeralObservers?.forEach {
+            $0.nodeTypeChanged(
+                oldType: oldType,
+                newType: newType,
+                kind: node.kind)
+        }
 
         // Convert all values which support type changing
         // Only network node doesn't change inputs
         if patchNode.patch != .networkRequest {
             node.updateNodeTypeAndInputs(
-                newType: type,
+                newType: newType,
                 currentGraphTime: graphTime,
                 activeIndex: activeIndex)
         } else {
             // For network request node, we just change the user-visible-type manually.
-            patchNode.userVisibleType = type
+            patchNode.userVisibleType = newType
         }
 
         switch patchNode.patch {
@@ -108,7 +109,7 @@ extension GraphState {
                 broadcastNodeId: patchNode.id,
                 patchNodes: patchNodes,
                 connections: self.connections,
-                newNodeType: type,
+                newNodeType: newType,
                 graphTime: graphTime,
                 activeIndex: activeIndex)
             return Set([node.id]).union(updatedReceivers)

--- a/Stitch/Graph/Node/Port/Util/TypeChange/NodeTypeChangedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/TypeChange/NodeTypeChangedActions.swift
@@ -17,7 +17,7 @@ struct NodeTypeChanged: GraphEvent {
     @MainActor
     func handle(state: GraphState) {
         let changedIds = state.nodeTypeChanged(nodeId: nodeId,
-                                                            newNodeType: newNodeType)
+                                               newNodeType: newNodeType)
         
         // if we successfully changed the node's type, create an LLMAction
         if changedIds.isDefined,

--- a/Stitch/Graph/Node/View/NodeTag/NodeTagMenuButtonsView.swift
+++ b/Stitch/Graph/Node/View/NodeTag/NodeTagMenuButtonsView.swift
@@ -29,8 +29,16 @@ struct NodeTagMenuButtonsView: View {
     // Also false when we only have minimum number of inputs
     let canRemoveInput: Bool
     
-    var atleastOneCommentBoxSelected: Bool
+    let atleastOneCommentBoxSelected: Bool
+    
+    var loopIndices: [Int]?
 
+    // MARK: very important to process this outside of NodeTagMenuButtonsView: doing so fixes a bug where the node type menu becomes unresponsive if values are constantly changing on iPad.
+    @MainActor
+    var _loopIndices: [Int] {
+        loopIndices ?? self.node.getLoopIndices()
+    }
+    
     @MainActor
     var graphUI: GraphUIState {
         self.graph.graphUI
@@ -44,11 +52,6 @@ struct NodeTagMenuButtonsView: View {
     @MainActor
     var activeIndex: ActiveIndex {
         self.graphUI.activeIndex
-    }
-
-    @MainActor
-    var loopIndices: [Int] {
-        self.node.getLoopIndices()
     }
 
     var nodeType: UserVisibleType? {
@@ -82,7 +85,7 @@ struct NodeTagMenuButtonsView: View {
     // only show loop-indices when more than just 1 index
     @MainActor
     var hasLoopIndexCarousel: Bool {
-        loopIndices.count > 1
+        _loopIndices.count > 1
     }
 
     // Only show splitter-type carousel if not at top-level
@@ -171,7 +174,7 @@ struct NodeTagMenuButtonsView: View {
 
             if hasLoopIndexCarousel {
                 loopIndexSubmenu(activeIndex: activeIndex,
-                                 loopIndices)
+                                 _loopIndices)
             }
 
 //            if isWirelessReceiver {

--- a/Stitch/Graph/Node/View/NodeView.swift
+++ b/Stitch/Graph/Node/View/NodeView.swift
@@ -282,7 +282,18 @@ struct CanvasItemTag: View {
                                nodeTypeChoices: sortedUserTypeChoices,
                                canAddInput: canAddInput,
                                canRemoveInput: canRemoveInput,
-                               atleastOneCommentBoxSelected: atleastOneCommentBoxSelected)
+                               atleastOneCommentBoxSelected: atleastOneCommentBoxSelected,
+                               loopIndices: self.loopIndices)
+    }
+    
+    @MainActor
+    var loopIndices: [Int]? {
+        // MARK: very important to process this outside of NodeTagMenuButtonsView: doing so fixes a bug where the node type menu becomes unresponsive if values are constantly changing on iPad.
+#if targetEnvironment(macCatalyst)
+        nil
+#else
+        self.stitch.getLoopIndices()
+#endif
     }
     
     var body: some View {

--- a/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
@@ -163,7 +163,8 @@ extension CanvasItemViewModel {
               parentGroupNodeId:self.parentGroupNodeId)
     }
 
-    func update(from schema: CanvasNodeEntity) {        
+    @MainActor
+    func update(from schema: CanvasNodeEntity) {
         if self.position != schema.position {
             self.position = schema.position
         }
@@ -178,6 +179,16 @@ extension CanvasItemViewModel {
         
         if self.parentGroupNodeId != schema.parentGroupNodeId {
             self.parentGroupNodeId = schema.parentGroupNodeId
+        }
+        
+        // Hack to fix issues where undo/redo sometimes doesn't refresh edges.
+        // Not perfect as it leads to a bit of a stutter when it works.
+        self.inputViewModels.forEach {
+            $0.updateAnchorPoint()
+        }
+        
+        self.outputViewModels.forEach {
+            $0.updateAnchorPoint()
         }
     }
     

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -17,6 +17,9 @@ import Vision
 
 @Observable
 final class GraphState: Sendable {
+    typealias CachedPortUI = NodePortType<NodeViewModel>
+    typealias NodePortCacheSet = Set<CachedPortUI>
+    
     // Updated when connections, new nodes etc change
     let topologicalData: GraphTopologicalData<NodeViewModel>
     
@@ -72,7 +75,7 @@ final class GraphState: Sendable {
     var networkRequestCompletedTimes = NetworkRequestLatestCompletedTimeDict()
     
     // Tracks IDs for rows that need to be updated for the view. Cached here for perf so we can throttle view updates.
-    var portsToUpdate: Set<NodePortType<NodeViewModel>> = .init()
+    var portsToUpdate: NodePortCacheSet = .init()
     
     var lastEncodedDocument: GraphEntity
     weak var documentDelegate: StitchDocumentViewModel?


### PR DESCRIPTION
Specifically, unresponsive whenever the node contained an upstream connection. New values caused the node's views to render due to logic for determining active loop counts. We're good so long as that logic is kept outside the menu view, because those extra renders cause the menu to freak out.

Additional logic was made to properly support undo scenarios of node type changing.