### PR TITLE
Do not crash when editing 3D Transform field on canvas

### DIFF
--- a/Stitch/Graph/GraphStep/GraphStepIncrementer.swift
+++ b/Stitch/Graph/GraphStep/GraphStepIncrementer.swift
@@ -144,7 +144,21 @@ extension NodeViewModel {
             let newValues = layerNode.previewLayerViewModels
                 .map { $0.transform3D }
             layerNode.transform3DPort.updatePortValues(newValues)
-            layerNode.transform3DPort.rowObserver.updatePortViewModels()
+            layerNode.transform3DPort.updateAllRowObserversPortViewModels()
+        }
+    }
+}
+
+extension LayerInputObserver {
+    @MainActor
+    func updateAllRowObserversPortViewModels() {
+        switch self.mode {
+        case .packed:
+            self._packedData.rowObserver.updatePortViewModels()
+        case .unpacked:
+            self._unpackedData.allPorts.forEach {
+                $0.rowObserver.updatePortViewModels()
+            }
         }
     }
 }

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
@@ -175,6 +175,7 @@ extension LayerInputObserver {
         return .packed
     }
     
+    // TODO: why is this _packed only ?
     /// Updates all-up values, handling scenarios like unpacked if applicable.
     @MainActor
     func updatePortValues(_ values: PortValues) {


### PR DESCRIPTION
Also: properly update the unpacked fields in response to user's gesture.