### PR TITLE
Introduced debug mode for editing paused graphs

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -255,6 +255,7 @@
 		B5EFD61A2C1134EC006F5E7F /* MediaLayerViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5EFD6192C1134EC006F5E7F /* MediaLayerViewModifier.swift */; };
 		B5F0FC162B4F2FB5009104A8 /* GraphReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F0FC152B4F2FB5009104A8 /* GraphReducer.swift */; };
 		B5F5FD432B37564500BBD9A2 /* WhatToTest.en-US.txt in Resources */ = {isa = PBXBuildFile; fileRef = B5F5FD422B37564500BBD9A2 /* WhatToTest.en-US.txt */; };
+		B5F88D6A2D2D6D8B00B5A45A /* StitchProjectOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F88D692D2D6D8500B5A45A /* StitchProjectOverlayView.swift */; };
 		B5F8D6A82C224A6600B99E5C /* LayerNodeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F8D6A72C224A6600B99E5C /* LayerNodeData.swift */; };
 		B5F9EB9B28D3848A00112799 /* FileManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F9EB9A28D3848A00112799 /* FileManagerTests.swift */; };
 		B5F9EB9E28D3927F00112799 /* MockFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F9EB9D28D3927F00112799 /* MockFileManager.swift */; };
@@ -1178,6 +1179,7 @@
 		B5EFD6192C1134EC006F5E7F /* MediaLayerViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaLayerViewModifier.swift; sourceTree = "<group>"; };
 		B5F0FC152B4F2FB5009104A8 /* GraphReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphReducer.swift; sourceTree = "<group>"; };
 		B5F5FD422B37564500BBD9A2 /* WhatToTest.en-US.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "WhatToTest.en-US.txt"; sourceTree = "<group>"; };
+		B5F88D692D2D6D8500B5A45A /* StitchProjectOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StitchProjectOverlayView.swift; sourceTree = "<group>"; };
 		B5F8D6A72C224A6600B99E5C /* LayerNodeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerNodeData.swift; sourceTree = "<group>"; };
 		B5F9EB9A28D3848A00112799 /* FileManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManagerTests.swift; sourceTree = "<group>"; };
 		B5F9EB9D28D3927F00112799 /* MockFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFileManager.swift; sourceTree = "<group>"; };
@@ -3323,6 +3325,7 @@
 		B56FFB682C19686C00623CC7 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				B5F88D692D2D6D8500B5A45A /* StitchProjectOverlayView.swift */,
 				B5C53FB02CED20AB0069612E /* InfiniteCanvas.swift */,
 				ECA3915A29A6C3C9005C10A8 /* StitchProjectView.swift */,
 				200BD85C254F66EB00692903 /* ContentView.swift */,
@@ -4900,6 +4903,7 @@
 				ECC2BCD92B9B73FA00D5F942 /* LegacySidebarActions.swift in Sources */,
 				ECFC975B296794DD000414C4 /* PopAnimationNode.swift in Sources */,
 				EC8A48ED2710EB2F001BB4FC /* GraphStepState.swift in Sources */,
+				B5F88D6A2D2D6D8B00B5A45A /* StitchProjectOverlayView.swift in Sources */,
 				ECEF8D0D2BFD4460004FABCD /* LayerSizeReader.swift in Sources */,
 				EC2614492B8960B800BEB066 /* Point4DPackNode.swift in Sources */,
 				ECF6AEF9263CB7E50011C679 /* PreviewShapeLayer.swift in Sources */,

--- a/Stitch/App/Serialization/DocumentLoading/DocumentLoader.swift
+++ b/Stitch/App/Serialization/DocumentLoading/DocumentLoader.swift
@@ -157,7 +157,8 @@ extension DocumentLoader {
             from: document,
             isPhoneDevice: isPhoneDevice,
             projectLoader: projectLoader,
-            store: store
+            store: store,
+            isDebugMode: false
         )
         
         documentViewModel?.didDocumentChange = true // creates fresh thumbnail

--- a/Stitch/Graph/GraphStep/GraphStepIncrementer.swift
+++ b/Stitch/Graph/GraphStep/GraphStepIncrementer.swift
@@ -34,9 +34,9 @@ extension StitchDocumentViewModel: GraphStepManagerDelegate {
         self.graph.calculateOnGraphStep()
         
         // Update fields every 30 frames
-        if !self.graph.portsToUpdate.isEmpty &&
+        if !self.visibleGraph.portsToUpdate.isEmpty &&
             frameCount % Self.fieldsFrequency(from: self.graphMovement.zoomData.zoom) == 0 {
-            self.graph.updatePortViews()
+            self.visibleGraph.updatePortViews()
         }
     }
     

--- a/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
+++ b/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
@@ -203,17 +203,21 @@ struct CatalystTopBarGraphButtons: View {
 
 //            CatalystNavBarButton(.TOGGLE_PREVIEW_WINDOW_SF_SYMBOL_NAME,
 //                                 rotationZ: isPreviewWindowShown ? 0 : 180) {
-            CatalystNavBarButton(isPreviewWindowShown ? .HIDE_PREVIEW_WINDOW_SF_SYMBOL_NAME : .SHOW_PREVIEW_WINDOW_SF_SYMBOL_NAME) {
-                dispatch(TogglePreviewWindow())
+            
+            if !document.isDebugMode {
+                CatalystNavBarButton(isPreviewWindowShown ? .HIDE_PREVIEW_WINDOW_SF_SYMBOL_NAME : .SHOW_PREVIEW_WINDOW_SF_SYMBOL_NAME) {
+                    dispatch(TogglePreviewWindow())
+                }
+                
+                CatalystNavBarButton(.RESTART_PROTOTYPE_SF_SYMBOL_NAME) {
+                    dispatch(PrototypeRestartedAction())
+                }
+                
+                CatalystNavBarButton(isFullscreen ? .SHRINK_FROM_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME : .EXPAND_TO_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME) {
+                    dispatch(ToggleFullScreenEvent())
+                }
             }
-
-            CatalystNavBarButton(.RESTART_PROTOTYPE_SF_SYMBOL_NAME) {
-                dispatch(PrototypeRestartedAction())
-            }
-
-            CatalystNavBarButton(isFullscreen ? .SHRINK_FROM_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME : .EXPAND_TO_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME) {
-                dispatch(ToggleFullScreenEvent())
-            }
+            
 
             CatalystNavBarButton(.SETTINGS_SF_SYMBOL_NAME) {
                 PROJECT_SETTINGS_ACTION()

--- a/Stitch/Graph/Toolbar/View/TopBarButtonView.swift
+++ b/Stitch/Graph/Toolbar/View/TopBarButtonView.swift
@@ -122,21 +122,23 @@ struct iPadGraphTopBarButtons: View {
             //            iPadNavBarButton(action: NEW_PROJECT_ACTION,
             //                             iconName: .sfSymbol(.NEW_PROJECT_SF_SYMBOL_NAME))
 
-            // toggle preview window
-            iPadNavBarButton(
-                action: PREVIEW_SHOW_TOGGLE_ACTION,
-                iconName: .sfSymbol(isPreviewWindowShown ? .HIDE_PREVIEW_WINDOW_SF_SYMBOL_NAME : .SHOW_PREVIEW_WINDOW_SF_SYMBOL_NAME))
-
-            // refresh prototype
-            iPadNavBarButton(action: RESTART_PROTOTYPE_ACTION,
-                             iconName: .sfSymbol(.RESTART_PROTOTYPE_SF_SYMBOL_NAME),
-                             rotationZ: restartPrototypeWindowIconRotationZ)
-
-            // full screen
-            iPadNavBarButton(
-                action: PREVIEW_FULL_SCREEN_ACTION,
-                //                iconName: .sfSymbol(.EXPAND_TO_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME))
-                iconName: .sfSymbol(isFullscreen ? .SHRINK_FROM_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME : .EXPAND_TO_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME))
+            if !document.isDebugMode {
+                // toggle preview window
+                iPadNavBarButton(
+                    action: PREVIEW_SHOW_TOGGLE_ACTION,
+                    iconName: .sfSymbol(isPreviewWindowShown ? .HIDE_PREVIEW_WINDOW_SF_SYMBOL_NAME : .SHOW_PREVIEW_WINDOW_SF_SYMBOL_NAME))
+                
+                // refresh prototype
+                iPadNavBarButton(action: RESTART_PROTOTYPE_ACTION,
+                                 iconName: .sfSymbol(.RESTART_PROTOTYPE_SF_SYMBOL_NAME),
+                                 rotationZ: restartPrototypeWindowIconRotationZ)
+                
+                // full screen
+                iPadNavBarButton(
+                    action: PREVIEW_FULL_SCREEN_ACTION,
+                    //                iconName: .sfSymbol(.EXPAND_TO_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME))
+                    iconName: .sfSymbol(isFullscreen ? .SHRINK_FROM_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME : .EXPAND_TO_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME))
+            }
 
             // TODO: implement
             //            // share project

--- a/Stitch/Graph/View/ContentView.swift
+++ b/Stitch/Graph/View/ContentView.swift
@@ -33,10 +33,6 @@ struct ContentView: View, KeyboardReadable {
 
     let alertState: ProjectAlertState
     let routerNamespace: Namespace.ID
-
-    var showPreviewWindow: Bool {
-        graphUI.showPreviewWindow
-    }
     
     var previewWindowSizing: PreviewWindowSizing {
         self.document.previewWindowSizingObserver
@@ -122,31 +118,10 @@ struct ContentView: View, KeyboardReadable {
                                       routerNamespace: routerNamespace)
                 .zIndex(showFullScreen.isTrue ? -99 : 0)
                 .overlay {
-                    VStack {
-                        if graphUI.groupNodeFocused?.component != nil {
-                            ComponentNavBarView(graph: document.visibleGraph,
-                                                store: store)
-                        }
-                        
-                        HStack(spacing: .zero) {
-                            Spacer()
-                            // Floating preview kept outside NavigationSplitView for animation purposes
-                            if !showFullScreen.isTrue {
-                                FloatingWindowView(
-                                    document: document,
-                                    deviceScreenSize: graphUI.frame.size,
-                                    showPreviewWindow: showPreviewWindow,
-                                    namespace: graphNamespace)
-                            }
-                        }
-                        
-                        Spacer()
-                    }
-                    // Hack to disable the split view sidebar swipe
-                    .gesture(
-                        DragGesture()
-                            .onChanged { _ in }
-                    )
+                    StitchProjectOverlayView(document: document,
+                                             store: store,
+                                             showFullScreen: showFullScreen.isTrue,
+                                             graphNamespace: graphNamespace)
                 }
 //                // Layer Inspector Flyout must sit above preview window
                 .overlay {

--- a/Stitch/Graph/View/StitchProjectOverlayView.swift
+++ b/Stitch/Graph/View/StitchProjectOverlayView.swift
@@ -1,0 +1,80 @@
+//
+//  StitchProjectOverlayView.swift
+//  Stitch
+//
+//  Created by Elliot Boschwitz on 1/7/25.
+//
+
+import SwiftUI
+import StitchSchemaKit
+
+struct StitchProjectOverlayView: View {
+    @Environment(\.appTheme) private var theme
+    
+    let document: StitchDocumentViewModel
+    let store: StitchStore
+    let showFullScreen: Bool
+    let graphNamespace: Namespace.ID
+    
+    var graphUI: GraphUIState {
+        self.document.graphUI
+    }
+    
+    var showPreviewWindow: Bool {
+        graphUI.showPreviewWindow
+    }
+    
+    var body: some View {
+        VStack {
+            if graphUI.groupNodeFocused?.component != nil {
+                ComponentNavBarView(graph: document.visibleGraph,
+                                    store: store)
+            }
+            
+            // Show debug mode tip view
+            if document.isDebugMode {
+                HStack {
+                    Image(systemName: ProjectContextMenuModifer.debugModeIcon)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 30)
+                        .foregroundStyle(theme.themeData.edgeColor)
+                    
+                    VStack(alignment: .leading) {
+                        Text("Welcome to Debug Mode")
+                            .font(.headline)
+                        Text("Prototypes are paused to enable inspection of faults in your graph. This is useful for debugging hangs in your prototype. Root causes could include a high loop count in some node's input field.")
+                            .font(.subheadline)
+                    }
+                    .frame(maxWidth: 800)
+                }
+                .padding()
+                .background(.ultraThinMaterial)
+                .cornerRadius(16)
+                .padding()
+            }
+            
+            HStack(spacing: .zero) {
+                Spacer()
+                // Floating preview kept outside NavigationSplitView for animation purposes
+                if !showFullScreen {
+                    FloatingWindowView(
+                        document: document,
+                        deviceScreenSize: graphUI.frame.size,
+                        showPreviewWindow: showPreviewWindow,
+                        namespace: graphNamespace)
+                }
+            }
+            // Hides prototype on debug mode
+            // Opacity needed for some keybinding detection (i.e. spacebar drag)
+            .opacity(document.isDebugMode ? 0 : 1)
+            
+            Spacer()
+        }
+        // Hack to disable the split view sidebar swipe
+        .gesture(
+            DragGesture()
+                .onChanged { _ in }
+        )
+    }
+}

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -463,8 +463,6 @@ extension GraphState {
         // to update them
         // TODO: move to delegate
         if self.documentDelegate?.isDebugMode ?? false {
-            let allPorts = self.visibleNodesViewModel.getCanvasItems()
-            
             self.updatePortViews()
         }
     }

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -163,10 +163,15 @@ extension GraphState {
         // Update connected port data
         self.visibleNodesViewModel.updateAllNodeViewData()
         
-        self.updateOrderedPreviewLayers()
-        
-        // Calculate graph
-        self.initializeGraphComputation()
+        if !document.isDebugMode {
+            self.updateOrderedPreviewLayers()
+            
+            // Calculate graph
+            self.initializeGraphComputation()
+        } else {
+            // Update all fields since calculation is skipped
+            self.updatePortViews()
+        }
     }
 
     @MainActor
@@ -453,6 +458,15 @@ extension GraphState {
         self.documentEncoderDelegate?.encodeProjectInBackground(from: self,
                                                                 temporaryUrl: temporaryURL,
                                                                 willUpdateUndoHistory: willUpdateUndoHistory)
+        
+        // If debug mode, make sure fields are updated as we aren't using calculate
+        // to update them
+        // TODO: move to delegate
+        if self.documentDelegate?.isDebugMode ?? false {
+            let allPorts = self.visibleNodesViewModel.getCanvasItems()
+            
+            self.updatePortViews()
+        }
     }
     
     @MainActor

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -25,6 +25,7 @@ extension StitchDocumentViewModel: Hashable {
 @Observable
 final class StitchDocumentViewModel: Sendable {
     let rootId: UUID
+    let isDebugMode: Bool
     let graph: GraphState
     let graphUI: GraphUIState
     let graphStepManager = GraphStepManager()
@@ -67,7 +68,8 @@ final class StitchDocumentViewModel: Sendable {
          graph: GraphState,
          isPhoneDevice: Bool,
          projectLoader: ProjectLoader,
-         store: StoreDelegate?) {
+         store: StoreDelegate?,
+         isDebugMode: Bool) {
         self.rootId = schema.id
         self.documentEncoder = projectLoader.encoder
         self.previewWindowSize = schema.previewWindowSize
@@ -78,6 +80,7 @@ final class StitchDocumentViewModel: Sendable {
         self.graphUI = GraphUIState(isPhoneDevice: isPhoneDevice)
         self.graph = graph
         self.projectLoader = projectLoader
+        self.isDebugMode = isDebugMode
         self.lastEncodedDocument = schema
         
         if let store = store {
@@ -101,8 +104,10 @@ final class StitchDocumentViewModel: Sendable {
         self.graph.initializeDelegate(document: self,
                                       documentEncoderDelegate: documentEncoder)
         
-        // Start graph
-        self.graphStepManager.start()
+        // Start graph if not in debug mode
+        if !self.isDebugMode {
+            self.graphStepManager.start()            
+        }
         
         // Updates node location data for perf + edge UI
         // MARK: currently testing perf without visibility check
@@ -110,8 +115,6 @@ final class StitchDocumentViewModel: Sendable {
             // Need all nodes to render initially
             let visibleGraph = self.visibleGraph
             visibleGraph.visibleNodesViewModel.setAllNodesVisible()
-        } else {
-//            self.refreshVisibleNodes()
         }
     }
     
@@ -119,7 +122,8 @@ final class StitchDocumentViewModel: Sendable {
     convenience init?(from schema: StitchDocument,
                       isPhoneDevice: Bool,
                       projectLoader: ProjectLoader,
-                      store: StoreDelegate?) async {
+                      store: StoreDelegate?,
+                      isDebugMode: Bool) async {
         let documentEncoder = DocumentEncoder(document: schema)
 
         let graph = await GraphState(from: schema.graph,
@@ -129,7 +133,8 @@ final class StitchDocumentViewModel: Sendable {
                   graph: graph,
                   isPhoneDevice: isPhoneDevice,
                   projectLoader: projectLoader,
-                  store: store)
+                  store: store,
+                  isDebugMode: isDebugMode)
     }
 }
 
@@ -320,6 +325,7 @@ extension StitchDocumentViewModel {
               graph: .init(),
               isPhoneDevice: false,
               projectLoader: .init(url: URL(fileURLWithPath: "")),
-              store: nil)
+              store: nil,
+              isDebugMode: false)
     }
 }

--- a/Stitch/Home/View/ProjectItem/ProjectsListItemLoadedView.swift
+++ b/Stitch/Home/View/ProjectItem/ProjectsListItemLoadedView.swift
@@ -69,6 +69,7 @@ extension StitchStore {
     func handleProjectTapped(projectLoader: ProjectLoader,
                              document: StitchDocument,
                              isPhoneDevice: Bool,
+                             isDebugMode: Bool,
                              loadedCallback: @MainActor @Sendable @escaping () -> ()) {
         Task { [weak projectLoader] in
             guard let projectLoader = projectLoader else { return }
@@ -77,7 +78,8 @@ extension StitchStore {
                 from: document,
                 isPhoneDevice: isPhoneDevice,
                 projectLoader: projectLoader,
-                store: self
+                store: self,
+                isDebugMode: isDebugMode
             )
             
             await MainActor.run { [weak self, weak documentViewModel] in

--- a/Stitch/Home/View/ProjectItem/ProjectsListItemView.swift
+++ b/Stitch/Home/View/ProjectItem/ProjectsListItemView.swift
@@ -103,6 +103,18 @@ struct ProjectsListItemView: View {
         }
     }
 
+    func openProject(document: StitchDocument,
+                     inDebug: Bool) {
+        self.isLoadingForPresentation = true
+        
+        store.handleProjectTapped(projectLoader: self.projectLoader,
+                                  document: document,
+                                  isPhoneDevice: GraphUIState.isPhoneDevice,
+                                  isDebugMode: inDebug) {
+            self.isLoadingForPresentation = false
+        }
+    }
+    
     var body: some View {
         ProjectsListItemThumbnailView {
             switch projectLoader.loadingDocument {
@@ -122,13 +134,8 @@ struct ProjectsListItemView: View {
                     modifiedDate: projectLoader.modifiedDate,
                     isLoading: self.isLoadingForPresentation)
                     .onTapGesture {
-                        self.isLoadingForPresentation = true
-                        
-                        store.handleProjectTapped(projectLoader: self.projectLoader,
-                                                  document: document,
-                                                  isPhoneDevice: GraphUIState.isPhoneDevice) {
-                            self.isLoadingForPresentation = false
-                        }
+                        self.openProject(document: document,
+                                         inDebug: false)
                     }
                     .transition(.opacity)
             }
@@ -158,7 +165,8 @@ struct ProjectsListItemView: View {
             self.projectLoader.loadingDocument = .initialized
         }
         .projectContextMenu(document: document,
-                            url: projectLoader.url)
+                            url: projectLoader.url,
+                            projectOpenCallback: openProject)
         .animation(.stitchAnimation, value: projectLoader.loadingDocument)
     }
 }

--- a/Stitch/Home/View/ProjectItem/ShareView.swift
+++ b/Stitch/Home/View/ProjectItem/ShareView.swift
@@ -140,6 +140,7 @@ struct ProjectContextMenuModifer: ViewModifier {
 
     let document: StitchDocument?
     let url: URL
+    let projectOpenCallback: (StitchDocument, Bool) -> ()
 
     func body(content: Content) -> some View {
         return content
@@ -157,6 +158,14 @@ struct ProjectContextMenuModifer: ViewModifier {
                     }, label: {
                         Text("Duplicate")
                         Image(systemName: "doc.on.doc")
+                    })
+                    
+                    StitchButton(action: {
+                        // Opens project in debug mode
+                        projectOpenCallback(document, true)
+                    }, label: {
+                        Text("Open in Debug Mode")
+                        Image(systemName: "wrench.and.screwdriver")
                     })
                     
                     // TODO: follow the full logic in `DeleteProject` to allow for undoing a project deletion, showing 'project recently deleted' modal etc.
@@ -189,8 +198,10 @@ struct ProjectContextMenuModifer: ViewModifier {
 
 extension View {
     func projectContextMenu(document: StitchDocument?,
-                            url: URL) -> some View {
+                            url: URL,
+                            projectOpenCallback: @escaping (StitchDocument, Bool) -> ()) -> some View {
         self.modifier(ProjectContextMenuModifer(document: document,
-                                                url: url))
+                                                url: url,
+                                                projectOpenCallback: projectOpenCallback))
     }
 }

--- a/Stitch/Home/View/ProjectItem/ShareView.swift
+++ b/Stitch/Home/View/ProjectItem/ShareView.swift
@@ -135,6 +135,8 @@ extension StitchStore {
 }
 
 struct ProjectContextMenuModifer: ViewModifier {
+    static let debugModeIcon = "wrench.and.screwdriver"
+    
     @Environment(StitchStore.self) private var store
     @State var willPresentShareSheet = false
 
@@ -160,13 +162,15 @@ struct ProjectContextMenuModifer: ViewModifier {
                         Image(systemName: "doc.on.doc")
                     })
                     
-                    StitchButton(action: {
-                        // Opens project in debug mode
-                        projectOpenCallback(document, true)
-                    }, label: {
-                        Text("Open in Debug Mode")
-                        Image(systemName: "wrench.and.screwdriver")
-                    })
+                    if !GraphUIState.isPhoneDevice {
+                        StitchButton(action: {
+                            // Opens project in debug mode
+                            projectOpenCallback(document, true)
+                        }, label: {
+                            Text("Open in Debug Mode")
+                            Image(systemName: Self.debugModeIcon)
+                        })
+                    }
                     
                     // TODO: follow the full logic in `DeleteProject` to allow for undoing a project deletion, showing 'project recently deleted' modal etc.
                     // -- see `DeleteProject` and `removeStitchProject`


### PR DESCRIPTION
Fixes an issue for users where some graph edit could cause a running prototype to hang, making edits impossible. Debug Mode is accessed by right-clicking a thumbnail in the home screen.

<img width="1123" alt="IMG_5400" src="https://github.com/user-attachments/assets/3524b613-e2f1-446b-8ecc-94815d05aa85" />

<img width="277" alt="Screenshot 2025-01-07 at 7 16 07 AM" src="https://github.com/user-attachments/assets/34f11bbc-ff70-45dc-92a0-9389e74924c8" />
