### PR TITLE
Fixed tabbing bug for 3D transform layer input

### DIFF
--- a/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
@@ -50,8 +50,10 @@ extension LayerNodeViewModel {
     func getLayerInspectorInputFields(_ key: LayerInputPort) -> InputFieldViewModels {
         let port = self[keyPath: key.layerNodeKeyPath]
         
-        return port.allInputData.flatMap {
-            $0.inspectorRowViewModel.fieldValueTypes.first?.fieldObservers ?? []
+        return port.allInputData.flatMap { inputData in
+            inputData.inspectorRowViewModel.fieldValueTypes.flatMap {
+                $0.fieldObservers
+            }
         }
     }
 }


### PR DESCRIPTION
The new input has multiple field groups, our code makes assumptions that there can only be one.