### PR TITLE
Fixed regression where undo would cause crash

### DIFF
--- a/Stitch/App/Serialization/DocumentLoading/DocumentEncodable.swift
+++ b/Stitch/App/Serialization/DocumentLoading/DocumentEncodable.swift
@@ -30,14 +30,7 @@ protocol DocumentEncodableDelegate: Observable, AnyObject, Sendable {
     
     @MainActor func willEncodeProject(schema: CodableDocument)
     
-    @MainActor func didEncodeProject(schema: CodableDocument)
-    
     @MainActor var storeDelegate: StoreDelegate? { get }
-}
-
-extension DocumentEncodableDelegate {
-    // Default function to make it optional to define.
-    @MainActor func didEncodeProject(schema: CodableDocument) { }
 }
 
 extension DocumentEncodable {
@@ -140,7 +133,6 @@ extension DocumentEncodable {
             if willUpdateUndoHistory {
                 await MainActor.run { [weak self] in
                     self?.lastEncodedDocument = document
-                    self?.delegate?.didEncodeProject(schema: document)
                 }
             }
             

--- a/Stitch/App/Serialization/DocumentLoading/DocumentLoader.swift
+++ b/Stitch/App/Serialization/DocumentLoading/DocumentLoader.swift
@@ -177,8 +177,7 @@ extension DocumentLoader {
         
         documentViewModel.previewSizeDevice = previewDevice
         documentViewModel.previewWindowSize = previewDevice.previewWindowDimensions
-        projectLoader.documentViewModel = documentViewModel
-        store.navPath = [projectLoader]
+        store.navPath = [documentViewModel]
     }
 
     func installDocument(document: StitchDocument) async throws -> ProjectLoader {

--- a/Stitch/App/Serialization/DocumentLoading/ProjectLoader.swift
+++ b/Stitch/App/Serialization/DocumentLoading/ProjectLoader.swift
@@ -8,30 +8,16 @@
 import Foundation
 import SwiftUI
 
-// MARK: hashable for navpath
-extension ProjectLoader: Hashable {
-    static func == (lhs: ProjectLoader, rhs: ProjectLoader) -> Bool {
-        lhs.id == rhs.id
-    }
-    
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(self.id)
-    }
-}
-
 /// Passed into view to property sort URLs by modified date and forces a new render cycle when the date changes.
 @Observable
 final class ProjectLoader: Sendable, Identifiable {
     let id: Int
-    let url: URL
+    @MainActor var encoder: DocumentEncoder?
     
     @MainActor var modifiedDate: Date
-    @MainActor var encoder: DocumentEncoder?
+    @MainActor var url: URL
     @MainActor var loadingDocument: DocumentLoadingStatus = .initialized
     @MainActor var thumbnail: UIImage?
-    
-    // assigned if project is opened
-    @MainActor var documentViewModel: StitchDocumentViewModel?
 
     /// Initialzes object with some URL, not yet loading document until loaded in lazy view.
     @MainActor init(url: URL) {

--- a/Stitch/App/View/StitchNavStack.swift
+++ b/Stitch/App/View/StitchNavStack.swift
@@ -14,13 +14,11 @@ struct StitchNavStack: View {
     var body: some View {
         NavigationStack(path: $store.navPath) {
             ProjectsHomeViewWrapper()
-                .navigationDestination(for: ProjectLoader.self) { projectLoader in
-                    if let document = projectLoader.documentViewModel {
-                        StitchProjectView(store: store,
-                                          document: document,
-                                          graphUI: document.graphUI,
-                                          alertState: store.alertState)
-                    }
+                .navigationDestination(for: StitchDocumentViewModel.self) { document in
+                    StitchProjectView(store: store,
+                                      document: document,
+                                      graphUI: document.graphUI,
+                                      alertState: store.alertState)
                 }
                 .onChange(of: store.isCurrentProjectSelected) {
                     // Rest undo if project closed

--- a/Stitch/App/ViewModel/StitchStore.swift
+++ b/Stitch/App/ViewModel/StitchStore.swift
@@ -27,7 +27,7 @@ final class StitchStore: Sendable, StoreDelegate {
     //    var defaultComponents = ComponentsDict()
 
     // Navigation path for viewing documents
-    @MainActor var navPath: [ProjectLoader] = []
+    @MainActor var navPath: [StitchDocumentViewModel] = []
 
     @MainActor var isShowingDrawer = false
 
@@ -118,7 +118,7 @@ extension StitchStore {
 
     @MainActor
     var currentDocument: StitchDocumentViewModel? {
-        self.navPath.first?.documentViewModel
+        self.navPath.first
     }
     
     var undoManager: StitchUndoManager {

--- a/Stitch/Home/View/ProjectItem/ProjectsListItemView.swift
+++ b/Stitch/Home/View/ProjectItem/ProjectsListItemView.swift
@@ -135,8 +135,7 @@ struct ProjectsListItemView: View {
         } labelView: {
             switch projectLoader.loadingDocument {
             case .loaded(let document, _):
-                ProjectThumbnailTextField(projectLoader: projectLoader,
-                                          document: document,
+                ProjectThumbnailTextField(document: document,
                                           namespace: namespace)
             default:
                 // Blank text view to copy height of loaded view


### PR DESCRIPTION
Caused by #635.

Encoder was using the wrong ID when undo was fired. To be safe I'm reverting the change where we replaced StitchDocumentViewModel with ProjectLoader in the navPath in case there were other ripple effects from this.

This revert keeps the perf improvements made on the home screen.