### PR TITLE
Use the nodeId from the Step created by the LLModel

### DIFF
--- a/Stitch/Graph/Node/Util/NodeCreatedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeCreatedAction.swift
@@ -56,12 +56,14 @@ extension StitchDocumentViewModel {
 
     // Used by InsertNodeMenu
     @MainActor
-    func nodeCreated(choice: NodeKind, center: CGPoint? = nil) -> NodeViewModel? {
+    func nodeCreated(choice: NodeKind,
+                     nodeId: UUID? = nil,
+                     center: CGPoint? = nil) -> NodeViewModel? {
         let nodeCenter = center ?? self.newNodeCenterLocation
         
         guard let node = self.createNode(
                 graphTime: self.graphStepManager.graphStepState.graphTime,
-                newNodeId: UUID(),
+                newNodeId: nodeId ?? UUID(),
                 highestZIndex: self.visibleGraph.highestZIndex,
                 choice: choice,
                 center: nodeCenter) else {

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StepActionToStateChange.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StepActionToStateChange.swift
@@ -51,8 +51,11 @@ extension StitchDocumentViewModel {
         case .addNode:
             
             guard let llmNodeId: String = action.nodeId,
+                  let nodeId: NodeId = UUID(uuidString: llmNodeId),
                   let nodeKind: PatchOrLayer = action.parseNodeKind(),
+                    // Need to explicitly pass in the nodeId from the action
                   let newNode = self.nodeCreated(choice: nodeKind.asNodeKind,
+                                                 nodeId: nodeId,
                                                  center: newCenter) else {
                 
                 log("❌ handleLLMStepAction: addNode failed:")


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/6820

## before
<img width="1184" alt="Screenshot 2025-01-25 at 7 04 03 PM" src="https://github.com/user-attachments/assets/f8d8848d-c448-4f53-9ad1-34c5606d8abf" />

## after
<img width="1160" alt="Screenshot 2025-01-25 at 7 05 40 PM" src="https://github.com/user-attachments/assets/4d2f8380-331e-4abc-aa3a-1eb3489c5bb3" />

