### PR TITLE
Removed references to documents when projects close

### DIFF
--- a/Stitch/App/View/StitchNavStack.swift
+++ b/Stitch/App/View/StitchNavStack.swift
@@ -40,6 +40,10 @@ struct StitchNavStack: View {
                     store.allProjectUrls.forEach { projectLoader in
                         if projectLoader.id != currentProjectId &&
                             projectLoader.documentViewModel != nil {
+                            // In case references are stored here (but probably not)
+                            projectLoader.lastEncodedDocument = nil
+                            
+                            // Remove document from memory
                             projectLoader.documentViewModel = nil
                         }
                     }

--- a/Stitch/App/View/StitchNavStack.swift
+++ b/Stitch/App/View/StitchNavStack.swift
@@ -27,10 +27,21 @@ struct StitchNavStack: View {
                         }
                     }
                 }
-                .onChange(of: store.isCurrentProjectSelected) {
+                .onChange(of: store.navPath.first) { _, currentProject in
+                    let currentProjectId = currentProject?.id
+                    
                     // Rest undo if project closed
                     if !store.isCurrentProjectSelected {
                         store.environment.undoManager.undoManager.removeAllActions()
+                    }
+                    
+                    // Remove references to other StitchDocuments to release them from memory
+                    // Logic here needed for drag-and-drop import with existing document open
+                    store.allProjectUrls.forEach { projectLoader in
+                        if projectLoader.id != currentProjectId &&
+                            projectLoader.documentViewModel != nil {
+                            projectLoader.documentViewModel = nil
+                        }
                     }
                 }
             


### PR DESCRIPTION
Not seeing memory usage decrease but debugger confirms StitchDocumentViewModel is no longer retained in some scenarios.