### PR TITLE
Edge edit mode: Compare distance between hovered output and node's inputs, not node's center

### DIFF
--- a/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
@@ -230,6 +230,29 @@ extension CanvasItemViewModel {
     }
     
     @MainActor
+    var locationOfInputs: CGPoint? {
+        if let size = self.sizeByLocalBounds {
+            // `node.center.x - node.width/2` = east face, where inputs are.
+            return .init(x: self.position.x - size.width/2,
+                         y: self.position.y)
+        } else {
+            return nil
+        }
+    }
+    
+    @MainActor
+    var locationOfOutputs: CGPoint? {
+        if let size = self.sizeByLocalBounds {
+            // `node.center.x + node.width/2` = west face, where outputs are.
+            return .init(x: self.position.x + size.width/2,
+                         y: self.position.y)
+        } else {
+            return nil
+        }
+    }
+    
+    
+    @MainActor
     var isMoving: Bool {
         self.position != self.previousPosition
     }


### PR DESCRIPTION
## before

<img width="718" alt="Screenshot 2024-12-02 at 10 26 10 AM" src="https://github.com/user-attachments/assets/6b48dc32-0db9-494d-aa80-bd92648d7aad">


## after 


https://github.com/user-attachments/assets/999830eb-41e7-479c-86c8-bde451ad3389

