### PR TITLE
Fix fitStyle = fill with images

### DIFF
--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewImage.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewImage.swift
@@ -195,7 +195,20 @@ struct ImageDisplayView: View {
                            height: imageDisplaySize.size.height)
                     .contentShape(Rectangle()) // for when image has shrunk smaller than explicit frame
                     .eraseToAnyView()
-            } else {
+            }
+            
+            // Note: not much different than what this earlier PR had moved away from: https://github.com/StitchDesign/Stitch/pull/593/files
+            // ... Yet behavior seems good.
+            else if let fitStyle = fitStyle, fitStyle == .fill {
+                return view
+                    .aspectRatio(contentMode: fitStyle.asContentMode)
+                    .frame(width: imageLayerSize.width.isFill ? nil : imageDisplaySize.size.width,
+                           height: imageLayerSize.height.isFill ? nil : imageDisplaySize.size.height)
+                    .contentShape(Rectangle()) // for when image has shrunk smaller than explicit frame
+                    .eraseToAnyView()
+            }
+            
+            else {
                 return view
                     .frame(width: imageLayerSize.width.isFill ? nil : imageDisplaySize.size.width,
                            height: imageLayerSize.height.isFill ? nil : imageDisplaySize.size.height)


### PR DESCRIPTION
Resolves regression while still solving hit areas from this earlier PR: https://github.com/StitchDesign/Stitch/pull/593/files

<img width="1436" alt="Screenshot 2024-12-02 at 3 31 41 PM" src="https://github.com/user-attachments/assets/158ab5e5-bb68-47ec-a8e0-fb51469e9bf4">
<img width="1434" alt="Screenshot 2024-12-02 at 3 31 36 PM" src="https://github.com/user-attachments/assets/cf13855e-c6d0-44a3-9df2-201a33411ec9">
<img width="1435" alt="Screenshot 2024-12-02 at 3 31 30 PM" src="https://github.com/user-attachments/assets/4e6c16ff-d859-4664-9f87-27f86844c13e">
