### PR TITLE
Fixed 3D entity handling when exiting reality view

### DIFF
--- a/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/Model3DView.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/Model3DView.swift
@@ -21,6 +21,7 @@ struct Model3DView: View {
     let sceneSize: CGSize
     let scale: Double
     let opacity: Double
+    let isRendering: Bool
 
     var body: some View {
         switch entity.type {
@@ -39,13 +40,13 @@ struct Model3DView: View {
                                 entity: entity,
                                 size: size,
                                 scale: scale,
-                                opacity: opacity)
+                                opacity: opacity,
+                                isRendering: isRendering)
         }
     }
 }
 
 struct Model3DGeometryView: View {
-    @State private var arView: ARView?
     @State private var anchorEntity: AnchorEntity = .init()
     
     let layerViewModel: LayerViewModel
@@ -54,6 +55,7 @@ struct Model3DGeometryView: View {
     let size: LayerSize
     let scale: Double
     let opacity: Double
+    let isRendering: Bool
     
     var body: some View {
         ZStack {
@@ -63,7 +65,7 @@ struct Model3DGeometryView: View {
                                  opacity: opacity,
                                  isShadowsEnabled: false)
             
-            if let arView = self.arView {
+            if let arView = layerViewModel.realityContent {
                 Color.clear
                     .modifier(ModelEntityLayerViewModifier(previewLayer: layerViewModel,
                                                            entity: entity,
@@ -72,7 +74,8 @@ struct Model3DGeometryView: View {
                                                            anchorEntityId: nil,
                                                            translationEnabled: false,
                                                            rotationEnabled: false,
-                                                           scaleEnabled: false))
+                                                           scaleEnabled: false,
+                                                           isRendering: isRendering))
             }
         }
     }

--- a/Stitch/Graph/Node/Layer/Type/Media/RealityView/PreviewRealityLayer.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/RealityView/PreviewRealityLayer.swift
@@ -139,7 +139,7 @@ struct RealityLayerView: View {
             case .loaded(let cameraFeedManager):
                 if let cameraFeedManager = cameraFeedManager.cameraFeedManager,
                    let arView = cameraFeedManager.arView {
-                    CameraRealityView(arView: arView,
+                    CameraRealityView(arView: arView.arView,
                                       size: layerSize,
                                       scale: scale,
                                       opacity: opacity,

--- a/Stitch/Graph/Node/Model/Definition/NodeDefinition.swift
+++ b/Stitch/Graph/Node/Model/Definition/NodeDefinition.swift
@@ -47,7 +47,7 @@ extension Layer {
     }
 }
 
-typealias LayerRealityCameraContent = ARView
+typealias LayerRealityCameraContent = StitchARView
 
 // fka `LayerGraphNode`
 protocol LayerNodeDefinition: NodeDefinition {

--- a/Stitch/Graph/Node/Patch/Type/ARRaycastingNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/ARRaycastingNode.swift
@@ -72,7 +72,7 @@ func arRayCastingEval(node: PatchNode) -> EvalResult {
     let arView = node.graphDelegate?.cameraFeed?.arView
         
     // Must be accessed on main thread
-    let centerPoint = arView?.center ?? .zero
+    let centerPoint = arView?.arView.center ?? .zero
 
     return node.loopedEval(MediaEvalOpObserver.self) { values, mediaObserver, loopIndex in
         // Needs to have AR view

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/AR/RealityView.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/AR/RealityView.swift
@@ -12,13 +12,13 @@ import StitchSchemaKit
 
 struct CameraRealityView: UIViewRepresentable {
     // AR view must already be created in media manager
-    let arView: StitchARView
+    let arView: ARView
     let size: LayerSize
     let scale: Double
     let opacity: Double
     let isShadowsEnabled: Bool
     
-    func makeUIView(context: Context) -> StitchARView {
+    func makeUIView(context: Context) -> ARView {
         arView.environment.background = .cameraFeed()
         arView.cameraMode = .ar
         arView.renderOptions = isShadowsEnabled ? [] : [.disableGroundingShadows]
@@ -26,7 +26,7 @@ struct CameraRealityView: UIViewRepresentable {
         return arView
     }
     
-    func updateUIView(_ uiView: StitchARView, context: Context) {
+    func updateUIView(_ uiView: ARView, context: Context) {
         uiView.frame.size = size.asAlgebraicCGSize
         uiView.alpha = opacity
         uiView.transform = CGAffineTransform(scaleX: scale, y: scale)
@@ -41,11 +41,11 @@ struct NonCameraRealityView: UIViewRepresentable {
     let opacity: Double
     let isShadowsEnabled: Bool
     
-    func makeUIView(context: Context) -> StitchARView {
+    func makeUIView(context: Context) -> ARView {
         let arView = StitchARView(cameraMode: .nonAR)
-        arView.environment.background = .color(.clear)
-        arView.cameraMode = .nonAR
-        arView.renderOptions = isShadowsEnabled ? [] : [.disableGroundingShadows]
+        arView.arView.environment.background = .color(.clear)
+        arView.arView.cameraMode = .nonAR
+        arView.arView.renderOptions = isShadowsEnabled ? [] : [.disableGroundingShadows]
         
         // MARK: useful for debugging gestures
 //        arView.debugOptions = .showPhysics
@@ -53,10 +53,10 @@ struct NonCameraRealityView: UIViewRepresentable {
         // Update object with scene
         layerViewModel.realityContent = arView
         
-        return arView
+        return arView.arView
     }
     
-    func updateUIView(_ uiView: StitchARView, context: Context) {        
+    func updateUIView(_ uiView: ARView, context: Context) {
         uiView.frame.size = size.asAlgebraicCGSize
         uiView.alpha = opacity
         uiView.transform = CGAffineTransform(scaleX: scale, y: scale)


### PR DESCRIPTION
New ARViews weren't creating new render cycles, which were needed to fix an issue where a 3D model layer could be dragged in/out of a reality view but not re-appear in the scene.