### PR TITLE
Show 3D Transform label in flyout and on packed canvas input

### DIFF
--- a/Stitch/Graph/Node/Model/RowData/LayerInputType.swift
+++ b/Stitch/Graph/Node/Model/RowData/LayerInputType.swift
@@ -1668,7 +1668,9 @@ extension LayerInputPort {
             return "Scale"
         case .isMetallic:
             return "Metallic"
-        case .transform3D, .size3D:
+        case .transform3D:
+            return "3D Transform"
+        case .size3D:
             return ""
         case .radius3D:
             return "Radius"

--- a/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
@@ -42,11 +42,16 @@ struct InputValueEntry: View {
     // So we check information about the parent (i.e. the whole layer input, LayerInputObserver) and compare against child (i.e. the individual field, UnpackedPortType).
     var fieldsRowLabel: String? {
         if let layerInputObserver = layerInputObserver,
-           layerInputObserver.port == .transform3D,
-           layerInputObserver.mode == .unpacked,
-           let fieldGroupLabel = rowObserverId.keyPath?.getUnpackedPortType?.fieldGroupLabelForUnpacked3DTransformInput {
+           layerInputObserver.port == .transform3D {
             
-            return layerInputObserver.port.label() + " " + fieldGroupLabel
+            if layerInputObserver.mode == .unpacked,
+               let fieldGroupLabel = rowObserverId.keyPath?.getUnpackedPortType?.fieldGroupLabelForUnpacked3DTransformInput {
+                
+                return layerInputObserver.port.label() + " " + fieldGroupLabel
+            } else {
+                // Show '3D Transform' label on packed 3D Transform input-on-canvas
+                return layerInputObserver.port.label()
+            }
         }
         
         return nil


### PR DESCRIPTION
Fixes a small regression and also properly labels the 3D Transform input on canvas (less confusing for user).

<img width="1426" alt="Screenshot 2025-01-20 at 12 50 38 PM" src="https://github.com/user-attachments/assets/ab3d4ba4-0148-40c3-988e-e1fdc01610dd" />
