### PR TITLE
Replaced BrightFutures with async/await

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -22,7 +22,6 @@
 		203D56BA25B0DA7C00EF7AC2 /* PortEdgeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203D56B925B0DA7C00EF7AC2 /* PortEdgeData.swift */; };
 		203D56BD25B0DAE000EF7AC2 /* LegacyNodeHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203D56BC25B0DAE000EF7AC2 /* LegacyNodeHelpers.swift */; };
 		204B24FF25B68C790041424F /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204B24FE25B68C790041424F /* Constants.swift */; };
-		20578DA7259EAF6400DACCA8 /* BrightFutures in Frameworks */ = {isa = PBXBuildFile; productRef = 20578DA6259EAF6400DACCA8 /* BrightFutures */; };
 		205BB3B125BA203D00F144A7 /* PortView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205BB3B025BA203D00F144A7 /* PortView.swift */; };
 		205BB3B425BA210500F144A7 /* InsertNodeMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205BB3B325BA210500F144A7 /* InsertNodeMenu.swift */; };
 		205E6DDA25AFCB16001C5C27 /* NodeTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E6DD925AFCB16001C5C27 /* NodeTesting.swift */; };
@@ -1868,7 +1867,6 @@
 				EC53F3C3287E27250021095B /* Numerics in Frameworks */,
 				EC15E42A2602A08B006F2E08 /* CloudKit.framework in Frameworks */,
 				201953DA25B25D3300D5296C /* Tagged in Frameworks */,
-				20578DA7259EAF6400DACCA8 /* BrightFutures in Frameworks */,
 				EC211A4B2698A8B70068A0F0 /* SwiftyJSON in Frameworks */,
 				E463E7EF2C6FC7090008E318 /* StitchSchemaKit in Frameworks */,
 			);
@@ -4488,7 +4486,6 @@
 			);
 			name = Stitch;
 			packageProductDependencies = (
-				20578DA6259EAF6400DACCA8 /* BrightFutures */,
 				20D1601825A802FF005AEB72 /* NonEmpty */,
 				201953D925B25D3300D5296C /* Tagged */,
 				EC39E75B26822ACA00674841 /* AudioKit */,
@@ -4579,7 +4576,6 @@
 			);
 			mainGroup = 200BD84E254F66EB00692903;
 			packageReferences = (
-				20578DA5259EAF6400DACCA8 /* XCRemoteSwiftPackageReference "BrightFutures" */,
 				20D1601725A802FF005AEB72 /* XCRemoteSwiftPackageReference "swift-nonempty" */,
 				201953D825B25D3300D5296C /* XCRemoteSwiftPackageReference "swift-tagged" */,
 				EC39E75A26822ACA00674841 /* XCRemoteSwiftPackageReference "AudioKit" */,
@@ -6343,14 +6339,6 @@
 				version = 0.7.0;
 			};
 		};
-		20578DA5259EAF6400DACCA8 /* XCRemoteSwiftPackageReference "BrightFutures" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Thomvis/BrightFutures.git";
-			requirement = {
-				kind = exactVersion;
-				version = 8.1.0;
-			};
-		};
 		20D1601725A802FF005AEB72 /* XCRemoteSwiftPackageReference "swift-nonempty" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pointfreeco/swift-nonempty.git";
@@ -6470,11 +6458,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 201953D825B25D3300D5296C /* XCRemoteSwiftPackageReference "swift-tagged" */;
 			productName = Tagged;
-		};
-		20578DA6259EAF6400DACCA8 /* BrightFutures */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 20578DA5259EAF6400DACCA8 /* XCRemoteSwiftPackageReference "BrightFutures" */;
-			productName = BrightFutures;
 		};
 		20D1601825A802FF005AEB72 /* NonEmpty */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "87be221b3fbded1c8027b1ce26671216264e4726379ed9409d52282eb1aab675",
+  "originHash" : "c180ad49e1ca6158a0cadf99cf3656d81dacab2d3997ddb71959385a7ec2ac54",
   "pins" : [
     {
       "identity" : "audiokit",
@@ -8,15 +8,6 @@
       "state" : {
         "revision" : "82cab9d4c168b5b03b67e2ff099819f589b530f7",
         "version" : "5.6.2"
-      }
-    },
-    {
-      "identity" : "brightfutures",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Thomvis/BrightFutures.git",
-      "state" : {
-        "revision" : "939858b811026f85e87847a808f0bea2f187e5c4",
-        "version" : "8.1.0"
       }
     },
     {

--- a/Stitch/App/Util/TypeExtension/MiscUtils.swift
+++ b/Stitch/App/Util/TypeExtension/MiscUtils.swift
@@ -35,6 +35,15 @@ extension Optional {
 }
 
 extension Result {
+    var value: Success? {
+        switch self {
+        case .success(let value):
+            return value
+        case .failure:
+            return nil
+        }
+    }
+    
     var isFailure: Bool {
         switch self {
         case .success:

--- a/Stitch/App/Util/URL/URLSessionExtensionUtils.swift
+++ b/Stitch/App/Util/URL/URLSessionExtensionUtils.swift
@@ -8,46 +8,21 @@
 import Foundation
 import StitchSchemaKit
 import SwiftUI
-import BrightFutures
 
-// Also consider: Alamofire library
-
-// https://github.com/Thomvis/FutureProofing/blob/2d5c240dac1c71a6e4bca71834cf8448a6ea2e73/FutureProofing/Foundation/URLSession.swift
-
-extension URLSession {
-    public typealias FutureSessionDataTask = (URLSessionDataTask, Future<(Data?, URLResponse?), AnyError>)
-    public typealias FutureSessionUploadTask = (URLSessionUploadTask, Future<(Data?, URLResponse?), AnyError>)
-    public typealias FutureSessionDownloadTask = (URLSessionDownloadTask, Future<(URL?, URLResponse?), AnyError>)
-
-    public func dataTask(with request: URLRequest) -> FutureSessionDataTask {
-        let p = Promise<(Data?, URLResponse?), AnyError>()
-
-        let task = self.dataTask(with: request, completionHandler: self.completionHandler(promise: p))
-
-        return (task, p.future)
-    }
-
-    public func completionHandler(promise p: Promise<(Data?, URLResponse?), AnyError>) -> (Data?, URLResponse?, Error?) -> Void {
-        return { (data, response, error) -> Void in
-            if let error = error {
-                p.failure(AnyError(cause: error))
-            } else {
-                p.success((data, response))
-            }
-        }
-    }
-
-    public func downloadTaskCompletionHandler(promise p: Promise<(URL?, URLResponse?), AnyError>) -> (URL?, URLResponse?, Error?) -> Void {
-        return { (url, response, error) -> Void in
-            if let error = error {
-                p.failure(AnyError(cause: error))
-            } else {
-                p.success((url, response))
-            }
-        }
-    }
-
-}
+//
+//extension URLSession {
+//    public typealias FutureSessionDataTask = (URLSessionDataTask, Future<(Data?, URLResponse?), AnyError>)
+//    public typealias FutureSessionUploadTask = (URLSessionUploadTask, Future<(Data?, URLResponse?), AnyError>)
+//    public typealias FutureSessionDownloadTask = (URLSessionDownloadTask, Future<(URL?, URLResponse?), AnyError>)
+//
+//    public func dataTask(with request: URLRequest) -> FutureSessionDataTask {
+//        let p = Promise<(Data?, URLResponse?), AnyError>()
+//
+//        let task = self.dataTask(with: request, completionHandler: self.completionHandler(promise: p))
+//
+//        return (task, p.future)
+//    }
+//}
 
 // https://github.com/Thomvis/FutureProofing/blob/2d5c240dac1c71a6e4bca71834cf8448a6ea2e73/FutureProofing/BrightFuture%2BFutureProofing.swift
 

--- a/Stitch/App/Util/URL/URLSessionExtensionUtils.swift
+++ b/Stitch/App/Util/URL/URLSessionExtensionUtils.swift
@@ -9,23 +9,6 @@ import Foundation
 import StitchSchemaKit
 import SwiftUI
 
-//
-//extension URLSession {
-//    public typealias FutureSessionDataTask = (URLSessionDataTask, Future<(Data?, URLResponse?), AnyError>)
-//    public typealias FutureSessionUploadTask = (URLSessionUploadTask, Future<(Data?, URLResponse?), AnyError>)
-//    public typealias FutureSessionDownloadTask = (URLSessionDownloadTask, Future<(URL?, URLResponse?), AnyError>)
-//
-//    public func dataTask(with request: URLRequest) -> FutureSessionDataTask {
-//        let p = Promise<(Data?, URLResponse?), AnyError>()
-//
-//        let task = self.dataTask(with: request, completionHandler: self.completionHandler(promise: p))
-//
-//        return (task, p.future)
-//    }
-//}
-
-// https://github.com/Thomvis/FutureProofing/blob/2d5c240dac1c71a6e4bca71834cf8448a6ea2e73/FutureProofing/BrightFuture%2BFutureProofing.swift
-
 // MARK: AnyError to allow materialize generique error
 public struct AnyError: Error {
     public let cause: Error

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/JSON/JSONReplViews.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/JSON/JSONReplViews.swift
@@ -248,60 +248,60 @@ struct JsonReplView: View {
 //    }
 //}
 
-struct JSON_REPL_View_3: View {
-
-    var s: String {
-        //        """
-        //        { "api": "love" }
-        //        """
-        """
-                { "api": "/" }
-                """
-    }
-
-    var json: JSON? {
-        parseJSON(s)
-    }
-
-    //    var k: Result<Int, Error> {
-    var k: Result<Int, StitchNetworkRequestError> {
-        //        let r: Result<Int, Error>
-
-        let p = 9.99
-        //        return .init(error: "Bad Result \(p)")
-        return .failure(.init(error: "bad result \(p)..."))
-    }
-
-    var body: some View {
-        HStack(spacing: 30) {
-
-            Text(
-                //                k.error?.localizedDescription ?? "No Error..."
-                k.error?.error ?? "No error"
-                //                Error("Badness \(77.77)").localizedDescription
-            )
-
-            //
-            //            let k = json!.rawString(options: [.withoutEscapingSlashes, .prettyPrinted])!
-            //            Text(k)
-            //
-            //            //            let k2 = try! json!.rawData(options: .withoutEscapingSlashes)
-            //            //            Text(JSON(k2).description)
-            //
-            //            Text(json?.description ?? "Parsing Failure")
-            //            Divider()
-            //            Text("love 2")
-        }
-        .padding(90)
-        .background(.green.opacity(0.5))
-
-    }
-}
-
-struct JsonReplView_Previews: PreviewProvider {
-    static var previews: some View {
-        //        JsonReplView()
-        //        JSON_REPL_View_2()
-        JSON_REPL_View_3()
-    }
-}
+//struct JSON_REPL_View_3: View {
+//
+//    var s: String {
+//        //        """
+//        //        { "api": "love" }
+//        //        """
+//        """
+//                { "api": "/" }
+//                """
+//    }
+//
+//    var json: JSON? {
+//        parseJSON(s)
+//    }
+//
+//    //    var k: Result<Int, Error> {
+//    var k: Result<Int, StitchNetworkRequestError> {
+//        //        let r: Result<Int, Error>
+//
+//        let p = 9.99
+//        //        return .init(error: "Bad Result \(p)")
+//        return .failure(.init(error: "bad result \(p)..."))
+//    }
+//
+//    var body: some View {
+//        HStack(spacing: 30) {
+//
+//            Text(
+//                //                k.error?.localizedDescription ?? "No Error..."
+//                k.error?.error ?? "No error"
+//                //                Error("Badness \(77.77)").localizedDescription
+//            )
+//
+//            //
+//            //            let k = json!.rawString(options: [.withoutEscapingSlashes, .prettyPrinted])!
+//            //            Text(k)
+//            //
+//            //            //            let k2 = try! json!.rawData(options: .withoutEscapingSlashes)
+//            //            //            Text(JSON(k2).description)
+//            //
+//            //            Text(json?.description ?? "Parsing Failure")
+//            //            Divider()
+//            //            Text("love 2")
+//        }
+//        .padding(90)
+//        .background(.green.opacity(0.5))
+//
+//    }
+//}
+//
+//struct JsonReplView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        //        JsonReplView()
+//        //        JSON_REPL_View_2()
+//        JSON_REPL_View_3()
+//    }
+//}

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/NetworkRequest/NetworkRequest.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/NetworkRequest/NetworkRequest.swift
@@ -9,24 +9,6 @@ import Foundation
 import StitchSchemaKit
 import SwiftUI
 import SwiftyJSON
-import BrightFutures
-
-typealias FutureRequestResult = Future<(Data?, URLResponse?), AnyError>
-
-func futureRequest(urlRequest: URLRequest) -> FutureRequestResult {
-    //    log("futureRequest called")
-
-    // https://stackoverflow.com/questions/31937686/how-to-make-http-post-request-with-json-body-in-swift
-
-    let (task, f): URLSession.FutureSessionDataTask = URLSession
-        .shared
-        .dataTask(with: urlRequest)
-
-    // have to kick off the task,
-    // and then return the future
-    task.resume()
-    return f
-}
 
 let HTTP_GET_METHOD = "GET"
 let HTTP_POST_METHOD = "POST"

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/NetworkRequest/NetworkRequestHandleResponse.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/NetworkRequest/NetworkRequestHandleResponse.swift
@@ -106,13 +106,13 @@ func handleRequestResponse(data: Data?,
     if let image = UIImage(data: data) {
         // log("handleRequestResponse: had image")
         image.accessibilityIdentifier = "Network Request Image"
-        return Result(value: (.image(image), headersAsJSON))
+        return .success((.image(image), headersAsJSON))
     }
 
     // json
     else if let json = try? JSON(data: data) {
         // log("handleRequestResponse: had json: \(json)")
-        return Result(value: (.json(json), headersAsJSON))
+        return .success((.json(json), headersAsJSON))
     }
 
     // text
@@ -122,14 +122,12 @@ func handleRequestResponse(data: Data?,
     else if let text = String(data: data, encoding: .utf8) {
         // log("handleRequestResponse: had text: \(text)")
         // log("handleRequestResponse: had utf8 encoded text")
-        return Result(value: (.text(text),
-                              headersAsJSON))
+        return .success((.text(text), headersAsJSON))
 
     } else if let text = String(data: data, encoding: .windowsCP1250) {
         // log("handleRequestResponse: had text, .windowsCP1250 encoding: \(text)")
         // log("handleRequestResponse: had windowsCP1250 encoded text")
-        return Result(value: (.text(text),
-                              headersAsJSON))
+        return .success((.text(text), headersAsJSON))
     }
 
     // failure

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/NetworkRequest/NetworkRequestUITestView.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/NetworkRequest/NetworkRequestUITestView.swift
@@ -11,72 +11,72 @@ import StitchSchemaKit
 
 // For testing
 
-@MainActor
-struct NetworkRequestReplView: View {
-
-    @Bindable private var store = StitchStore()
-
-    @State private var result: String = "no result yet..."
-
-    @State private var resultImage: UIImage?
-
-    var body: some View {
-
-        //        let dispatch: Dispatch = { state.dispatch($0) }
-
-        if let image = resultImage {
-            Image(uiImage: image).resizable().scaledToFit()
-        }
-
-        Text("Make Request").font(.headline).onTapGesture {
-            log("make request text tapped")
-            let delayPOSTUrl: URL = URL(string: "https://httpbin.org/delay/6")!
-            let postRequest: URLRequest = simplePOSTRequest(url: delayPOSTUrl)
-
-            //            let jsonBodyPOSTUrl: URL = URL(string: "https://reqbin.com/echo/post/json")!
-            //            let jsonBodyString = "{\"Id\": 78912, \"Customer\": \"Jason Sweet\", \"Quantity\": 1, \"Price\": 18.00}"
-            //
-            //            let jsonBodyPostRequest: URLRequest = jsonPOSTRequest(
-            //                url: jsonBodyPOSTUrl,
-            //                body: parseJSON(jsonBodyString)!,
-            //                headers: emptyJSON)
-
-            let f = futureRequest(urlRequest: postRequest)
-
-            //        let nodeType: UserVisibleType = .image
-            let nodeType: UserVisibleType = .json
-
-            f.onSuccess { (d: Data?, r: URLResponse?) in
-                // can still have 'failed' for our purposes, if we didn't get the response we wanted
-
-                let result = handleRequestResponse(
-                    data: d,
-                    response: r,
-                    error: nil)
-
-                log("success: result: \(result)")
-
-                if case let .success(x) = result,
-                   case let .image(x2) = x.0 {
-                    resultImage = x2
-                }
-
-            }.onFailure { (error: AnyError) in
-                let result = handleRequestResponse(
-                    data: nil,
-                    response: nil,
-                    error: error)
-
-                log("error: result: \(result)")
-
-                log("createErrorJSON(error: error.localizedDescription): \(createErrorJSON(error: error.localizedDescription))")
-            }
-        }.padding()
-    }
-}
-
-struct NetworkRequestReplView_Previews: PreviewProvider {
-    static var previews: some View {
-        NetworkRequestReplView()
-    }
-}
+//@MainActor
+//struct NetworkRequestReplView: View {
+//
+//    @Bindable private var store = StitchStore()
+//
+//    @State private var result: String = "no result yet..."
+//
+//    @State private var resultImage: UIImage?
+//
+//    var body: some View {
+//
+//        //        let dispatch: Dispatch = { state.dispatch($0) }
+//
+//        if let image = resultImage {
+//            Image(uiImage: image).resizable().scaledToFit()
+//        }
+//
+//        Text("Make Request").font(.headline).onTapGesture {
+//            log("make request text tapped")
+//            let delayPOSTUrl: URL = URL(string: "https://httpbin.org/delay/6")!
+//            let postRequest: URLRequest = simplePOSTRequest(url: delayPOSTUrl)
+//
+//            //            let jsonBodyPOSTUrl: URL = URL(string: "https://reqbin.com/echo/post/json")!
+//            //            let jsonBodyString = "{\"Id\": 78912, \"Customer\": \"Jason Sweet\", \"Quantity\": 1, \"Price\": 18.00}"
+//            //
+//            //            let jsonBodyPostRequest: URLRequest = jsonPOSTRequest(
+//            //                url: jsonBodyPOSTUrl,
+//            //                body: parseJSON(jsonBodyString)!,
+//            //                headers: emptyJSON)
+//
+//            let f = futureRequest(urlRequest: postRequest)
+//
+//            //        let nodeType: UserVisibleType = .image
+//            let nodeType: UserVisibleType = .json
+//
+//            f.onSuccess { (d: Data?, r: URLResponse?) in
+//                // can still have 'failed' for our purposes, if we didn't get the response we wanted
+//
+//                let result = handleRequestResponse(
+//                    data: d,
+//                    response: r,
+//                    error: nil)
+//
+//                log("success: result: \(result)")
+//
+//                if case let .success(x) = result,
+//                   case let .image(x2) = x.0 {
+//                    resultImage = x2
+//                }
+//
+//            }.onFailure { (error: AnyError) in
+//                let result = handleRequestResponse(
+//                    data: nil,
+//                    response: nil,
+//                    error: error)
+//
+//                log("error: result: \(result)")
+//
+//                log("createErrorJSON(error: error.localizedDescription): \(createErrorJSON(error: error.localizedDescription))")
+//            }
+//        }.padding()
+//    }
+//}
+//
+//struct NetworkRequestReplView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        NetworkRequestReplView()
+//    }
+//}


### PR DESCRIPTION
Prioritized for Swift 6 migration work, which had some concurrency issues with BrightFutures.

Validated with JSON + image requests that things are good here.