### PR TITLE
Record user's actions when "Edit Before Submit" modal is open; visually indicate AI-created nodes etc.

### DIFF
--- a/Stitch/Graph/Node/View/NodeView.swift
+++ b/Stitch/Graph/Node/View/NodeView.swift
@@ -138,6 +138,14 @@ struct NodeView<InputsViews: View, OutputsViews: View>: View {
                 .cornerRadius(CANVAS_ITEM_CORNER_RADIUS)
                 .allowsHitTesting(!isLayerInvisible)
         }
+        // TODO: perf cost?
+        .overlay {
+            let isAICreated = graph.llmRecording.nodeIdToNameMapping.get(stitch.id).isDefined
+//            Color.blue.opacity(isAICreated ? 0.3 : 0)
+            Color.blue.opacity(isAICreated ? 0.2 : 0)
+                .cornerRadius(CANVAS_ITEM_CORNER_RADIUS)
+                .allowsHitTesting(!isAICreated)
+        }
         .modifier(CanvasItemBackground(color: nodeUIColor.body))
         
         .modifier(CanvasItemSelectedViewModifier(isSelected: isSelected))

--- a/Stitch/Graph/StitchAI/DatasetRecording/LLMActionHelpers.swift
+++ b/Stitch/Graph/StitchAI/DatasetRecording/LLMActionHelpers.swift
@@ -7,13 +7,14 @@
 
 import Foundation
 
-struct LLMAugmentationStarted: StitchDocumentEvent {
-    func handle(state: StitchDocumentViewModel) {
-        state.llmRecording.mode = .augmentation
-        state.llmRecording.isRecording = true
-        state.llmRecording.modal = .none
-    }
-}
+//struct LLMAugmentationStarted: StitchDocumentEvent {
+//    func handle(state: StitchDocumentViewModel) {
+//        state.llmRecording.mode = .augmentation
+//        state.llmRecording.isRecording = true
+////        state.llmRecording.modal = .none
+//        state.llmRecording.modal = .editBeforeSubmit
+//    }
+//}
 
 // WE CANCELLED THE WHOLE THING
 struct LLMAugmentationCancelled: StitchDocumentEvent {
@@ -30,7 +31,11 @@ struct ShowLLMApprovalModal: StitchDocumentEvent {
         log("ShowLLMApprovalModal called")
         
         // Don't need to do this again here, since we've already done it whenever user edits the LLMAction list
-        // state.reapplyLLMActions()
+        // TODO: should not need to do this final application again, not really?
+        state.reapplyLLMActions()
+        
+        // End recording when we open the final submit
+        state.llmRecordingEnded()
         
         // Show modal
         state.llmRecording.modal = .approveAndSubmit
@@ -40,6 +45,14 @@ struct ShowLLMApprovalModal: StitchDocumentEvent {
 struct ShowLLMEditModal: StitchDocumentEvent {
     func handle(state: StitchDocumentViewModel) {
         log("ShowLLMEditModal called")
+//        state.llmRecording.modal = .editBeforeSubmit
+        
+//        state.llmRecordingStarted()
+        state.llmRecording.isRecording = true
+        
+        // Always treat edit modal as an augmentation
+        state.llmRecording.mode = .augmentation
+        
         state.llmRecording.modal = .editBeforeSubmit
     }
 }

--- a/Stitch/Graph/StitchAI/DatasetRecording/LLMActionHelpers.swift
+++ b/Stitch/Graph/StitchAI/DatasetRecording/LLMActionHelpers.swift
@@ -7,15 +7,6 @@
 
 import Foundation
 
-//struct LLMAugmentationStarted: StitchDocumentEvent {
-//    func handle(state: StitchDocumentViewModel) {
-//        state.llmRecording.mode = .augmentation
-//        state.llmRecording.isRecording = true
-////        state.llmRecording.modal = .none
-//        state.llmRecording.modal = .editBeforeSubmit
-//    }
-//}
-
 // WE CANCELLED THE WHOLE THING
 struct LLMAugmentationCancelled: StitchDocumentEvent {
     
@@ -45,9 +36,7 @@ struct ShowLLMApprovalModal: StitchDocumentEvent {
 struct ShowLLMEditModal: StitchDocumentEvent {
     func handle(state: StitchDocumentViewModel) {
         log("ShowLLMEditModal called")
-//        state.llmRecording.modal = .editBeforeSubmit
-        
-//        state.llmRecordingStarted()
+
         state.llmRecording.isRecording = true
         
         // Always treat edit modal as an augmentation

--- a/Stitch/Graph/StitchAI/DatasetRecording/LLMActionRecording.swift
+++ b/Stitch/Graph/StitchAI/DatasetRecording/LLMActionRecording.swift
@@ -34,6 +34,9 @@ struct LLMRecordingToggled: GraphEvent {
             // Set augmentation mode
             document.llmRecording.mode = .augmentation
             
+            // Open the Edit-before-submit modal
+            document.llmRecording.modal = .editBeforeSubmit
+            
             // We keep the actions as they are - don't clear them
             log("🤖 💾 Verified Actions Count: \(currentActions.count)")
             log("🤖 💾 Verified Actions Content: \(currentActions.asJSONDisplay())")

--- a/Stitch/Graph/StitchAI/DatasetRecording/LLMModalViews.swift
+++ b/Stitch/Graph/StitchAI/DatasetRecording/LLMModalViews.swift
@@ -19,7 +19,7 @@ struct LLMApprovalModalView: View {
                 Button {
                     dispatch(ShowLLMEditModal())
                 } label: {
-                    Text("Add More")
+                    Text("Edit")
                 }
                 
                 Button {
@@ -28,7 +28,7 @@ struct LLMApprovalModalView: View {
                     // call the logic in `SupabaseManager.uploadLLMRecording`
                     dispatch(SubmitLLMActionsToSupabase())
                 } label: {
-                    Text("Submit") // "Send to Supabase"
+                    Text("Upload") // "Send to Supabase"
                 }
             }
             

--- a/Stitch/Graph/StitchAI/DatasetRecording/LLMRecordingState.swift
+++ b/Stitch/Graph/StitchAI/DatasetRecording/LLMRecordingState.swift
@@ -33,13 +33,70 @@ struct LLMRecordingState: Equatable {
     
     var mode: LLMRecordingMode = .normal
     
-    var actions: [LLMStepAction] = .init()
+    var actions: [LLMStepAction] = .init() {
+        didSet {
+            var acc = [NodeId: String]()
+            self.actions.forEach { (action: LLMStepAction) in
+                // Add Node step uses nodeId; but Connect Nodes step uses toNodeId and fromNodeId
+                if let nodeId = action.parseNodeId,
+                   let nodeName = action.nodeName {
+                    acc.updateValue(nodeName, forKey: nodeId)
+                }
+                
+                if let nodeId = action.fromNodeId?.parseNodeId,
+                   let nodeName = action.nodeName {
+                    acc.updateValue(nodeName, forKey: nodeId)
+                }
+                
+                if let nodeId = action.toNodeId?.parseNodeId,
+                   let nodeName = action.nodeName {
+                    acc.updateValue(nodeName, forKey: nodeId)
+                }
+                
+                log("LLMRecordingState: nodeIdToNameMapping: \(acc)")
+            } // forEach
+            
+            return self.nodeIdToNameMapping = acc
+        }
+    }
     
     var promptState = LLMPromptState()
     
     var jsonEntryState = LLMJsonEntryState()
     
     var modal: LLMRecordinModal = .none
+
+    // Maps nodeIds to Patch/Layer name;
+    // Also serves as source of truth for which nodes (ids) have been created by
+
+    // Alternatively: use a stored var that is updated by `self.actions`'s `didSet`
+    // Note: it's okay for this just to be patch nodes and entire layer nodes; any layer inputs from an AI-created layer node will be 'blue' 
+    var nodeIdToNameMapping: [NodeId: String] = .init()
+//    {
+//        var acc = [NodeId: String]()
+//        self.actions.forEach { (action: LLMStepAction) in
+//            // Add Node step uses nodeId; but Connect Nodes step uses toNodeId and fromNodeId
+//            if let nodeId = action.parseNodeId,
+//               let nodeName = action.nodeName {
+//                acc.updateValue(nodeName, forKey: nodeId)
+//            }
+//            
+//            if let nodeId = action.fromNodeId?.parseNodeId,
+//               let nodeName = action.nodeName {
+//                acc.updateValue(nodeName, forKey: nodeId)
+//            }
+//            
+//            if let nodeId = action.toNodeId?.parseNodeId,
+//               let nodeName = action.nodeName {
+//                acc.updateValue(nodeName, forKey: nodeId)
+//            }
+//            
+//            log("LLMRecordingState: nodeIdToNameMapping: \(acc)")
+//        } // forEach
+//        
+//        return acc
+//    }
+    
 }
 
 extension StitchDocumentViewModel {

--- a/Stitch/Graph/StitchAI/GraphPrompting/UI/EditBeforeSubmitModalView.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/UI/EditBeforeSubmitModalView.swift
@@ -21,7 +21,10 @@ struct EditBeforeSubmitModalView: View {
         recordingState.actions
     }
     
-    @State private var nodeIdToNameMapping: [String: String] = .init()
+//    @State private var nodeIdToNameMapping: [String: String] = .init()
+    var nodeIdToNameMapping: [NodeId: String] {
+        recordingState.nodeIdToNameMapping
+    }
     
     var body: some View {
         VStack {
@@ -50,13 +53,6 @@ struct EditBeforeSubmitModalView: View {
             }
             
             Button(action: {
-                dispatch(LLMAugmentationStarted())
-            }) {
-                Text("Add More")
-                    .padding()
-            }
-            
-            Button(action: {
                 log("will complete and dismiss")
                 dispatch(ShowLLMApprovalModal())
             }) {
@@ -70,29 +66,30 @@ struct EditBeforeSubmitModalView: View {
     var actionsView: some View {
         VStack {
             StitchTextView(string: "Prompt: \(prompt)")
-                .onAppear {
-                    // Note: must do this here and not in view's `init`?
-                    // Alternatively, pass in the data/mapping already created
-                    actions.forEach { (action: LLMStepAction) in
-                        // Add Node step uses nodeId; but Connect Nodes step uses toNodeId and fromNodeId
-                        if let nodeId = action.nodeId,
-                           let nodeName = action.nodeName {
-                            self.nodeIdToNameMapping.updateValue(nodeName, forKey: nodeId)
-                        }
-                        
-                        if let nodeId = action.fromNodeId,
-                           let nodeName = action.nodeName {
-                            self.nodeIdToNameMapping.updateValue(nodeName, forKey: nodeId)
-                        }
-                        
-                        if let nodeId = action.toNodeId,
-                           let nodeName = action.nodeName {
-                            self.nodeIdToNameMapping.updateValue(nodeName, forKey: nodeId)
-                        }
-                        
-                        log("self.nodeIdToNameMapping is now: \(self.nodeIdToNameMapping)")
-                    }
-                }
+//                .onAppear {
+//                .onChange(of: self.actions, initial: true) { oldValue, newValue in
+//                    // Note: must do this here and not in view's `init`?
+//                    // Alternatively, pass in the data/mapping already created
+//                    newValue.forEach { (action: LLMStepAction) in
+//                        // Add Node step uses nodeId; but Connect Nodes step uses toNodeId and fromNodeId
+//                        if let nodeId = action.nodeId,
+//                           let nodeName = action.nodeName {
+//                            self.nodeIdToNameMapping.updateValue(nodeName, forKey: nodeId)
+//                        }
+//                        
+//                        if let nodeId = action.fromNodeId,
+//                           let nodeName = action.nodeName {
+//                            self.nodeIdToNameMapping.updateValue(nodeName, forKey: nodeId)
+//                        }
+//                        
+//                        if let nodeId = action.toNodeId,
+//                           let nodeName = action.nodeName {
+//                            self.nodeIdToNameMapping.updateValue(nodeName, forKey: nodeId)
+//                        }
+//                        
+//                        log("self.nodeIdToNameMapping is now: \(self.nodeIdToNameMapping)")
+//                    }
+//                }
             
             // `id:` by hashable ought to be okay?
             ForEach(actions, id: \.hashValue) { (action: LLMStepAction) in
@@ -106,11 +103,11 @@ struct EditBeforeSubmitModalView: View {
 
 struct LLMActionToNodeAndPortView: View {
     let action: Step
-    let nodeIdToNameMapping: [String: String]
+    let nodeIdToNameMapping: [NodeId: String]
     
     var body: some View {
         // Step.fromNodeId
-        if let toNodeId = action.toNodeId,
+        if let toNodeId = action.toNodeId?.parseNodeId,
            let toNodeKind = nodeIdToNameMapping.get(toNodeId)?.parseNodeKind() {
             StitchTextView(string: "To Node: \(toNodeKind.asNodeKind.description), \(toNodeId.debugFriendlyId)")
             
@@ -138,11 +135,11 @@ struct LLMFromPortDisplayView: View {
 
 struct LLMActionFromNodeView: View {
     let action: Step
-    let nodeIdToNameMapping: [String: String]
+    let nodeIdToNameMapping: [NodeId: String]
     
     var body: some View {
         // Step.fromNodeId
-        if let fromNodeId = action.fromNodeId,
+        if let fromNodeId = action.fromNodeId?.parseNodeId,
            let fromNodeKind = nodeIdToNameMapping.get(fromNodeId)?.parseNodeKind() {
             StitchTextView(string: "From Node: \(fromNodeKind.asNodeKind.description), \(fromNodeId.debugFriendlyId)")
         }
@@ -186,14 +183,14 @@ struct LLMPortDisplayView: View {
 
 struct LLMActionCorrectionView: View {
     let action: Step
-    let nodeIdToNameMapping: [String: String]
+    let nodeIdToNameMapping: [NodeId: String]
     
     var body: some View {
         
         VStack(alignment: .leading, spacing: 8) {
             stepTypeAndDeleteView
             
-            if let nodeId = action.nodeId,
+            if let nodeId = action.parseNodeId,
                let nodeKind: PatchOrLayer = nodeIdToNameMapping.get(nodeId)?.parseNodeKind() {
                 StitchTextView(string: "Node: \(nodeKind.asNodeKind.description) \(nodeId.debugFriendlyId)")
                 

--- a/Stitch/Graph/StitchAI/GraphPrompting/UI/EditBeforeSubmitModalView.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/UI/EditBeforeSubmitModalView.swift
@@ -66,31 +66,7 @@ struct EditBeforeSubmitModalView: View {
     var actionsView: some View {
         VStack {
             StitchTextView(string: "Prompt: \(prompt)")
-//                .onAppear {
-//                .onChange(of: self.actions, initial: true) { oldValue, newValue in
-//                    // Note: must do this here and not in view's `init`?
-//                    // Alternatively, pass in the data/mapping already created
-//                    newValue.forEach { (action: LLMStepAction) in
-//                        // Add Node step uses nodeId; but Connect Nodes step uses toNodeId and fromNodeId
-//                        if let nodeId = action.nodeId,
-//                           let nodeName = action.nodeName {
-//                            self.nodeIdToNameMapping.updateValue(nodeName, forKey: nodeId)
-//                        }
-//                        
-//                        if let nodeId = action.fromNodeId,
-//                           let nodeName = action.nodeName {
-//                            self.nodeIdToNameMapping.updateValue(nodeName, forKey: nodeId)
-//                        }
-//                        
-//                        if let nodeId = action.toNodeId,
-//                           let nodeName = action.nodeName {
-//                            self.nodeIdToNameMapping.updateValue(nodeName, forKey: nodeId)
-//                        }
-//                        
-//                        log("self.nodeIdToNameMapping is now: \(self.nodeIdToNameMapping)")
-//                    }
-//                }
-            
+
             // `id:` by hashable ought to be okay?
             ForEach(actions, id: \.hashValue) { (action: LLMStepAction) in
                 LLMActionCorrectionView(action: action,


### PR DESCRIPTION

https://github.com/user-attachments/assets/765938f0-1275-44e2-96ca-ceac6650761c

