### PR TITLE
Fixed media regression on loop selector

### DIFF
--- a/Stitch/Graph/Node/Eval/MediaEvalOpObservable.swift
+++ b/Stitch/Graph/Node/Eval/MediaEvalOpObservable.swift
@@ -22,6 +22,16 @@ protocol MediaEvalOpObservable: NodeEphemeralObservable, MediaEvalOpViewable, Se
     var mediaActor: MediaEvalOpCoordinator { get }
 }
 
+final class MediaReferenceObserver: MediaEvalOpViewable {
+    let mediaViewModel: MediaViewModel
+    
+    @MainActor init() {
+        self.mediaViewModel = .init()
+    }
+    
+    func onPrototypeRestart() { }
+}
+
 final class MediaEvalOpObserver: MediaEvalOpObservable {
     let mediaViewModel: MediaViewModel
     var currentLoadingMediaId: UUID?

--- a/Stitch/Graph/Node/Eval/PatchEvaluateExtensions.swift
+++ b/Stitch/Graph/Node/Eval/PatchEvaluateExtensions.swift
@@ -11,7 +11,7 @@ import StitchSchemaKit
 
 extension Patch {
     @MainActor
-    var evaluate: PureEvals {
+    var evaluate: PureEvals? {
         switch self {
         case
             // wireless nodes are just splitter nodes with covered up edges and invisible edges
@@ -114,8 +114,6 @@ extension Patch {
             return .graphStep(sampleAndHoldEval)
         case .grayscale:
             return .node(grayscaleEval)
-        case .loopSelect:
-            return .node(outputsOnlyEval(loopSelectEval))
         case .videoImport:
             return .node(videoImportEval)
         case .sampleRange:
@@ -340,6 +338,8 @@ extension Patch {
             return .node(outputsOnlyEval(springFromResponseAndDampingRatioEval))
         case .springFromSettlingDurationAndDampingRatio:
             return .node(outputsOnlyEval(springFromSettlingDurationAndDampingRatioEval))
+        default:
+            return nil
         }
     }
 }

--- a/Stitch/Graph/Node/Model/Definition/NodeDefinition.swift
+++ b/Stitch/Graph/Node/Model/Definition/NodeDefinition.swift
@@ -14,25 +14,40 @@ import RealityKit
 // fka `GraphNode`
 protocol NodeDefinition {
     static var graphKind: NodeDefinitionKind { get }
+    
     static var defaultTitle: String { get }
     
-    // TODO: `LayerGraphNode.rowDefinitions` can NEVER have a UserVisibleType
     @MainActor
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions
+    
+    @MainActor
+    static func evaluate(node: NodeViewModel) -> EvalResult?
     
     @MainActor
     static func createEphemeralObserver() -> NodeEphemeralObservable?
 
     static var inputCountVariesByType: Bool { get }
+    
     static var outputCountVariesByType: Bool { get }
 }
 
 // fka `PatchGraphNode`
 protocol PatchNodeDefinition: NodeDefinition {
     static var patch: Patch { get }
+    
     static var defaultUserVisibleType: UserVisibleType? { get }
+    
     static var inputCountVariesByType: Bool { get }
+    
     static var outputCountVariesByType: Bool { get }
+}
+
+extension NodeDefinition {
+    /// Default eval caller which calls legacy eval.
+    @MainActor
+    static func evaluate(node: NodeViewModel) -> EvalResult? {
+        node.evaluate()
+    }
 }
 
 extension PatchNodeDefinition {

--- a/Stitch/Graph/Node/Model/Definition/PatchNodeDefinitionKinds.swift
+++ b/Stitch/Graph/Node/Model/Definition/PatchNodeDefinitionKinds.swift
@@ -116,7 +116,7 @@ extension Patch {
         case .grayscale:
             return GrayscaleNode.self
         case .loopSelect:
-            return nil
+            return LoopSelectNode.self
         case .videoImport:
             return VideoImportNode.self
         case .sampleRange:

--- a/Stitch/Graph/Node/Patch/Type/Loop/LoopSelectNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Loop/LoopSelectNode.swift
@@ -9,83 +9,107 @@ import Foundation
 import SwiftUI
 import StitchSchemaKit
 
-@MainActor
-func loopSelectNode(id: NodeId,
-                    position: CGSize = .zero,
-                    zIndex: Double = 0) -> PatchNode {
-
-    let inputs = toInputs(
-        id: id,
-        values:
-            ("Input", [.string(.init(""))]), // 0
-        ("Index Loop", [.number(0)]) // 1
-    )
-
-    // loop Builder has TWO outputs:
-    // 1. indices: ALWAYS a loop of ints, where each int is just an index
-    // 2. values: a loop of the user-chosen value-type (here: color)
-
-    let outputs = toOutputs(
-        id: id,
-        offset: inputs.count,
-        // it's called index, but it's actually the loop that's coming out
-        values:
-            ("Loop", [.string(.init(""))]),
-        ("Index", [.number(0)]))
-
-    return PatchNode(
-        position: position,
-        zIndex: zIndex,
-        id: id,
-        patchName: .loopSelect,
-        userVisibleType: .string,
-        inputs: inputs,
-        outputs: outputs)
-}
-
-func loopSelectEval(inputs: PortValuesList,
-                    outputs: PortValuesList) -> PortValuesList {
-
-    // operates at the level of loops (rather than 'value-at-index of a loop'),
-    // and so we can't use op, etc.
-
-    let valueLoop: PortValues = inputs.first!
-    let indexLoop: PortValues = inputs[1]
-
-    let longestLoopLength: Int = getLongestLoopLength(inputs)
-    let adjustedValueLoop = lengthenArray(loop: valueLoop, length: longestLoopLength)
-    let adjustedIndexLoop = lengthenArray(loop: indexLoop, length: longestLoopLength)
-
-    // The Index Loop input's values could be [7, 8, 9],
-    // i.e. indices we don't have;
-    // so we mod those values by the length of the original,
-    // unextended valueLoop.
-    let valueLoopLength = valueLoop.count
-
-    //                log("loopSelectEval: longestLoopLength: \(longestLoopLength)")
-    //                log("loopSelectEval: valueLoop: \(valueLoop)")
-    //                log("loopSelectEval: indexLoop: \(indexLoop)")
-    //                log("loopSelectEval: adjustedValueLoop: \(adjustedValueLoop)")
-    //                log("loopSelectEval: adjustedIndexLoop: \(adjustedIndexLoop)")
-    //                log("loopSelectEval: valueLoopLength: \(valueLoopLength)")
-
-    var outputLoop: PortValues = adjustedIndexLoop
-        .map { Int($0.getNumber!) }
-        .asLoopFriendlyIndices(valueLoopLength)
-        //            .asLoopInsertFriendlyIndices(valueLoopLength)
-        //            .map { adjustedValueLoop[$0 % valueLoopLength] }
-        .map { adjustedValueLoop[$0] }
-
-    //                log("loopSelectEval: outputLoop: \(outputLoop)")
-    //                log("loopSelectEval: outputLoop.asLoopIndices: \(outputLoop.asLoopIndices)")
-
-    let outputLoopCount = outputLoop.count
-    let indexLoopCount = indexLoop.count
-
-    // Outputs cannot be longer than index-loop input
-    outputLoop = outputLoop.dropLast(outputLoopCount - indexLoopCount)
-
-    return [outputLoop, outputLoop.asLoopIndices]
+struct LoopSelectNode: PatchNodeDefinition {
+    static let patch: Patch = .loopSelect
+    
+    private static let _defaultUserVisibleType: UserVisibleType = .string
+    
+    // overrides protocol
+    static let defaultUserVisibleType: UserVisibleType? = Self._defaultUserVisibleType
+    
+    static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
+        .init(inputs: [
+            .init(label: "Input",
+                  defaultType: Self._defaultUserVisibleType),
+            .init(label: "Index Loop",
+                  staticType: .number)
+        ],
+              outputs: [
+                .init(label: "Loop", type: Self._defaultUserVisibleType),
+                .init(label: "Index", type: .number)
+              ])
+    }
+    
+    static func createEphemeralObserver() -> NodeEphemeralObservable? {
+        MediaReferenceObserver()
+    }
+    
+    @MainActor
+    static func evaluate(node: NodeViewModel) -> EvalResult? {
+        let inputs = node.inputs
+        let defaultOutputs = node.defaultOutputs
+        
+        guard //let mediaObserver = node.ephemeralObservers?.first as? MediaReferenceObserver,
+              let valueLoop: PortValues = inputs.first,
+              let indexLoop: PortValues = inputs[safe: 1] else {
+            fatalErrorIfDebug()
+            return .init(outputsValues: [defaultOutputs])
+        }
+        
+        // operates at the level of loops (rather than 'value-at-index of a loop'),
+        // and so we can't use op, etc.
+        
+        let longestLoopLength: Int = getLongestLoopLength(inputs)
+        let adjustedValueLoop = lengthenArray(loop: valueLoop, length: longestLoopLength)
+        let adjustedIndexLoop = lengthenArray(loop: indexLoop, length: longestLoopLength)
+        
+        // The Index Loop input's values could be [7, 8, 9],
+        // i.e. indices we don't have;
+        // so we mod those values by the length of the original,
+        // unextended valueLoop.
+        let valueLoopLength = valueLoop.count
+        
+        let indexLoopCount = indexLoop.count
+        
+        // Match output loop count with indexLoopCount. We pass in fake values to match media observers with output loop count.
+        let fakeValuesLoop: PortValues = (0..<indexLoopCount)
+            .map { PortValue.number(Double($0)) }
+        
+        return node.loopedEval(MediaReferenceObserver.self,
+                               inputsValuesList: [fakeValuesLoop]) { _, mediaObserver, loopIndex in
+            guard let inputLoopIndex = adjustedIndexLoop[safe: loopIndex]?.getInt else {
+                return MediaEvalOpResult(from: defaultOutputs)
+            }
+            
+            // Protects divide by 0
+            guard valueLoopLength != 0 else {
+                fatalErrorIfDebug()
+                return .init(from: defaultOutputs)
+            }
+            
+            // Use mod to wrap selected index if input exceeds length
+            var modInputIndex = inputLoopIndex % valueLoopLength
+            
+            // Use positive index if mod creates negative result
+            if modInputIndex < 0 {
+                modInputIndex += valueLoopLength
+            }
+            
+            guard let value = adjustedValueLoop[safe: modInputIndex] else {
+                return MediaEvalOpResult(from: defaultOutputs)
+            }
+            
+            return Self.createMediaEvalOp(value: value,
+                                          loopIndex: loopIndex,
+                                          node: node)
+        }
+                               .createPureEvalResult(node: node)
+    }
+    
+    @MainActor
+    private static func createMediaEvalOp(value: PortValue,
+                                          loopIndex: Int,
+                                          node: NodeViewModel) -> MediaEvalOpResult {
+        let outputs = [value, .number(Double(loopIndex))]
+        if value.asyncMedia != nil,
+           let mediaObject = node.getInputMediaValue(portIndex: 0,
+                                                     loopIndex: loopIndex) {
+            return .init(values: outputs,
+                         media: mediaObject)
+        }
+        
+        return MediaEvalOpResult(from: outputs)
+    }
 }
 
 extension Double {

--- a/Stitch/Graph/Node/Patch/Type/Loop/LoopSelectNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Loop/LoopSelectNode.swift
@@ -90,7 +90,8 @@ struct LoopSelectNode: PatchNodeDefinition {
             }
             
             return Self.createMediaEvalOp(value: value,
-                                          loopIndex: loopIndex,
+                                          selectedLoopIndex: modInputIndex,
+                                          outputLoopIndex: loopIndex,
                                           node: node)
         }
                                .createPureEvalResult(node: node)
@@ -98,12 +99,13 @@ struct LoopSelectNode: PatchNodeDefinition {
     
     @MainActor
     private static func createMediaEvalOp(value: PortValue,
-                                          loopIndex: Int,
+                                          selectedLoopIndex: Int,
+                                          outputLoopIndex: Int,
                                           node: NodeViewModel) -> MediaEvalOpResult {
-        let outputs = [value, .number(Double(loopIndex))]
+        let outputs = [value, .number(Double(outputLoopIndex))]
         if value.asyncMedia != nil,
            let mediaObject = node.getInputMediaValue(portIndex: 0,
-                                                     loopIndex: loopIndex) {
+                                                     loopIndex: selectedLoopIndex) {
             return .init(values: outputs,
                          media: mediaObject)
         }

--- a/Stitch/Graph/Node/Patch/Util/PatchDefaultNodeExtensions.swift
+++ b/Stitch/Graph/Node/Patch/Util/PatchDefaultNodeExtensions.swift
@@ -82,8 +82,6 @@ extension Patch {
             node = notNode(id: id, position: position, zIndex: zIndex)
         case .transition:
             node = transitionNode(id: id, position: position, zIndex: zIndex)
-        case .loopSelect:
-            node = loopSelectNode(id: id, position: position, zIndex: zIndex)
         case .speaker:
             node = speakerNode(id: id, position: position, zIndex: zIndex)
         case .loopOverArray:

--- a/Stitch/Graph/Node/Port/Util/PortValue/PortValueUtils.swift
+++ b/Stitch/Graph/Node/Port/Util/PortValue/PortValueUtils.swift
@@ -34,6 +34,7 @@ extension PortValue {
     var getInt: Int? {
         switch self {
         case .int(let x): return x
+        case .number(let x): return Int(x)
         default: return nil
         }
     }

--- a/StitchTests/evalTests.swift
+++ b/StitchTests/evalTests.swift
@@ -25,6 +25,29 @@ class EvalTests: XCTestCase {
         self.document.graphStepManager.delegate = self.document
         self.document.graph.documentDelegate = self.document
     }
+    
+    @MainActor
+    func loopSelectEval(inputs: PortValuesList,
+                        outputs: PortValuesList) -> PortValuesList {
+        guard let node = Patch.loopSelect.defaultNode(id: .init(),
+                                                      position: .zero,
+                                                      zIndex: .zero,
+                                                      graphDelegate: self.graphState) else {
+            fatalError()
+        }
+        
+        zip(inputs, node.inputsObservers).forEach { values, inputObserver in
+            inputObserver.updateValues(values)
+        }
+        
+        let result = LoopSelectNode.evaluate(node: node)
+        
+        guard let outputs = result?.outputsValues else {
+            fatalError()
+        }
+        
+        return outputs
+    }
 
     /// Runs all evals to make sure nodes can initialize.
     @MainActor
@@ -801,6 +824,7 @@ class EvalTests: XCTestCase {
     }
 
     // single value selection
+    @MainActor
     func testLoopSelectEvalSingleSelection() throws {
 
         // "input"
@@ -824,6 +848,7 @@ class EvalTests: XCTestCase {
         XCTAssertEqual(result[1], expectedOutput2)
     }
 
+    @MainActor
     func testLoopSelectEvalNegativeSingleSelection() throws {
 
         let apple = "apple"
@@ -841,9 +866,9 @@ class EvalTests: XCTestCase {
         let input2: PortValues = [.number(-1)]
 
         let getResult = { (index: Int) -> PortValuesList in
-            loopSelectEval(inputs: [input1,
-                                    [.number(Double(index))]],
-                           outputs: [])
+            self.loopSelectEval(inputs: [input1,
+                                         [.number(Double(index))]],
+                                outputs: [])
         }
 
         // POSITIVE INDICES
@@ -921,6 +946,7 @@ class EvalTests: XCTestCase {
     //    func testLoopFriendlyIndicies
 
     // see for details: https://origami.design/documentation/patches/builtin.loop.selectReorder.html
+    @MainActor
     func testLoopSelectEvalMultiSelection() throws {
 
         // "input"
@@ -944,6 +970,7 @@ class EvalTests: XCTestCase {
         XCTAssertEqual(result[1], expectedOutput2)
     }
 
+    @MainActor
     func testLoopSelectEvalMultiSelectionUnequalLength() throws {
 
         // "input"
@@ -966,7 +993,7 @@ class EvalTests: XCTestCase {
         XCTAssertEqual(result.first!, expectedOutput1)
         XCTAssertEqual(result[1], expectedOutput2)
     }
-
 }
 
 let fakeGraphTime: TimeInterval = .zero
+


### PR DESCRIPTION
This PR continues recent media refactoring by adding support for the loop select node.

In addition, we improved eval support for nodes by no longer requiring usage of the eval switch statement for node kinds.