### PR TITLE
Perf improvements from decreased field updates

### DIFF
--- a/Stitch/Graph/Node/Patch/Type/Shape/LayerInfoNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Shape/LayerInfoNode.swift
@@ -24,13 +24,18 @@ struct AssignedLayerUpdated: GraphEvent {
     
     @MainActor
     func handle(state: GraphState) {
-        for id in state.layerListeningPatchNodes(assignedTo: changedLayerNode) {
-            state.calculate(id) // TODO: batch calculate?
-        }
+        state.assignedLayerUpdated(changedLayerNode: changedLayerNode)
     }
 }
 
 extension GraphState {
+    @MainActor
+    func assignedLayerUpdated(changedLayerNode: LayerNodeId) {
+        for id in self.layerListeningPatchNodes(assignedTo: changedLayerNode) {
+            self.calculate(id)
+        }
+    }
+    
     // Some patch nodes (e.g. LayerInfo, ConvertPosition) effectively 'listen' to their assigned layer and must be eval'd whenever certain inputs change.
     // TODO: cache these?
     @MainActor

--- a/Stitch/Graph/Node/Port/Util/NodeRowObserverUtil.swift
+++ b/Stitch/Graph/Node/Port/Util/NodeRowObserverUtil.swift
@@ -98,8 +98,6 @@ extension NodeRowObserver {
             return
         }
 
-        var effects = SideEffects()
-
         // Some values for some node inputs (like delay node) can directly be copied into the input and must bypass the type coercion logic
         if canCopyInputValues {
             self.updateValues(newValues)
@@ -128,19 +126,10 @@ extension NodeRowObserver {
         if node.kind.isLayer,
            oldValues != coercedValues {
             let layerId = node.id.asLayerNodeId
-            
-            // TODO: return a proper (but non-DispatchQueue.main.async) side-effect? or just calculate graph directly?
-            // https://github.com/vpl-codesign/stitch/issues/5528
-//            dispatch(AssignedLayerUpdated(changedLayerNode: layerNodeId))
-            // NOTE: this MUST BE RETURNED AS A SIDE-EFFECT; otherwise a graph-eval can trigger a node view model input update, which dispatches `AssignedLayerUpdated`, which then evaluates the graph again. (Just an issue for cycles?_
-            effects.append({
-                AssignedLayerUpdated(changedLayerNode: layerId)
-            })
+            graph.assignedLayerUpdated(changedLayerNode: layerId)
         }
         
         // Update view ports
         self.nodeDelegate?.graphDelegate?.portsToUpdate.insert(NodePortType.input(self.id))
-        
-        effects.processEffects()
     }
 }

--- a/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
@@ -154,7 +154,8 @@ struct InputValueView: View {
     }
 
     var body: some View {
-//        NodeLayout(observer: viewModel) {
+        NodeLayout(observer: viewModel,
+                   existingCache: viewModel.viewCache) {
             switch fieldValue {
             case .string:
                 CommonEditingViewWrapper(graph: graph,
@@ -353,6 +354,6 @@ struct InputValueView: View {
                                    fontColor: STITCH_FONT_GRAY_COLOR,
                                    isSelectedInspectorRow: isSelectedInspectorRow)
             }            
-//        }
+        }
     }
 }

--- a/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
@@ -71,9 +71,9 @@ struct NodeFieldsView<FieldType, ValueEntryView>: View where FieldType: FieldVie
             .padding(.vertical, INSPECTOR_LIST_ROW_TOP_AND_BOTTOM_INSET * 2)
         }
         else {
-            NodeLayoutView(observer: fieldGroupViewModel) {
+//            NodeLayoutView(observer: fieldGroupViewModel) {
                 fields
-            }
+//            }
         }
     }
     

--- a/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
@@ -71,9 +71,9 @@ struct NodeFieldsView<FieldType, ValueEntryView>: View where FieldType: FieldVie
             .padding(.vertical, INSPECTOR_LIST_ROW_TOP_AND_BOTTOM_INSET * 2)
         }
         else {
-//            NodeLayout(observer: fieldGroupViewModel) {
+            NodeLayoutView(observer: fieldGroupViewModel) {
                 fields
-//            }
+            }
         }
     }
     

--- a/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
@@ -104,7 +104,7 @@ struct OutputValueView: View {
     }
 
     var body: some View {
-//        NodeLayout(observer: viewModel) {
+        NodeLayoutView(observer: viewModel) {
             switch fieldValue {
             case .string(let string):
                 // Leading alignment when multifield
@@ -234,6 +234,6 @@ struct OutputValueView: View {
                                    fontColor: STITCH_FONT_GRAY_COLOR,
                                    isSelectedInspectorRow: isSelectedInspectorRow)
             }
-//        }
+        }
     }
 }

--- a/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
@@ -104,7 +104,7 @@ struct OutputValueView: View {
     }
 
     var body: some View {
-        NodeLayoutView(observer: viewModel) {
+//        NodeLayoutView(observer: viewModel) {
             switch fieldValue {
             case .string(let string):
                 // Leading alignment when multifield
@@ -234,6 +234,6 @@ struct OutputValueView: View {
                                    fontColor: STITCH_FONT_GRAY_COLOR,
                                    isSelectedInspectorRow: isSelectedInspectorRow)
             }
-        }
+//        }
     }
 }

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
@@ -56,7 +56,11 @@ extension NodeRowObserver {
     /// Updates port view models when the backend port observer has been updated.
     /// Also invoked when nodes enter the viewframe incase they need to be udpated.
     @MainActor
-    func updatePortViewModels() {        
+    func updatePortViewModels() {
+        guard (self.nodeDelegate?.isVisibleInFrame ?? false) else {
+            return
+        }
+        
         self.getVisibleRowViewModels().forEach { rowViewModel in
             rowViewModel.didPortValuesUpdate(values: self.allLoopedValues)
         }

--- a/Stitch/Graph/Node/View/NodeLayout.swift
+++ b/Stitch/Graph/Node/View/NodeLayout.swift
@@ -28,6 +28,18 @@ extension View {
     }
 }
 
+struct NodeLayoutView<T: StitchLayoutCachable, Content: View>: View {
+    let observer: T
+    @ViewBuilder var content: () -> Content
+    
+    var body: some View {
+        NodeLayout(observer: observer,
+                   existingCache: observer.viewCache) {
+            content()
+        }
+    }
+}
+
 struct NodeLayout<T: StitchLayoutCachable>: Layout, Sendable {
     typealias Cache = ()
     

--- a/Stitch/Graph/Node/View/NodeView.swift
+++ b/Stitch/Graph/Node/View/NodeView.swift
@@ -52,8 +52,7 @@ struct NodeView<InputsViews: View, OutputsViews: View>: View {
     }
 
     var body: some View {
-        NodeLayout(observer: node,
-                   existingCache: node.viewCache) {
+        NodeLayoutView(observer: node) {
             nodeBody
                 .opacity(node.viewCache.isDefined ? 1 : 0)
             .onAppear {

--- a/Stitch/Graph/Node/View/NodeViewType.swift
+++ b/Stitch/Graph/Node/View/NodeViewType.swift
@@ -120,7 +120,7 @@ struct DefaultNodeInputView: View {
             let layerInputObserver: LayerInputObserver? = rowObserver.id.layerInput
                 .flatMap { node.layerNode?.getLayerInputObserver($0.layerInput) }
             
-//            NodeLayout(observer: rowViewModel) {
+            NodeLayoutView(observer: rowViewModel) {
                 HStack {
                     NodeRowPortView(graph: graph,
                                     rowObserver: rowObserver,
@@ -142,7 +142,7 @@ struct DefaultNodeInputView: View {
                                   isCanvasItemSelected: isNodeSelected,
                                   label: rowObserver.label())
                 }
-//            }
+            }
         }
     }
 }
@@ -161,7 +161,7 @@ struct DefaultNodeOutputView: View {
                            rowViewModels: canvas.outputViewModels,
                            nodeIO: .output,
                            adjustmentBarSessionId: adjustmentBarSessionId) { rowObserver, rowViewModel in
-//            NodeLayout(observer: rowViewModel) {
+            NodeLayoutView(observer: rowViewModel) {
                 HStack {
                     NodeOutputView(graph: graph,
                                    rowObserver: rowObserver,
@@ -180,7 +180,7 @@ struct DefaultNodeOutputView: View {
                     graph: graph,
                     outputCoordinate: .init(portId: rowViewModel.id.portId,
                                             canvasId: canvas.id)))
-//            }
+            }
         }
     }
 }

--- a/Stitch/Graph/Node/View/NodeViewType.swift
+++ b/Stitch/Graph/Node/View/NodeViewType.swift
@@ -120,7 +120,7 @@ struct DefaultNodeInputView: View {
             let layerInputObserver: LayerInputObserver? = rowObserver.id.layerInput
                 .flatMap { node.layerNode?.getLayerInputObserver($0.layerInput) }
             
-            NodeLayoutView(observer: rowViewModel) {
+//            NodeLayoutView(observer: rowViewModel) {
                 HStack {
                     NodeRowPortView(graph: graph,
                                     rowObserver: rowObserver,
@@ -142,7 +142,7 @@ struct DefaultNodeInputView: View {
                                   isCanvasItemSelected: isNodeSelected,
                                   label: rowObserver.label())
                 }
-            }
+//            }
         }
     }
 }
@@ -161,7 +161,7 @@ struct DefaultNodeOutputView: View {
                            rowViewModels: canvas.outputViewModels,
                            nodeIO: .output,
                            adjustmentBarSessionId: adjustmentBarSessionId) { rowObserver, rowViewModel in
-            NodeLayoutView(observer: rowViewModel) {
+//            NodeLayoutView(observer: rowViewModel) {
                 HStack {
                     NodeOutputView(graph: graph,
                                    rowObserver: rowObserver,
@@ -181,7 +181,7 @@ struct DefaultNodeOutputView: View {
                     outputCoordinate: .init(portId: rowViewModel.id.portId,
                                             canvasId: canvas.id)))
             }
-        }
+//        }
     }
 }
 

--- a/Stitch/Graph/Node/View/NodesOnlyView.swift
+++ b/Stitch/Graph/Node/View/NodesOnlyView.swift
@@ -15,8 +15,8 @@ struct NodesOnlyView: View {
     @Bindable var graphUI: GraphUIState
     @Bindable var nodePageData: NodePageData
     
-    var canvasNodeIds: Set<CanvasItemId> {
-        self.graph.visibleNodesViewModel.visibleCanvasIds
+    var canvasNodeIds: [CanvasItemId] {
+        self.graph.visibleNodesViewModel.allViewModels.map(\.id)
     }
 
     var selection: GraphUISelectionState {

--- a/Stitch/Graph/Util/NodeSelection/NodeSelectionUtil.swift
+++ b/Stitch/Graph/Util/NodeSelection/NodeSelectionUtil.swift
@@ -175,11 +175,14 @@ extension GraphState {
                                       y: -self.graphMovement.localPosition.y)
         let graphView = CGRect(origin: viewframeOrigin,
                                size: viewFrameSize)
-        let scaledViewFrame = GraphMovementViewModifier.getScaledViewFrame(scale: zoom,
-                                                                           graphView: graphView)
-        let selectionBoxInViewFrame = Self.getScaledSelectionBox(selectionBox: selectionBox,
-                                                                 scale: zoom,
-                                                                 scaledViewFrameOrigin: scaledViewFrame.origin)
+        let scaledViewFrame = GraphState.getScaledViewFrame(scale: zoom,
+                                                            graphView: graphView)
+        guard let selectionBoxInViewFrame = GraphState
+            .getScaledSelectionBox(selectionBox: selectionBox,
+                                   scale: zoom,
+                                   scaledViewFrameOrigin: scaledViewFrame.origin) else {
+            return
+        }
         
         for cachedSubviewData in self.visibleNodesViewModel.infiniteCanvasCache {
             let id = cachedSubviewData.key
@@ -232,20 +235,4 @@ extension GraphState {
     }
     
     /// Uses graph local offset and scale to get a modified `CGRect` of the selection box view frame.
-    static func getScaledSelectionBox(selectionBox: CGRect,
-                                      scale: Double,
-                                      scaledViewFrameOrigin: CGPoint) -> CGRect {
-        let scaledSelectionBoxSize = CGSize(
-            // must explicitly graph .size to get correct magnitude
-            width: selectionBox.size.width * scale,
-            height: selectionBox.size.height * scale)
-        
-        let scaledOrigin = CGPoint(x: selectionBox.origin.x * scale,
-                                   y: selectionBox.origin.y * scale)
-        
-        let scaledSelectionBox = CGRect(origin: scaledOrigin + scaledViewFrameOrigin,
-                                           size: scaledSelectionBoxSize)
-        
-        return scaledSelectionBox
-    }
 }

--- a/Stitch/Graph/View/InfiniteCanvas.swift
+++ b/Stitch/Graph/View/InfiniteCanvas.swift
@@ -88,6 +88,9 @@ struct InfiniteCanvas: Layout {
             self.isUpdatingCache = false
             graph?.visibleNodesViewModel.needsInfiniteCanvasCacheReset = false
             graph?.visibleNodesViewModel.infiniteCanvasCache = cache
+            
+            // Update visible nodes (fixes init case)
+            graph?.updateVisibleNodes()
         }
         
         return cache


### PR DESCRIPTION
The problem addressed in this PR is lost FPS for scenarios involving static large graphs.

Two main changes here:
1. Brought back functionality which prevent field updates from off-screen fields
2. Removed an unnecessary dispatch used for recalculating layers