### PR TITLE
Fixed regression where media objects sometimes aren't retained

### DIFF
--- a/Stitch/Graph/Edge/Util/PortActions.swift
+++ b/Stitch/Graph/Edge/Util/PortActions.swift
@@ -51,7 +51,8 @@ extension InputNodeRowObserver {
                 let node = self.nodeDelegate {
             self.allLoopedValues.enumerated().compactMap { loopIndex, _ in
                 node.getInputMedia(portIndex: 0,
-                                   loopIndex: loopIndex)
+                                   loopIndex: loopIndex,
+                                   mediaId: nil)  // setting nil will get object without equality checking
             }.forEach { media in
                 // Run effect to mute sound player
                 self.upstreamOutputObserver?.getMediaObjects().forEach { media in

--- a/Stitch/Graph/Node/Eval/MediaEvalOpObservable.swift
+++ b/Stitch/Graph/Node/Eval/MediaEvalOpObservable.swift
@@ -135,7 +135,8 @@ extension MediaEvalOpObservable {
         let inputMediaValue = MediaEvalResult.getInputMediaValue(from: values)
         
         // This kind of media is saved in ephemeral observers
-        let currentMedia = node.getComputedMediaValue(loopIndex: loopIndex)
+        let currentMedia = node.getComputedMediaValue(loopIndex: loopIndex,
+                                                      mediaId: nil)
                 
         let didMediaChange = inputMediaValue?.id != currentMedia?.id
         let isLoadingNewMedia = mediaObserver.currentLoadingMediaId != nil
@@ -201,7 +202,8 @@ extension MediaEvalOpObservable {
         
         // No media key scenario
         if let mediaObject = node.getInputMedia(portIndex: inputPortIndex,
-                                                loopIndex: loopIndex) {
+                                                loopIndex: loopIndex,
+                                                mediaId: inputMediaValue.id) {
             // Create computed copy from another computed media object
             guard let copy = try? await mediaObject.createComputedCopy() else {
                 fatalErrorIfDebug()

--- a/Stitch/Graph/Node/Patch/Type/CoreMLClassifyNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/CoreMLClassifyNode.swift
@@ -73,7 +73,8 @@ func coreMLClassifyEval(node: PatchNode) -> EvalResult {
                                              loopIndex: loopIndex,
                                              defaultOutputs: defaultOutputs) { media in
             guard let image = node.getInputMedia(portIndex: 1,
-                                                 loopIndex: loopIndex)?.image else {
+                                                 loopIndex: loopIndex,
+                                                 mediaId: media.id)?.image else {
                 return defaultOutputs
             }
             

--- a/Stitch/Graph/Node/Patch/Type/CoreMLDetectionNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/CoreMLDetectionNode.swift
@@ -79,7 +79,10 @@ func coreMLDetectionEval(node: PatchNode) -> EvalResult {
     let inputs = node.inputs
     
     guard let mediaObserver = node.ephemeralObservers?.first as? VisionOpObserver,
-          let image = node.getInputMedia(portIndex: 1, loopIndex: 0)?.image,
+          let imageMediaId = inputs[safe: 1]?.first?.asyncMedia?.id,
+          let image = node.getInputMedia(portIndex: 1,
+                                         loopIndex: 0,
+                                         mediaId: imageMediaId)?.image,
           let cropAndScaleOption = inputs[safe: 2]?.first?.vnImageCropOption else {
         return .init(outputsValues: defaultOutputs)
     }

--- a/Stitch/Graph/Node/Patch/Type/Delay/DelayNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Delay/DelayNode.swift
@@ -150,14 +150,18 @@ func delayEval(node: PatchNode) -> EvalResult {
         if currentOutput.toNodeType != inputValue.toNodeType {
             currentOutput = inputValue.defaultFalseValue
         }
+        
+        let mediaId: UUID? = inputValue.asyncMedia != nil ? inputValue.asyncMedia!.id : nil
+        let mediaValue: GraphMediaValue? = mediaId != nil ? node.getInputMediaValue(portIndex: 0,
+                                                                                    loopIndex: index,
+                                                                                    mediaId: mediaId!) : nil
 
         let createTimer = {
             let id = UUID()
             let timer = DelayNodeTimer(timerId: id,
                                        delayValue: delayValue,
                                        value: inputValue,
-                                       media: node.getInputMediaValue(portIndex: 0,
-                                                                      loopIndex: index),
+                                       media: mediaValue,
                                        loopIndex: index,
                                        originalNodeType: node.userVisibleType,
                                        ephemeralObserver: timerObserver,

--- a/Stitch/Graph/Node/Patch/Type/Loop/LoopBuilder.swift
+++ b/Stitch/Graph/Node/Patch/Type/Loop/LoopBuilder.swift
@@ -92,7 +92,8 @@ func loopBuilderEval(node: PatchNode,
             guard let inputMediaValue = values.first?.asyncMedia,
                   // MARK: loop and port index are flipped
                   let mediaObject = node.getInputMediaValue(portIndex: index,
-                                                            loopIndex: 0) else {
+                                                            loopIndex: 0,
+                                                            mediaId: inputMediaValue.id) else {
                 return .init(from: [indexPortValue,
                                     .asyncMedia(nil)])
             }

--- a/Stitch/Graph/Node/Patch/Type/Loop/LoopSelectNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Loop/LoopSelectNode.swift
@@ -103,9 +103,10 @@ struct LoopSelectNode: PatchNodeDefinition {
                                           outputLoopIndex: Int,
                                           node: NodeViewModel) -> MediaEvalOpResult {
         let outputs = [value, .number(Double(outputLoopIndex))]
-        if value.asyncMedia != nil,
+        if let mediaValue = value.asyncMedia,
            let mediaObject = node.getInputMediaValue(portIndex: 0,
-                                                     loopIndex: selectedLoopIndex) {
+                                                     loopIndex: selectedLoopIndex,
+                                                     mediaId: mediaValue.id) {
             return .init(values: outputs,
                          media: mediaObject)
         }

--- a/Stitch/Graph/Node/Patch/Type/Media/SoundImportNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Media/SoundImportNode.swift
@@ -149,7 +149,9 @@ func soundImportEval(node: PatchNode) -> EvalResult {
     
     // MARK: frequencies logic saved for end due to loop of values
     
-    if let soundPlayer = node.getComputedMedia(loopIndex: 0)?.soundFilePlayer {
+    if let mediaId = node.getInputRowObserver(0)?.values.first?.asyncMedia?.id,
+       let soundPlayer = node.getComputedMedia(loopIndex: 0,
+                                               mediaId: mediaId)?.soundFilePlayer {
         // Frequencies logic
         let frequencyAmplitudes = soundPlayer.delegate.frequencyAmplitudes
         

--- a/Stitch/Graph/Node/Patch/Type/Media/SpeakerNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Media/SpeakerNode.swift
@@ -38,9 +38,11 @@ func speakerNode(id: NodeId,
 func speakerEval(node: PatchNode) -> EvalResult {
     let _ = loopedEval(node: node) { values, loopIndex in
         // MARK: media object is obtained by looking at upstream connected node's saved media objects. This system isn't perfect as not all nodes which can hold media use the MediaEvalOpObserver.
-        guard let volume = values[safe: 1]?.getNumber,
+        guard let mediaId = values.first?.asyncMedia?.id,
+              let volume = values[safe: 1]?.getNumber,
               let mediaObject = node.getInputMedia(portIndex: 0,
-                                                   loopIndex: loopIndex),
+                                                   loopIndex: loopIndex,
+                                                   mediaId: mediaId),
               let speakerMedia = mediaObject.soundFilePlayer else {
             log("speakerEval error: no engine or soundinput found.")
             return

--- a/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
@@ -423,10 +423,12 @@ struct InputValueView: View {
                 
             case .media(let media):
                 let loopIndex = graph.activeIndex.adjustedIndex(viewModel.rowViewModelDelegate?.rowDelegate?.allLoopedValues.count ?? .zero)
+                let mediaId: UUID? = viewModel.rowViewModelDelegate?.activeValue.asyncMedia?.id
                 
-                let mediaObserver = viewModel.rowViewModelDelegate?.nodeDelegate?
+                let mediaObserver = mediaId != nil ? viewModel.rowViewModelDelegate?.nodeDelegate?
                     .getInputMediaObserver(inputCoordinate: rowObserverId,
-                                           loopIndex: loopIndex)
+                                           loopIndex: loopIndex,
+                                           mediaId: mediaId!) : nil
                 
                 if let mediaObserver = mediaObserver {
                     MediaFieldValueView(

--- a/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
@@ -227,9 +227,12 @@ struct OutputValueView: View {
             case .media(let media):
                 // No keypaths ever used for output
                 let portIndex = coordinate.portId!
+                let mediaId: UUID? = viewModel.rowViewModelDelegate?.activeValue.asyncMedia?.id
+                let mediaObserver = mediaId != nil ? viewModel.rowViewModelDelegate?.nodeDelegate?
+                    .getVisibleMediaObserver(outputPortId: portIndex,
+                                             mediaId: mediaId!) : nil
                 
-                if let mediaObserver = viewModel.rowViewModelDelegate?.nodeDelegate?
-                    .getVisibleMediaObserver(outputPortId: portIndex) {
+                if let mediaObserver = mediaObserver {
                     MediaFieldValueView(inputCoordinate: coordinate,
                                         layerInputObserver: nil,
                                         isUpstreamValue: false,     // only valid for inputs

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowViewModel.swift
@@ -123,8 +123,6 @@ protocol NodeRowViewModel: StitchLayoutCachable, Observable, Identifiable {
     
     @MainActor func findConnectedCanvasItems() -> CanvasItemIdSet
     
-    @MainActor func getMediaObject() -> GraphMediaValue?
-    
     @MainActor
     init(id: NodeRowViewModelId,
          rowDelegate: RowObserver?,
@@ -361,13 +359,6 @@ extension InputNodeRowViewModel {
         
         return graphDelegate.selectedEdges.contains { $0.to == portViewData }
     }
-    
-    @MainActor func getMediaObject() -> GraphMediaValue? {
-        let inputCoordinate = self.id.asNodeIOCoordinate
-        let loopIndex = self.rowDelegate?.getActiveLoopIndex() ?? 0
-        return self.nodeDelegate?.getInputMediaValue(coordinate: inputCoordinate,
-                                                     loopIndex: loopIndex)
-    }
 }
 
 @Observable
@@ -444,12 +435,6 @@ extension OutputNodeRowViewModel {
         }
         
         return graphDelegate.selectedEdges.contains { $0.from == portViewData }
-    }
-    
-    @MainActor func getMediaObject() -> GraphMediaValue? {
-        // No port index needed as there's only a max of one computed media
-        let loopIndex = self.rowDelegate?.getActiveLoopIndex() ?? 0
-        return self.nodeDelegate?.getComputedMediaValue(loopIndex: loopIndex)
     }
 }
 

--- a/Stitch/Graph/Node/Util/NodeMediaUtils.swift
+++ b/Stitch/Graph/Node/Util/NodeMediaUtils.swift
@@ -147,50 +147,63 @@ extension NodeViewModel {
     @MainActor
     /// Gets the media object for some connected input.
     func getInputMedia(coordinate: NodeIOCoordinate,
-                       loopIndex: Int) -> StitchMediaObject? {
+                       loopIndex: Int,
+                       mediaId: UUID) -> StitchMediaObject? {
         self.getInputMediaObserver(inputCoordinate: coordinate,
-                                   loopIndex: loopIndex)?.currentMedia?.mediaObject
+                                   loopIndex: loopIndex,
+                                   mediaId: mediaId)?.currentMedia?.mediaObject
     }
     
     @MainActor
     /// Gets the media object for some connected input.
     func getInputMedia(portIndex: Int,
-                       loopIndex: Int) -> StitchMediaObject? {
+                       loopIndex: Int,
+                       mediaId: UUID) -> StitchMediaObject? {
         self.getInputMediaValue(portIndex: portIndex,
-                                loopIndex: loopIndex)?.mediaObject
+                                loopIndex: loopIndex,
+                                mediaId: mediaId)?.mediaObject
     }
     
     @MainActor
     /// Gets the media object for some connected input.
     func getInputMediaValue(portIndex: Int,
-                            loopIndex: Int) -> GraphMediaValue? {
+                            loopIndex: Int,
+                            mediaId: UUID) -> GraphMediaValue? {
         self.getInputMediaObserver(portIndex: portIndex,
-                                   loopIndex: loopIndex)?.currentMedia
+                                   loopIndex: loopIndex,
+                                   mediaId: mediaId)?.currentMedia
     }
     
     @MainActor
     /// Gets the media object for some connected input.
     func getInputMediaValue(coordinate: NodeIOCoordinate,
-                            loopIndex: Int) -> GraphMediaValue? {
+                            loopIndex: Int,
+                            mediaId: UUID) -> GraphMediaValue? {
         self.getInputMediaObserver(inputCoordinate: coordinate,
-                                   loopIndex: loopIndex)?.currentMedia
+                                   loopIndex: loopIndex,
+                                   mediaId: mediaId)?.currentMedia
     }
 
     @MainActor
     /// Gets the media object for some connected input.
-    func getComputedMediaValue(loopIndex: Int) -> GraphMediaValue? {
-        self.getComputedMediaObserver(loopIndex: loopIndex)?.currentMedia
+    func getComputedMediaValue(loopIndex: Int,
+                               mediaId: UUID) -> GraphMediaValue? {
+        self.getComputedMediaObserver(loopIndex: loopIndex,
+                                      mediaId: mediaId)?.currentMedia
     }
     
     @MainActor
     /// Gets the media object for some connected input.
-    func getComputedMedia(loopIndex: Int) -> StitchMediaObject? {
-        self.getComputedMediaValue(loopIndex: loopIndex)?.mediaObject
+    func getComputedMedia(loopIndex: Int,
+                          mediaId: UUID) -> StitchMediaObject? {
+        self.getComputedMediaValue(loopIndex: loopIndex,
+                                   mediaId: mediaId)?.mediaObject
     }
     
     /// Used for fields.
     @MainActor
-    func getVisibleMediaObserver(inputCoordinate: NodeIOCoordinate) -> MediaViewModel? {
+    func getVisibleMediaObserver(inputCoordinate: NodeIOCoordinate,
+                                 mediaId: UUID) -> MediaViewModel? {
         guard let rowObserver = self.getInputRowObserver(for: inputCoordinate.portType) else {
             fatalErrorIfDebug()
             return nil
@@ -198,28 +211,33 @@ extension NodeViewModel {
         
         let loopIndex = rowObserver.getActiveLoopIndex()
         return self.getInputMediaObserver(inputCoordinate: inputCoordinate,
-                                          loopIndex: loopIndex)
+                                          loopIndex: loopIndex,
+                                          mediaId: mediaId)
     }
     
     /// Used for fields.
     @MainActor
-    func getVisibleMediaObserver(outputPortId: Int) -> MediaViewModel? {
+    func getVisibleMediaObserver(outputPortId: Int,
+                                 mediaId: UUID) -> MediaViewModel? {
         guard let rowObserver = self.getOutputRowObserver(outputPortId) else {
             fatalErrorIfDebug()
             return nil
         }
         
         let loopIndex = rowObserver.getActiveLoopIndex()
-        return self.getComputedMediaObserver(loopIndex: loopIndex)
+        return self.getComputedMediaObserver(loopIndex: loopIndex,
+                                             mediaId: mediaId)
     }
     
     @MainActor
     func getInputMediaObserver(inputCoordinate: NodeIOCoordinate,
-                               loopIndex: Int) -> MediaViewModel? {
+                               loopIndex: Int,
+                               mediaId: UUID) -> MediaViewModel? {
         switch inputCoordinate.portType {
         case .portIndex(let portIndex):
             return self.getInputMediaObserver(portIndex: portIndex,
-                                      loopIndex: loopIndex)
+                                              loopIndex: loopIndex,
+                                              mediaId: mediaId)
             
         case .keyPath(let keyPath):
             guard let layerNode = self.layerNode else {
@@ -229,35 +247,53 @@ extension NodeViewModel {
             
             // MARK: helpers here will not retrieve local imported layer view model, thorough testing needed if scope increases
             return layerNode.getConnectedInputMediaObserver(keyPath: keyPath,
-                                                            loopIndex: loopIndex)
+                                                            loopIndex: loopIndex,
+                                                            mediaId: mediaId)
         }
     }
     
     @MainActor
     /// Gets the media object for some connected input.
     func getInputMediaObserver(portIndex: Int,
-                               loopIndex: Int) -> MediaViewModel? {
+                               loopIndex: Int,
+                               mediaId: UUID) -> MediaViewModel? {
         // Do nothing if no upstream connection for media
         guard let connectedUpstreamObserver = self.inputsObservers[safe: portIndex]?.upstreamOutputObserver,
                 let connectedUpstreamNode = connectedUpstreamObserver.nodeDelegate else {
+            
             // MARK: below functionality allows nodes like media import patch nodes to display media at the input even though computed ephemeral observers only hold media. For some nodes like loop builder this isn't ideal as it'll incorrectly display valid data at an empty input.
             if self.kind == .patch(.loopBuilder) {
                 return nil
             }
             
             // Check if media eval op exists here if no connection
-            return self.getComputedMediaObserver(loopIndex: loopIndex)
+            return self.getComputedMediaObserver(loopIndex: loopIndex,
+                                                 mediaId: mediaId)
         }
         
         // Media object is obtained by looking at upstream connected node's saved media objects.
-        return connectedUpstreamNode.getComputedMediaObserver(loopIndex: loopIndex)
+        if let viewModel = connectedUpstreamNode.getComputedMediaObserver(loopIndex: loopIndex,
+                                                                          mediaId: mediaId) {
+            return viewModel
+        }
+        
+        // Fallback logic below: recursively check upstream nodes at the firt port index. Provides support for nodes like splitters which don't directly hold media.
+        return connectedUpstreamNode.getInputMediaObserver(portIndex: 0,
+                                                           loopIndex: loopIndex,
+                                                           mediaId: mediaId)
     }
     
     @MainActor
     /// Gets the media object for some connected input.
-    func getComputedMediaObserver(loopIndex: Int) -> MediaViewModel? {
+    func getComputedMediaObserver(loopIndex: Int,
+                                  mediaId: UUID) -> MediaViewModel? {
         // Check if media eval op exists here if no connection
-        (self.ephemeralObservers?[safe: loopIndex] as? MediaEvalOpViewable)?.mediaViewModel
+        if let viewModel = (self.ephemeralObservers?[safe: loopIndex] as? MediaEvalOpViewable)?.mediaViewModel,
+           viewModel.currentMedia?.id == mediaId {
+            return viewModel
+        }
+        
+        return nil
     }
 }
 
@@ -271,25 +307,35 @@ extension NodeRowObserver {
 extension LayerNodeViewModel {
     @MainActor
     func getConnectedInputMedia(keyPath: LayerInputType,
-                                loopIndex: Int) -> StitchMediaObject? {
-        self.getConnectedInputMediaObserver(keyPath: keyPath,
-                                            loopIndex: loopIndex)?
-            .currentMedia?.mediaObject
+                                loopIndex: Int,
+                                mediaId: UUID) -> StitchMediaObject? {
+        if let mediaValue = self.getConnectedInputMediaObserver(keyPath: keyPath,
+                                            loopIndex: loopIndex,
+                                            mediaId: mediaId)?
+            .currentMedia,
+           mediaValue.id == mediaId {
+            return mediaValue.mediaObject
+        }
+        
+        return nil
     }
     
     @MainActor
     /// Gets the media observer for some connected input.
     func getConnectedInputMediaObserver(keyPath: LayerInputType,
-                                        loopIndex: Int) -> MediaViewModel? {
+                                        loopIndex: Int,
+                                        mediaId: UUID) -> MediaViewModel? {
         let port = self[keyPath: keyPath.layerNodeKeyPath]
         
         if let upstreamObserver = port.rowObserver.upstreamOutputObserver,
            let upstreamNode = upstreamObserver.nodeDelegate {
-            return upstreamNode.getComputedMediaObserver(loopIndex: loopIndex)
+            return upstreamNode.getComputedMediaObserver(loopIndex: loopIndex,
+                                                         mediaId: mediaId)
         }
         
         // No upstream connection, find media at layer view model
-        guard let layerViewModel = self.previewLayerViewModels[safe: loopIndex] else {
+        guard let layerViewModel = self.previewLayerViewModels[safe: loopIndex],
+              layerViewModel.mediaViewModel.currentMedia?.id == mediaId else {
             return nil
         }
 

--- a/Stitch/Graph/Node/Util/NodeMediaUtils.swift
+++ b/Stitch/Graph/Node/Util/NodeMediaUtils.swift
@@ -158,7 +158,7 @@ extension NodeViewModel {
     /// Gets the media object for some connected input.
     func getInputMedia(portIndex: Int,
                        loopIndex: Int,
-                       mediaId: UUID) -> StitchMediaObject? {
+                       mediaId: UUID?) -> StitchMediaObject? {
         self.getInputMediaValue(portIndex: portIndex,
                                 loopIndex: loopIndex,
                                 mediaId: mediaId)?.mediaObject
@@ -168,7 +168,7 @@ extension NodeViewModel {
     /// Gets the media object for some connected input.
     func getInputMediaValue(portIndex: Int,
                             loopIndex: Int,
-                            mediaId: UUID) -> GraphMediaValue? {
+                            mediaId: UUID?) -> GraphMediaValue? {
         self.getInputMediaObserver(portIndex: portIndex,
                                    loopIndex: loopIndex,
                                    mediaId: mediaId)?.currentMedia
@@ -187,7 +187,7 @@ extension NodeViewModel {
     @MainActor
     /// Gets the media object for some connected input.
     func getComputedMediaValue(loopIndex: Int,
-                               mediaId: UUID) -> GraphMediaValue? {
+                               mediaId: UUID?) -> GraphMediaValue? {
         self.getComputedMediaObserver(loopIndex: loopIndex,
                                       mediaId: mediaId)?.currentMedia
     }
@@ -256,7 +256,7 @@ extension NodeViewModel {
     /// Gets the media object for some connected input.
     func getInputMediaObserver(portIndex: Int,
                                loopIndex: Int,
-                               mediaId: UUID) -> MediaViewModel? {
+                               mediaId: UUID?) -> MediaViewModel? {
         // Do nothing if no upstream connection for media
         guard let connectedUpstreamObserver = self.inputsObservers[safe: portIndex]?.upstreamOutputObserver,
                 let connectedUpstreamNode = connectedUpstreamObserver.nodeDelegate else {
@@ -286,10 +286,15 @@ extension NodeViewModel {
     @MainActor
     /// Gets the media object for some connected input.
     func getComputedMediaObserver(loopIndex: Int,
-                                  mediaId: UUID) -> MediaViewModel? {
+                                  mediaId: UUID?) -> MediaViewModel? {
         // Check if media eval op exists here if no connection
-        if let viewModel = (self.ephemeralObservers?[safe: loopIndex] as? MediaEvalOpViewable)?.mediaViewModel,
-           viewModel.currentMedia?.id == mediaId {
+        if let viewModel = (self.ephemeralObservers?[safe: loopIndex] as? MediaEvalOpViewable)?.mediaViewModel {
+            // Only check on media ID if provided, else always return object
+            if let mediaId = mediaId,
+               viewModel.currentMedia?.id == mediaId {
+                return viewModel
+            }
+            
             return viewModel
         }
         

--- a/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
@@ -509,7 +509,8 @@ struct NonGroupPreviewLayersView: View {
                 // Checks for connected upstream media
                 if let existingMedia = self.layerNode
                     .getConnectedInputMedia(keyPath: layerInputType,
-                                            loopIndex: self.layerViewModel.id.loopIndex) {
+                                            loopIndex: self.layerViewModel.id.loopIndex,
+                                            mediaId: mediaValue.id) {
                     self.layerViewModel.mediaViewModel.currentMedia = .init(computedMedia: existingMedia)
                     return
                 }


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/6856.

Solves an issue that directly targets nodes like splitters which have the ability to point to some media.

Given recent changes, media isn't directly passed from node to node via port values. This PR fixes media referencing for nodes that don't mutate objects. The solution uses a fallback method for searching for media, rather than requiring updates to each node eval, thus providing a maintainable approach.