### PR TITLE
Use StitchSchemaKit `main` branch

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -6397,8 +6397,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StitchDesign/StitchSchemaKit";
 			requirement = {
-				kind = revision;
-				revision = 5f19fe9a5d1de6adc176200e099a7ba376784eb3;
+				branch = main;
+				kind = branch;
 			};
 		};
 		EC1137362719F9B400ADCA72 /* XCRemoteSwiftPackageReference "swift-collections" */ = {

--- a/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -58,7 +58,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StitchDesign/StitchSchemaKit",
       "state" : {
-        "revision" : "5f19fe9a5d1de6adc176200e099a7ba376784eb3"
+        "branch" : "main",
+        "revision" : "0ebda76aeee9cf922b4dc53cf59b2c05b6fe09a7"
       }
     },
     {


### PR DESCRIPTION
Has latest changed for SSK V29 migrations.