### PR TITLE
UX improvements for previewing a port's looped values

### DIFF
--- a/Stitch/Graph/Node/Port/Model/Field/FieldValue.swift
+++ b/Stitch/Graph/Node/Port/Model/Field/FieldValue.swift
@@ -51,17 +51,22 @@ extension FieldValue {
             return x
         case .bool(let x):
             return x.description
-        case .pulse(let x):
+        case .pulse(let x): // TODO: show port that pulses, rather than the graph time?
             return x.description
-        case .anchorPopover(let x):
-            return x.display
         case .pinTo(let x):
             return x.display
         // case .layerDropdown(let x): // TODO: retrieve layer name?
             // TODO: provide real values here
         case .layerGroupOrientationDropdown(let x):
             return x.display
-        case .color, .layerDropdown, .textFontDropdown, .spacing:
+        case .layerDropdown(let x):
+            return x?.asNodeId.description ?? "None"
+        case .textFontDropdown(let x):
+            return x.display
+        case .spacing(let x):
+            return x.display
+            // Handled by own views
+        case .color, .anchorPopover:
             return ""
         }
     }

--- a/Stitch/Graph/Node/Port/View/PortValuesPreviewView.swift
+++ b/Stitch/Graph/Node/Port/View/PortValuesPreviewView.swift
@@ -21,6 +21,8 @@ struct PortPreviewData: Identifiable {
 
 struct PortValuesPreviewView<NodeRowObserverType: NodeRowObserver>: View {
 
+    @Environment(\.appTheme) var theme
+    
     @Bindable var rowObserver: NodeRowObserverType
         
     let nodeIO: NodeIO
@@ -64,58 +66,60 @@ struct PortValuesPreviewView<NodeRowObserverType: NodeRowObserver>: View {
         ScrollView {
             valueGrid
         }
+        .scrollBounceBehavior(.basedOnSize)
         .padding()
     }
     
+    @State var hoveredIndex: Int? = nil
+    
     var valueGrid: some View {
-        Grid {
-            GridRow {
-                StitchTextView(string: "Loop")
-                    .monospaced()
-                    .frame(minWidth: 40)    // necessary to prevent overflow scenarios
-                    .gridCellAnchor(UnitPoint(x: 0.5, y: 0.5))
-               
-                StitchTextView(string: "Values", lineLimit: 1)
-                    .monospaced()
-                    .gridCellAnchor(UnitPoint(x: 0, y: 0.5))
-                    .gridCellColumns(2)
-            }
-            .padding(.bottom, 2)
-
+        VStack(alignment: .leading) {
+            
             ForEach(tableRows, id: \.id) { (data: PortPreviewData) in
-                GridRow {
-                    StitchTextView(string: "\(data.loopIndex)")
+                
+                HStack(alignment: .center) {
+                    StitchTextView(string: "\(data.loopIndex)", fontColor: STITCH_FONT_GRAY_COLOR)
                         .monospaced()
                         .gridCellAnchor(UnitPoint(x: 0.5, y: 0)) // aligns middle, top
-
+                    
                     ForEach(data.fields, id: \.0) { field in
                         let label = field.fieldLabel
-
-                        Group {
+                        HStack {
                             if !label.isEmpty {
-                                StitchTextView(string: "\(field.fieldLabel):",
+                                StitchTextView(string: "\(field.fieldLabel)",
                                                truncationMode: .tail)
-                                    .monospaced()
+                                .monospaced()
                             }
+                            
+                            PortValuesPreviewValueView(fieldValue: field.fieldValue)
                         }
-                        .gridCellAnchor(UnitPoint(x: 0, y: 0)) // aligns right, top
-
-                        PortValuesPreviewValueView(fieldValue: field.fieldValue)
-                            .fixedSize(horizontal: true, vertical: false) // make sure
-                            .gridCellAnchor(UnitPoint(x: 0, y: 0)) // aligns left, top
+                    } // ForEach(date.fields)
+                    
+                } // HStack
+                .padding(4)
+                .background {
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(self.hoveredIndex == data.loopIndex ? theme.fontColor : .clear)
+                }
+                
+                .onHover { hovering in
+                    if hovering {
+                        log("hovered data.loopIndex \(data.loopIndex)")
+                        self.hoveredIndex = data.loopIndex
+                        dispatch(ActiveIndexChangedAction(index: .init(data.loopIndex)))
                     }
                 }
+                
                 .padding(.top, 2)
-            }
+            } // ForEach
         }
     }
 }
 
-// just pass the FieldValue and
 struct PortValuesPreviewValueView: View {
-
-    let fieldValue: FieldValue
-
+    
+    let fieldValue: FieldValue // what 
+    
     var body: some View {
 
         switch fieldValue {
@@ -125,12 +129,20 @@ struct PortValuesPreviewValueView: View {
                                        height: 18,
                                        alignment: .center)
 
+        case .anchorPopover(let anchoring):
+            AnchoringGridIconView(anchor: anchoring, isSelectedInspectorRow: false)
+                .scaleEffect(0.18)
+                .frame(width: NODE_INPUT_OR_OUTPUT_WIDTH,
+                       height: NODE_ROW_HEIGHT)
+                
+            
         default:
             // Every other value
             StitchTextView(string: "\(fieldValue.portValuePreview)",
+                           lineLimit: 1,
                            truncationMode: .tail)
                 .monospaced()
-                .frame(minWidth: 40) // necessary to prevent overflow scenarios
+                .frame(width: NODE_INPUT_OR_OUTPUT_WIDTH, alignment: .leading) // necessary to prevent overflow scenarios
         }
     }
 }

--- a/Stitch/Graph/Node/Port/View/PortValuesPreviewView.swift
+++ b/Stitch/Graph/Node/Port/View/PortValuesPreviewView.swift
@@ -118,10 +118,10 @@ struct PortValuesPreviewView<NodeRowObserverType: NodeRowObserver>: View {
 
 struct PortValuesPreviewValueView: View {
     
-    let fieldValue: FieldValue // what 
+    let fieldValue: FieldValue
     
     var body: some View {
-
+        
         switch fieldValue {
 
         case .color(let color):


### PR DESCRIPTION
We now: 
1. support more types (like anchoring), 
2. use fixed width (to avoid jitters when e.g. a Time node connected)
3. change active index upon hover

Also cleaned up the UI some.



https://github.com/user-attachments/assets/4def0480-fb2a-4bea-8103-4f0b14ab6a42


