### PR TITLE
Fixed issue where graph media could be retained by onHover

### DIFF
--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeView.swift
@@ -12,7 +12,6 @@ struct SidebarListItemSwipeView<SidebarViewModel>: View where SidebarViewModel: 
     typealias ItemViewModel = SidebarViewModel.ItemViewModel
     
     @Environment(\.appTheme) private var theme
-    @State private var isHovered = false
     
     @Bindable var graph: GraphState
     @Bindable var sidebarViewModel: SidebarViewModel
@@ -79,14 +78,16 @@ struct SidebarListItemSwipeView<SidebarViewModel>: View where SidebarViewModel: 
             theme.fontColor
                 .opacity(backgroundOpacity)
         }
-        .onHover { hovering in
-            // log("hovering: sidebar item \(gestureViewModel.id)")
-            // log("hovering: \(hovering)")
-            self.isHovered = hovering
+        .onHover { [weak gestureViewModel] hovering in
+            // MARK: - SUPER DUPER IMPORTANT TO WEAKLY REFERENCE **EVERYTHING** ELSE SEE RETAIN CYCLES
+            
+            guard let gestureViewModel = gestureViewModel else { return }
+            
+            gestureViewModel.isHovered = hovering
             if hovering {
-                self.gestureViewModel.sidebarLayerHovered(itemId: gestureViewModel.id)
+                gestureViewModel.sidebarLayerHovered(itemId: gestureViewModel.id)
             } else {
-                self.gestureViewModel.sidebarLayerHoverEnded(itemId: gestureViewModel.id)
+                gestureViewModel.sidebarLayerHoverEnded(itemId: gestureViewModel.id)
             }
         }
         

--- a/Stitch/Graph/Sidebar/ViewModel/SidebarItemGestureViewModel.swift
+++ b/Stitch/Graph/Sidebar/ViewModel/SidebarItemGestureViewModel.swift
@@ -43,6 +43,8 @@ final class SidebarItemGestureViewModel: SidebarItemSwipable {
 
     @MainActor internal var previousSwipeX: CGFloat = 0
     
+    @MainActor var isHovered = false
+    
     @MainActor weak var sidebarDelegate: LayersSidebarViewModel?
     
     @MainActor weak var parentDelegate: SidebarItemGestureViewModel? {

--- a/Stitch/Graph/Sidebar/ViewModel/SidebarItemSwipable.swift
+++ b/Stitch/Graph/Sidebar/ViewModel/SidebarItemSwipable.swift
@@ -42,6 +42,8 @@ protocol SidebarItemSwipable: StitchNestedListElementObservable, Sendable, Ident
     
     @MainActor var isMasking: Bool { get }
     
+    @MainActor var isHovered: Bool { get set }
+    
     @MainActor
     init(data: Self.EncodedItemData,
          parentDelegate: Self?,


### PR DESCRIPTION
Fixes an issue where graph state is retained by .onHover, specifically with the sidebar.

Strange behavior as we're implementing best practices. Appears the view isn't garbaged collected as a consequence of .onHover.