### PR TITLE
Display a splitter's output fields if splitterType = output and we are viewing the group from the outside

### DIFF
--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
@@ -192,11 +192,10 @@ extension NodeRowObserver {
 
         let isSplitterPatch = self.nodeKind.getPatch == .splitter
         let parentGroupNode = self.nodeDelegate?.patchNodeViewModel?.parentGroupNodeId
-        let hasParentGroupNode = parentGroupNode.isDefined ?? false
+        let hasParentGroupNode = parentGroupNode.isDefined
         
         let currentTraversalLevel = self.nodeDelegate?.graphDelegate?.groupNodeFocused
-        
-        let areWeCurrentlyInsideParent = parentGroupNode == currentTraversalLevel
+        let isSplitterAtCurrentTraversalLevel = parentGroupNode == currentTraversalLevel
      
         /*
          Two scenarios re: a Group Node and its splitters:
@@ -207,7 +206,7 @@ extension NodeRowObserver {
          */
         if isSplitterPatch,
             hasParentGroupNode,
-           !areWeCurrentlyInsideParent {
+           !isSplitterAtCurrentTraversalLevel {
             // Rows in a group-ui-node use the underlying splitter node's title
             let labelFromSplitter = self.nodeDelegate?.displayTitle
             assertInDebug(labelFromSplitter.isDefined)


### PR DESCRIPTION
<img width="1230" alt="Screenshot 2025-02-05 at 9 10 15 PM" src="https://github.com/user-attachments/assets/b0fa1937-ce14-4011-af26-384efef6c746" />
<img width="1036" alt="Screenshot 2025-02-05 at 9 09 40 PM" src="https://github.com/user-attachments/assets/446df59f-1f1b-45e1-bd0f-5362b3b19ddd" />
