### PR TITLE
A layer's fields on canvas no longer lose their value when the layer is selected again in sidebar

### DIFF
--- a/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
@@ -251,6 +251,8 @@ struct LayerInputFieldAddedToGraph: GraphEventWithResponse {
         
         let portObserver: LayerInputObserver = layerNode[keyPath: layerInput.layerNodeKeyPath]
         
+        let previousPackMode = portObserver.mode
+        
         if let unpackedPort: InputLayerNodeRowData = portObserver._unpackedData.allPorts[safe: fieldIndex] {
             
             let parentGroupNodeId = state.groupNodeFocused
@@ -276,6 +278,11 @@ struct LayerInputFieldAddedToGraph: GraphEventWithResponse {
                 node,
                 unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
                 unpackedPortIndex: fieldIndex)
+            
+            let newPackMode = portObserver.mode
+            if previousPackMode != newPackMode {
+                portObserver.wasPackModeToggled()
+            }
             
             state.resetLayerInputsCache(layerNode: layerNode)
         } else {

--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -61,9 +61,14 @@ struct LayerInspectorInputPortView: View {
                               // Inspector Row always uses the overall input label, never an individual field label
                               label: layerInputObserver.overallPortLabel(usesShortLabel: true))
             }
-            .onChange(of: layerInputObserver.mode) {
-                self.layerInputObserver.wasPackModeToggled()
-            }
+//            .onChange(of: layerInputObserver.mode) { oldValue, newValue in
+//                
+//                log("LayerInspectorInputPortView: nodeId: \(nodeId)")
+//                log("LayerInspectorInputPortView: self.layerInputObserver.port: \(self.layerInputObserver.port)")
+//                log("LayerInspectorInputPortView: oldValue: \(oldValue)")
+//                log("LayerInspectorInputPortView: newValue: \(newValue)")
+//                self.layerInputObserver.wasPackModeToggled()
+//            }
     }
 }
 

--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -61,12 +61,9 @@ struct LayerInspectorInputPortView: View {
                               // Inspector Row always uses the overall input label, never an individual field label
                               label: layerInputObserver.overallPortLabel(usesShortLabel: true))
             }
+        
+        // NOTE: this fires unexpectedly, so we rely on canvas item deletion and `layer input field added to canvas` to handle changes in pack vs unpacked mode.
 //            .onChange(of: layerInputObserver.mode) { oldValue, newValue in
-//                
-//                log("LayerInspectorInputPortView: nodeId: \(nodeId)")
-//                log("LayerInspectorInputPortView: self.layerInputObserver.port: \(self.layerInputObserver.port)")
-//                log("LayerInspectorInputPortView: oldValue: \(oldValue)")
-//                log("LayerInspectorInputPortView: newValue: \(newValue)")
 //                self.layerInputObserver.wasPackModeToggled()
 //            }
     }

--- a/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
+++ b/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
@@ -242,7 +242,9 @@ extension LayerInputObserver {
     var packedObserver: InputLayerNodeRowData? {
         switch self.mode {
         case .packed:
-            return self.packedObserver
+            // TODO: infinite loop? What was this method supposed to be?
+//            return self.packedObserver
+            return self._packedData
         case .unpacked:
             return nil
         }

--- a/Stitch/Graph/Node/Util/NodeDeletedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeDeletedAction.swift
@@ -93,7 +93,7 @@ extension GraphState {
                 return
             }
 
-            let inputPort = layerNode[keyPath: x.keyPath.layerInput.layerNodeKeyPath]
+            let inputPort: LayerInputObserver = layerNode[keyPath: x.keyPath.layerInput.layerNodeKeyPath]
             let prevPackMode = inputPort.mode
             
             layerNode[keyPath: x.keyPath.layerNodeKeyPath].canvasObserver = nil


### PR DESCRIPTION
The unpacked field's value was being overwritten by an unexpected call to `layerInputObserver.wasPackModeToggled()` in `LayerInspectorInputPortView`. 

We now only rely on redux actions like `deleteCanvasItem` and `LayerInputFieldAddedToCanvas`, instead of the view, to synchronize packed vs unpacked fields.

Ideally, if not too bad for perf, we could update both the packed and unpacked fields.

https://github.com/user-attachments/assets/22684333-435f-4c28-aab0-1d7ace6bf0ed

