### PR TITLE
Header for 3D Transform flyout, left-align labels

### DIFF
--- a/Stitch/Graph/Node/Model/RowData/LayerInputType.swift
+++ b/Stitch/Graph/Node/Model/RowData/LayerInputType.swift
@@ -1605,7 +1605,8 @@ extension LayerInputPort {
         case .scrollJumpToYLocation:
             return "Jump Position Y"
         case .transform3D:
-            return ""  // skip in favor of header section
+//            return ""  // skip in favor of header section
+            return "3D Transform" // want some kind of title 
         case .anchorEntity:
             return "Anchor Entity"
         case .isEntityAnimating:

--- a/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
@@ -93,8 +93,9 @@ struct NodeFieldsView<FieldType, ValueEntryView>: View where FieldType: FieldVie
         // Only non-nil for 3D transform
         if let fieldGroupLabel = fieldGroupViewModel.groupLabel {
             HStack {
-                Spacer()
+//                Spacer()
                 StitchTextView(string: fieldGroupLabel)
+                Spacer()
             }
         }
         

--- a/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
+++ b/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
@@ -185,6 +185,10 @@ struct NodeInputView: View {
         layerInputObserver?.port == SHADOW_FLYOUT_LAYER_INPUT_PROXY
     }
     
+    var is3DTransform: Bool {
+        layerInputObserver?.port == .transform3D
+    }
+    
     var body: some View {
         HStack(alignment: hStackAlignment) {
             
@@ -195,7 +199,10 @@ struct NodeInputView: View {
                                         propertyIsSelected: propertyIsSelected)
             }  else {
                 
-                labelView
+                // Skip the label if we have a 3D transform input but are not in the flyout
+                if !(is3DTransform && !forFlyout) {
+                    labelView
+                }
                 
                 if forPropertySidebar {
                     Spacer()
@@ -203,7 +210,7 @@ struct NodeInputView: View {
                 
                 // If the input has multiple rows of fields (e.g. 3D Transform)
                 // then vertically stack those.
-                if layerInputObserver?.port == .transform3D {
+                if is3DTransform {
                     VStack {
                         fieldsListView
                     }


### PR DESCRIPTION
Just a small UI change. 

TODO: the labels probably need to be on same row as the fields? do we drop the x,y,z labels? 

