### PR TITLE
SplitText patch only uses last value in each input's loop

### DIFF
--- a/Stitch/Graph/Node/Patch/Type/Text/SplitTextNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Text/SplitTextNode.swift
@@ -36,17 +36,15 @@ func splitTextNode(id: NodeId,
 func splitTextEval(inputs: PortValuesList,
                    outputs: PortValuesList) -> PortValuesList {
 
-    let op: Operation = { (values: PortValues) -> PortValue in
-        let text: String = (values[safe: 0]?.getString?.string ?? .empty)
-        let token: String = (values[safe: 1]?.getString?.string ?? .empty)
-
-        if let first = text.split(separator: token).first {
-            log("splitTextEval: first: \(first)")
-            return .string(.init(String(first)))
-        } else {
-            return .string(.init(.empty))
-        }
+    // Note: if any input on this node has a loop, we only use the last index
+    guard let text = inputs[safe: 0]?.last?.getString?.string, // last value in first input
+          let token = inputs[safe: 1]?.last?.getString?.string // last value in second input
+    else {
+        return [[.string(.init(.empty))]]
     }
-
-    return resultsMaker(inputs)(op)
+    
+    let splitText: [String] = text.split(separator: token).map { String($0) }
+    return [
+        splitText.map { PortValue.string(.init($0))}
+    ]
 }


### PR DESCRIPTION
<img width="1440" alt="Screenshot 2025-02-03 at 4 17 36 PM" src="https://github.com/user-attachments/assets/d2e3c1c9-5636-45a6-a967-eb8c95af8d8a" />
<img width="736" alt="Screenshot 2025-02-03 at 4 15 38 PM" src="https://github.com/user-attachments/assets/b28c5e15-3a8b-4bc7-b7e5-a3266ce64925" />
