### PR TITLE
Improved number formatting for many significant digits

### DIFF
--- a/Stitch/Graph/Node/Port/Model/Field/FieldValue.swift
+++ b/Stitch/Graph/Node/Port/Model/Field/FieldValue.swift
@@ -81,7 +81,7 @@ extension FieldValue {
         case .readOnly(let string):
             return string
         case .number(let double):
-            return GlobalFormatter.string(for: double) ?? double.description
+            return double.description
         case .layerDimension(let numberValue):
             return numberValue.stringValue
         case .json(let json):

--- a/Stitch/Graph/Node/Port/ViewModel/NumberFormatterObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NumberFormatterObserver.swift
@@ -14,7 +14,7 @@ import StitchSchemaKit
 // (Tested on Mac Release Build.)
 let GlobalFormatter = NumberFormatterObserver()
 
-final class NumberFormatterObserver: NumberFormatter {
+final class NumberFormatterObserver: NumberFormatter, @unchecked Sendable {
     override init() {
         super.init()
         self.maximumFractionDigits = 4


### PR DESCRIPTION
Shows sig digits now when previously would just show "0.0".

<img width="250" alt="Screenshot 2025-01-17 at 10 33 42 AM" src="https://github.com/user-attachments/assets/c7e1db0f-2c85-4021-af8b-56b9cf260594" />
