### PR TITLE
Add nodes to center of canvas when node menu has been dismissed

### DIFF
--- a/Stitch/Graph/Menu/InsertNodeMenu/Model/InsertNodeMenuState.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/Model/InsertNodeMenuState.swift
@@ -28,6 +28,9 @@ struct InsertNodeMenuState: Equatable, Hashable {
     // Whether the menu shows or not; not the same as whether we're animating.
     var show = false
 
+    // Moved here from GraphUIState, since only used by 
+    var doubleTapLocation: CGPoint?
+    
     var searchResults: [InsertNodeMenuOptionData] = allSearchOptions
 
     // Ensures an option is selected when the menu appears

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -76,7 +76,14 @@ final class GraphUIState: Sendable {
     // Hackiness for handling option+drag "duplicate node and drag it"
     @MainActor var dragDuplication: Bool = false
 
-    @MainActor var doubleTapLocation: CGPoint?
+//    @MainActor var doubleTapLocation: CGPoint?
+    @MainActor var doubleTapLocation: CGPoint? {
+        get {
+            self.insertNodeMenuState.doubleTapLocation
+        } set(newValue) {
+            self.insertNodeMenuState.doubleTapLocation = newValue
+        }
+    }
 
     // which loop index to show
     @MainActor var activeIndex: ActiveIndex = ActiveIndex(0)


### PR DESCRIPTION
(Resolves regression from updating node menu to no longer be moved by opening or closing the left sidebar.)

`doubleTapLocation` was really only for InsertNodeMenuState, where it is now stored and properly reset when node menu state reset.

https://github.com/user-attachments/assets/7d9be48b-a204-4931-a92d-951b5b6e8c13

