### PR TITLE
Manually update StitchStore with the loaded StitchDocument's name change

### DIFF
--- a/Stitch/Home/View/ProjectItem/ProjectsListItemLoadedView.swift
+++ b/Stitch/Home/View/ProjectItem/ProjectsListItemLoadedView.swift
@@ -8,7 +8,21 @@
 import SwiftUI
 import StitchSchemaKit
 
+extension ProjectLoader {
+    @MainActor
+    var loadedDocument: (StitchDocument, UIImage?)? {
+        switch self.loadingDocument {
+        case .loaded(let doc, let image):
+            return (doc, image)
+        default:
+            return nil
+        }
+    }
+}
+
 struct ProjectThumbnailTextField: View {
+    @Environment(StitchStore.self) var store
+    
     @FocusedValue(\.focusedField) private var focusedField
     @State private var contextMenuOpen: Bool = false
     @State private var projectName: String = ""
@@ -31,7 +45,23 @@ struct ProjectThumbnailTextField: View {
         .onSubmit {
             var document = document
             document.graph.name = projectName
-    
+
+            // TODO: why wasn't the encodeDocument logic enough to trigger a view re-render? But also, it's better not to rely on a side-effect (encoding) to trigger a view re-render.
+            // TODO: will this have properly updated the modified-date on the project?
+            
+            // Manually update the project's name in the state that other views (e.g. ProjectsListItemView) listen to.
+            if let project: ProjectLoader = store.allProjectUrls.first { $0.loadedDocument?.0.id == document.id },
+            let index = store.allProjectUrls.firstIndex { $0.id == project.id },
+            var (loadedDocument, loadedImage) = project.loadedDocument {
+                
+                // Update the project's name
+                loadedDocument.graph.name = projectName
+                project.loadingDocument = .loaded(loadedDocument, loadedImage)
+                
+                // Place the project back in state
+                store.allProjectUrls[index] = project
+            }
+            
             Task(priority: .high) {
                 do {
                     // Must write a version of the project with an updated name


### PR DESCRIPTION
Problem: the thumbnail view had an outdated version of the StitchDocument struct, which was supposed to have been modified and encoded by the text edit view. 

Original implementation seemed to expect a side-effect (persistence) to trigger our directory-listening logic, which would then update our UI.

Rather than rely on a side-effect, we can just make the state change manually, which triggers the view updates.


https://github.com/user-attachments/assets/aacf77e1-e14e-435c-bc67-e6070f11652e

https://github.com/user-attachments/assets/6a06069e-0ad9-498c-b7a9-21aa555301da

