### PR TITLE
SpringAnimationState: Do not crash with fatalError on production

### DIFF
--- a/Stitch/Graph/Node/Port/Util/TypeChange/NodeTypeChangedHelpers.swift
+++ b/Stitch/Graph/Node/Port/Util/TypeChange/NodeTypeChangedHelpers.swift
@@ -112,9 +112,12 @@ extension SpringAnimationState {
         // eg from Number to Position
         case .position:
             return .two(.init())
+            
+        // Currently, only .number and .position are supported
         default:
             // Crash if we don't recognize the nodeType
-            fatalError()
+            fatalErrorIfDebug()
+            return .two(.init())
         }
     }
 }


### PR DESCRIPTION
There are probably a few other places where we are using fatal errors that would cause an undesired crash on a release build. 

We encountered this on a TestFlight for AI work.

TODO: support more node-types in Spring Animation patch?