### PR TITLE
Disable fatal error regression on node kind getter

### DIFF
--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -50,7 +50,8 @@ extension NodeRowObserver {
     @MainActor
     var nodeKind: NodeKind {
         guard let nodeKind = self.nodeDelegate?.kind else {
-            fatalErrorIfDebug()
+            // Gets called on layer deletion, commenting out fatal error
+//            fatalErrorIfDebug()
             return .patch(.splitter)
         }
         


### PR DESCRIPTION
Caused by recent schema changes which used to save node kind in schema.