### PR TITLE
Fixed race condition with 3D layers causing crash

### DIFF
--- a/Stitch/Graph/Node/Layer/Type/Canvas/CanvasSketchLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Canvas/CanvasSketchLayerNode.swift
@@ -64,7 +64,7 @@ struct CanvasSketchLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         CanvasSketchView(document: document,
                          graph: graph,
                          layerViewModel: viewModel,

--- a/Stitch/Graph/Node/Layer/Type/ColorFillLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/ColorFillLayerNode.swift
@@ -33,7 +33,7 @@ struct ColorFillLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         PreviewColorFillLayer(
             document: document,
             graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/Gradients/AngularGradientNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Gradients/AngularGradientNode.swift
@@ -45,7 +45,7 @@ struct AngularGradientLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         PreviewAngularGradientLayer(
             document: document,
             graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/Gradients/LinearGradientNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Gradients/LinearGradientNode.swift
@@ -47,7 +47,7 @@ struct LinearGradientLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         PreviewLinearGradientLayer(
             document: document,
             graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/Gradients/RadialGradientNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Gradients/RadialGradientNode.swift
@@ -45,7 +45,7 @@ struct RadialGradientLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         PreviewRadialGradientLayer(
             document: document,
             graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/GroupLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/GroupLayerNode.swift
@@ -120,7 +120,7 @@ struct GroupLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         PreviewGroupLayer(
             document: document,
             graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/HitAreaLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/HitAreaLayerNode.swift
@@ -38,7 +38,7 @@ struct HitAreaLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         PreviewHitAreaLayer(
             document: document,
             graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/MapLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/MapLayerNode.swift
@@ -56,7 +56,7 @@ struct MapLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         PreviewMapLayer(
             document: document,
             graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/MaterialLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/MaterialLayerNode.swift
@@ -51,7 +51,7 @@ struct MaterialLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         
         PreviewMaterialLayer(document: document,
                              graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/Model3DView.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/Model3DView.swift
@@ -15,6 +15,7 @@ struct Model3DView: View {
     @State private var anchorEntity: AnchorEntity = .init()
     
     let layerViewModel: LayerViewModel
+    let realityContent: StitchRealityContent?
     let graph: GraphState
     let entity: StitchEntity
     let size: LayerSize
@@ -36,6 +37,7 @@ struct Model3DView: View {
         default:
             // geometry case
             Model3DGeometryView(layerViewModel: layerViewModel,
+                                realityContent: realityContent,
                                 graph: graph,
                                 entity: entity,
                                 size: size,
@@ -50,6 +52,7 @@ struct Model3DGeometryView: View {
     @State private var anchorEntity: AnchorEntity = .init()
     
     let layerViewModel: LayerViewModel
+    let realityContent: StitchRealityContent?
     let graph: GraphState
     let entity: StitchEntity
     let size: LayerSize
@@ -60,12 +63,13 @@ struct Model3DGeometryView: View {
     var body: some View {
         ZStack {
             NonCameraRealityView(layerViewModel: layerViewModel,
+                                 realityContent: nil,   // not a grouping scenario so make nil
                                  size: size,
                                  scale: scale,
                                  opacity: opacity,
                                  isShadowsEnabled: false)
             
-            if let arView = layerViewModel.realityContent {
+            if let arView = realityContent?.arView {
                 Color.clear
                     .modifier(ModelEntityLayerViewModifier(previewLayer: layerViewModel,
                                                            entity: entity,

--- a/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/Nodes/BoxLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/Nodes/BoxLayerNode.swift
@@ -43,7 +43,7 @@ struct BoxLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         Model3DLayerNode
             .content(document: document,
                      graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/Nodes/ConeLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/Nodes/ConeLayerNode.swift
@@ -43,7 +43,7 @@ struct ConeLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         Model3DLayerNode
             .content(document: document,
                      graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/Nodes/CylinderLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/Nodes/CylinderLayerNode.swift
@@ -43,7 +43,7 @@ struct CylinderLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         Model3DLayerNode
             .content(document: document,
                      graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/Nodes/Model3DLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/Nodes/Model3DLayerNode.swift
@@ -53,7 +53,7 @@ struct Model3DLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         Preview3DModelLayer(
             document: document,
             graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/Nodes/SphereLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/Nodes/SphereLayerNode.swift
@@ -42,7 +42,7 @@ struct SphereLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         Model3DLayerNode
             .content(document: document,
                      graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/PreviewModel3DLayer.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/PreviewModel3DLayer.swift
@@ -32,8 +32,8 @@ struct Preview3DModelLayer: View {
     @Bindable var document: StitchDocumentViewModel
     @Bindable var graph: GraphState
     @Bindable var layerViewModel: LayerViewModel
-    @Binding var realityContent: LayerRealityCameraContent?
     
+    let realityContent: LayerRealityCameraContent?
     let isPinnedViewRendering: Bool
     let interactiveLayer: InteractiveLayer
     let entity: StitchEntity?
@@ -75,17 +75,22 @@ struct Preview3DModelLayer: View {
     }
     
     @ViewBuilder
-    func entityView(realityContent: StitchARView) -> some View {
-        Color.clear
-            .modifier(ModelEntityLayerViewModifier(previewLayer: layerViewModel,
-                                                   entity: self.entity,
-                                                   realityContent: realityContent,
-                                                   graph: graph,
-                                                   anchorEntityId: anchorEntityId,
-                                                   translationEnabled: translation3DEnabled,
-                                                   rotationEnabled: rotation3DEnabled,
-                                                   scaleEnabled: scale3DEnabled,
-                                                   isRendering: isPinnedViewRendering))
+    func entityView(realityContent: StitchRealityContent) -> some View {
+        if let realityContent = realityContent.arView {
+            Color.clear
+                .modifier(ModelEntityLayerViewModifier(previewLayer: layerViewModel,
+                                                       entity: self.entity,
+                                                       realityContent: realityContent,
+                                                       graph: graph,
+                                                       anchorEntityId: anchorEntityId,
+                                                       translationEnabled: translation3DEnabled,
+                                                       rotationEnabled: rotation3DEnabled,
+                                                       scaleEnabled: scale3DEnabled,
+                                                       isRendering: isPinnedViewRendering))
+        } else {
+            // Loading nothing if ARView isn't set yet
+            EmptyView()
+        }
     }
     
     var body: some View {
@@ -100,6 +105,7 @@ struct Preview3DModelLayer: View {
             
             else if let entity = entity {
                 Model3DView(layerViewModel: layerViewModel,
+                            realityContent: realityContent,
                             graph: graph,
                             entity: entity,
                             size: self.size,
@@ -155,7 +161,7 @@ struct ModelEntityLayerViewModifier: ViewModifier {
     @Bindable var previewLayer: LayerViewModel
     
     let entity: StitchEntity?
-    let realityContent: LayerRealityCameraContent
+    let realityContent: StitchARView
     let graph: GraphState
     let anchorEntityId: UUID?
     let translationEnabled: Bool
@@ -181,7 +187,7 @@ struct ModelEntityLayerViewModifier: ViewModifier {
     
     func asssignNewAnchor(_ newAnchor: AnchorEntity,
                           entity: StitchEntity?,
-                          to realityContent: LayerRealityCameraContent) {
+                          to realityContent: StitchARView) {
         self.anchorEntity = newAnchor
         
         if let entity = entity {

--- a/Stitch/Graph/Node/Layer/Type/Media/RealityView/PreviewRealityLayer.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/RealityView/PreviewRealityLayer.swift
@@ -79,7 +79,10 @@ struct PreviewRealityLayer: View {
     }
 }
 
-struct RealityLayerView: View {    
+struct RealityLayerView: View {
+    // New reality content defined from this group context
+    @State private var realityContent = StitchRealityContent()
+
     @Bindable var document: StitchDocumentViewModel
     @Bindable var graph: GraphState
     @Bindable var node: NodeViewModel
@@ -148,10 +151,9 @@ struct RealityLayerView: View {
                         // Update list of node Ids using camera
                         graph.enabledCameraNodeIds.insert(node.id)
                         
-                        self.layerViewModel.realityContent = arView
-                    }
-                    .onDisappear {
-                        self.layerViewModel.realityContent = nil
+                        // Reality content must be assigned due to race conditions with other views (like 3D Model layers) which need it to exist, or else those views will use the wrong flow
+                        self.realityContent.arView = arView
+//                        self.layerViewModel.realityContent = self.realityContent
                     }
                 }
                 
@@ -177,13 +179,11 @@ struct RealityLayerView: View {
         
         else {
             NonCameraRealityView(layerViewModel: layerViewModel,
+                                 realityContent: self.realityContent,
                                  size: layerSize,
                                  scale: scale,
                                  opacity: opacity,
                                  isShadowsEnabled: isShadowsEnabled)
-                                 .onDisappear {
-                                     self.layerViewModel.realityContent = nil
-                                 }
         }
     }
     
@@ -227,7 +227,7 @@ struct RealityLayerView: View {
                                    isPinnedViewRendering: isPinnedViewRendering,
                                    parentDisablesPosition: parentDisablesPosition,
                                    parentIsScrollableGrid: parentIsScrollableGrid,
-                                   realityContent: self.$layerViewModel.realityContent)
+                                   realityContent: self.realityContent)
         }
     }
 }

--- a/Stitch/Graph/Node/Layer/Type/Media/RealityView/RealityNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/RealityView/RealityNode.swift
@@ -49,9 +49,9 @@ struct RealityViewLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         // Create reality view if reality layer AND no reality content is created at this hierarchy
-        if realityContent.wrappedValue != nil {
+        if let realityContent = realityContent {
             GroupLayerNode.content(document: document,
                                    graph: graph,
                                    viewModel: viewModel,
@@ -62,7 +62,10 @@ struct RealityViewLayerNode: LayerNodeDefinition {
                                    parentIsScrollableGrid: parentIsScrollableGrid,
                                    realityContent: realityContent)
             .eraseToAnyView()
-        } else {
+        }
+        
+        // ONLY create a reality view session if none yet made
+        else {
             PreviewRealityLayer(document: document,
                                 graph: graph,
                                 viewModel: viewModel,

--- a/Stitch/Graph/Node/Layer/Type/Media/VideoLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/VideoLayerNode.swift
@@ -44,7 +44,7 @@ struct VideoLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         VisualMediaLayerView(document: document,
                              graph: graph,
                              viewModel: viewModel,

--- a/Stitch/Graph/Node/Layer/Type/Media/VideoStreamingLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/VideoStreamingLayerNode.swift
@@ -48,7 +48,7 @@ struct VideoStreamingLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         PreviewVideoStreamLayer(
             document: document,
             graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/Media/VisualMedia.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/VisualMedia.swift
@@ -47,7 +47,7 @@ struct ImageLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         VisualMediaLayerView(document: document,
                              graph: graph,
                              viewModel: viewModel,

--- a/Stitch/Graph/Node/Layer/Type/ProgressIndicatorLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/ProgressIndicatorLayerNode.swift
@@ -41,7 +41,7 @@ struct ProgressIndicatorLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         PreviewProgressIndicatorLayer(
             document: document,
             graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/SFSymbolLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/SFSymbolLayerNode.swift
@@ -52,7 +52,7 @@ struct SFSymbolLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         
         let stroke = viewModel.getLayerStrokeData()
         

--- a/Stitch/Graph/Node/Layer/Type/Shapes/OvalLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Shapes/OvalLayerNode.swift
@@ -66,7 +66,7 @@ struct OvalLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         ShapeLayerView(document: document,
                        graph: graph,
                        viewModel: viewModel,

--- a/Stitch/Graph/Node/Layer/Type/Shapes/RectangleLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Shapes/RectangleLayerNode.swift
@@ -78,7 +78,7 @@ struct RectangleLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         ShapeLayerView(document: document,
                        graph: graph,
                        viewModel: viewModel,

--- a/Stitch/Graph/Node/Layer/Type/Shapes/ShapeLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Shapes/ShapeLayerNode.swift
@@ -176,7 +176,7 @@ struct ShapeLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         ShapeLayerView(document: document,
                        graph: graph,
                        viewModel: viewModel,

--- a/Stitch/Graph/Node/Layer/Type/SwitchLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/SwitchLayerNode.swift
@@ -48,7 +48,7 @@ struct SwitchLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         PreviewSwitchLayer(
             document: document,
             graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/Text/TextFieldLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Text/TextFieldLayerNode.swift
@@ -66,7 +66,7 @@ struct TextFieldLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         PreviewTextFieldLayer(
             document: document,
             graph: graph,

--- a/Stitch/Graph/Node/Layer/Type/Text/TextLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Text/TextLayerNode.swift
@@ -79,7 +79,7 @@ struct TextLayerNode: LayerNodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> some View {
+                        realityContent: LayerRealityCameraContent?) -> some View {
         PreviewTextLayer(
             document: document,
             graph: graph,

--- a/Stitch/Graph/Node/Model/Definition/NodeDefinition.swift
+++ b/Stitch/Graph/Node/Model/Definition/NodeDefinition.swift
@@ -47,8 +47,6 @@ extension Layer {
     }
 }
 
-typealias LayerRealityCameraContent = StitchARView
-
 // fka `LayerGraphNode`
 protocol LayerNodeDefinition: NodeDefinition {
     associatedtype Content: View
@@ -66,7 +64,7 @@ protocol LayerNodeDefinition: NodeDefinition {
                         isPinnedViewRendering: Bool,
                         parentDisablesPosition: Bool,
                         parentIsScrollableGrid: Bool,
-                        realityContent: Binding<LayerRealityCameraContent?>) -> Content
+                        realityContent: LayerRealityCameraContent?) -> Content
 }
 
 extension LayerNodeDefinition {

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/AR/RealityView.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/AR/RealityView.swift
@@ -10,6 +10,15 @@ import RealityKit
 import SwiftUI
 import StitchSchemaKit
 
+typealias LayerRealityCameraContent = StitchRealityContent
+
+/// Views point to `StitchRealityContent` when child layers are nested inside of a Reality View.
+/// A `StitchRealityContent` always exists even when its `StitchARView` may not be present due to race conditions assigning the AR view.
+@Observable
+final class StitchRealityContent {
+    var arView: StitchARView?
+}
+
 struct CameraRealityView: UIViewRepresentable {
     // AR view must already be created in media manager
     let arView: ARView
@@ -36,6 +45,7 @@ struct CameraRealityView: UIViewRepresentable {
 
 struct NonCameraRealityView: UIViewRepresentable {
     @Bindable var layerViewModel: LayerViewModel
+    let realityContent: StitchRealityContent?
     let size: LayerSize
     let scale: Double
     let opacity: Double
@@ -50,8 +60,8 @@ struct NonCameraRealityView: UIViewRepresentable {
         // MARK: useful for debugging gestures
 //        arView.debugOptions = .showPhysics
         
-        // Update object with scene
-        layerViewModel.realityContent = arView
+        // Update object with scene if this is a valid group reality view
+        realityContent?.arView = arView
         
         return arView.arView
     }

--- a/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
@@ -35,7 +35,7 @@ struct GeneratePreview: View {
                           noFixedSizeForLayerGroup: false,
                           parentGridData: nil,
                           isGhostView: false,
-                          realityContent: .constant(nil))
+                          realityContent: nil)
         .background {
             // Invisible views used for reporting pinning position data
             PreviewLayersView(document: document,
@@ -52,7 +52,7 @@ struct GeneratePreview: View {
                               noFixedSizeForLayerGroup: false,
                               parentGridData: nil,
                               isGhostView: true,
-                              realityContent: .constant(nil))
+                              realityContent: nil)
             .hidden()
             .disabled(true)
         }
@@ -98,7 +98,7 @@ struct PreviewLayersView: View {
     let noFixedSizeForLayerGroup: Bool
     let parentGridData: PreviewGridData?
     let isGhostView: Bool
-    @Binding var realityContent: LayerRealityCameraContent?
+    let realityContent: LayerRealityCameraContent?
     
      /*
       Note: [.red, .yellow, .black] in a ZStack places black "on top" (i.e. highest z-index), in a VStack places black "last"; i.e. ZStack and VStack/HStack have opposite expectations about ordering.
@@ -157,7 +157,7 @@ struct PreviewLayersView: View {
                           parentDisablesPosition: parentDisablesPosition,
                           parentIsScrollableGrid: parentIsScrollableGrid,
                           isGhostView: isGhostView,
-                          realityContent: $realityContent)
+                          realityContent: realityContent)
             
             if spacing.isEvenly {
                 Spacer()
@@ -189,7 +189,7 @@ struct PreviewLayersView: View {
                                   parentDisablesPosition: parentDisablesPosition,
                                   parentIsScrollableGrid: parentIsScrollableGrid,
                                   isGhostView: isGhostView,
-                                  realityContent: $realityContent)
+                                  realityContent: realityContent)
                 }
             }
         } .modifier(LayerGroupInteractableViewModifier(
@@ -360,7 +360,7 @@ struct LayerDataView: View {
     let parentDisablesPosition: Bool
     let parentIsScrollableGrid: Bool
     let isGhostView: Bool
-    @Binding var realityContent: LayerRealityCameraContent?
+    let realityContent: LayerRealityCameraContent?
     
     var body: some View {
         
@@ -386,7 +386,7 @@ struct LayerDataView: View {
                         parentDisablesPosition: parentDisablesPosition,
                         parentIsScrollableGrid: parentIsScrollableGrid,
                         isGhostView: isGhostView,
-                        realityContent: $realityContent)
+                        realityContent: realityContent)
                     
                     // Turn masker LayerData into a single view
                     let masker: some View = LayerDataView(
@@ -396,7 +396,7 @@ struct LayerDataView: View {
                         parentDisablesPosition: parentDisablesPosition,
                         parentIsScrollableGrid: parentIsScrollableGrid,
                         isGhostView: isGhostView,
-                        realityContent: $realityContent)
+                        realityContent: realityContent)
                     
                     // Return
                     masked.mask(masker)
@@ -416,7 +416,7 @@ struct LayerDataView: View {
                                           parentSize: parentSize,
                                           parentDisablesPosition: parentDisablesPosition,
                                           parentIsScrollableGrid: parentIsScrollableGrid,
-                                          realityContent: $realityContent)
+                                          realityContent: realityContent)
             } else {
                 EmptyView()
             }
@@ -432,7 +432,7 @@ struct LayerDataView: View {
                                        parentSize: parentSize,
                                        parentDisablesPosition: parentDisablesPosition,
                                        parentIsScrollableGrid: parentIsScrollableGrid,
-                                       realityContent: $realityContent)
+                                       realityContent: realityContent)
             } else {
                 EmptyView()
             }
@@ -449,7 +449,7 @@ struct NonGroupPreviewLayersView: View {
     let parentSize: CGSize
     let parentDisablesPosition: Bool
     let parentIsScrollableGrid: Bool
-    @Binding var realityContent: LayerRealityCameraContent?
+    let realityContent: LayerRealityCameraContent?
     
     var mediaValue: AsyncMediaValue? {
         isPinnedViewRendering ? self.layerViewModel.mediaPortValue : nil
@@ -482,7 +482,7 @@ struct NonGroupPreviewLayersView: View {
                              parentSize: parentSize,
                              parentDisablesPosition: parentDisablesPosition,
                              parentIsScrollableGrid: parentIsScrollableGrid,
-                             realityContent: $realityContent)
+                             realityContent: realityContent)
             .onChange(of: mediaValue, initial: true) {
                 guard let mediaPort = self.mediaPort else {
                     assertInDebug(self.mediaValue == nil)
@@ -535,7 +535,7 @@ struct GroupPreviewLayersView: View {
     let parentSize: CGSize
     let parentDisablesPosition: Bool
     let parentIsScrollableGrid: Bool
-    @Binding var realityContent: LayerRealityCameraContent?
+    let realityContent: LayerRealityCameraContent?
     
     var body: some View {
         if layerNode.hasSidebarVisibility,
@@ -550,7 +550,7 @@ struct GroupPreviewLayersView: View {
                                        isPinnedViewRendering: isPinnedViewRendering,
                                        parentDisablesPosition: parentDisablesPosition,
                                        parentIsScrollableGrid: parentIsScrollableGrid,
-                                       realityContent: $realityContent)
+                                       realityContent: realityContent)
 
             case .realityView:
                 RealityViewLayerNode.content(document: document,
@@ -561,7 +561,7 @@ struct GroupPreviewLayersView: View {
                                              isPinnedViewRendering: isPinnedViewRendering,
                                              parentDisablesPosition: parentDisablesPosition,
                                              parentIsScrollableGrid: parentIsScrollableGrid,
-                                             realityContent: $realityContent)
+                                             realityContent: realityContent)
                 
             default:
                 Color.clear

--- a/Stitch/Graph/PrototypePreview/Layer/View/PreviewLayerView.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/PreviewLayerView.swift
@@ -18,7 +18,7 @@ struct PreviewLayerView: View {
     let parentSize: CGSize
     let parentDisablesPosition: Bool
     let parentIsScrollableGrid: Bool
-    @Binding var realityContent: LayerRealityCameraContent?
+    let realityContent: LayerRealityCameraContent?
 
     var id: PreviewCoordinate {
         self.layerViewModel.id
@@ -33,7 +33,7 @@ struct PreviewLayerView: View {
                                      isPinnedViewRendering: isPinnedViewRendering,
                                      parentDisablesPosition: parentDisablesPosition,
                                      parentIsScrollableGrid: parentIsScrollableGrid,
-                                     realityContent: $realityContent)
+                                     realityContent: realityContent)
         .eraseToAnyView()
     }
 }

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
@@ -33,7 +33,7 @@ struct PreviewGroupLayer: View {
     @Bindable var document: StitchDocumentViewModel
     @Bindable var graph: GraphState
     @Bindable var layerViewModel: LayerViewModel
-    @Binding var realityContent: LayerRealityCameraContent?
+    let realityContent: LayerRealityCameraContent?
     let layersInGroup: LayerDataList // child layers for THIS group
     let isPinnedViewRendering: Bool
     let interactiveLayer: InteractiveLayer
@@ -267,7 +267,7 @@ struct PreviewGroupLayer: View {
                               noFixedSizeForLayerGroup: noFixedSizeForLayerGroup,
                               parentGridData: gridData,
                               isGhostView: !isPinnedViewRendering,
-                              realityContent: $realityContent)
+                              realityContent: realityContent)
             }
     }
 }

--- a/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
@@ -56,7 +56,6 @@ final class LayerViewModel: Sendable {
     let layer: Layer
     let interactiveLayer: InteractiveLayer
     
-    @MainActor var realityContent: LayerRealityCameraContent?
     @MainActor weak var nodeDelegate: NodeDelegate?
     
     // PINNING: "View A is pinned to View B"


### PR DESCRIPTION
Fixes an issue where we attempt to create a non-camera reality view when we shouldn't. Previous logic would create the required object from inside a var body—now it's created from within the view's instance properties.

Fixes homepod demo, especially on iPad which is slower and memory constrained.