### PR TITLE
Use up- and down-arrow keys to increment or decrement a number field

### DIFF
--- a/Stitch/App/View/Component/StitchButton.swift
+++ b/Stitch/App/View/Component/StitchButton.swift
@@ -91,6 +91,7 @@ struct UIKitTappableWrapper<T: View>: UIViewControllerRepresentable {
             rootView: view(),
             ignoresSafeArea: false,
             ignoreKeyCommands: true,
+            inputTextFieldFocused: false, // N/A
             name: .uiKitTappableWrapper)
         let delegate = context.coordinator
 

--- a/Stitch/App/View/Component/StitchSheet.swift
+++ b/Stitch/App/View/Component/StitchSheet.swift
@@ -48,6 +48,7 @@ struct SheetViewModifier<T: View>: ViewModifier {
         content
             .sheet(isPresented: isPresentedBinding) {
                 StitchHostingControllerView(ignoreKeyCommands: false,
+                                            inputTextFieldFocused: false, // TODO: should this be provided to the sheet view?
                                             name: .sheetView) {
                     VStack(alignment: .leading) {
                         titleView

--- a/Stitch/App/View/Component/StitchTextEditingField.swift
+++ b/Stitch/App/View/Component/StitchTextEditingField.swift
@@ -31,7 +31,7 @@ struct StitchTextEditingField: View {
     var font: Font = STITCH_FONT
     var fontColor: Color = STITCH_TITLE_FONT_COLOR
     let fieldEditCallback: @MainActor (String, Bool) -> ()
-
+    
     var body: some View {
         StitchTextEditingBindingField(currentEdit: $currentEdit,
                                       fieldType: fieldType,

--- a/Stitch/App/View/Component/StitchTextEditingField.swift
+++ b/Stitch/App/View/Component/StitchTextEditingField.swift
@@ -166,11 +166,56 @@ struct StitchTextEditingBindingField: View {
             .onChange(of: currentEdit) { _, _ in
                 self.textFieldEditAction()
             }
-            .onChange(of: canvasDimensionInput) {
-                if let newLabel = $0 {
+            .onChange(of: canvasDimensionInput) { _, newValue in
+                if let newLabel = newValue {
                     self.currentEdit = newLabel
                 }
             }
+        // When an input's field is focused, we treat an up- or down-arrow as a user "increment" or "decrement" input
+            .onChange(of: self.store.currentDocument?.graphUI.reduxFocusedFieldChangedByArrowKey) { _, _ in
+                if let numberEdit = self.store.currentDocument?.graph.handleArrowKeyInput(self.currentEdit) {
+                    self.currentEdit = numberEdit
+                }
+            }
+    }
+}
+
+extension GraphState {
+    
+    @MainActor
+    func handleArrowKeyInput(_ currentEdit: String) -> String? {
+        
+        guard self.graphUI.reduxFocusedField?.getTextInputEdit.isDefined ?? false, // only for an input's fields, not node title etc.
+              let arrowKey = self.graphUI.reduxFocusedFieldChangedByArrowKey else {
+            
+            log("handleArrowKeyInput: no text field focused or no relevant arrow key")
+            self.graphUI.reduxFocusedFieldChangedByArrowKey = nil
+            
+            return nil
+        }
+        
+        // Always wipe
+        self.graphUI.reduxFocusedFieldChangedByArrowKey = nil
+                
+        // If we had a regular, non-percentage number:
+        if let n: Double = toNumber(currentEdit) {
+            switch arrowKey {
+            case .upArrow:
+                return (n + 1).formattedForFieldDisplay()
+            case .downArrow:
+                return (n - 1).formattedForFieldDisplay()
+            }
+        } else if let n = toNumberFromPercentage(currentEdit) {
+            switch arrowKey {
+            case .upArrow:
+                return (n + 1).asPercentage
+            case .downArrow:
+                return (n - 1).asPercentage
+            }
+        } else {
+            log("handleArrowKeyInput: did not have a number or percent")
+            return nil
+        }
     }
 }
 

--- a/Stitch/App/View/ViewUtil/StitchHostingController.swift
+++ b/Stitch/App/View/ViewUtil/StitchHostingController.swift
@@ -112,7 +112,7 @@ class StitchHostingController<T: View>: UIHostingController<T> {
     @MainActor
     override func pressesBegan(_ presses: Set<UIPress>,
                                with event: UIPressesEvent?) {
-        // log("KEY: StitchHostingController: name: \(name): pressesBegan: presses.first?.key: \(presses.first?.key)")
+        log("KEY: StitchHostingController: name: \(name): pressesBegan: presses.first?.key: \(presses.first?.key)")
         presses.first?.key.map(keyPressed)
         //        super.pressesBegan(presses, with: event)
         
@@ -125,20 +125,34 @@ class StitchHostingController<T: View>: UIHostingController<T> {
 
          So, we simply don't pass the Option key's pressesBegan along the chain.
          */
-#if targetEnvironment(macCatalyst)
+        
+        
+        // If an input text field on a node is actively focused,
+        // do not pass the up- or down-arrow keys to the next responder in the chain.
+        // Prevents up- and down-arrow keys from jumping the cursor to the start or end of the text when we merely want to increment or decrement the focused field's value.
         if let key = presses.first?.key,
-           !self.isOptionKey(key) {
+//           state.graphUI.reduxFocusedField.getTextInputEdit,
+           (key.keyCode == .keyboardUpArrow || key.keyCode == .keyboardDownArrow) {
+           
+            log("pressesBegan: will not pass on up-arrow")
+        } else {
             super.pressesBegan(presses, with: event)
         }
-#else
-        super.pressesBegan(presses, with: event)
-#endif
+        
+//#if targetEnvironment(macCatalyst)
+//        if let key = presses.first?.key,
+//           !self.isOptionKey(key) {
+//            super.pressesBegan(presses, with: event)
+//        }
+//#else
+//        super.pressesBegan(presses, with: event)
+//#endif
     }
 
     @MainActor
     override func pressesEnded(_ presses: Set<UIPress>,
                                with event: UIPressesEvent?) {
-        // log("KEY: StitchHostingController: name: \(name): pressesEnded: presses.first?.key: \(presses.first?.key)")
+        log("KEY: StitchHostingController: name: \(name): pressesEnded: presses.first?.key: \(presses.first?.key)")
         presses.first?.key.map(keyReleased)
         super.pressesEnded(presses, with: event)
     }
@@ -146,14 +160,21 @@ class StitchHostingController<T: View>: UIHostingController<T> {
     @MainActor
     override func pressesCancelled(_ presses: Set<UIPress>,
                                    with event: UIPressesEvent?) {
-        // log("KEY: StitchHostingController: name: \(name): pressesCancelled: presses.first?.key: \(presses.first?.key)")
+        log("KEY: StitchHostingController: name: \(name): pressesCancelled: presses.first?.key: \(presses.first?.key)")
         presses.first?.key.map(keyReleased)
         super.pressesCancelled(presses, with: event)
     }
 
     @MainActor
     func keyPressed(_ key: UIKey) {
-        // log("KEY: StitchHostingController: name: \(name): keyPressed: key: \(key)")
+        log("KEY: StitchHostingController: name: \(name): keyPressed: key: \(key)")
+        
+        if key.keyCode == .keyboardUpArrow {
+            log("KEY: StitchHostingController: name: \(name): keyPressed: UP ARROW")
+            dispatch(UpArrowPressed())
+        } else if key.keyCode == .keyboardDownArrow {
+            log("KEY: StitchHostingController: name: \(name): keyPressed: DOWN ARROW")
+        }
         
         // TODO: key-modifiers (Tab, Shift etc.) and key-characters are not exclusive
         if let modifiers = key.asStitchKeyModifiers {
@@ -181,18 +202,22 @@ class StitchHostingController<T: View>: UIHostingController<T> {
     // MARK: arrow key callbacks
 
     @objc func arrowKeyUp(_ sender: UIKeyCommand) {
+        log("KEY: StitchHostingController: name: \(name): arrowKeyUp")
         dispatch(ArrowKeyPressed(arrowKey: .up))
     }
 
     @objc func arrowKeyDown(_ sender: UIKeyCommand) {
+        log("KEY: StitchHostingController: name: \(name): arrowKeyDown")
         dispatch(ArrowKeyPressed(arrowKey: .down))
     }
 
     @objc func arrowKeyLeft(_ sender: UIKeyCommand) {
+        log("KEY: StitchHostingController: name: \(name): arrowKeyLeft")
         dispatch(ArrowKeyPressed(arrowKey: .left))
     }
 
     @objc func arrowKeyRight(_ sender: UIKeyCommand) {
+        log("KEY: StitchHostingController: name: \(name): arrowKeyRight")
         dispatch(ArrowKeyPressed(arrowKey: .right))
     }
 

--- a/Stitch/App/View/ViewUtil/StitchHostingController.swift
+++ b/Stitch/App/View/ViewUtil/StitchHostingController.swift
@@ -57,7 +57,10 @@ enum KeyListenerName: String, Equatable {
 class StitchHostingController<T: View>: UIHostingController<T> {
     let ignoresSafeArea: Bool
     let ignoreKeyCommands: Bool
+    
+    // TODO: better to just pass `weak var graph: GraphState` here? Avoids having to update this variable in the various `updateUIView` functions of views that consume SHC
     var inputTextFieldFocused: Bool
+    
     var usesArrowKeyBindings: Bool = false
     let name: KeyListenerName
 
@@ -175,16 +178,16 @@ class StitchHostingController<T: View>: UIHostingController<T> {
     @MainActor
     func keyPressed(_ key: UIKey) {
         log("KEY: StitchHostingController: name: \(name): keyPressed: key: \(key)")
-        
+                
         if key.keyCode == .keyboardUpArrow && self.inputTextFieldFocused {
             log("KEY: StitchHostingController: name: \(name): keyPressed: UP ARROW")
-            dispatch(UpArrowPressed())
+            dispatch(ArrowPressedWhileInputTextFieldFocused(wasUpArrow: true))
             return
         }
         
         if key.keyCode == .keyboardDownArrow && self.inputTextFieldFocused {
             log("KEY: StitchHostingController: name: \(name): keyPressed: DOWN ARROW")
-            dispatch(DownArrowPressed())
+            dispatch(ArrowPressedWhileInputTextFieldFocused(wasUpArrow: false))
             return
         }
         

--- a/Stitch/App/View/ViewUtil/UIKitWrapper.swift
+++ b/Stitch/App/View/ViewUtil/UIKitWrapper.swift
@@ -13,6 +13,7 @@ import StitchSchemaKit
 // a SwiftUI view that accepts another SwiftUI view T, and which wraps T in a UIKit view
 struct UIKitWrapper<T: View>: UIViewControllerRepresentable {
     let ignoresKeyCommands: Bool
+    let inputTextFieldFocused: Bool
     let name: KeyListenerName
     @ViewBuilder var content: () -> T
 
@@ -25,6 +26,7 @@ struct UIKitWrapper<T: View>: UIViewControllerRepresentable {
             rootView: content(),
             ignoresSafeArea: true,
             ignoreKeyCommands: ignoresKeyCommands,
+            inputTextFieldFocused: inputTextFieldFocused,
             name: name)
     }
 
@@ -32,6 +34,7 @@ struct UIKitWrapper<T: View>: UIViewControllerRepresentable {
     func updateUIViewController(_ uiViewController: StitchHostingController<T>,
                                 context: Context) {
         uiViewController.rootView = content()
+        uiViewController.inputTextFieldFocused = self.inputTextFieldFocused
     }
 }
 

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuSearchBar.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuSearchBar.swift
@@ -107,7 +107,7 @@ struct InsertNodeMenuSearchBar: View {
         // Hosting controller needed to register arrow key presses in this view;
         // this is also the main key-press listener for the app, since the insert node menu is always on-screen
         StitchHostingControllerView(ignoreKeyCommands: false,
-                                    inputTextFieldFocused: self.store.currentDocument?.graphUI.reduxFocusedField?.getTextInputEdit.isDefined ?? false,
+                                    inputTextFieldFocused: false, // N/A
                                     usesArrowKeyBindings: true, // N/A ?
                                     name: .insertNodeMenuSearchbar) {
             searchInput

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuSearchBar.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuSearchBar.swift
@@ -107,8 +107,9 @@ struct InsertNodeMenuSearchBar: View {
         // Hosting controller needed to register arrow key presses in this view;
         // this is also the main key-press listener for the app, since the insert node menu is always on-screen
         StitchHostingControllerView(ignoreKeyCommands: false,
-                                  usesArrowKeyBindings: true,
-                                  name: .insertNodeMenuSearchbar) {
+                                    inputTextFieldFocused: self.store.currentDocument?.graphUI.reduxFocusedField?.getTextInputEdit.isDefined ?? false,
+                                    usesArrowKeyBindings: true, // N/A ?
+                                    name: .insertNodeMenuSearchbar) {
             searchInput
         }
         .height(INSERT_NODE_MENU_SEARCH_BAR_HEIGHT) // need to set height again

--- a/Stitch/Graph/Node/Port/Model/Field/FieldValue.swift
+++ b/Stitch/Graph/Node/Port/Model/Field/FieldValue.swift
@@ -99,6 +99,23 @@ extension FieldValue {
         }
     }
 
+    var isNumberForArrowKeyIncrementAndDecrement: Bool {
+        switch self {
+        case .number:
+            return true
+        case .layerDimension(let x):
+            switch x {
+            case .number, .percent:
+                return true
+            default:
+                return false
+            }
+        default:
+            return false
+        }
+    }
+    
+    
     var numberValue: Double {
         switch self {
         case .number(let double):

--- a/Stitch/Graph/Node/Port/Model/Field/FocusedUserEditField.swift
+++ b/Stitch/Graph/Node/Port/Model/Field/FocusedUserEditField.swift
@@ -54,6 +54,24 @@ enum FocusedUserEditField: Equatable, Hashable {
             return nil
         }
     }
+    
+    @MainActor
+    func inputTextFieldWithNumberIsFocused(_ graph: GraphState) -> Bool {
+        guard let focusedField = self.getTextInputEdit else {
+            return false
+        }
+        
+        // Determine whether the focused-field has a number (numeric or percentage);
+        // if not, then up and down arrow keys should be passed down like normal.
+        let rowId = focusedField.rowId
+        let nodeId = rowId.nodeId
+        
+        if let rowViewModel = graph.getInputRowViewModel(for: rowId, nodeId: nodeId),
+           let fieldObserver = rowViewModel.fieldValueTypes.first?.fieldObservers[safeIndex: focusedField.fieldIndex] {
+            return fieldObserver.fieldValue.isNumberForArrowKeyIncrementAndDecrement
+        }
+        return false
+    }
 
     var getNodeTitleEdit: StitchTitleEdit? {
         switch self {

--- a/Stitch/Graph/Node/Port/Util/PortValue/Parsers.swift
+++ b/Stitch/Graph/Node/Port/Util/PortValue/Parsers.swift
@@ -116,6 +116,16 @@ func toNumber(_ userEdit: String) -> Double? {
     return result
 }
 
+func toNumberFromPercentage(_ userEdit: String) -> Double? {
+    toNumber(userEdit.replacing("%", with: ""))
+}
+
+extension Double {
+    func formattedForFieldDisplay() -> String {
+        GlobalFormatter.string(for: self) ?? self.description
+    }
+}
+
 func toBool(_ userEdit: String) -> Bool? {
     Bool(userEdit)
 }

--- a/Stitch/Graph/PrototypePreview/Frame/View/FullScreenGestureRecognizerView.swift
+++ b/Stitch/Graph/PrototypePreview/Frame/View/FullScreenGestureRecognizerView.swift
@@ -26,6 +26,7 @@ struct FullScreenGestureRecognizerView<Content: View>: UIViewControllerRepresent
             rootView: content(),
             ignoresSafeArea: ignoresSafeArea,
             ignoreKeyCommands: true,
+            inputTextFieldFocused: false, // N/A
             name: .fullScreenGestureRecognzer)
         vc.delegate = delegate
 

--- a/Stitch/Graph/PrototypePreview/Frame/View/PreviewContent.swift
+++ b/Stitch/Graph/PrototypePreview/Frame/View/PreviewContent.swift
@@ -58,7 +58,9 @@ struct PreviewContent: View {
         
         // TODO: still needed to contain gestures?
         // TODO: needed with `ignoresKeyCommands: false` to detect key presses for keyboard nodes
-        UIKitWrapper(ignoresKeyCommands: false, name: .previewWindow) {
+        UIKitWrapper(ignoresKeyCommands: false,
+                     inputTextFieldFocused: document.graphUI.reduxFocusedField?.getTextInputEdit.isDefined ?? false,
+                     name: .previewWindow) {
             generatedPreview
                 .frame(finalSize)
                 .coordinateSpace(name: Self.prototypeCoordinateSpace)

--- a/Stitch/Graph/PrototypePreview/Frame/View/PreviewContent.swift
+++ b/Stitch/Graph/PrototypePreview/Frame/View/PreviewContent.swift
@@ -59,7 +59,7 @@ struct PreviewContent: View {
         // TODO: still needed to contain gestures?
         // TODO: needed with `ignoresKeyCommands: false` to detect key presses for keyboard nodes
         UIKitWrapper(ignoresKeyCommands: false,
-                     inputTextFieldFocused: document.graphUI.reduxFocusedField?.getTextInputEdit.isDefined ?? false,
+                     inputTextFieldFocused: document.graphUI.reduxFocusedField?.inputTextFieldWithNumberIsFocused(document.graph) ?? false,
                      name: .previewWindow) {
             generatedPreview
                 .frame(finalSize)

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
@@ -44,6 +44,7 @@ struct SidebarListItemGestureRecognizerView<T: View,
             rootView: view,
             ignoresSafeArea: false,
             ignoreKeyCommands: true,
+            inputTextFieldFocused: false, // N/A
             name: .sidebarListItem)
 
         let delegate = context.coordinator

--- a/Stitch/Graph/Util/KeyBindingActions.swift
+++ b/Stitch/Graph/Util/KeyBindingActions.swift
@@ -15,66 +15,35 @@ extension NodeRowViewModelId {
     }
 }
 
+
 struct UpArrowPressed: GraphEvent {
     
     func handle(state: GraphState) {
-        if let activelyFocusedTextFieldOnCanvas = state.graphUI.reduxFocusedField?.getTextInputEdit {
-            log("UpArrowPressed: activelyFocusedTextFieldOnCanvas: \(activelyFocusedTextFieldOnCanvas)")
-            // increment the value of the field
-            
-            // Treat this is as a user edit; find the string for the active
-            let rowId = activelyFocusedTextFieldOnCanvas.rowId
-            let nodeId = rowId.nodeId
-            log("UpArrowPressed: nodeId: \(nodeId)")
-            log("UpArrowPressed: rowId: \(rowId)")
-            
-            if let node = state.getNodeViewModel(nodeId),
-               let rowViewModel = node.getInputRowViewModel(for: rowId) {
-                
-                
- //                ,
- //               let nodeRowObserver = node.getInputRowObserver(for: rowId.portType)
-                
-                
-                let fieldObservers = rowViewModel.fieldValueTypes.first?.fieldObservers
-                let fieldObserver = fieldObservers?[safeIndex: activelyFocusedTextFieldOnCanvas.fieldIndex]
-                
-                log("UpArrowPressed: fieldObserver?.fieldValue: \(fieldObserver?.fieldValue)")
-                
-                if let fieldObserver = fieldObserver {
-                    switch fieldObserver.fieldValue {
-                    case .number(let n):
-                        log("UpArrowPressed: .number: n: \(n)")
-                        state.inputEdited(fieldValue: FieldValue.number(n + 1),
-                                          fieldIndex: activelyFocusedTextFieldOnCanvas.fieldIndex,
-                                          coordinate: rowId.asNodeIOCoordinate,
-                                          // does this matter? yes, for if we have edited a single field while actually multiple layers in the sidebar are selected
-                                          isFieldInsideLayerInspector: false,
-                                          isCommitting: true)
-                        
-                    case .layerDimension(let n):
-                        log("UpArrowPressed: .layerDimension: n: \(n)")
-                        switch n {
-                        case .percent(let _n):
-                            log("UpArrowPressed: .layerDimension: _n: \(_n)")
-                            state.inputEdited(fieldValue: FieldValue.number(_n + 1),
-                                              fieldIndex: activelyFocusedTextFieldOnCanvas.fieldIndex,
-                                              coordinate: rowId.asNodeIOCoordinate,
-                                              // does this matter? yes, for if we have edited a single field while actually multiple layers in the sidebar are selected
-                                              isFieldInsideLayerInspector: false,
-                                              isCommitting: true)
-                        default:
-                            log("UpArrowPressed: .layerDimension: did not have a number")
-                        }
-                    default:
-                        log("UpArrowPressed: default: \(fieldObserver.fieldValue)")
-                    }
-                }
-                
-            }
+        
+        guard state.graphUI.reduxFocusedField?.getTextInputEdit.isDefined ?? false else {
+            log("UpArrowPressed: no text field focused")
+            return
         }
+                
+        // View will now respond to this
+        state.graphUI.reduxFocusedFieldChangedByArrowKey = .upArrow
     }
 }
+
+struct DownArrowPressed: GraphEvent {
+    
+    func handle(state: GraphState) {
+        
+        guard state.graphUI.reduxFocusedField?.getTextInputEdit.isDefined ?? false else {
+            log("DownArrowPressed: no text field focused")
+            return
+        }
+                
+        // View will now respond to this
+        state.graphUI.reduxFocusedFieldChangedByArrowKey = .downArrow
+    }
+}
+
 
 /// Process arrow key events.
 struct ArrowKeyPressed: GraphEvent {

--- a/Stitch/Graph/Util/KeyBindingActions.swift
+++ b/Stitch/Graph/Util/KeyBindingActions.swift
@@ -8,6 +8,74 @@
 import SwiftUI
 import StitchSchemaKit
 
+extension NodeRowViewModelId {
+    var asNodeIOCoordinate: NodeIOCoordinate {
+        NodeIOCoordinate(portType: self.portType,
+                         nodeId: self.nodeId)
+    }
+}
+
+struct UpArrowPressed: GraphEvent {
+    
+    func handle(state: GraphState) {
+        if let activelyFocusedTextFieldOnCanvas = state.graphUI.reduxFocusedField?.getTextInputEdit {
+            log("UpArrowPressed: activelyFocusedTextFieldOnCanvas: \(activelyFocusedTextFieldOnCanvas)")
+            // increment the value of the field
+            
+            // Treat this is as a user edit; find the string for the active
+            let rowId = activelyFocusedTextFieldOnCanvas.rowId
+            let nodeId = rowId.nodeId
+            log("UpArrowPressed: nodeId: \(nodeId)")
+            log("UpArrowPressed: rowId: \(rowId)")
+            
+            if let node = state.getNodeViewModel(nodeId),
+               let rowViewModel = node.getInputRowViewModel(for: rowId) {
+                
+                
+ //                ,
+ //               let nodeRowObserver = node.getInputRowObserver(for: rowId.portType)
+                
+                
+                let fieldObservers = rowViewModel.fieldValueTypes.first?.fieldObservers
+                let fieldObserver = fieldObservers?[safeIndex: activelyFocusedTextFieldOnCanvas.fieldIndex]
+                
+                log("UpArrowPressed: fieldObserver?.fieldValue: \(fieldObserver?.fieldValue)")
+                
+                if let fieldObserver = fieldObserver {
+                    switch fieldObserver.fieldValue {
+                    case .number(let n):
+                        log("UpArrowPressed: .number: n: \(n)")
+                        state.inputEdited(fieldValue: FieldValue.number(n + 1),
+                                          fieldIndex: activelyFocusedTextFieldOnCanvas.fieldIndex,
+                                          coordinate: rowId.asNodeIOCoordinate,
+                                          // does this matter? yes, for if we have edited a single field while actually multiple layers in the sidebar are selected
+                                          isFieldInsideLayerInspector: false,
+                                          isCommitting: true)
+                        
+                    case .layerDimension(let n):
+                        log("UpArrowPressed: .layerDimension: n: \(n)")
+                        switch n {
+                        case .percent(let _n):
+                            log("UpArrowPressed: .layerDimension: _n: \(_n)")
+                            state.inputEdited(fieldValue: FieldValue.number(_n + 1),
+                                              fieldIndex: activelyFocusedTextFieldOnCanvas.fieldIndex,
+                                              coordinate: rowId.asNodeIOCoordinate,
+                                              // does this matter? yes, for if we have edited a single field while actually multiple layers in the sidebar are selected
+                                              isFieldInsideLayerInspector: false,
+                                              isCommitting: true)
+                        default:
+                            log("UpArrowPressed: .layerDimension: did not have a number")
+                        }
+                    default:
+                        log("UpArrowPressed: default: \(fieldObserver.fieldValue)")
+                    }
+                }
+                
+            }
+        }
+    }
+}
+
 /// Process arrow key events.
 struct ArrowKeyPressed: GraphEvent {
     let arrowKey: ArrowKey

--- a/Stitch/Graph/Util/KeyBindingActions.swift
+++ b/Stitch/Graph/Util/KeyBindingActions.swift
@@ -15,35 +15,21 @@ extension NodeRowViewModelId {
     }
 }
 
-
-struct UpArrowPressed: GraphEvent {
+struct ArrowPressedWhileInputTextFieldFocused: GraphEvent {
+    let wasUpArrow: Bool // currently only up vs down arrows supported
     
     func handle(state: GraphState) {
         
         guard state.graphUI.reduxFocusedField?.getTextInputEdit.isDefined ?? false else {
-            log("UpArrowPressed: no text field focused")
+            fatalErrorIfDebug("ArrowKeyPressedWhileInputTextFieldFocused: no text field focused")
+            // Should never happen
             return
         }
                 
-        // View will now respond to this
-        state.graphUI.reduxFocusedFieldChangedByArrowKey = .upArrow
+        // View then responds to this
+        state.graphUI.reduxFocusedFieldChangedByArrowKey = wasUpArrow ? .upArrow : .downArrow
     }
 }
-
-struct DownArrowPressed: GraphEvent {
-    
-    func handle(state: GraphState) {
-        
-        guard state.graphUI.reduxFocusedField?.getTextInputEdit.isDefined ?? false else {
-            log("DownArrowPressed: no text field focused")
-            return
-        }
-                
-        // View will now respond to this
-        state.graphUI.reduxFocusedFieldChangedByArrowKey = .downArrow
-    }
-}
-
 
 /// Process arrow key events.
 struct ArrowKeyPressed: GraphEvent {

--- a/Stitch/Graph/View/ContentView.swift
+++ b/Stitch/Graph/View/ContentView.swift
@@ -48,7 +48,9 @@ struct ContentView: View, KeyboardReadable {
         ZStack {
             
             // Best place to listen for TAB key for flyout
-            UIKitWrapper(ignoresKeyCommands: true, name: .mainGraph) {
+            UIKitWrapper(ignoresKeyCommands: true,
+                         inputTextFieldFocused: graphUI.reduxFocusedField?.getTextInputEdit.isDefined ?? false,
+                         name: .mainGraph) {
                 contentView // the graph
             }
             

--- a/Stitch/Graph/View/ContentView.swift
+++ b/Stitch/Graph/View/ContentView.swift
@@ -49,7 +49,7 @@ struct ContentView: View, KeyboardReadable {
             
             // Best place to listen for TAB key for flyout
             UIKitWrapper(ignoresKeyCommands: true,
-                         inputTextFieldFocused: graphUI.reduxFocusedField?.getTextInputEdit.isDefined ?? false,
+                         inputTextFieldFocused: graphUI.reduxFocusedField?.inputTextFieldWithNumberIsFocused(document.graph) ?? false,
                          name: .mainGraph) {
                 contentView // the graph
             }

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -28,6 +28,11 @@ struct ActiveDragInteractionNodeVelocityData: Equatable, Hashable {
     var activeDragInteractionNodes = NodeIdSet()
 }
 
+enum FocusedFieldChangedByArrowKey: Equatable, Hashable {
+    case upArrow, // increment
+         downArrow // decrement
+}
+
 @Observable
 final class GraphUIState: Sendable {
         
@@ -60,6 +65,10 @@ final class GraphUIState: Sendable {
 
     // nil = no field focused
     @MainActor var reduxFocusedField: FocusedUserEditField?
+    
+    // set non-nil by up- and down-arrow key presses while an input's fields are focused
+    // set nil after key press has been handled by `StitchTextEditingBindingField`
+    @MainActor var reduxFocusedFieldChangedByArrowKey: FocusedFieldChangedByArrowKey?
 
     // Hack: to differentiate state updates that came from undo/redo (and which close the adjustment bar popover),
     // vs those that came from user manipulation of adjustment bar (which do not close the adjustment bar popover).


### PR DESCRIPTION
Notes:
1. we still support regular up- and down-arrow functionality in text fields that do not use numbers (first part of video)
2. we support changing a percentage!
3. currently, we do not continue to inc/dec when the arrow key is held down

https://github.com/user-attachments/assets/6da8ea62-0580-457e-a040-0d8cc656cd06

