### PR TITLE
Use ScrollView offset, rather than programmatic offset on content, with Adaptive Grid

### DIFF
--- a/Stitch/Graph/Node/Layer/Type/Canvas/CanvasSketchLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Canvas/CanvasSketchLayerNode.swift
@@ -47,7 +47,10 @@ struct CanvasSketchLayerNode: LayerNodeDefinition {
         .union(.strokeInputs)
         .union(.layerEffects)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
+        .union(.sizing)
+        .union(.pinning)
+        .union(.layerPaddingAndMargin)
+        .union(.offsetInGroup)
 
         static func createEphemeralObserver() -> NodeEphemeralObservable? {
         MediaEvalOpObserver()
@@ -59,7 +62,9 @@ struct CanvasSketchLayerNode: LayerNodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList,
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool) -> some View {
+                        parentDisablesPosition: Bool,
+                        parentIsScrollableGrid: Bool) -> some View {
+        
         CanvasSketchView(document: document,
                          graph: graph,
                          layerViewModel: viewModel,
@@ -90,7 +95,8 @@ struct CanvasSketchLayerNode: LayerNodeDefinition {
                          shadowOffset: viewModel.shadowOffset.getPosition ?? .defaultShadowOffset,
                          lines: viewModel.lines,
                          parentSize: parentSize,
-                         parentDisablesPosition: parentDisablesPosition)
+                         parentDisablesPosition: parentDisablesPosition,
+                         parentIsScrollableGrid: parentIsScrollableGrid)
     }
 }
 

--- a/Stitch/Graph/Node/Layer/Type/ColorFillLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/ColorFillLayerNode.swift
@@ -50,6 +50,7 @@ struct ColorFillLayerNode: LayerNodeDefinition {
             hueRotation: viewModel.hueRotation.getNumber ?? .defaultHueRotationForLayerEffect,
             saturation: viewModel.saturation.getNumber ?? .defaultSaturationForLayerEffect,
             parentSize: parentSize,
-            parentDisablesPosition: true)
+            parentDisablesPosition: true,
+            parentIsScrollableGrid: parentIsScrollableGrid)
     }
 }

--- a/Stitch/Graph/Node/Layer/Type/ColorFillLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/ColorFillLayerNode.swift
@@ -31,7 +31,8 @@ struct ColorFillLayerNode: LayerNodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList, 
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool) -> some View {
+                        parentDisablesPosition: Bool,
+                        parentIsScrollableGrid: Bool) -> some View {
         PreviewColorFillLayer(
             document: document,
             graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/Gradients/AngularGradientNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Gradients/AngularGradientNode.swift
@@ -43,7 +43,8 @@ struct AngularGradientLayerNode: LayerNodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList, 
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool, parentIsScrollableGrid: Bool) -> some View {
+                        parentDisablesPosition: Bool,
+                        parentIsScrollableGrid: Bool) -> some View {
         PreviewAngularGradientLayer(
             document: document,
             graph: graph,
@@ -69,7 +70,8 @@ struct AngularGradientLayerNode: LayerNodeDefinition {
             startAngle: viewModel.startAngle.getNumber ?? DEFAULT_ANGULAR_GRADIENT_START_ANGLE,
             endAngle: viewModel.endAngle.getNumber ?? DEFAULT_ANGULAR_GRADIENT_END_ANGLE,
             parentSize: parentSize,
-            parentDisablesPosition: parentDisablesPosition)
+            parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid)
     }
 }
 

--- a/Stitch/Graph/Node/Layer/Type/Gradients/AngularGradientNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Gradients/AngularGradientNode.swift
@@ -43,7 +43,7 @@ struct AngularGradientLayerNode: LayerNodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList, 
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool) -> some View {
+                        parentDisablesPosition: Bool, parentIsScrollableGrid: Bool) -> some View {
         PreviewAngularGradientLayer(
             document: document,
             graph: graph,
@@ -100,6 +100,7 @@ struct PreviewAngularGradientLayer: View {
     let endAngle: Double
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
 
     var body: some View {
 
@@ -135,6 +136,7 @@ struct PreviewAngularGradientLayer: View {
                 shadowRadius: .defaultShadowRadius,
                 shadowOffset: .defaultShadowOffset,
                 parentSize: parentSize,
-                parentDisablesPosition: parentDisablesPosition))
+                parentDisablesPosition: parentDisablesPosition,
+                parentIsScrollableGrid: parentIsScrollableGrid))
     }
 }

--- a/Stitch/Graph/Node/Layer/Type/Gradients/LinearGradientNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Gradients/LinearGradientNode.swift
@@ -45,7 +45,8 @@ struct LinearGradientLayerNode: LayerNodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList, 
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool) -> some View {
+                        parentDisablesPosition: Bool,
+                        parentIsScrollableGrid: Bool) -> some View {
         PreviewLinearGradientLayer(
             document: document,
             graph: graph,
@@ -70,7 +71,8 @@ struct LinearGradientLayerNode: LayerNodeDefinition {
             firstColor: viewModel.startColor.getColor ?? .yellow,
             secondColor: viewModel.endColor.getColor ?? .blue,
             parentSize: parentSize,
-            parentDisablesPosition: parentDisablesPosition)
+            parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid)
     }
 }
 
@@ -100,6 +102,7 @@ struct PreviewLinearGradientLayer: View {
     let secondColor: Color
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
 
     var body: some View {
 
@@ -133,7 +136,8 @@ struct PreviewLinearGradientLayer: View {
             shadowRadius: .defaultShadowRadius,
             shadowOffset: .defaultShadowOffset,
             parentSize: parentSize,
-            parentDisablesPosition: parentDisablesPosition))
+            parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid))
     }
 }
 

--- a/Stitch/Graph/Node/Layer/Type/Gradients/RadialGradientNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Gradients/RadialGradientNode.swift
@@ -43,7 +43,8 @@ struct RadialGradientLayerNode: LayerNodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList, 
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool) -> some View {
+                        parentDisablesPosition: Bool,
+                        parentIsScrollableGrid: Bool) -> some View {
         PreviewRadialGradientLayer(
             document: document,
             graph: graph,
@@ -69,7 +70,8 @@ struct RadialGradientLayerNode: LayerNodeDefinition {
             startRadius: viewModel.startRadius.getNumber ?? DEFAULT_RADIAL_GRADIENT_START_RADIUS,
             endRadius: viewModel.endRadius.getNumber ?? DEFAULT_RADIAL_GRADIENT_END_RADIUS,
             parentSize: parentSize,
-            parentDisablesPosition: parentDisablesPosition)
+            parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid)
     }
 }
 
@@ -100,6 +102,7 @@ struct PreviewRadialGradientLayer: View {
     let endRadius: Double
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
 
     var body: some View {
 
@@ -134,6 +137,7 @@ struct PreviewRadialGradientLayer: View {
             shadowRadius: .defaultShadowRadius,
             shadowOffset: .defaultShadowOffset,
             parentSize: parentSize,
-            parentDisablesPosition: parentDisablesPosition))
+            parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid))
     }
 }

--- a/Stitch/Graph/Node/Layer/Type/GroupLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/GroupLayerNode.swift
@@ -173,7 +173,7 @@ extension LayerSize {
 func nativeScrollInteractionEval(node: LayerNode,
                                  state: GraphDelegate) -> EvalResult {
     
-    log("nativeScrollInteractionEval: called")
+    // log("nativeScrollInteractionEval: called")
     let defaultOutputs: PortValuesList =  [[.position(.zero)]]
     
     guard !node.outputs.isEmpty else {
@@ -204,7 +204,7 @@ func nativeScrollInteractionEvalOp(layerViewModel: LayerViewModel, // for the gr
                                    currentGraphTime: TimeInterval,
                                    currentGraphFrameCount: Int) -> ImpureEvalOpResult {
     
-    log("nativeScrollInteractionEvalOp: called")
+    // log("nativeScrollInteractionEvalOp: called")
     
     // Update interactiveLayer according to inputs
     // Note: only update the properties that changed, else @Observable fires unnecessarily

--- a/Stitch/Graph/Node/Layer/Type/GroupLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/GroupLayerNode.swift
@@ -116,7 +116,8 @@ struct GroupLayerNode: LayerNodeDefinition {
                         viewModel: LayerViewModel,
                         parentSize: CGSize,
                         layersInGroup: LayerDataList, isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool) -> some View {
+                        parentDisablesPosition: Bool,
+                        parentIsScrollableGrid: Bool) -> some View {
         PreviewGroupLayer(
             document: document,
             graph: graph,
@@ -128,6 +129,7 @@ struct GroupLayerNode: LayerNodeDefinition {
             size: viewModel.size.getSize ?? .defaultLayerGroupSize,
             parentSize: parentSize,
             parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid,
             isClipped: viewModel.isClipped.getBool ?? DEFAULT_GROUP_CLIP_SETTING,
             scale: viewModel.scale.getNumber ?? defaultScaleNumber,
             anchoring: viewModel.anchoring.getAnchoring ?? .defaultAnchoring,

--- a/Stitch/Graph/Node/Layer/Type/HitAreaLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/HitAreaLayerNode.swift
@@ -25,7 +25,10 @@ struct HitAreaLayerNode: LayerNodeDefinition {
         .setupMode
     ])
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
+        .union(.sizing)
+        .union(.pinning)
+        .union(.layerPaddingAndMargin)
+        .union(.offsetInGroup)
     
     static func content(document: StitchDocumentViewModel,
                         graph: GraphState,
@@ -33,7 +36,8 @@ struct HitAreaLayerNode: LayerNodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList,
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool) -> some View {
+                        parentDisablesPosition: Bool,
+                        parentIsScrollableGrid: Bool) -> some View {
         PreviewHitAreaLayer(
             document: document,
             graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/HitAreaLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/HitAreaLayerNode.swift
@@ -51,6 +51,7 @@ struct HitAreaLayerNode: LayerNodeDefinition {
             anchoring: viewModel.anchoring.getAnchoring ?? .defaultAnchoring,
             setupMode: viewModel.setupMode.getBool ?? false,
             parentSize: parentSize,
-            parentDisablesPosition: parentDisablesPosition)
+            parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid)
     }
 }

--- a/Stitch/Graph/Node/Layer/Type/MapLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/MapLayerNode.swift
@@ -43,7 +43,10 @@ struct MapLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
+        .union(.sizing)
+        .union(.pinning)
+        .union(.layerPaddingAndMargin)
+        .union(.offsetInGroup)
     
     static func content(document: StitchDocumentViewModel,
                         graph: GraphState,
@@ -51,7 +54,8 @@ struct MapLayerNode: LayerNodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList, 
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool) -> some View {
+                        parentDisablesPosition: Bool,
+                        parentIsScrollableGrid: Bool) -> some View {
         PreviewMapLayer(
             document: document,
             graph: graph,
@@ -81,7 +85,8 @@ struct MapLayerNode: LayerNodeDefinition {
             shadowRadius: viewModel.shadowRadius.getNumber ?? .defaultShadowOpacity,
             shadowOffset: viewModel.shadowOffset.getPosition ?? .defaultShadowOffset,
             parentSize: parentSize,
-            parentDisablesPosition: parentDisablesPosition)
+            parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid)
     }
 }
 
@@ -121,6 +126,7 @@ struct PreviewMapLayer: View {
     
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
 
     @ViewBuilder
     var mapView: some View {
@@ -169,6 +175,7 @@ struct PreviewMapLayer: View {
             shadowOffset: shadowOffset,
             parentSize: parentSize,
             parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid,
             frameAlignment: .topLeading,
             clipForMapLayerProjetThumbnailCreation: document.isGeneratingProjectThumbnail))
     }

--- a/Stitch/Graph/Node/Layer/Type/MaterialLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/MaterialLayerNode.swift
@@ -38,7 +38,10 @@ struct MaterialLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
+        .union(.sizing)
+        .union(.pinning)
+        .union(.layerPaddingAndMargin)
+        .union(.offsetInGroup)
     
     static func content(document: StitchDocumentViewModel,
                         graph: GraphState,
@@ -46,14 +49,15 @@ struct MaterialLayerNode: LayerNodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList,
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool) -> some View {
+                        parentDisablesPosition: Bool,
+                        parentIsScrollableGrid: Bool) -> some View {
         
-        //
         PreviewMaterialLayer(document: document,
                              graph: graph,
                              viewModel: viewModel,
                              parentSize: parentSize,
                              isPinnedViewRendering: isPinnedViewRendering,
-                             parentDisablesPosition: parentDisablesPosition)
+                             parentDisablesPosition: parentDisablesPosition,
+                             parentIsScrollableGrid: parentIsScrollableGrid)
     }
 }

--- a/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/Model3DLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/Model3DLayerNode.swift
@@ -65,8 +65,10 @@ struct Model3DLayerNode: LayerNodeDefinition {
                         graph: GraphState,
                         viewModel: LayerViewModel,
                         parentSize: CGSize,
-                        layersInGroup: LayerDataList, isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool) -> some View {
+                        layersInGroup: LayerDataList,
+                        isPinnedViewRendering: Bool,
+                        parentDisablesPosition: Bool,
+                        parentIsScrollableGrid: Bool) -> some View {
         Preview3DModelLayer(
             document: document,
             graph: graph,
@@ -90,6 +92,7 @@ struct Model3DLayerNode: LayerNodeDefinition {
             saturation: viewModel.saturation.getNumber ?? .defaultSaturationForLayerEffect,
             pivot: viewModel.pivot.getAnchoring ?? .defaultPivot,
             parentSize: parentSize,
-            parentDisablesPosition: parentDisablesPosition)
+            parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid)
     }
 }

--- a/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/PreviewModel3DLayer.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/PreviewModel3DLayer.swift
@@ -56,6 +56,7 @@ struct Preview3DModelLayer: View {
     
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
     
     var mediaValue: AsyncMediaValue? {
         self.layerViewModel.model3D._asyncMedia
@@ -126,7 +127,8 @@ struct Preview3DModelLayer: View {
             shadowRadius: .defaultShadowRadius,
             shadowOffset: .defaultShadowOffset,
             parentSize: parentSize,
-            parentDisablesPosition: parentDisablesPosition))
+            parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid))
     }
 }
 

--- a/Stitch/Graph/Node/Layer/Type/Media/RealityView/PreviewRealityLayer.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/RealityView/PreviewRealityLayer.swift
@@ -17,6 +17,7 @@ struct PreviewRealityLayer: View {
     let isPinnedViewRendering: Bool
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
     
     var body: some View {
         let position = viewModel.position.getPosition ?? .zero
@@ -63,7 +64,8 @@ struct PreviewRealityLayer: View {
                              shadowRadius: viewModel.shadowRadius.getNumber ?? .defaultShadowOpacity,
                              shadowOffset: viewModel.shadowOffset.getPosition ?? .defaultShadowOffset,
                              parentSize: parentSize,
-                             parentDisablesPosition: parentDisablesPosition)
+                             parentDisablesPosition: parentDisablesPosition,
+                             parentIsScrollableGrid: parentIsScrollableGrid)
         } else {
             EmptyView()
                 .onAppear {
@@ -112,6 +114,7 @@ struct RealityLayerView: View {
     
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
     
     // Override camera setting on Mac
     var _isCameraEnabled: Bool {
@@ -201,6 +204,7 @@ struct RealityLayerView: View {
             shadowRadius: shadowRadius,
             shadowOffset: shadowOffset,
             parentSize: parentSize,
-            parentDisablesPosition: parentDisablesPosition))
+            parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid))
     }
 }

--- a/Stitch/Graph/Node/Layer/Type/Media/RealityView/RealityNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/RealityView/RealityNode.swift
@@ -47,12 +47,15 @@ struct RealityViewLayerNode: LayerNodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList,
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool, parentIsScrollableGrid: Bool) -> some View {
+                        parentDisablesPosition: Bool,
+                        parentIsScrollableGrid: Bool) -> some View {
+        
         PreviewRealityLayer(document: document,
                             graph: graph,
                             viewModel: viewModel,
                             isPinnedViewRendering: isPinnedViewRendering,
                             parentSize: parentSize,
-                            parentDisablesPosition: parentDisablesPosition)
+                            parentDisablesPosition: parentDisablesPosition,
+                            parentIsScrollableGrid: parentIsScrollableGrid)
     }
 }

--- a/Stitch/Graph/Node/Layer/Type/Media/RealityView/RealityNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/RealityView/RealityNode.swift
@@ -47,7 +47,7 @@ struct RealityViewLayerNode: LayerNodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList,
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool) -> some View {
+                        parentDisablesPosition: Bool, parentIsScrollableGrid: Bool) -> some View {
         PreviewRealityLayer(document: document,
                             graph: graph,
                             viewModel: viewModel,

--- a/Stitch/Graph/Node/Layer/Type/Media/VideoLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/VideoLayerNode.swift
@@ -42,13 +42,15 @@ struct VideoLayerNode: LayerNodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList, 
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool, parentIsScrollableGrid: Bool) -> some View {
+                        parentDisablesPosition: Bool,
+                        parentIsScrollableGrid: Bool) -> some View {
         VisualMediaLayerView(document: document,
                              graph: graph,
                              viewModel: viewModel,
                              isPinnedViewRendering: isPinnedViewRendering,
                              parentSize: parentSize,
-                             parentDisablesPosition: parentDisablesPosition)
+                             parentDisablesPosition: parentDisablesPosition,
+                             parentIsScrollableGrid: parentIsScrollableGrid)
     }
     
         static func createEphemeralObserver() -> NodeEphemeralObservable? {

--- a/Stitch/Graph/Node/Layer/Type/Media/VideoLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/VideoLayerNode.swift
@@ -42,7 +42,7 @@ struct VideoLayerNode: LayerNodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList, 
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool) -> some View {
+                        parentDisablesPosition: Bool, parentIsScrollableGrid: Bool) -> some View {
         VisualMediaLayerView(document: document,
                              graph: graph,
                              viewModel: viewModel,

--- a/Stitch/Graph/Node/Layer/Type/Media/VideoStreamingLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/VideoStreamingLayerNode.swift
@@ -46,7 +46,8 @@ struct VideoStreamingLayerNode: LayerNodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList, 
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool) -> some View {
+                        parentDisablesPosition: Bool,
+                        parentIsScrollableGrid: Bool) -> some View {
         PreviewVideoStreamLayer(
             document: document,
             graph: graph,
@@ -74,7 +75,8 @@ struct VideoStreamingLayerNode: LayerNodeDefinition {
             hueRotation: viewModel.hueRotation.getNumber ?? .defaultHueRotationForLayerEffect,
             saturation: viewModel.saturation.getNumber ?? .defaultSaturationForLayerEffect,
             parentSize: parentSize,
-            parentDisablesPosition: parentDisablesPosition)
+            parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid)
     }
 }
 
@@ -103,6 +105,7 @@ struct PreviewVideoStreamLayer: View {
     let saturation: Double
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
 
     var body: some View {
         VideoStreamPlayerView(urlString: $currentVideoURLString, volume: volume, enabled: enabled)
@@ -133,7 +136,8 @@ struct PreviewVideoStreamLayer: View {
                 shadowRadius: .defaultShadowRadius,
                 shadowOffset: .defaultShadowOffset,
                 parentSize: parentSize,
-                parentDisablesPosition: parentDisablesPosition))
+                parentDisablesPosition: parentDisablesPosition,
+                parentIsScrollableGrid: parentIsScrollableGrid))
     }
 }
 

--- a/Stitch/Graph/Node/Layer/Type/Media/VisualMedia.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/VisualMedia.swift
@@ -34,7 +34,10 @@ struct ImageLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
+        .union(.sizing)
+        .union(.pinning)
+        .union(.layerPaddingAndMargin)
+        .union(.offsetInGroup)
     
     static func content(document: StitchDocumentViewModel,
                         graph: GraphState,
@@ -42,13 +45,16 @@ struct ImageLayerNode: LayerNodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList, 
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool) -> some View {
+                        parentDisablesPosition: Bool,
+                        parentIsScrollableGrid: Bool) -> some View {
+        
         VisualMediaLayerView(document: document,
                              graph: graph,
                              viewModel: viewModel,
                              isPinnedViewRendering: isPinnedViewRendering,
                              parentSize: parentSize,
-                             parentDisablesPosition: parentDisablesPosition)
+                             parentDisablesPosition: parentDisablesPosition,
+                             parentIsScrollableGrid: parentIsScrollableGrid)
     }
     
         static func createEphemeralObserver() -> NodeEphemeralObservable? {

--- a/Stitch/Graph/Node/Layer/Type/Media/VisualMediaLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/VisualMediaLayerNode.swift
@@ -20,6 +20,7 @@ struct VisualMediaLayerView: View {
     let isPinnedViewRendering: Bool
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
     
     var mediaValue: AsyncMediaValue? {
         self.mediaPortValue._asyncMedia
@@ -88,7 +89,8 @@ struct VisualMediaLayerView: View {
                                image: image, 
                                isPinnedViewRendering: isPinnedViewRendering,
                                parentSize: parentSize,
-                               parentDisablesPosition: parentDisablesPosition)
+                               parentDisablesPosition: parentDisablesPosition,
+                               parentIsScrollableGrid: parentIsScrollableGrid)
             case .video(let video):
                 VideoLayerView(document: document,
                                graph: graph,
@@ -96,7 +98,8 @@ struct VisualMediaLayerView: View {
                                video: video,
                                isPinnedViewRendering: isPinnedViewRendering,
                                parentSize: parentSize,
-                               parentDisablesPosition: parentDisablesPosition)
+                               parentDisablesPosition: parentDisablesPosition,
+                               parentIsScrollableGrid: parentIsScrollableGrid)
             default:
                 // MARK: can't be EmptyView for the onChange below doesn't get called!
                 Color.clear
@@ -119,6 +122,7 @@ struct ImageLayerView: View {
     let isPinnedViewRendering: Bool
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
 
     var body: some View {
         PreviewImageLayer(
@@ -151,6 +155,7 @@ struct ImageLayerView: View {
             shadowOffset: viewModel.shadowOffset.getPosition ?? .defaultShadowOffset,
             parentSize: parentSize,
             parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid,
             isClipped: viewModel.isClipped.getBool ?? false)
     }
 }
@@ -164,6 +169,7 @@ struct VideoLayerView: View {
     let isPinnedViewRendering: Bool
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
 
     var body: some View {
         PreviewVideoLayer(
@@ -196,6 +202,7 @@ struct VideoLayerView: View {
             shadowOffset: viewModel.shadowOffset.getPosition ?? .defaultShadowOffset,
             parentSize: parentSize,
             parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid,
             isClipped: viewModel.isClipped.getBool ?? false,
             volume: viewModel.volume.getNumber ?? StitchVideoImportPlayer.DEFAULT_VIDEO_PLAYER_VOLUME
         )

--- a/Stitch/Graph/Node/Layer/Type/ProgressIndicatorLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/ProgressIndicatorLayerNode.swift
@@ -29,7 +29,9 @@ struct ProgressIndicatorLayerNode: LayerNodeDefinition {
     ])
         .union(.layerEffects)
         .union(.strokeInputs)
-        .union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
+        .union(.pinning)
+        .union(.layerPaddingAndMargin)
+        .union(.offsetInGroup)
     
     static func content(document: StitchDocumentViewModel,
                         graph: GraphState,
@@ -37,7 +39,7 @@ struct ProgressIndicatorLayerNode: LayerNodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList,
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool) -> some View {
+                        parentDisablesPosition: Bool, parentIsScrollableGrid: Bool) -> some View {
         PreviewProgressIndicatorLayer(
             document: document,
             graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/ProgressIndicatorLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/ProgressIndicatorLayerNode.swift
@@ -39,7 +39,8 @@ struct ProgressIndicatorLayerNode: LayerNodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList,
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool, parentIsScrollableGrid: Bool) -> some View {
+                        parentDisablesPosition: Bool,
+                        parentIsScrollableGrid: Bool) -> some View {
         PreviewProgressIndicatorLayer(
             document: document,
             graph: graph,
@@ -70,7 +71,8 @@ struct ProgressIndicatorLayerNode: LayerNodeDefinition {
             shadowRadius: .defaultShadowRadius,
             shadowOffset: .defaultShadowOffset,
             parentSize: parentSize,
-            parentDisablesPosition: parentDisablesPosition)
+            parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid)
     }
 }
 
@@ -104,6 +106,7 @@ struct PreviewProgressIndicatorLayer: View {
     
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
     
     var body: some View {
         Group {
@@ -145,7 +148,8 @@ struct PreviewProgressIndicatorLayer: View {
             shadowRadius: shadowRadius,
             shadowOffset: shadowOffset,
             parentSize: parentSize,
-            parentDisablesPosition: parentDisablesPosition
+            parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid
         ))
     }
 }

--- a/Stitch/Graph/Node/Layer/Type/SFSymbolLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/SFSymbolLayerNode.swift
@@ -39,7 +39,10 @@ struct SFSymbolLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
+        .union(.sizing)
+        .union(.pinning)
+        .union(.layerPaddingAndMargin)
+        .union(.offsetInGroup)
     
     static func content(document: StitchDocumentViewModel,
                         graph: GraphState,
@@ -47,7 +50,8 @@ struct SFSymbolLayerNode: LayerNodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList,
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool) -> some View {
+                        parentDisablesPosition: Bool,
+                        parentIsScrollableGrid: Bool) -> some View {
         
         let stroke = viewModel.getLayerStrokeData()
         
@@ -81,7 +85,8 @@ struct SFSymbolLayerNode: LayerNodeDefinition {
             shadowRadius: viewModel.shadowRadius.getNumber ?? .defaultShadowOpacity,
             shadowOffset: viewModel.shadowOffset.getPosition ?? .defaultShadowOffset,
             parentSize: parentSize,
-            parentDisablesPosition: parentDisablesPosition)
+            parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid)
     }
 }
 
@@ -119,6 +124,7 @@ struct PreviewSFSymbolLayer: View {
     
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
 
     var body: some View {
 
@@ -152,6 +158,7 @@ struct PreviewSFSymbolLayer: View {
                 shadowRadius: shadowRadius,
                 shadowOffset: shadowOffset,
                 parentSize: parentSize,
-                parentDisablesPosition: parentDisablesPosition))
+                parentDisablesPosition: parentDisablesPosition,
+                parentIsScrollableGrid: parentIsScrollableGrid))
     }
 }

--- a/Stitch/Graph/Node/Layer/Type/Shapes/OvalLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Shapes/OvalLayerNode.swift
@@ -52,7 +52,10 @@ struct OvalLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
+        .union(.sizing)
+        .union(.pinning)
+        .union(.layerPaddingAndMargin)
+        .union(.offsetInGroup)
     
     
     static func content(document: StitchDocumentViewModel,
@@ -61,12 +64,14 @@ struct OvalLayerNode: LayerNodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList, 
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool) -> some View {
+                        parentDisablesPosition: Bool,
+                        parentIsScrollableGrid: Bool) -> some View {
         ShapeLayerView(document: document,
                        graph: graph,
                        viewModel: viewModel,
                        isPinnedViewRendering: isPinnedViewRendering,
                        parentSize: parentSize,
-                       parentDisablesPosition: parentDisablesPosition)
+                       parentDisablesPosition: parentDisablesPosition,
+                       parentIsScrollableGrid: parentIsScrollableGrid)
     }
 }

--- a/Stitch/Graph/Node/Layer/Type/Shapes/RectangleLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Shapes/RectangleLayerNode.swift
@@ -65,7 +65,10 @@ struct RectangleLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
+        .union(.sizing)
+        .union(.pinning)
+        .union(.layerPaddingAndMargin)
+        .union(.offsetInGroup)
     
     static func content(document: StitchDocumentViewModel,
                         graph: GraphState,
@@ -73,12 +76,15 @@ struct RectangleLayerNode: LayerNodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList, 
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool) -> some View {
+                        parentDisablesPosition: Bool,
+                        parentIsScrollableGrid: Bool) -> some View {
+        
         ShapeLayerView(document: document,
                        graph: graph,
                        viewModel: viewModel,
                        isPinnedViewRendering: isPinnedViewRendering,
                        parentSize: parentSize,
-                       parentDisablesPosition: parentDisablesPosition)
+                       parentDisablesPosition: parentDisablesPosition,
+                       parentIsScrollableGrid: parentIsScrollableGrid)
     }
 }

--- a/Stitch/Graph/Node/Layer/Type/Shapes/ShapeLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Shapes/ShapeLayerNode.swift
@@ -194,7 +194,10 @@ struct ShapeLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
+        .union(.sizing)
+        .union(.pinning)
+        .union(.layerPaddingAndMargin)
+        .union(.offsetInGroup)
     
     static func content(document: StitchDocumentViewModel,
                         graph: GraphState,
@@ -202,12 +205,15 @@ struct ShapeLayerNode: LayerNodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList, 
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool) -> some View {
+                        parentDisablesPosition: Bool,
+                        parentIsScrollableGrid: Bool) -> some View {
+        
         ShapeLayerView(document: document,
                        graph: graph,
                        viewModel: viewModel,
                        isPinnedViewRendering: isPinnedViewRendering,
                        parentSize: parentSize,
-                       parentDisablesPosition: parentDisablesPosition)
+                       parentDisablesPosition: parentDisablesPosition,
+                       parentIsScrollableGrid: parentIsScrollableGrid)
     }
 }

--- a/Stitch/Graph/Node/Layer/Type/SwitchLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/SwitchLayerNode.swift
@@ -46,7 +46,8 @@ struct SwitchLayerNode: LayerNodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList,
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool) -> some View {
+                        parentDisablesPosition: Bool,
+                        parentIsScrollableGrid: Bool) -> some View {
         PreviewSwitchLayer(
             document: document,
             graph: graph,
@@ -70,7 +71,8 @@ struct SwitchLayerNode: LayerNodeDefinition {
             hueRotation: viewModel.hueRotation.getNumber ?? .defaultHueRotationForLayerEffect,
             saturation: viewModel.saturation.getNumber ?? .defaultSaturationForLayerEffect,
             parentSize: parentSize,
-            parentDisablesPosition: false)
+            parentDisablesPosition: false,
+            parentIsScrollableGrid: parentIsScrollableGrid)
     }
 }
 
@@ -111,6 +113,7 @@ struct PreviewSwitchLayer: View {
     
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
 
     var body: some View {
         let view = Toggle("", isOn: $viewModel.isUIToggled)
@@ -146,7 +149,8 @@ struct PreviewSwitchLayer: View {
                 shadowRadius: .defaultShadowRadius,
                 shadowOffset: .defaultShadowOffset,
                 parentSize: parentSize,
-                parentDisablesPosition: parentDisablesPosition
+                parentDisablesPosition: parentDisablesPosition,
+                parentIsScrollableGrid: parentIsScrollableGrid
             ))
         .onChange(of: self.viewModel.isUIToggled) {
             dispatch(SwitchLayerToggled(id: id))

--- a/Stitch/Graph/Node/Layer/Type/Text/TextFieldLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Text/TextFieldLayerNode.swift
@@ -53,7 +53,10 @@ struct TextFieldLayerNode: LayerNodeDefinition {
         .union(.layerEffects)
         .union(.strokeInputs)
         .union(.aspectRatio)
-        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
+        .union(.sizing)
+        .union(.pinning)
+        .union(.layerPaddingAndMargin)
+        .union(.offsetInGroup)
     
     static func content(document: StitchDocumentViewModel,
                         graph: GraphState,
@@ -61,7 +64,9 @@ struct TextFieldLayerNode: LayerNodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList, 
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool) -> some View {
+                        parentDisablesPosition: Bool,
+                        parentIsScrollableGrid: Bool) -> some View {
+        
         PreviewTextFieldLayer(
             document: document,
             graph: graph,
@@ -97,6 +102,7 @@ struct TextFieldLayerNode: LayerNodeDefinition {
             shadowOffset: viewModel.shadowOffset.getPosition ?? .defaultShadowOffset,
             parentSize: parentSize,
             parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid,
             focusedTextFieldLayer: document.graphUI.reduxFocusedField?.getTextFieldLayerInputEdit)
     }
 }

--- a/Stitch/Graph/Node/Layer/Type/Text/TextLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Text/TextLayerNode.swift
@@ -77,7 +77,9 @@ struct TextLayerNode: LayerNodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList, 
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool) -> some View {
+                        parentDisablesPosition: Bool,
+                        parentIsScrollableGrid: Bool) -> some View {
+        
         PreviewTextLayer(
             document: document,
             graph: graph,
@@ -112,6 +114,7 @@ struct TextLayerNode: LayerNodeDefinition {
             shadowRadius: viewModel.shadowRadius.getNumber ?? .defaultShadowOpacity,
             shadowOffset: viewModel.shadowOffset.getPosition ?? .defaultShadowOffset,
             parentSize: parentSize,
-            parentDisablesPosition: parentDisablesPosition)
+            parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid)
     }
 }

--- a/Stitch/Graph/Node/Layer/Util/LayerEvalHelpers.swift
+++ b/Stitch/Graph/Node/Layer/Util/LayerEvalHelpers.swift
@@ -73,6 +73,7 @@ struct ShapeLayerView: View {
     let isPinnedViewRendering: Bool
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
 
     var body: some View {
         let stroke = viewModel.getLayerStrokeData()
@@ -113,6 +114,7 @@ struct ShapeLayerView: View {
                                                        shape: viewModel.shape.getShape),
             parentSize: parentSize,
             parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid,
             usesAbsoluteCoordinates: coordinateSystem == .absolute)
     }
 

--- a/Stitch/Graph/Node/Model/Definition/NodeDefinition.swift
+++ b/Stitch/Graph/Node/Model/Definition/NodeDefinition.swift
@@ -61,7 +61,8 @@ protocol LayerNodeDefinition: NodeDefinition {
                         parentSize: CGSize,
                         layersInGroup: LayerDataList, 
                         isPinnedViewRendering: Bool,
-                        parentDisablesPosition: Bool) -> Content
+                        parentDisablesPosition: Bool,
+                        parentIsScrollableGrid: Bool) -> Content
 }
 
 extension LayerNodeDefinition {

--- a/Stitch/Graph/PrototypePreview/Frame/View/NativeScrollGestureView.swift
+++ b/Stitch/Graph/PrototypePreview/Frame/View/NativeScrollGestureView.swift
@@ -111,6 +111,19 @@ struct NativeScrollGestureViewInner: ViewModifier {
         customContentSize.height > 0 ? customContentSize.height : nil
     }
     
+    var groupOrientation: StitchOrientation {
+        layerViewModel.orientation.getOrientation ?? .defaultOrientation
+    }
+    
+    var finalScrollOffset: CGPoint {
+        if groupOrientation != .grid {
+            return self.scrollOffset
+        } else {
+            return .zero
+        }
+        
+    }
+    
     @State var viewId: UUID = .init()
     
     func body(content: Content) -> some View {
@@ -125,8 +138,10 @@ struct NativeScrollGestureViewInner: ViewModifier {
                 .frame(height: self.customContentHeight)
             
             // factor out parent-scroll's offset, so that view does not move unless we explicitly connect scroll interaction node's output to the layer's position input
-                .offset(x: self.scrollOffset.x,
-                        y: self.scrollOffset.y)
+//                .offset(x: self.scrollOffset.x,
+//                        y: self.scrollOffset.y)
+                .offset(x: self.finalScrollOffset.x,
+                        y: self.finalScrollOffset.y)
         }
         
         /*

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommon.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommon.swift
@@ -51,6 +51,7 @@ struct PreviewCommonModifier: ViewModifier {
     // Assumes parentSize has already been scaled etc.
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
 
     // Only Text layers have their own alignment,
     // based on text alignment and vertical alignment.

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommon.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommon.swift
@@ -112,7 +112,8 @@ struct PreviewCommonModifier: ViewModifier {
                 shadowOffset: shadowOffset,
                 isForShapeLayer: isForShapeLayer,
                 parentSize: parentSize,
-                parentDisablesPosition: parentDisablesPosition))
+                parentDisablesPosition: parentDisablesPosition,
+                parentIsScrollableGrid: parentIsScrollableGrid))
     }
 }
 

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonModifierWithoutFrame.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonModifierWithoutFrame.swift
@@ -53,6 +53,7 @@ struct PreviewCommonModifierWithoutFrame: ViewModifier {
     // Assumes parentSize has already been scaled etc.
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
 
     var stroke: LayerStrokeData {
         // shape layers will already have had their strokes applied
@@ -127,7 +128,8 @@ struct PreviewCommonModifierWithoutFrame: ViewModifier {
                 graph: graph,
                 viewModel: layerViewModel,
                 isPinnedViewRendering: isPinnedViewRendering,
-                parentDisablesPosition: parentDisablesPosition, 
+                parentDisablesPosition: parentDisablesPosition,
+                parentIsScrollableGrid: parentIsScrollableGrid,
                 parentSize: parentSize,
                 pos: pos))
                 

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonPositionModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonPositionModifier.swift
@@ -30,6 +30,10 @@ struct PreviewCommonPositionModifier: ViewModifier {
     // TODO: use .offset instead of .position when layer is a child
     let parentDisablesPosition: Bool
     
+    // The lazy children in a ScrollView { LazyVGrid } are not loaded by .offset / .position modifier changes,
+    // so we disable both .offset and .position when this layer is inside a scrollable adaptive grid.
+    let parentIsScrollableGrid: Bool
+    
     let parentSize: CGSize
 
     // Position already adjusted by anchoring
@@ -75,8 +79,9 @@ struct PreviewCommonPositionModifier: ViewModifier {
     
     @ViewBuilder func positioningView(_ content: Content) -> some View {
         // logInView("PreviewCommonPositionModifier: regular: \(viewModel.layer)")
-        
-        if parentDisablesPosition {
+        if parentIsScrollableGrid {
+            content
+        } else if parentDisablesPosition {
            let offset = viewModel.offsetInGroup.getSize?.asCGSize(parentSize) ?? .zero
             content
                .offset(x: offset.width, y: offset.height)

--- a/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
@@ -28,6 +28,7 @@ struct GeneratePreview: View {
                           parentId: nil,
                           parentOrientation: .none,
                           parentSpacing: .zero,
+                          parentUsesScroll: false,
                           parentCornerRadius: 0,
                           parentUsesHug: false,
                           noFixedSizeForLayerGroup: false,
@@ -42,6 +43,7 @@ struct GeneratePreview: View {
                               parentId: nil,
                               parentOrientation: .none,
                               parentSpacing: .zero,
+                              parentUsesScroll: false,
                               parentCornerRadius: 0,
                               parentUsesHug: false,
                               noFixedSizeForLayerGroup: false,
@@ -82,6 +84,8 @@ struct PreviewLayersView: View {
     // Spacing between the children; N/A for ZStack
     var parentSpacing: StitchSpacing // = .defaultStitchSpacing
     
+    var parentUsesScroll: Bool
+    
     let parentCornerRadius: CGFloat
     let parentUsesHug: Bool
     let noFixedSizeForLayerGroup: Bool
@@ -121,7 +125,11 @@ struct PreviewLayersView: View {
     var parentDisablesPosition: Bool {
         parentOrientation != .none
     }
-
+    
+    var parentIsScrollableGrid: Bool {
+        parentUsesScroll && parentOrientation == .grid
+    }
+    
     @ViewBuilder
     func layersAsViews(_ spacing: StitchSpacing) -> some View {
         
@@ -139,6 +147,7 @@ struct PreviewLayersView: View {
                           layerData: layerData,
                           parentSize: parentSize,
                           parentDisablesPosition: parentDisablesPosition,
+                          parentIsScrollableGrid: parentIsScrollableGrid,
                           isGhostView: isGhostView)
             
             if spacing.isEvenly {
@@ -169,6 +178,7 @@ struct PreviewLayersView: View {
                                   layerData: layerData,
                                   parentSize: parentSize,
                                   parentDisablesPosition: parentDisablesPosition,
+                                  parentIsScrollableGrid: parentIsScrollableGrid,
                                   isGhostView: isGhostView)
                 }
             }
@@ -255,6 +265,7 @@ struct LayerDataView: View {
     let layerData: LayerData
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
     let isGhostView: Bool
     
     var body: some View {
@@ -279,6 +290,7 @@ struct LayerDataView: View {
                         layerData: maskedLayerData,
                         parentSize: parentSize,
                         parentDisablesPosition: parentDisablesPosition,
+                        parentIsScrollableGrid: parentIsScrollableGrid,
                         isGhostView: isGhostView)
                     
                     // Turn masker LayerData into a single view
@@ -287,6 +299,7 @@ struct LayerDataView: View {
                         layerData: maskerLayerData,
                         parentSize: parentSize,
                         parentDisablesPosition: parentDisablesPosition,
+                        parentIsScrollableGrid: parentIsScrollableGrid,
                         isGhostView: isGhostView)
                     
                     // Return
@@ -305,7 +318,8 @@ struct LayerDataView: View {
                                           layerViewModel: layerViewModel,
                                           isPinnedViewRendering: !isGhostView,
                                           parentSize: parentSize,
-                                          parentDisablesPosition: parentDisablesPosition)
+                                          parentDisablesPosition: parentDisablesPosition,
+                                          parentIsScrollableGrid: parentIsScrollableGrid)
             } else {
                 EmptyView()
             }
@@ -319,7 +333,8 @@ struct LayerDataView: View {
                                        childrenData: childrenData,
                                        isPinnedViewRendering: !isGhostView,
                                        parentSize: parentSize,
-                                       parentDisablesPosition: parentDisablesPosition)
+                                       parentDisablesPosition: parentDisablesPosition,
+                                       parentIsScrollableGrid: parentIsScrollableGrid)
             } else {
                 EmptyView()
             }
@@ -335,6 +350,7 @@ struct NonGroupPreviewLayersView: View {
     let isPinnedViewRendering: Bool
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
     
     var body: some View {
         if layerNode.hasSidebarVisibility,
@@ -345,7 +361,8 @@ struct NonGroupPreviewLayersView: View {
                              layer: layerNode.layer,
                              isPinnedViewRendering: isPinnedViewRendering,
                              parentSize: parentSize,
-                             parentDisablesPosition: parentDisablesPosition)
+                             parentDisablesPosition: parentDisablesPosition,
+                             parentIsScrollableGrid: parentIsScrollableGrid)
         } else {
             EmptyView()
         }
@@ -360,6 +377,7 @@ struct GroupPreviewLayersView: View {
     let isPinnedViewRendering: Bool
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
     
     var body: some View {
         if layerNode.hasSidebarVisibility,
@@ -370,7 +388,8 @@ struct GroupPreviewLayersView: View {
                                        parentSize: parentSize,
                                        layersInGroup: childrenData,
                                        isPinnedViewRendering: isPinnedViewRendering,
-                                       parentDisablesPosition: parentDisablesPosition)
+                                       parentDisablesPosition: parentDisablesPosition,
+                                       parentIsScrollableGrid: parentIsScrollableGrid)
             
         } else {
             EmptyView()

--- a/Stitch/Graph/PrototypePreview/Layer/View/PreviewLayerView.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/PreviewLayerView.swift
@@ -17,6 +17,7 @@ struct PreviewLayerView: View {
     let isPinnedViewRendering: Bool
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
 
     var id: PreviewCoordinate {
         self.layerViewModel.id
@@ -29,7 +30,8 @@ struct PreviewLayerView: View {
                                      parentSize: parentSize,
                                      layersInGroup: [],
                                      isPinnedViewRendering: isPinnedViewRendering,
-                                     parentDisablesPosition: parentDisablesPosition)
+                                     parentDisablesPosition: parentDisablesPosition,
+                                     parentIsScrollableGrid: parentIsScrollableGrid)
         .eraseToAnyView()
     }
 }

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/CanvasSketchView.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/CanvasSketchView.swift
@@ -55,6 +55,7 @@ struct CanvasSketchView: View {
 
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
 
     var body: some View {
 
@@ -95,7 +96,8 @@ struct CanvasSketchView: View {
             shadowRadius: shadowRadius,
             shadowOffset: shadowOffset,
             parentSize: parentSize,
-            parentDisablesPosition: parentDisablesPosition
+            parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid
         ))
     }
 }

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewColorFillLayer.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewColorFillLayer.swift
@@ -33,6 +33,7 @@ struct PreviewColorFillLayer: View {
     let saturation: Double
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
 
     var body: some View {
 
@@ -65,7 +66,9 @@ struct PreviewColorFillLayer: View {
                 shadowRadius: .defaultShadowRadius,
                 shadowOffset: .defaultShadowOffset,
                 parentSize: parentSize,
-                parentDisablesPosition: parentDisablesPosition))
+                parentDisablesPosition: parentDisablesPosition,
+                parentIsScrollableGrid: parentIsScrollableGrid
+            ))
     }
 }
 

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
@@ -43,6 +43,7 @@ struct PreviewGroupLayer: View {
     // Assumes parentSize has already been scaled, etc.
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
 
     let isClipped: Bool
     let scale: CGFloat
@@ -226,7 +227,8 @@ struct PreviewGroupLayer: View {
                 graph: graph,
                 viewModel: layerViewModel,
                 isPinnedViewRendering: isPinnedViewRendering,
-                parentDisablesPosition: parentDisablesPosition, 
+                parentDisablesPosition: parentDisablesPosition,
+                parentIsScrollableGrid: parentIsScrollableGrid,
                 parentSize: parentSize,
                 pos: pos))
         

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
@@ -279,6 +279,7 @@ struct PreviewGroupLayer: View {
                               parentId: interactiveLayer.id.layerNodeId,
                               parentOrientation: orientation,
                               parentSpacing: spacing,
+                              parentUsesScroll: layerViewModel.isScrollXEnabled || layerViewModel.isScrollYEnabled,
                               parentCornerRadius: cornerRadius,
                               // i.e. if this view (a LayerGroup) uses .hug, then its children will not use their own .position values.
                               parentUsesHug: usesHug,

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewHitAreaLayer.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewHitAreaLayer.swift
@@ -25,6 +25,7 @@ struct PreviewHitAreaLayer: View {
     
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
     
     var color: Color {
         setupMode ? .red.opacity(0.5) : Color.white.opacity(0.0001)
@@ -66,7 +67,8 @@ struct PreviewHitAreaLayer: View {
                 shadowRadius: .defaultShadowRadius,
                 shadowOffset: .defaultShadowOffset,
                 parentSize: parentSize,
-                parentDisablesPosition: parentDisablesPosition))
+                parentDisablesPosition: parentDisablesPosition,
+                parentIsScrollableGrid: parentIsScrollableGrid))
         }
     }
 }

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewImage.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewImage.swift
@@ -263,6 +263,7 @@ struct PreviewImageLayer: View {
     
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
     
     let isClipped: Bool
 
@@ -324,6 +325,7 @@ struct PreviewImageLayer: View {
             shadowRadius: shadowRadius,
             shadowOffset: shadowOffset,
             parentSize: parentSize,
-            parentDisablesPosition: parentDisablesPosition))
+            parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid))
     }
 }

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewMaterialLayer.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewMaterialLayer.swift
@@ -98,6 +98,7 @@ struct PreviewMaterialLayer: View {
     let parentSize: CGSize
     let isPinnedViewRendering: Bool
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
          
     var materialThickness: MaterialThickness {
         viewModel.materialThickness.getMaterialThickness ?? .defaultMaterialThickness
@@ -166,6 +167,7 @@ struct PreviewMaterialLayer: View {
                 shadowRadius: .defaultShadowRadius,
                 shadowOffset: .defaultShadowOffset,
                 parentSize: parentSize,
-                parentDisablesPosition: parentDisablesPosition))
+                parentDisablesPosition: parentDisablesPosition,
+                parentIsScrollableGrid: parentIsScrollableGrid))
     }
 }

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewShapeLayer.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewShapeLayer.swift
@@ -48,6 +48,7 @@ struct PreviewShapeLayer: View {
     
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
     
     let usesAbsoluteCoordinates: Bool
     
@@ -137,7 +138,8 @@ struct PreviewShapeLayer: View {
                     shadowOffset: shadowOffset,
                     isForShapeLayer: true,
                     parentSize: parentSize,
-                    parentDisablesPosition: parentDisablesPosition))
+                    parentDisablesPosition: parentDisablesPosition,
+                    parentIsScrollableGrid: parentIsScrollableGrid))
         }
     }
     

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewVideo.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewVideo.swift
@@ -42,7 +42,8 @@ struct PreviewVideoLayer: View {
     
     let parentSize: CGSize
     let parentDisablesPosition: Bool
-        
+    let parentIsScrollableGrid: Bool
+    
     let isClipped: Bool
     let volume: Double
 
@@ -94,6 +95,7 @@ struct PreviewVideoLayer: View {
             shadowRadius: shadowRadius,
             shadowOffset: shadowOffset,
             parentSize: parentSize,
-            parentDisablesPosition: parentDisablesPosition))
+            parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid))
     }
 }

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/Text/PreviewText.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/Text/PreviewText.swift
@@ -56,6 +56,7 @@ struct PreviewTextLayer: View {
     
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
 
     var body: some View {
 
@@ -95,6 +96,7 @@ struct PreviewTextLayer: View {
             shadowOffset: shadowOffset,
             parentSize: parentSize,
             parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid,
             frameAlignment: alignment ?? .topLeading
         ))
     }

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/TextField/PreviewTextFieldLayer.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/TextField/PreviewTextFieldLayer.swift
@@ -48,6 +48,7 @@ struct PreviewTextFieldLayer: View {
     
     let parentSize: CGSize
     let parentDisablesPosition: Bool
+    let parentIsScrollableGrid: Bool
 
     let focusedTextFieldLayer: PreviewCoordinate?
 
@@ -162,6 +163,7 @@ struct PreviewTextFieldLayer: View {
             shadowOffset: shadowOffset,
             parentSize: parentSize,
             parentDisablesPosition: parentDisablesPosition,
+            parentIsScrollableGrid: parentIsScrollableGrid,
             frameAlignment: verticalAlignment.asVerticalAlignmentForTextField))
     }
 }


### PR DESCRIPTION
`.offset` and `.position` modifiers applied to content (our normal method of programmatic scrolling) within a LazyVGrid does load lazy views; however, a user's gesture on ScrollView will.

So we disable `.offset` and `.position` on scrollable grids and use the ScrollView's own offset. 

Note: the Group's Scroll-Offset output is still updated, so we know where we are within the scroll view. We also still properly respond to e.g. `Jump To X` etc.