### PR TITLE
Do not open LLM Edit Modal when regular recording session ends

### DIFF
--- a/Stitch/Graph/StitchAI/DatasetRecording/LLMActionRecording.swift
+++ b/Stitch/Graph/StitchAI/DatasetRecording/LLMActionRecording.swift
@@ -102,7 +102,6 @@ extension StitchDocumentViewModel {
         }
     }
     
-    // When prompt modal is closed, we write the JSON of prompt + actions to file.
     @MainActor func closedLLMRecordingPrompt() {
         let currentMode = self.llmRecording.mode
         log("📼 💾 Closing LLM Recording Prompt - Saving Data 💾 📼")
@@ -119,7 +118,10 @@ extension StitchDocumentViewModel {
             return
         }
         
-        dispatch(ShowLLMEditModal())
+        // Only open the Edit Modal if we were in Augment mode
+        if currentMode == .augmentation {
+            dispatch(ShowLLMEditModal())
+        }
     }
 }
 

--- a/Stitch/Graph/StitchAI/DatasetRecording/LLMRecordingState.swift
+++ b/Stitch/Graph/StitchAI/DatasetRecording/LLMRecordingState.swift
@@ -19,8 +19,7 @@ enum LLMRecordinModal: Equatable, Hashable {
     // No active modal
     case none
     
-    // Modal from which we can edit the LLM actions (created by model + user)
-    // and then either (1) test and submit or (2) completely cancel.
+    // Modal from which user can edit LLM Actions (remove those created by model or user; add new ones by interacting with the graph)
     case editBeforeSubmit
     
     // Modal from which either (1) re-enter LLM edit mode or (2) finally approve the LLM action list and send to Supabase

--- a/Stitch/Graph/StitchAI/GraphPrompting/API/OpenAIRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/OpenAIRequest.swift
@@ -76,7 +76,6 @@ struct MakeOpenAIRequest: StitchDocumentEvent {
                 userPrompt: prompt,
                 jsonResponse: nil
             )
-//            state.graphUI.insertNodeMenuState.isGeneratingAINode = false
             return
         }
 
@@ -141,12 +140,7 @@ struct MakeOpenAIRequest: StitchDocumentEvent {
             )
             return
         }
-        
-//        // Update UI state for first attempt
-//        if attempt == 1 {
-//            state.stitchAI.promptState.isGenerating = true
-//        }
-        
+                
         // Execute network request
         URLSession.shared.dataTask(with: request) { data, response, error in
             DispatchQueue.main.async {
@@ -163,7 +157,6 @@ struct MakeOpenAIRequest: StitchDocumentEvent {
                                 userPrompt: prompt,
                                 jsonResponse: nil
                             )
-//                            state.stitchAI.promptState.isGenerating = false
                             state.graphUI.insertNodeMenuState.isGeneratingAINode = false
                             Self.timeoutErrorCount = 0  // Reset counter
                             return
@@ -187,7 +180,6 @@ struct MakeOpenAIRequest: StitchDocumentEvent {
                             jsonResponse: nil
                         )
                         // Reset to Submit Prompt state
-//                        state.stitchAI.promptState.isGenerating = false
                         state.graphUI.insertNodeMenuState.isGeneratingAINode = false
                         return
                     }

--- a/Stitch/Graph/StitchAI/GraphPrompting/API/OpenAIRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/OpenAIRequest.swift
@@ -30,6 +30,7 @@ struct OpenAIRequestConfig {
     )
 }
 
+// Note: an event is usually not a long-lived data structure; but this is used for retry attempts.
 /// Main event handler for initiating OpenAI API requests
 struct MakeOpenAIRequest: StitchDocumentEvent {
     private let OPEN_AI_BASE_URL = "https://api.openai.com/v1/chat/completions"
@@ -75,8 +76,7 @@ struct MakeOpenAIRequest: StitchDocumentEvent {
                 userPrompt: prompt,
                 jsonResponse: nil
             )
-            state.stitchAI.promptState.isGenerating = false
-            state.graphUI.insertNodeMenuState.isGeneratingAINode = false
+//            state.graphUI.insertNodeMenuState.isGeneratingAINode = false
             return
         }
 
@@ -89,8 +89,6 @@ struct MakeOpenAIRequest: StitchDocumentEvent {
                 userPrompt: prompt,
                 jsonResponse: nil
             )
-            state.stitchAI.promptState.isGenerating = false
-            state.graphUI.insertNodeMenuState.isGeneratingAINode = false
             return
         }
         
@@ -144,10 +142,10 @@ struct MakeOpenAIRequest: StitchDocumentEvent {
             return
         }
         
-        // Update UI state for first attempt
-        if attempt == 1 {
-            state.stitchAI.promptState.isGenerating = true
-        }
+//        // Update UI state for first attempt
+//        if attempt == 1 {
+//            state.stitchAI.promptState.isGenerating = true
+//        }
         
         // Execute network request
         URLSession.shared.dataTask(with: request) { data, response, error in
@@ -165,7 +163,7 @@ struct MakeOpenAIRequest: StitchDocumentEvent {
                                 userPrompt: prompt,
                                 jsonResponse: nil
                             )
-                            state.stitchAI.promptState.isGenerating = false
+//                            state.stitchAI.promptState.isGenerating = false
                             state.graphUI.insertNodeMenuState.isGeneratingAINode = false
                             Self.timeoutErrorCount = 0  // Reset counter
                             return
@@ -189,7 +187,7 @@ struct MakeOpenAIRequest: StitchDocumentEvent {
                             jsonResponse: nil
                         )
                         // Reset to Submit Prompt state
-                        state.stitchAI.promptState.isGenerating = false
+//                        state.stitchAI.promptState.isGenerating = false
                         state.graphUI.insertNodeMenuState.isGeneratingAINode = false
                         return
                     }
@@ -200,7 +198,7 @@ struct MakeOpenAIRequest: StitchDocumentEvent {
                         userPrompt: prompt,
                         jsonResponse: nil
                     )
-                    state.stitchAI.promptState.isGenerating = false
+
                     state.graphUI.insertNodeMenuState.isGeneratingAINode = false
                     return
                 }
@@ -295,14 +293,13 @@ struct OpenAIRequestCompleted: StitchDocumentEvent {
             )
         }
         
-        state.closeStitchAIModal()
+        state.graphUI.reduxFocusedField = nil
         state.graphUI.insertNodeMenuState.show = false
         state.graphUI.insertNodeMenuState.isGeneratingAINode = false
     }
     
     /// Main handler for completed requests
     func handle(state: StitchDocumentViewModel) {
-        state.stitchAI.promptState.isGenerating = false
         
         if let error = error {
             state.showErrorModal(
@@ -346,7 +343,6 @@ struct OpenAIRequestCompleted: StitchDocumentEvent {
     
     @MainActor func handleError(_ error: Error, state: StitchDocumentViewModel) {
         log("Error generating graph with StitchAI: \(error)", .logToServer)
-        state.stitchAI.promptState.isGenerating = false
         state.graphUI.insertNodeMenuState.show = false
         state.graphUI.insertNodeMenuState.isGeneratingAINode = false
     }

--- a/Stitch/Graph/StitchAI/GraphPrompting/API/OpenAIRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/OpenAIRequest.swift
@@ -282,9 +282,7 @@ struct OpenAIRequestCompleted: StitchDocumentEvent {
         log(" Original Actions to store: \(steps.asJSONDisplay())")
         state.llmRecording.actions = steps
         state.llmRecording.promptState.prompt = originalPrompt
-        
-        state.lastAIGeneratedPrompt = originalPrompt
-        
+                
         var canvasItemsAdded = 0
         steps.forEach { step in
             canvasItemsAdded = state.handleLLMStepAction(

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StepActionToStateChange.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StepActionToStateChange.swift
@@ -31,7 +31,7 @@ extension StitchDocumentViewModel {
             log("   - Node ID: \(action.nodeId ?? "nil")")
             log("   - Node Name: \(action.nodeName ?? "nil")")
             log("   - Port: \(action.port?.value ?? "nil")")
-            stitchAI.promptState.isGenerating = false
+//            stitchAI.promptState.isGenerating = false
             return canvasItemsAdded
         }
         
@@ -170,11 +170,6 @@ extension StitchDocumentViewModel {
                                          input: input,
                                          coordinate: layerInput,
                                          manualLLMStepCenter: newCenter)
-
-//            // TODO: why do we have to do this?
-//            if let layerNode = node.layerNode {
-//                graph.resetLayerInputsCache(layerNode: layerNode)
-//            }
             
             return canvasItemsAdded + 1
             
@@ -244,13 +239,13 @@ extension StitchDocumentViewModel {
     @MainActor
     private func retryOpenAIRequest() {
         // Re-trigger the OpenAI request with the original prompt
-        if let lastPrompt = stitchAI.promptState.lastPrompt,
+        if let lastPrompt = stitchAI.lastPrompt,
            !lastPrompt.isEmpty {
             log("🔄 Retrying OpenAI request with last prompt")
             dispatch(MakeOpenAIRequest(prompt: lastPrompt))
         } else {
             log("❌ Cannot retry OpenAI request: No last prompt available")
-            stitchAI.promptState.isGenerating = false
+//            stitchAI.promptState.isGenerating = false
         }
     }
 }

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StepActionToStateChange.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StepActionToStateChange.swift
@@ -31,7 +31,6 @@ extension StitchDocumentViewModel {
             log("   - Node ID: \(action.nodeId ?? "nil")")
             log("   - Node Name: \(action.nodeName ?? "nil")")
             log("   - Port: \(action.port?.value ?? "nil")")
-//            stitchAI.promptState.isGenerating = false
             return canvasItemsAdded
         }
         
@@ -245,7 +244,6 @@ extension StitchDocumentViewModel {
             dispatch(MakeOpenAIRequest(prompt: lastPrompt))
         } else {
             log("❌ Cannot retry OpenAI request: No last prompt available")
-//            stitchAI.promptState.isGenerating = false
         }
     }
 }

--- a/Stitch/Graph/StitchAI/GraphPrompting/StitchAIEvents.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/StitchAIEvents.swift
@@ -10,39 +10,7 @@ import SwiftUI
 import SwiftyJSON
 
 extension StitchDocumentViewModel {
-    
-    @MainActor
-    func openedStitchAIModal() {
-        self.stitchAI.promptState.showModal = true
-        self.graphUI.reduxFocusedField = .stitchAIPromptModal
-    }
-    
-    // When json-entry modal is closed, we turn the JSON of LLMActions into state changes
-    @MainActor
-    func closedStitchAIModal() {
-        let prompt = self.stitchAI.promptState.prompt
-        
-        self.stitchAI.promptState.showModal = false
-        self.graphUI.reduxFocusedField = nil
-        
-        // HACK until we figure out why this is called twice
-        if prompt == "" {
-            return
-        }
-        
-        // Only submit API request via 'submit'
-        // dispatch(MakeOpenAIRequest(prompt: prompt))
-        
-        self.stitchAI.promptState.prompt = ""
-    }
-    
-    @MainActor
-    func closeStitchAIModal() {
-        self.stitchAI.promptState.showModal = false
-        self.stitchAI.promptState.prompt = ""
-        self.graphUI.reduxFocusedField = nil
-    }
-    
+     
     func showErrorModal(message: String, userPrompt: String, jsonResponse: String?) {
         DispatchQueue.main.async {
             if let rootViewController = UIApplication.shared.windows.first?.rootViewController {
@@ -54,16 +22,5 @@ extension StitchDocumentViewModel {
                 rootViewController.present(hostingController, animated: true, completion: nil)
             }
         }
-    }
-}
-
-struct StitchAIPromptSubmitted: StitchDocumentEvent {
-    @MainActor func handle(state: StitchDocumentViewModel) {
-        let prompt = state.stitchAI.promptState.prompt
-        // Store the prompt as the lastPrompt before making the request
-        state.stitchAI.promptState.lastPrompt = prompt
-        state.stitchAI.promptState.showModal = false
-        
-        dispatch(MakeOpenAIRequest(prompt: prompt))
     }
 }

--- a/Stitch/Graph/StitchAI/GraphPrompting/UI/StitchAIPromptView.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/UI/StitchAIPromptView.swift
@@ -7,51 +7,9 @@
 
 import SwiftUI
 
-struct StitchAIPromptEntryModalView: View {
-    @Binding var prompt: String
-    let isGenerating: Bool
-    let onSubmit: (String) -> Void
-    
-    var body: some View {
-        VStack(alignment: .leading) {
-            StitchTextView(string: "Enter prompt to generate a project")
-            Divider()
-            TextEditor(text: $prompt)
-                .font(STITCH_FONT)
-                .scrollContentBackground(.hidden)
-            
-            if isGenerating {
-                Text("Generating response...")
-                    .font(STITCH_FONT)
-                    .foregroundColor(.gray)
-                    .padding(.top)
-            } else {
-                Button("Submit") {
-                    onSubmit(prompt)
-                }
-                .disabled(prompt.isEmpty)
-                .padding(.top)
-            }
-        }
-        .padding()
-    }
-}
-
 struct StitchAIState: Equatable {
-    var promptState = StitchAIPromptState()
-}
-
-struct StitchAIPromptState: Equatable {
-    var showModal = false
-    var prompt: String = ""
-    var isGenerating = false
+    // Saved prompt from insert-node-menu, used during retries
+    // TODO: don't need this? can just grab from InsertNodeMenuState?
     var lastPrompt: String? = nil
 }
 
-struct StitchAIPromptEdited: StitchDocumentEvent {
-    let prompt: String
-    
-    func handle(state: StitchDocumentViewModel) {
-        state.stitchAI.promptState.prompt = prompt
-    }
-}

--- a/Stitch/Graph/StitchAI/GraphPrompting/UI/StitchAIPromptView.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/UI/StitchAIPromptView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct StitchAIState: Equatable {
     // Saved prompt from insert-node-menu, used during retries
-    // TODO: don't need this? can just grab from InsertNodeMenuState?
+    // TODO: don't need this? can just grab from InsertNodeMenuState.searchQuery?
     var lastPrompt: String? = nil
 }
-

--- a/Stitch/Graph/Util/GraphUIActions.swift
+++ b/Stitch/Graph/Util/GraphUIActions.swift
@@ -156,18 +156,23 @@ struct InsertNodeSelectionChanged: GraphUIEvent {
 }
 
 /// Process search results in the insert node menu sheet
-struct GenerateAINode: GraphEvent {
+struct GenerateAINode: StitchDocumentEvent {
     let prompt: String
     
-    func handle(state: GraphState) {
+    func handle(state: StitchDocumentViewModel) {
         print("🤖 🔥 GENERATE AI NODE - STARTING AI GENERATION MODE 🔥 🤖")
         print("🤖 Prompt: \(prompt)")
         
         // Set loading state
-        state.graphUI.insertNodeMenuState.isGeneratingAINode = true
+        state.graph.graphUI.insertNodeMenuState.isGeneratingAINode = true
+        
         // Set flag to indicate this is from AI generation
-        state.graphUI.insertNodeMenuState.isFromAIGeneration = true
-        print("🤖 isFromAIGeneration set to: \(state.graphUI.insertNodeMenuState.isFromAIGeneration)")
+        state.graph.graphUI.insertNodeMenuState.isFromAIGeneration = true
+        
+        print("🤖 isFromAIGeneration set to: \(state.graph.graphUI.insertNodeMenuState.isFromAIGeneration)")
+        
+        // Update lastPrompt for retry attempts
+        state.stitchAI.lastPrompt = prompt
         
         // Dispatch OpenAI request
         dispatch(MakeOpenAIRequest(prompt: prompt))

--- a/Stitch/Graph/View/ContentView.swift
+++ b/Stitch/Graph/View/ContentView.swift
@@ -160,20 +160,6 @@ struct ContentView: View, KeyboardReadable {
                      sheetBody: {
             LLMPromptModalView(actionsAsDisplay: document.llmRecording.promptState.actionsAsDisplayString)
         })
-        
-        // NOTE: THIS IS ACTUALLY ONLY FOR SHOWING AN ERROR MODAL LIKE "THE MODEL COULD NOT CREATE A LIST OF ACTIONS AFTER 3 ATTEMPTS"
-        .stitchSheet(isPresented: document.stitchAI.promptState.showModal,
-                      titleLabel: "Stitch AI",
-                      hideAction: document.closedStitchAIModal,
-                      sheetBody: {
-             StitchAIPromptEntryModalView(
-                 prompt: $document.stitchAI.promptState.prompt,
-                 isGenerating: document.stitchAI.promptState.isGenerating,
-                 onSubmit: { prompt in
-                     dispatch(MakeOpenAIRequest(prompt: prompt))
-                 }
-             )
-         })
     }
 
     private var fullScreenPreviewView: some View {

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -426,11 +426,6 @@ extension GraphState {
     var llmRecording: LLMRecordingState {
         self.documentDelegate?.llmRecording ?? .init()
     }
-        
-    @MainActor
-    var lastAIGeneratedPrompt: String {
-        self.documentDelegate?.lastAIGeneratedPrompt ?? .init()
-    }
     
     @MainActor
     var graphStepManager: GraphStepManager {

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -39,10 +39,7 @@ final class StitchDocumentViewModel: Sendable {
     @MainActor var keypressState = KeyPressState()
     
     @MainActor var llmRecording = LLMRecordingState()
-    
-    //
-    @MainActor var lastAIGeneratedPrompt: String = ""
-    
+        
     @MainActor var stitchAI = StitchAIState()
 
     

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -37,10 +37,15 @@ final class StitchDocumentViewModel: Sendable {
     @MainActor var cameraSettings = CameraSettings()
     
     @MainActor var keypressState = KeyPressState()
+    
     @MainActor var llmRecording = LLMRecordingState()
+    
+    //
     @MainActor var lastAIGeneratedPrompt: String = ""
+    
     @MainActor var stitchAI = StitchAIState()
 
+    
     // Remains false if an encoding action never happened (used for thumbnail creation)
     @MainActor var didDocumentChange: Bool = false
     


### PR DESCRIPTION
This PR:
1. LLM Edit Modal would open when regular recording modal closed (messed up Supabase uploads)
2. Cleans up code (mostly removes older implementation)