### PR TITLE
Improved graph responsiveness from insert node menu closing

### DIFF
--- a/Stitch/App/View/StitchRootView.swift
+++ b/Stitch/App/View/StitchRootView.swift
@@ -53,8 +53,7 @@ struct StitchRootView: View {
              return false
          }
 
-         return document.graphUI.insertNodeMenuState.menuAnimatingToNode ||
-         document.graphUI.insertNodeMenuState.show
+         return document.graphUI.insertNodeMenuState.show
      }
     
     var body: some View {

--- a/Stitch/Graph/Gesture/View/GraphMovementViewModifier.swift
+++ b/Stitch/Graph/Gesture/View/GraphMovementViewModifier.swift
@@ -40,8 +40,9 @@ struct GraphMovementViewModifier: ViewModifier {
                  - https://github.com/StitchDesign/Stitch--Old/issues/6779
                  */
                 self.graph.visibleNodesViewModel.setAllNodesVisible()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                    self.graph.updateVisibleNodes()
+                
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak graph] in
+                    graph?.updateVisibleNodes()
                 }
             }
             .onChange(of: graphMovement.localPosition) { _, newValue in

--- a/Stitch/Graph/Menu/InsertNodeMenu/Model/InsertNodeMenuState.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/Model/InsertNodeMenuState.swift
@@ -23,7 +23,7 @@ struct UpdateSearchQuery: Action {
     // False = we are not animating, or the menu has just first been shown.
 struct InsertNodeMenuState: Hashable {
     var hiddenNodeId: NodeId?
-    var menuAnimatingToNode: Bool = false
+
     // The bounds of the user-committed node; we need this node size so that we can know the starting size for animation node.
 //    var activeSelectionBounds: CGRect?
 

--- a/Stitch/Graph/Menu/InsertNodeMenu/Util/InsertNodeMenuActions.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/Util/InsertNodeMenuActions.swift
@@ -15,10 +15,9 @@ import StitchSchemaKit
 struct ToggleInsertNodeMenu: GraphUIEvent {
     func handle(state: GraphUIState) {
         log("ToggleInsertNodeMenu called")
-        if !state.insertNodeMenuState.menuAnimatingToNode {
-            state.toggleInsertNodeMenu()
-            state.doubleTapLocation = nil
-        }
+
+        state.toggleInsertNodeMenu()
+        state.doubleTapLocation = nil
     }
 }
 
@@ -66,7 +65,7 @@ extension GraphUIState {
 
             // whenever we toggle (open or close) the menu,
             // set `menuAnimating = false`
-            self.insertNodeMenuState.menuAnimatingToNode = false
+//            self.insertNodeMenuState.menuAnimatingToNode = false
 //        }
     }
 }
@@ -80,11 +79,11 @@ struct CloseAndResetInsertNodeMenu: GraphUIEvent {
     func handle(state: GraphUIState) {
         // log("CloseAndResetInsertNodeMenu called")
 
-        if !state.insertNodeMenuState.menuAnimatingToNode {
-            withAnimation(.INSERT_NODE_MENU_TOGGLE_ANIMATION) {
-                state.insertNodeMenuState = InsertNodeMenuState()
-            }
-        }
+        state.insertNodeMenuState = InsertNodeMenuState()
+//        if !state.insertNodeMenuState.menuAnimatingToNode {
+////            withAnimation(.INSERT_NODE_MENU_TOGGLE_ANIMATION) {
+////            }
+//        }
     }
 }
 
@@ -170,7 +169,7 @@ extension GraphState {
         self.graphUI.insertNodeMenuState.show = false
 
         // mark the animation as completed
-        self.graphUI.insertNodeMenuState.menuAnimatingToNode = false
+//        self.graphUI.insertNodeMenuState.menuAnimatingToNode = false
 
         // reset active selection
         //        self.graphUI.insertNodeMenuState.activeSelection = nil

--- a/Stitch/Graph/Menu/InsertNodeMenu/Util/InsertNodeMenuActions.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/Util/InsertNodeMenuActions.swift
@@ -60,13 +60,14 @@ extension GraphUIState {
         
         // `withAnimation` still seems to cause view to scroll
         
-        withAnimation(.INSERT_NODE_MENU_TOGGLE_ANIMATION) {
+        // MARK: animation cancels possible gestures like scroll, removing for now
+//        withAnimation(.INSERT_NODE_MENU_TOGGLE_ANIMATION) {
             self.insertNodeMenuState.show = showMenu
 
             // whenever we toggle (open or close) the menu,
             // set `menuAnimating = false`
             self.insertNodeMenuState.menuAnimatingToNode = false
-        }
+//        }
     }
 }
 

--- a/Stitch/Graph/Menu/InsertNodeMenu/Util/InsertNodeMenuActions.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/Util/InsertNodeMenuActions.swift
@@ -55,18 +55,7 @@ extension GraphUIState {
             self.insertNodeMenuState.activeSelection = InsertNodeMenuState.startingActiveSelection
         }
 
-        // Only animate the properties relevant to animation
-        
-        // `withAnimation` still seems to cause view to scroll
-        
-        // MARK: animation cancels possible gestures like scroll, removing for now
-//        withAnimation(.INSERT_NODE_MENU_TOGGLE_ANIMATION) {
-            self.insertNodeMenuState.show = showMenu
-
-            // whenever we toggle (open or close) the menu,
-            // set `menuAnimating = false`
-//            self.insertNodeMenuState.menuAnimatingToNode = false
-//        }
+        self.insertNodeMenuState.show = showMenu
     }
 }
 
@@ -80,10 +69,6 @@ struct CloseAndResetInsertNodeMenu: GraphUIEvent {
         // log("CloseAndResetInsertNodeMenu called")
 
         state.insertNodeMenuState = InsertNodeMenuState()
-//        if !state.insertNodeMenuState.menuAnimatingToNode {
-////            withAnimation(.INSERT_NODE_MENU_TOGGLE_ANIMATION) {
-////            }
-//        }
     }
 }
 
@@ -167,9 +152,6 @@ extension GraphState {
 
         // hide the menu and animated-node
         self.graphUI.insertNodeMenuState.show = false
-
-        // mark the animation as completed
-//        self.graphUI.insertNodeMenuState.menuAnimatingToNode = false
 
         // reset active selection
         //        self.graphUI.insertNodeMenuState.activeSelection = nil

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenu.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenu.swift
@@ -39,8 +39,6 @@ struct InsertNodeMenuView: View {
     @Environment(StitchStore.self) private var store
     @Environment(\.appTheme) var theme
 
-    @Binding var cornerRadius: CGFloat
-
     let insertNodeMenuState: InsertNodeMenuState
     let isPortraitMode: Bool
     let showMenu: Bool
@@ -49,13 +47,11 @@ struct InsertNodeMenuView: View {
 
     @State var footerRect: CGRect = .zero
 
-    let animatingNodeOpacity: CGFloat
-
     var body: some View {
         sheetView
             .frame(width: InsertNodeMenuWrapper.menuWidth,
                    height: menuHeight)
-            .cornerRadius(cornerRadius)
+            .cornerRadius(InsertNodeMenuWrapper.shownMenuCornerRadius)
     }
 
     @MainActor
@@ -69,8 +65,7 @@ struct InsertNodeMenuView: View {
                     searchResults: insertNodeMenuState.searchResults,
                     activeSelection: insertNodeMenuState.activeSelection,
                     footerRect: self.$footerRect,
-                    show: store.currentDocument?.graphUI.insertNodeMenuState.show ?? false,
-                    animatingNodeOpacity: animatingNodeOpacity)
+                    show: store.currentDocument?.graphUI.insertNodeMenuState.show ?? false)
                     //                    .frame(width: 170, height: 300) // Figma
                     .frame(width: INSERT_NODE_MENU_SEARCH_RESULTS_WIDTH)
                 //                    .compositingGroup() // added
@@ -84,7 +79,7 @@ struct InsertNodeMenuView: View {
                 footerView
             }
         } // VStack
-        .background(INSERT_NODE_SEARCH_BACKGROUND.opacity(1 - animatingNodeOpacity))
+        .background(INSERT_NODE_SEARCH_BACKGROUND)
         .foregroundColor(INSERT_NODE_MENU_SEARCH_TEXT)
         // Important: animates the entire view's appearance at same time; otherwise e.g. the frosted background fades in separately
         .compositingGroup()
@@ -123,7 +118,7 @@ struct InsertNodeMenuView: View {
                     }
                 }
                 .padding(8)
-                .background(theme.themeData.edgeColor.opacity(1 - animatingNodeOpacity))
+                .background(theme.themeData.edgeColor)
                 .cornerRadius(8)
             })
         }
@@ -142,12 +137,10 @@ struct InsertNodeMenu_Previews: PreviewProvider {
 
     static var previews: some View {
         ZStack {
-            InsertNodeMenuView(cornerRadius: .constant(20),
-                               insertNodeMenuState: .init(),
+            InsertNodeMenuView(insertNodeMenuState: .init(),
                                isPortraitMode: false,
                                showMenu: true,
-                               menuHeight: INSERT_NODE_MENU_MAX_HEIGHT,
-                               animatingNodeOpacity: 0.0)
+                               menuHeight: INSERT_NODE_MENU_MAX_HEIGHT)
         }
         .previewDevice("iPad mini (6th generation)")
     }

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuSearchResults.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuSearchResults.swift
@@ -10,6 +10,9 @@ import StitchSchemaKit
 
 struct InsertNodeMenuSearchResults: View {
 
+    @State private var nodeResultSizes: [UUID: CGRect] = .init()
+    @State private var localId = UUID()
+
     @Environment(\.appTheme) var theme
 
     // All the nodes and components (default or custom) that met the entered search criteria
@@ -21,12 +24,6 @@ struct InsertNodeMenuSearchResults: View {
     @Binding var footerRect: CGRect
 
     let show: Bool
-    
-    let animatingNodeOpacity: CGFloat
-
-    @State var nodeResultSizes: [UUID: CGRect] = .init()
-
-    @State var localId = UUID()
     
     // TODO: iterate through DefaultComponents enum
     var defaultComponents: [InsertNodeMenuOptionData] {
@@ -42,7 +39,6 @@ struct InsertNodeMenuSearchResults: View {
     }
 
     var body: some View {
-
         ScrollViewReader { (proxy: ScrollViewProxy) in
             ScrollView(showsIndicators: false) {
                 LazyVStack(spacing: 0) {
@@ -115,7 +111,7 @@ struct InsertNodeMenuSearchResults: View {
     }
 
     var selectionColor: Color {
-        theme.themeData.edgeColor.opacity(1 - animatingNodeOpacity)
+        theme.themeData.edgeColor
     }
 
     @MainActor

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWrapper.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWrapper.swift
@@ -10,35 +10,9 @@ import SwiftUI
 
 struct InsertNodeMenuWrapper: View {
     static let menuWidth: CGFloat = INSERT_NODE_MENU_WIDTH
-    static let opacityAnimationDelay: Double = 0.25
     static let shownMenuScale: CGFloat = 1
     
-    // let opacity animation last a tiny bit longer
-    static let opacityAnimationDuration = Self.scaleAnimationDuration - Self.opacityAnimationDelay/2
-
-    static let opacityAnimation = Animation
-        .linear(duration: opacityAnimationDuration)
-        .delay(Self.opacityAnimationDelay)
-    
-    static let scaleAnimationDuration: Double = 0.4
-    static let scaleAnimation = Animation.linear(duration: scaleAnimationDuration)
-
-    // These values set in onAppear and when insertion animation completes
-    @State private var nodeOpacity: CGFloat = .zero
-
-    @State private var menuScaleX: CGFloat = .zero
-    @State private var menuScaleY: CGFloat = .zero
-
-    @State private var nodeScaleX: CGFloat = .zero
-    @State private var nodeScaleY: CGFloat = .zero
-
-    @State private var menuPosition: CGPoint = .zero
-    @State private var nodePosition: CGPoint = .zero
-
-    // doesn't really matter, since overridden by actual node size
-    @State private var nodeWidth: CGFloat = 300.0
-    @State private var nodeHeight: CGFloat = 200.0
-    @State private var animatedNode: NodeViewModel?
+//    @State private var animatedNode: NodeViewModel?
 
     @Bindable var document: StitchDocumentViewModel
     @Bindable var graphUI: GraphUIState
@@ -79,27 +53,17 @@ struct InsertNodeMenuWrapper: View {
         graphUI.insertNodeMenuState
     }
 
-    // `showMenu: false` = animate from menu to node
-    var showMenu: Bool {
-        !graphUI.insertNodeMenuState.menuAnimatingToNode
-    }
-
     static let shownMenuCornerRadius: CGFloat = 16
     //    static let hiddenMenuCornerRadius: CGFloat = 98
     static let hiddenMenuCornerRadius: CGFloat = 60
 
-    @State var menuCornerRadius: CGFloat = Self.shownMenuCornerRadius
+//    @State var menuCornerRadius: CGFloat = Self.shownMenuCornerRadius
 
     // We show the modal background when menu is toggled but node-animation has not yet started
     var showModalBackground: Bool {
         graphUI.insertNodeMenuState.show
-            && !graphUI.insertNodeMenuState.menuAnimatingToNode
     }
 
-    var menuAnimatingToNode: Bool {
-        graphUI.insertNodeMenuState.menuAnimatingToNode
-    }
-    
     @MainActor
     func getNodeDestination() -> CGPoint {
         
@@ -124,65 +88,63 @@ struct InsertNodeMenuWrapper: View {
     
     // i.e. placing the menu in the center of the screen again;
     // done whenever view first appears, or we change menuOrigin (due to screen-resizing from on-screen keyboard)
-    func prepareHiddenMenu(setHeightToMax: Bool = true) {
-        // log("prepareHiddenMenu called: menuOrigin: \(menuOrigin)")
-
-        self.menuCornerRadius = Self.shownMenuCornerRadius
-
-        self.nodeOpacity = .zero
-        self.menuScaleX = Self.shownMenuScale
-        self.menuScaleY = Self.shownMenuScale
-
-        self.nodeScaleX = self.getLargeNodeWidthScale()
-        self.nodeScaleY = self.getLargeNodeHeightScale()
-
-        // menu and animating-node start out in center of screen
-        self.menuPosition = menuOrigin
-
-        // Need to factor out graph offset, to get node placed under the menu
-        self.nodePosition = self.getAdjustedMenuOrigin() // menuOrigin
-
-        if setHeightToMax {
-//            self.menuHeight = INSERT_NODE_MENU_MAX_HEIGHT
-            dispatch(NodeMenuHeightSet(newHeight: INSERT_NODE_MENU_MAX_HEIGHT))
-        }
-    }
+//    func prepareHiddenMenu(setHeightToMax: Bool = true) {
+//        // log("prepareHiddenMenu called: menuOrigin: \(menuOrigin)")
+//
+//        self.menuCornerRadius = Self.shownMenuCornerRadius
+//
+//        self.nodeOpacity = .zero
+//        self.menuScaleX = Self.shownMenuScale
+//        self.menuScaleY = Self.shownMenuScale
+//
+//        self.nodeScaleX = self.getLargeNodeWidthScale()
+//        self.nodeScaleY = self.getLargeNodeHeightScale()
+//
+//        // menu and animating-node start out in center of screen
+//        self.menuPosition = menuOrigin
+//
+//        // Need to factor out graph offset, to get node placed under the menu
+//        self.nodePosition = self.getAdjustedMenuOrigin() // menuOrigin
+//
+//        if setHeightToMax {
+////            self.menuHeight = INSERT_NODE_MENU_MAX_HEIGHT
+//            dispatch(NodeMenuHeightSet(newHeight: INSERT_NODE_MENU_MAX_HEIGHT))
+//        }
+//    }
     
-    func getLargeNodeWidthScale() -> CGFloat {
-        Self.menuWidth / self.nodeWidth * (1 / graphScale)
-    }
-    
-    func getLargeNodeHeightScale() -> CGFloat {
-        self.nodeHeight / menuHeight * graphScale
-    }
-    
-    @MainActor
-    func animateNode() {
-        // factor out the graphScale,
-        // since now the node needs to look like the menu
-        let largeNodeWidthScale: CGFloat = self.getLargeNodeWidthScale()
-        
-        let largeNodeHeightScale: CGFloat = self.getLargeNodeHeightScale()
-
-        withAnimation(Self.opacityAnimation) {
-            nodeOpacity = showMenu ? 0 : 1
-        }
-
-        withAnimation(Self.scaleAnimation) {
-
-            // Adjust the corner radius when menu hidden
-            menuCornerRadius = showMenu ? Self.shownMenuCornerRadius : Self.hiddenMenuCornerRadius
-
-            // Menu's opacity does not actually change during animation;
-            // we merely let the node appear over it (z-index)
-
-            nodeScaleX = showMenu ? largeNodeWidthScale : 1
-            nodeScaleY = showMenu ? largeNodeHeightScale : 1
-
-            // Node's hidden position = menu position + graph offset factored OUT
-            nodePosition = showMenu ? getAdjustedMenuOrigin() : getNodeDestination()
-        }
-    }
+//    func getLargeNodeWidthScale() -> CGFloat {
+//        Self.menuWidth / self.nodeWidth * (1 / graphScale)
+//    }
+//    
+//    func getLargeNodeHeightScale() -> CGFloat {
+//        self.nodeHeight / menuHeight * graphScale
+//    }
+//    
+//    @MainActor
+//    func showNode() {
+//        // factor out the graphScale,
+//        // since now the node needs to look like the menu
+//        let largeNodeWidthScale: CGFloat = self.getLargeNodeWidthScale()
+//        
+//        let largeNodeHeightScale: CGFloat = self.getLargeNodeHeightScale()
+//
+//        self.nodeOpacity = 1
+//        
+//        withAnimation(Self.scaleAnimation) {
+//
+//            // Adjust the corner radius when menu hidden
+//            menuCornerRadius = showMenu ? Self.shownMenuCornerRadius : Self.hiddenMenuCornerRadius
+//
+//            // Menu's opacity does not actually change during animation;
+//            // we merely let the node appear over it (z-index)
+//
+//            nodeScaleX = showMenu ? largeNodeWidthScale : 1
+//            nodeScaleY = showMenu ? largeNodeHeightScale : 1
+//
+//            // Node's hidden position = menu position + graph offset factored OUT
+//            nodePosition = showMenu ? getAdjustedMenuOrigin() : getNodeDestination()
+//        }
+//    }
     
     var graphOffset: CGPoint {
         graphMovement.localPosition
@@ -200,109 +162,107 @@ struct InsertNodeMenuWrapper: View {
         return d
     }
     
-    @MainActor
-    func animateMenu() {
-        let graphOffset: CGSize = graphMovement.localPosition.toCGSize
-        let graphScale: CGFloat = graphMovement.zoomData.zoom
-        let nodeDestination = self.getNodeDestination()
-        
-        // factor in the graphScale,
-        // since now the menu needs to look like the node
-        let smallMenuWidthScale: CGFloat = nodeWidth/Self.menuWidth * graphScale
-        
-        //        nodeHeight/Self.menuHeight * graphScale
-        let smallMenuHeightScale: CGFloat = nodeHeight/menuHeight * graphScale
-
-        withAnimation(Self.scaleAnimation) {
-            menuScaleX = showMenu ? Self.shownMenuScale : smallMenuWidthScale
-            menuScaleY = showMenu ? Self.shownMenuScale : smallMenuHeightScale
-
-            // node destination's diff from center
-            let diffX = screenWidth/2 - nodeDestination.x
-
-            //            let diffY = screenHeight/2 - nodeDestination.height
-
-            // Use non-changing height of screen for menu's animation-end position;
-            // i.e. animate the menu to a position as if the keyboard were not on screen.
-            let diffY = graphUI.frame.size.height/2 - nodeDestination.y
-
-            let finalDiffX = diffX * (1 - graphScale)
-            let finalDiffY = diffY * (1 - graphScale)
-
-            let scaledOffsetWidth = graphOffset.width * graphScale
-            let scaledOffsetHeight = graphOffset.height * graphScale
-
-            let menuHiddenPositionX = nodeDestination.x
-                + finalDiffX
-                + scaledOffsetWidth
-
-            let menuHiddenPositionY = nodeDestination.y
-                + finalDiffY
-                + scaledOffsetHeight
-            
-            let menuHiddenPosition = CGPoint(x: menuHiddenPositionX,
-                                             y: menuHiddenPositionY)
-
-            menuPosition = showMenu
-                ? menuOrigin
-                : menuHiddenPosition
-        } // withAnimation
-
-    }
+//    @MainActor
+//    func animateMenu() {
+//        let graphOffset: CGSize = graphMovement.localPosition.toCGSize
+//        let graphScale: CGFloat = graphMovement.zoomData.zoom
+//        let nodeDestination = self.getNodeDestination()
+//        
+//        // factor in the graphScale,
+//        // since now the menu needs to look like the node
+//        let smallMenuWidthScale: CGFloat = nodeWidth/Self.menuWidth * graphScale
+//        
+//        //        nodeHeight/Self.menuHeight * graphScale
+//        let smallMenuHeightScale: CGFloat = nodeHeight/menuHeight * graphScale
+//
+//        withAnimation(Self.scaleAnimation) {
+//            menuScaleX = showMenu ? Self.shownMenuScale : smallMenuWidthScale
+//            menuScaleY = showMenu ? Self.shownMenuScale : smallMenuHeightScale
+//
+//            // node destination's diff from center
+//            let diffX = screenWidth/2 - nodeDestination.x
+//
+//            //            let diffY = screenHeight/2 - nodeDestination.height
+//
+//            // Use non-changing height of screen for menu's animation-end position;
+//            // i.e. animate the menu to a position as if the keyboard were not on screen.
+//            let diffY = graphUI.frame.size.height/2 - nodeDestination.y
+//
+//            let finalDiffX = diffX * (1 - graphScale)
+//            let finalDiffY = diffY * (1 - graphScale)
+//
+//            let scaledOffsetWidth = graphOffset.width * graphScale
+//            let scaledOffsetHeight = graphOffset.height * graphScale
+//
+//            let menuHiddenPositionX = nodeDestination.x
+//                + finalDiffX
+//                + scaledOffsetWidth
+//
+//            let menuHiddenPositionY = nodeDestination.y
+//                + finalDiffY
+//                + scaledOffsetHeight
+//            
+//            let menuHiddenPosition = CGPoint(x: menuHiddenPositionX,
+//                                             y: menuHiddenPositionY)
+//
+//            menuPosition = showMenu
+//                ? menuOrigin
+//                : menuHiddenPosition
+//        } // withAnimation
+//
+//    }
     
-    /*
-     Two uses of NodeView by node menu:
-    
-     1. reading the size of the node, before animation starts: `boundsDisabled = false`, `updateMenuActiveSelectionBounds = true`
-     
-     2. animating the node, using the read animation starts: `boundsDisabled = false`, `updateMenuActiveSelectionBounds = true`
-     */
-    @MainActor @ViewBuilder
-    func fakeNodeView(boundsDisabled: Bool,
-                      updateMenuActiveSelectionBounds: Bool) -> some View {
-
-        if let node = self.animatedNode,
-           let canvas = node.patchCanvasItem {
-            @Bindable var canvas = canvas
-            NodeTypeView(document: document,
-                         graph: document.visibleGraph,
-                         node: node,
-                         canvasNode: canvas,
-                         atleastOneCommentBoxSelected: false,
-                         activeIndex: .init(1),
-                         groupNodeFocused: nil,
-                         adjustmentBarSessionId: .fakeId,
-                         isSelected: false,
-                         boundsReaderDisabled: boundsDisabled,
-                         // fake node does NOT use position handler
-                         usePositionHandler: false,
-                         updateMenuActiveSelectionBounds: updateMenuActiveSelectionBounds)
-            .onChange(of: canvas.sizeByLocalBounds) { _, newSize in
-                guard let newSize = newSize,
-                      newSize.width.isNormal && newSize.height.isNormal else { return }
-                
-                self.nodeWidth = newSize.width
-                self.nodeHeight = newSize.height
-                
-                prepareHiddenMenu(setHeightToMax: false)
-            }
-        } // if let nodeType =
-        else {
-            EmptyView()
-        }
-    }
+//    /*
+//     Two uses of NodeView by node menu:
+//    
+//     1. reading the size of the node, before animation starts: `boundsDisabled = false`, `updateMenuActiveSelectionBounds = true`
+//     
+//     2. animating the node, using the read animation starts: `boundsDisabled = false`, `updateMenuActiveSelectionBounds = true`
+//     */
+//    @MainActor @ViewBuilder
+//    func fakeNodeView(boundsDisabled: Bool,
+//                      updateMenuActiveSelectionBounds: Bool) -> some View {
+//
+//        if let node = self.animatedNode,
+//           let canvas = node.patchCanvasItem {
+//            @Bindable var canvas = canvas
+//            NodeTypeView(document: document,
+//                         graph: document.visibleGraph,
+//                         node: node,
+//                         canvasNode: canvas,
+//                         atleastOneCommentBoxSelected: false,
+//                         activeIndex: .init(1),
+//                         groupNodeFocused: nil,
+//                         adjustmentBarSessionId: .fakeId,
+//                         isSelected: false,
+//                         boundsReaderDisabled: boundsDisabled,
+//                         // fake node does NOT use position handler
+//                         usePositionHandler: false,
+//                         updateMenuActiveSelectionBounds: updateMenuActiveSelectionBounds)
+//            .onChange(of: canvas.sizeByLocalBounds) { _, newSize in
+//                guard let newSize = newSize,
+//                      newSize.width.isNormal && newSize.height.isNormal else { return }
+//                
+//                self.nodeWidth = newSize.width
+//                self.nodeHeight = newSize.height
+//                
+////                prepareHiddenMenu(setHeightToMax: false)
+//            }
+//        } // if let nodeType =
+//        else {
+//            EmptyView()
+//        }
+//    }
 
     var menuView: some View {
         // InsertNodeMenu should NOT ignore the .keyboard and/or .bottom safe areas
         // however, GeometryReader (used for determining preview window size) SHOULD;
         // so, we need to apply the InsertNodeMenu SwiftUI .modifier after we've ignored safe areas.
         InsertNodeMenuView(
-            cornerRadius: $menuCornerRadius,
             insertNodeMenuState: insertNodeMenuState,
             isPortraitMode: document.previewWindowSize.isPortrait,
             showMenu: insertNodeMenuState.show,
-            menuHeight: menuHeight,
-            animatingNodeOpacity: self.nodeOpacity)
+            menuHeight: menuHeight)
         
             // scale first, THEN position
 //            .scaleEffect(x: menuScaleX, y: menuScaleY)
@@ -354,21 +314,21 @@ struct InsertNodeMenuWrapper: View {
 ////                    .offset(x: -sidebarHalfWidth)
 //            }
         }
-        .onAppear {
-            //            log("onAppear")
-
-            // default, but also updated when GeometryReader changes
-            //            self.screenHeight = graphUI.frame.height
-            prepareHiddenMenu()
-        }
-        .onChange(of: self.menuOrigin, initial: true) { _, _ in
-            //            log("ContentView: onChange of menuOrigin: oldValue: \(oldValue)")
-            //            log("ContentView: onChange of menuOrigin: newValue: \(newValue)")
-            // don't change during animation
-            if !graphUI.insertNodeMenuState.menuAnimatingToNode {
-                prepareHiddenMenu(setHeightToMax: false)
-            }
-        }
+//        .onAppear {
+//            //            log("onAppear")
+//
+//            // default, but also updated when GeometryReader changes
+//            //            self.screenHeight = graphUI.frame.height
+//            prepareHiddenMenu()
+//        }
+//        .onChange(of: self.menuOrigin, initial: true) { _, _ in
+//            //            log("ContentView: onChange of menuOrigin: oldValue: \(oldValue)")
+//            //            log("ContentView: onChange of menuOrigin: newValue: \(newValue)")
+//            // don't change during animation
+//            if !graphUI.insertNodeMenuState.menuAnimatingToNode {
+//                prepareHiddenMenu(setHeightToMax: false)
+//            }
+//        }
 //        .onChange(of: self.screenSize, initial: true) { _, _ in
 //            //            log("ContentView: onChange of self.screenSize: oldValue: \(oldValue)")
 //            //            log("ContentView: onChange of self.screenSize: newValue: \(newValue)")
@@ -376,55 +336,55 @@ struct InsertNodeMenuWrapper: View {
 //                prepareHiddenMenu(setHeightToMax: false)
 //            }
 //        }
-        .onChange(of: graphUI.insertNodeMenuState.menuAnimatingToNode, initial: true) { _, newValue in
-            // log("ContentView: onChange of menuAnimatingToNode: oldValue: \(oldValue)")
-            // log("ContentView: onChange of menuAnimatingToNode: newValue: \(newValue)")
-
-            // Only fire these when animating = true and the menu toggle status = open
-            if newValue && graphUI.insertNodeMenuState.show {
-                animateMenu()
-                animateNode()
-            }
-            // When animation completes, reset menu state
-            if !newValue {
-                prepareHiddenMenu()
-            }
-        }
+//        .onChange(of: graphUI.insertNodeMenuState.menuAnimatingToNode, initial: true) { _, newValue in
+//            // log("ContentView: onChange of menuAnimatingToNode: oldValue: \(oldValue)")
+//            // log("ContentView: onChange of menuAnimatingToNode: newValue: \(newValue)")
+//
+//            // Only fire these when animating = true and the menu toggle status = open
+//            if newValue && graphUI.insertNodeMenuState.show {
+//                animateMenu()
+//                animateNode()
+//            }
+//            // When animation completes, reset menu state
+//            if !newValue {
+//                prepareHiddenMenu()
+//            }
+//        }
         // Keeping the local state `animatedNode` up to date with our activeSelection.
-        .onChange(of: graphUI.insertNodeMenuState.activeSelection, initial: true) { _, _ in
-            //            log("ContentView: onChange of activeSelection: oldValue: \(oldValue)")
-            //            log("ContentView: onChange of activeSelection: newValue: \(newValue)")
-            self.animatedNode = graphUI.insertNodeMenuState.fakeNode(nodePosition)
-        }
+//        .onChange(of: graphUI.insertNodeMenuState.activeSelection, initial: true) { _, _ in
+//            //            log("ContentView: onChange of activeSelection: oldValue: \(oldValue)")
+//            //            log("ContentView: onChange of activeSelection: newValue: \(newValue)")
+//            self.animatedNode = graphUI.insertNodeMenuState.fakeNode(nodePosition)
+//        }
     }
     
-    @ViewBuilder @MainActor
-    var sizeReadingNodeView: some View {
-        fakeNodeView(boundsDisabled: false,
-                     updateMenuActiveSelectionBounds: true)        
-    }
+//    @ViewBuilder @MainActor
+//    var sizeReadingNodeView: some View {
+//        fakeNodeView(boundsDisabled: false,
+//                     updateMenuActiveSelectionBounds: true)        
+//    }
     
-    @MainActor
-    var animatedNodeView: some View {
-        fakeNodeView(boundsDisabled: true,
-                     // animated-node view does not update active selection bounds
-                     updateMenuActiveSelectionBounds: false)
-        .frame(width: nodeWidth, height: nodeHeight)
-        
-        .scaleEffect(x: nodeScaleX, y: nodeScaleY)
-        // NOTE: the node's .position comes AFTER the scaleEffect for the nodeScaleX etc.
-        .position(nodePosition)
-        
-        //            .animation(Self.scaleAnimation, value: nodeScaleY)
-        //            .animation(Self.scaleAnimation, value: nodeScaleX)
-        
-        .opacity(nodeOpacity)
-        
-        //            .animation(Self.opacityAnimation, value: nodeOpacity)
-        
-        // Apply GraphBaseView modifiers AFTER the node's frame, position, etc.
-        // Applying same offset and scale as what nodes have, in same order.
-        .offset(graphOffset.toCGSize)
-        .scaleEffect(graphScale)
-    }
+//    @MainActor
+//    var animatedNodeView: some View {
+//        fakeNodeView(boundsDisabled: true,
+//                     // animated-node view does not update active selection bounds
+//                     updateMenuActiveSelectionBounds: false)
+//        .frame(width: nodeWidth, height: nodeHeight)
+//        
+//        .scaleEffect(x: nodeScaleX, y: nodeScaleY)
+//        // NOTE: the node's .position comes AFTER the scaleEffect for the nodeScaleX etc.
+//        .position(nodePosition)
+//        
+//        //            .animation(Self.scaleAnimation, value: nodeScaleY)
+//        //            .animation(Self.scaleAnimation, value: nodeScaleX)
+//        
+//        .opacity(nodeOpacity)
+//        
+//        //            .animation(Self.opacityAnimation, value: nodeOpacity)
+//        
+//        // Apply GraphBaseView modifiers AFTER the node's frame, position, etc.
+//        // Applying same offset and scale as what nodes have, in same order.
+//        .offset(graphOffset.toCGSize)
+//        .scaleEffect(graphScale)
+//    }
 }

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWrapper.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWrapper.swift
@@ -12,17 +12,12 @@ struct InsertNodeMenuWrapper: View {
     static let menuWidth: CGFloat = INSERT_NODE_MENU_WIDTH
     static let shownMenuScale: CGFloat = 1
     
-//    @State private var animatedNode: NodeViewModel?
-
     @Bindable var document: StitchDocumentViewModel
     @Bindable var graphUI: GraphUIState
     
     var menuHeight: CGFloat {
         graphUI.nodeMenuHeight
     }
-    
-    // TODO: add back or fully remove when we reintroduce
-    //    @Binding var screenSize: CGSize
     
     var graphScale: CGFloat {
         graphMovement.zoomData.zoom
@@ -33,15 +28,13 @@ struct InsertNodeMenuWrapper: View {
         CGPoint(x: screenWidth/2,
                 y: screenHeight/2)
     }
-
+    
     var screenWidth: CGFloat {
-         graphUI.frame.width
-//        self.screenSize.width
+        graphUI.frame.width
     }
-
+    
     var screenHeight: CGFloat {
-         graphUI.frame.height
-//        self.screenSize.height
+        graphUI.frame.height
     }
     
     private var graphMovement: GraphMovementObserver {
@@ -52,104 +45,19 @@ struct InsertNodeMenuWrapper: View {
     var insertNodeMenuState: InsertNodeMenuState {
         graphUI.insertNodeMenuState
     }
-
+    
     static let shownMenuCornerRadius: CGFloat = 16
-    //    static let hiddenMenuCornerRadius: CGFloat = 98
     static let hiddenMenuCornerRadius: CGFloat = 60
-
-//    @State var menuCornerRadius: CGFloat = Self.shownMenuCornerRadius
-
+    
     // We show the modal background when menu is toggled but node-animation has not yet started
     var showModalBackground: Bool {
         graphUI.insertNodeMenuState.show
     }
-
-    @MainActor
-    func getNodeDestination() -> CGPoint {
-        
-        let adjustedDoubleTapLocation = document.adjustedDoubleTapLocation(document.visibleGraph.localPosition)
-        
-        var defaultCenter = document.viewPortCenter
-        
-        let sidebarAdjustment = 0.0 //(self.sidebarHalfWidth * 1/self.graphScale)
-        
-//        if document.llmRecording.isRecording {
-//            return defaultCenter
-//        } else
-        if var adjustedDoubleTapLocation = adjustedDoubleTapLocation {
-            adjustedDoubleTapLocation.x += sidebarAdjustment
-            return adjustedDoubleTapLocation
-        } else {
-            // add back the half sidebar width?
-            defaultCenter.x += sidebarAdjustment
-            return defaultCenter
-        }
-    }
-    
-    // i.e. placing the menu in the center of the screen again;
-    // done whenever view first appears, or we change menuOrigin (due to screen-resizing from on-screen keyboard)
-//    func prepareHiddenMenu(setHeightToMax: Bool = true) {
-//        // log("prepareHiddenMenu called: menuOrigin: \(menuOrigin)")
-//
-//        self.menuCornerRadius = Self.shownMenuCornerRadius
-//
-//        self.nodeOpacity = .zero
-//        self.menuScaleX = Self.shownMenuScale
-//        self.menuScaleY = Self.shownMenuScale
-//
-//        self.nodeScaleX = self.getLargeNodeWidthScale()
-//        self.nodeScaleY = self.getLargeNodeHeightScale()
-//
-//        // menu and animating-node start out in center of screen
-//        self.menuPosition = menuOrigin
-//
-//        // Need to factor out graph offset, to get node placed under the menu
-//        self.nodePosition = self.getAdjustedMenuOrigin() // menuOrigin
-//
-//        if setHeightToMax {
-////            self.menuHeight = INSERT_NODE_MENU_MAX_HEIGHT
-//            dispatch(NodeMenuHeightSet(newHeight: INSERT_NODE_MENU_MAX_HEIGHT))
-//        }
-//    }
-    
-//    func getLargeNodeWidthScale() -> CGFloat {
-//        Self.menuWidth / self.nodeWidth * (1 / graphScale)
-//    }
-//    
-//    func getLargeNodeHeightScale() -> CGFloat {
-//        self.nodeHeight / menuHeight * graphScale
-//    }
-//    
-//    @MainActor
-//    func showNode() {
-//        // factor out the graphScale,
-//        // since now the node needs to look like the menu
-//        let largeNodeWidthScale: CGFloat = self.getLargeNodeWidthScale()
-//        
-//        let largeNodeHeightScale: CGFloat = self.getLargeNodeHeightScale()
-//
-//        self.nodeOpacity = 1
-//        
-//        withAnimation(Self.scaleAnimation) {
-//
-//            // Adjust the corner radius when menu hidden
-//            menuCornerRadius = showMenu ? Self.shownMenuCornerRadius : Self.hiddenMenuCornerRadius
-//
-//            // Menu's opacity does not actually change during animation;
-//            // we merely let the node appear over it (z-index)
-//
-//            nodeScaleX = showMenu ? largeNodeWidthScale : 1
-//            nodeScaleY = showMenu ? largeNodeHeightScale : 1
-//
-//            // Node's hidden position = menu position + graph offset factored OUT
-//            nodePosition = showMenu ? getAdjustedMenuOrigin() : getNodeDestination()
-//        }
-//    }
     
     var graphOffset: CGPoint {
         graphMovement.localPosition
     }
-
+    
     // Used by node-view only
     func getAdjustedMenuOrigin() -> CGPoint {
         // When the menu is shown and the node is hidden,
@@ -162,98 +70,6 @@ struct InsertNodeMenuWrapper: View {
         return d
     }
     
-//    @MainActor
-//    func animateMenu() {
-//        let graphOffset: CGSize = graphMovement.localPosition.toCGSize
-//        let graphScale: CGFloat = graphMovement.zoomData.zoom
-//        let nodeDestination = self.getNodeDestination()
-//        
-//        // factor in the graphScale,
-//        // since now the menu needs to look like the node
-//        let smallMenuWidthScale: CGFloat = nodeWidth/Self.menuWidth * graphScale
-//        
-//        //        nodeHeight/Self.menuHeight * graphScale
-//        let smallMenuHeightScale: CGFloat = nodeHeight/menuHeight * graphScale
-//
-//        withAnimation(Self.scaleAnimation) {
-//            menuScaleX = showMenu ? Self.shownMenuScale : smallMenuWidthScale
-//            menuScaleY = showMenu ? Self.shownMenuScale : smallMenuHeightScale
-//
-//            // node destination's diff from center
-//            let diffX = screenWidth/2 - nodeDestination.x
-//
-//            //            let diffY = screenHeight/2 - nodeDestination.height
-//
-//            // Use non-changing height of screen for menu's animation-end position;
-//            // i.e. animate the menu to a position as if the keyboard were not on screen.
-//            let diffY = graphUI.frame.size.height/2 - nodeDestination.y
-//
-//            let finalDiffX = diffX * (1 - graphScale)
-//            let finalDiffY = diffY * (1 - graphScale)
-//
-//            let scaledOffsetWidth = graphOffset.width * graphScale
-//            let scaledOffsetHeight = graphOffset.height * graphScale
-//
-//            let menuHiddenPositionX = nodeDestination.x
-//                + finalDiffX
-//                + scaledOffsetWidth
-//
-//            let menuHiddenPositionY = nodeDestination.y
-//                + finalDiffY
-//                + scaledOffsetHeight
-//            
-//            let menuHiddenPosition = CGPoint(x: menuHiddenPositionX,
-//                                             y: menuHiddenPositionY)
-//
-//            menuPosition = showMenu
-//                ? menuOrigin
-//                : menuHiddenPosition
-//        } // withAnimation
-//
-//    }
-    
-//    /*
-//     Two uses of NodeView by node menu:
-//    
-//     1. reading the size of the node, before animation starts: `boundsDisabled = false`, `updateMenuActiveSelectionBounds = true`
-//     
-//     2. animating the node, using the read animation starts: `boundsDisabled = false`, `updateMenuActiveSelectionBounds = true`
-//     */
-//    @MainActor @ViewBuilder
-//    func fakeNodeView(boundsDisabled: Bool,
-//                      updateMenuActiveSelectionBounds: Bool) -> some View {
-//
-//        if let node = self.animatedNode,
-//           let canvas = node.patchCanvasItem {
-//            @Bindable var canvas = canvas
-//            NodeTypeView(document: document,
-//                         graph: document.visibleGraph,
-//                         node: node,
-//                         canvasNode: canvas,
-//                         atleastOneCommentBoxSelected: false,
-//                         activeIndex: .init(1),
-//                         groupNodeFocused: nil,
-//                         adjustmentBarSessionId: .fakeId,
-//                         isSelected: false,
-//                         boundsReaderDisabled: boundsDisabled,
-//                         // fake node does NOT use position handler
-//                         usePositionHandler: false,
-//                         updateMenuActiveSelectionBounds: updateMenuActiveSelectionBounds)
-//            .onChange(of: canvas.sizeByLocalBounds) { _, newSize in
-//                guard let newSize = newSize,
-//                      newSize.width.isNormal && newSize.height.isNormal else { return }
-//                
-//                self.nodeWidth = newSize.width
-//                self.nodeHeight = newSize.height
-//                
-////                prepareHiddenMenu(setHeightToMax: false)
-//            }
-//        } // if let nodeType =
-//        else {
-//            EmptyView()
-//        }
-//    }
-
     var menuView: some View {
         // InsertNodeMenu should NOT ignore the .keyboard and/or .bottom safe areas
         // however, GeometryReader (used for determining preview window size) SHOULD;
@@ -263,128 +79,21 @@ struct InsertNodeMenuWrapper: View {
             isPortraitMode: document.previewWindowSize.isPortrait,
             showMenu: insertNodeMenuState.show,
             menuHeight: menuHeight)
-        
-            // scale first, THEN position
-//            .scaleEffect(x: menuScaleX, y: menuScaleY)
-            // use .position modifier to match node's use of .position modifier
-//            .position(menuPosition)
-//            .offset(x: -sidebarHalfWidth)
     }
-    
-    // should be subtracted
-//    var sidebarHalfWidth: CGFloat {
-//        graphUI.sidebarWidth/2
-//    }
     
     var body: some View {
         ZStack {
-
-            
-#if DEV_DEBUG || DEBUG
-            let pseudoPopoverBackgroundOpacity = 0.1
-#else
-            let pseudoPopoverBackgroundOpacity = 0.001
-#endif
-            
             ModalBackgroundGestureRecognizer(dismissalCallback: { dispatch(CloseAndResetInsertNodeMenu()) }) {
-//                Color.blue.opacity(pseudoPopoverBackgroundOpacity)
                 Color.clear
             }
-//            .opacity(showModalBackground ? 1 : 0)
             
             // Insert Node Menu view
             if graphUI.insertNodeMenuState.show {
                 menuView
-                .shadow(radius: 4)
-                .shadow(radius: 8, x: 4, y: 2)
+                    .shadow(radius: 4)
+                    .shadow(radius: 8, x: 4, y: 2)
                     .animation(.default, value: graphUI.insertNodeMenuState.show)
             }
-                        
-//            // NodeView used only for animation; does not read size,
-//            // since its size changes during animation.
-//            // Note: don't render this NodeView until we have committed our choice.
-//            if graphUI.insertNodeMenuState.menuAnimatingToNode {
-//                animatedNodeView
-//                    .opacity(graphUI.insertNodeMenuState.show ? 1 : 0)
-//                    .onChange(of: graphUI.insertNodeMenuState.show) {
-//                        // Surfacing the menu may cause the responder chain to break, causing key modifiers
-//                        // to lose tracking for end state
-//                        dispatch(KeyModifierReset())
-//                    }
-////                    .offset(x: -sidebarHalfWidth)
-//            }
         }
-//        .onAppear {
-//            //            log("onAppear")
-//
-//            // default, but also updated when GeometryReader changes
-//            //            self.screenHeight = graphUI.frame.height
-//            prepareHiddenMenu()
-//        }
-//        .onChange(of: self.menuOrigin, initial: true) { _, _ in
-//            //            log("ContentView: onChange of menuOrigin: oldValue: \(oldValue)")
-//            //            log("ContentView: onChange of menuOrigin: newValue: \(newValue)")
-//            // don't change during animation
-//            if !graphUI.insertNodeMenuState.menuAnimatingToNode {
-//                prepareHiddenMenu(setHeightToMax: false)
-//            }
-//        }
-//        .onChange(of: self.screenSize, initial: true) { _, _ in
-//            //            log("ContentView: onChange of self.screenSize: oldValue: \(oldValue)")
-//            //            log("ContentView: onChange of self.screenSize: newValue: \(newValue)")
-//            if !graphUI.insertNodeMenuState.menuAnimatingToNode {
-//                prepareHiddenMenu(setHeightToMax: false)
-//            }
-//        }
-//        .onChange(of: graphUI.insertNodeMenuState.menuAnimatingToNode, initial: true) { _, newValue in
-//            // log("ContentView: onChange of menuAnimatingToNode: oldValue: \(oldValue)")
-//            // log("ContentView: onChange of menuAnimatingToNode: newValue: \(newValue)")
-//
-//            // Only fire these when animating = true and the menu toggle status = open
-//            if newValue && graphUI.insertNodeMenuState.show {
-//                animateMenu()
-//                animateNode()
-//            }
-//            // When animation completes, reset menu state
-//            if !newValue {
-//                prepareHiddenMenu()
-//            }
-//        }
-        // Keeping the local state `animatedNode` up to date with our activeSelection.
-//        .onChange(of: graphUI.insertNodeMenuState.activeSelection, initial: true) { _, _ in
-//            //            log("ContentView: onChange of activeSelection: oldValue: \(oldValue)")
-//            //            log("ContentView: onChange of activeSelection: newValue: \(newValue)")
-//            self.animatedNode = graphUI.insertNodeMenuState.fakeNode(nodePosition)
-//        }
     }
-    
-//    @ViewBuilder @MainActor
-//    var sizeReadingNodeView: some View {
-//        fakeNodeView(boundsDisabled: false,
-//                     updateMenuActiveSelectionBounds: true)        
-//    }
-    
-//    @MainActor
-//    var animatedNodeView: some View {
-//        fakeNodeView(boundsDisabled: true,
-//                     // animated-node view does not update active selection bounds
-//                     updateMenuActiveSelectionBounds: false)
-//        .frame(width: nodeWidth, height: nodeHeight)
-//        
-//        .scaleEffect(x: nodeScaleX, y: nodeScaleY)
-//        // NOTE: the node's .position comes AFTER the scaleEffect for the nodeScaleX etc.
-//        .position(nodePosition)
-//        
-//        //            .animation(Self.scaleAnimation, value: nodeScaleY)
-//        //            .animation(Self.scaleAnimation, value: nodeScaleX)
-//        
-//        .opacity(nodeOpacity)
-//        
-//        //            .animation(Self.opacityAnimation, value: nodeOpacity)
-//        
-//        // Apply GraphBaseView modifiers AFTER the node's frame, position, etc.
-//        // Applying same offset and scale as what nodes have, in same order.
-//        .offset(graphOffset.toCGSize)
-//        .scaleEffect(graphScale)
-//    }
 }

--- a/Stitch/Graph/Node/View/StitchUIScrollView.swift
+++ b/Stitch/Graph/Node/View/StitchUIScrollView.swift
@@ -145,21 +145,18 @@ struct StitchUIScrollView<Content: View>: UIViewRepresentable {
     }
     
     private func initializeContentOffset(_ scrollView: UIScrollView) {
-        DispatchQueue.main.async {
-            
 //            let newOffset =  CGPoint(x: WHOLE_GRAPH_LENGTH/2,
 //                                     y: WHOLE_GRAPH_LENGTH/2)
-            
-            let newOffset =  self.document.localPosition
-            log("StitchUIScrollView: initializeContentOffset: newOffset: \(newOffset)")
-            
-            scrollView.setContentOffset(newOffset, animated: false)
-            
-            dispatch(GraphScrollDataUpdated(
-                newOffset: newOffset,
-                newZoom: scrollView.zoomScale
-            ))
-        }
+        
+        let newOffset =  self.document.localPosition
+        log("StitchUIScrollView: initializeContentOffset: newOffset: \(newOffset)")
+        
+        scrollView.setContentOffset(newOffset, animated: false)
+        
+        dispatch(GraphScrollDataUpdated(
+            newOffset: newOffset,
+            newZoom: scrollView.zoomScale
+        ))
     }
     
 
@@ -174,10 +171,13 @@ struct StitchUIScrollView<Content: View>: UIViewRepresentable {
                 newZoom: uiView.zoomScale
             ))
             
+            // Note: `self` is a struct but `GraphUIState` is a reference type, so we had a potential retain cycle even when callinh on MainThread (?)
+            let graphUI = document.graphUI
+            
             // During the animation to the jump-location,
             // we do not want to check the borders
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                document.graphUI.canvasJumpLocation = nil
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak graphUI] in
+                graphUI?.canvasJumpLocation = nil
             }
         }
         

--- a/Stitch/Graph/View/ContentView.swift
+++ b/Stitch/Graph/View/ContentView.swift
@@ -40,7 +40,6 @@ struct ContentView: View, KeyboardReadable {
 
     /// Shows menu wrapper view while node animation takes place
     var showMenu: Bool {
-//        graphUI.insertNodeMenuState.menuAnimatingToNode ||
         graphUI.insertNodeMenuState.show
     }
 

--- a/Stitch/Graph/View/ContentView.swift
+++ b/Stitch/Graph/View/ContentView.swift
@@ -40,7 +40,7 @@ struct ContentView: View, KeyboardReadable {
 
     /// Shows menu wrapper view while node animation takes place
     var showMenu: Bool {
-        graphUI.insertNodeMenuState.menuAnimatingToNode ||
+//        graphUI.insertNodeMenuState.menuAnimatingToNode ||
         graphUI.insertNodeMenuState.show
     }
 
@@ -76,9 +76,7 @@ struct ContentView: View, KeyboardReadable {
                                     showFullScreenAnimateCompleted: $showFullScreenAnimateCompleted,
                                     showFullScreenObserver: showFullScreen,
 //                                    menuHeight: $menuHeight,
-                                    menuHeight: menuHeight,
-//                                    screenSize: $screenSize,
-                                    menuAnimatingToNode: graphUI.insertNodeMenuState.menuAnimatingToNode)
+                                    menuHeight: menuHeight)
 
             // Must IGNORE keyboard safe-area
             nodeAndMenu

--- a/Stitch/Graph/View/Util/ProjectWindowSizeReader.swift
+++ b/Stitch/Graph/View/Util/ProjectWindowSizeReader.swift
@@ -32,7 +32,7 @@ struct ProjectWindowSizeReader: View {
     let menuHeight: CGFloat
 //    @Binding var screenSize: CGSize
 
-    let menuAnimatingToNode: Bool
+//    let menuAnimatingToNode: Bool
 
     @State private var defaultLandscapeSize: CGSize?
 
@@ -74,11 +74,11 @@ struct ProjectWindowSizeReader: View {
                         self.previewWindowSizing.userDeviceSize = geometry.size
                     }
 
-                    // TODO: not necessary?
-                    if menuAnimatingToNode {
-                        // log("ProjectWindowSizeReader: animating to node; will not change size")
-                        return
-                    }
+//                    // TODO: not necessary?
+//                    if menuAnimatingToNode {
+//                        // log("ProjectWindowSizeReader: animating to node; will not change size")
+//                        return
+//                    }
 
                     // TODO: ignore geometry changes when magic keyboard attached, so that we don't "slightly move up" the insert node menu?
 //                    screenSize = geometry.size

--- a/Stitch/Graph/View/Util/ProjectWindowSizeReader.swift
+++ b/Stitch/Graph/View/Util/ProjectWindowSizeReader.swift
@@ -32,8 +32,6 @@ struct ProjectWindowSizeReader: View {
     let menuHeight: CGFloat
 //    @Binding var screenSize: CGSize
 
-//    let menuAnimatingToNode: Bool
-
     @State private var defaultLandscapeSize: CGSize?
 
     var body: some View {
@@ -73,12 +71,6 @@ struct ProjectWindowSizeReader: View {
                         // log("ProjectWindowSizeReader: onChange of: geometry.size: we are fullscreen, so will update previewWindowSizing")
                         self.previewWindowSizing.userDeviceSize = geometry.size
                     }
-
-//                    // TODO: not necessary?
-//                    if menuAnimatingToNode {
-//                        // log("ProjectWindowSizeReader: animating to node; will not change size")
-//                        return
-//                    }
 
                     // TODO: ignore geometry changes when magic keyboard attached, so that we don't "slightly move up" the insert node menu?
 //                    screenSize = geometry.size


### PR DESCRIPTION
This PR removes animation logic for the insert node menu, which had been cancelling UI gestures while the insert node menu closes.