### PR TITLE
Revert parsing logic to better handle string types

### DIFF
--- a/Stitch/Graph/StitchAI/GraphPrompting/API/OpenAIRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/OpenAIRequest.swift
@@ -433,8 +433,8 @@ extension Stitch.Step: CustomStringConvertible {
             nodeId: \(nodeId?.value.uuidString ?? "nil"),
             nodeName: \(nodeName?.asNodeKind.asLLMStepNodeName ?? "nil"),
             port: \(port?.asLLMStepPort() ?? "nil"),
-            fromNodeId: \(fromNodeId?.uuidString ?? "nil"),
-            toNodeId: \(toNodeId?.uuidString ?? "nil"),
+            fromNodeId: \(fromNodeId?.value.uuidString ?? "nil"),
+            toNodeId: \(toNodeId?.value.uuidString ?? "nil"),
             value: \(String(describing: value)),
             nodeType: \(nodeType?.display ?? "nil")
         )

--- a/Stitch/Graph/StitchAI/GraphPrompting/API/OpenAIRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/OpenAIRequest.swift
@@ -430,7 +430,7 @@ extension Stitch.Step: CustomStringConvertible {
         return """
         Step(
             stepType: "\(stepType)",
-            nodeId: \(nodeId?.uuidString ?? "nil"),
+            nodeId: \(nodeId?.value.uuidString ?? "nil"),
             nodeName: \(nodeName?.asNodeKind.asLLMStepNodeName ?? "nil"),
             port: \(port?.asLLMStepPort() ?? "nil"),
             fromNodeId: \(fromNodeId?.uuidString ?? "nil"),

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/LLMValueParsingUtils.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/LLMValueParsingUtils.swift
@@ -216,6 +216,7 @@ extension String {
 enum StitchAICodingError: Error {
     case typeCasting
     case stepDecoding
+    case action
 }
 
 extension PortValue {

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StateChangeToStepAction.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StateChangeToStepAction.swift
@@ -135,7 +135,7 @@ func createLLMStepConnectionAdded(input: InputCoordinate,
 func createLLMStepAddLayerInput(nodeId: NodeId,
                                 input: LayerInputPort) -> LLMStepAction {
       LLMStepAction(stepType: StepType.addLayerInput,
-                    nodeId: nodeId, // Don't need to specify node name?
+                    nodeId: .init(nodeId), // Don't need to specify node name?
                     port: .keyPath(.init(layerInput: input,
                                          portType: .packed)))
   }

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/Step.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/Step.swift
@@ -71,7 +71,7 @@ struct Step: Hashable {
     var nodeId: StitchAIUUID?        // Identifier for the node
     var nodeName: PatchOrLayer?      // Display name for the node
     var port: NodeIOPortType?  // Port identifier (can be string or number)
-    var fromPort: Int?  // Source port for connections
+    var fromPort: StitchAIInt?  // Source port for connections
     var fromNodeId: StitchAIUUID?   // Source node for connections
     var toNodeId: StitchAIUUID?     // Target node for connections
     var value: PortValue? // Associated value data
@@ -90,7 +90,7 @@ struct Step: Hashable {
         self.nodeId = .init(value: nodeId)
         self.nodeName = nodeName
         self.port = port
-        self.fromPort = fromPort
+        self.fromPort = .init(value: fromPort)
         self.fromNodeId = .init(value: fromNodeId)
         self.toNodeId = .init(value: toNodeId)
         self.value = value
@@ -144,6 +144,7 @@ extension Step: Codable {
         self.nodeId = try container.decodeIfPresent(StitchAIUUID.self, forKey: .nodeId)
         self.fromNodeId = try container.decodeIfPresent(StitchAIUUID.self, forKey: .fromNodeId)
         self.toNodeId = try container.decodeIfPresent(StitchAIUUID.self, forKey: .toNodeId)
+        self.fromPort = try container.decodeIfPresent(StitchAIInt.self, forKey: .fromPort)
         
         if let nodeNameString = try? container.decode(String?.self, forKey: .nodeName) {
             self.nodeName = .fromLLMNodeName(nodeNameString)
@@ -153,8 +154,6 @@ extension Step: Codable {
             self.port = NodeIOPortType(stringValue: portString)
         }
         
-        self.fromPort = try? container.decode(Int?.self, forKey: .fromPort)
-
         guard let nodeTypeString = try? container.decode(String?.self, forKey: .nodeType),
               let nodeType = NodeType(llmString: nodeTypeString) else {
             return

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/Step.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/Step.swift
@@ -72,8 +72,8 @@ struct Step: Hashable {
     var nodeName: PatchOrLayer?      // Display name for the node
     var port: NodeIOPortType?  // Port identifier (can be string or number)
     var fromPort: Int?  // Source port for connections
-    var fromNodeId: UUID?   // Source node for connections
-    var toNodeId: UUID?     // Target node for connections
+    var fromNodeId: StitchAIUUID?   // Source node for connections
+    var toNodeId: StitchAIUUID?     // Target node for connections
     var value: PortValue? // Associated value data
     var nodeType: NodeType?     // Type of the node
     
@@ -87,12 +87,12 @@ struct Step: Hashable {
          value: PortValue? = nil,
          nodeType: NodeType? = nil) {
         self.stepType = stepType
-        self.nodeId = nodeId != nil ? .init(value: nodeId!) : nil
+        self.nodeId = .init(value: nodeId)
         self.nodeName = nodeName
         self.port = port
         self.fromPort = fromPort
-        self.fromNodeId = fromNodeId
-        self.toNodeId = toNodeId
+        self.fromNodeId = .init(value: fromNodeId)
+        self.toNodeId = .init(value: toNodeId)
         self.value = value
         self.nodeType = nodeType
     }
@@ -122,8 +122,8 @@ extension Step: Codable {
         try container.encodeIfPresent(nodeName?.asNodeKind.asLLMStepNodeName, forKey: .nodeName)
         try container.encodeIfPresent(port?.asLLMStepPort(), forKey: .port)
         try container.encodeIfPresent(fromPort, forKey: .fromPort)
-        try container.encodeIfPresent(fromNodeId?.description, forKey: .fromNodeId)
-        try container.encodeIfPresent(toNodeId?.description, forKey: .toNodeId)
+        try container.encodeIfPresent(fromNodeId, forKey: .fromNodeId)
+        try container.encodeIfPresent(toNodeId, forKey: .toNodeId)
         try container.encodeIfPresent(nodeType?.asLLMStepNodeType, forKey: .nodeType)
         
         if let valueCodable = value?.anyCodable {
@@ -141,15 +141,9 @@ extension Step: Codable {
         }
         
         self.stepType = stepType
-        
         self.nodeId = try container.decodeIfPresent(StitchAIUUID.self, forKey: .nodeId)
-
-        if let fromNodeIdString = try? container.decode(String?.self, forKey: .fromNodeId) {
-            self.fromNodeId = UUID(uuidString: fromNodeIdString)
-        }
-        if let toNodeIdString = try? container.decode(String?.self, forKey: .toNodeId) {
-            self.toNodeId = UUID(uuidString: toNodeIdString)
-        }
+        self.fromNodeId = try container.decodeIfPresent(StitchAIUUID.self, forKey: .fromNodeId)
+        self.toNodeId = try container.decodeIfPresent(StitchAIUUID.self, forKey: .toNodeId)
         
         if let nodeNameString = try? container.decode(String?.self, forKey: .nodeName) {
             self.nodeName = .fromLLMNodeName(nodeNameString)

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/Step.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/Step.swift
@@ -9,62 +9,6 @@ import Foundation
 import SwiftUI
 import SwiftyJSON
 
-//protocol StitchAIStepActionable: Hashable, Codable {
-//    static var stepType: StepType { get }
-//    
-//    // Type of step (e.g., "add_node", "connect_nodes")
-//    var stepType: StepType  { get set }
-//    
-//    // Identifier for the node
-//    var nodeId: UUID? { get set }
-//    
-//    // Display name for the node
-//    var nodeName: PatchOrLayer? { get set }
-//    
-//    // Port identifier (can be string or number)
-//    var port: NodeIOPortType? { get set }
-//    
-//    // Source port for connections
-//    var fromPort: Int? { get set }
-//    
-//    // Source node for connections
-//    var fromNodeId: UUID? { get set }
-//    
-//    // Target node for connections
-//    var toNodeId: UUID? { get set }
-//    
-//    // Associated value data
-//    var value: PortValue? { get set }
-//    
-//    // Type of the node
-//    var nodeType: NodeType? { get set }
-//    
-//    
-//    init(nodeId: StitchAIUUID?,
-//         nodeName: PatchOrLayer?,
-//         port: NodeIOPortType?,
-//         fromPort: Int?,
-//         fromNodeId: UUID?,
-//         toNodeId: UUID?,
-//         value: PortValue?,
-//         nodeType: NodeType?
-//    )
-//}
-//
-//extension StitchAIStepActionable {
-//    var toStep: Step {
-//        Step(stepType: Self.stepType,
-//             nodeId: self.nodeId != nil ? .init(self.nodeId!) : nil,
-//             nodeName: self.nodeName,
-//             port: self.port,
-//             fromPort: self.fromPort,
-//             fromNodeId: self.fromNodeId,
-//             toNodeId: self.toNodeId,
-//             value: self.value,
-//             nodeType: self.nodeType)
-//    }
-//}
-
 /// Represents a single step/action in the visual programming sequence
 struct Step: Hashable {
     var stepType: StepType        // Type of step (e.g., "add_node", "connect_nodes")

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StepTypeAction.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StepTypeAction.swift
@@ -216,7 +216,7 @@ struct StepActionAddNode: Equatable, Hashable, Codable {
     }
     
     static func fromStep(_ action: Step) -> Self? {
-        if let nodeId = action.nodeId,
+        if let nodeId = action.nodeId?.value,
            let nodeKind = action.nodeName {
             return .init(nodeId: nodeId,
                          nodeName: nodeKind)
@@ -242,12 +242,13 @@ struct StepActionAddLayerInput: Equatable, Hashable, Codable {
     }
     
     static func fromStep(_ action: Step) -> Self? {
-        guard let nodeId = action.nodeId,
+        guard let nodeId = action.nodeId?.value,
               let layerInput = action.port?.keyPath?.layerInput else {
             return nil
         }
         
-        return .init(nodeId: nodeId, port: layerInput)
+        return .init(nodeId: nodeId,
+                     port: layerInput)
     }
 }
 
@@ -273,9 +274,9 @@ struct StepActionConnectionAdded: Equatable, Hashable, Codable {
     }
     
     static func fromStep(_ action: Step) -> Self? {
-        guard let fromNodeId = action.nodeId,
+        guard let fromNodeId = action.nodeId?.value,
               let toPort = action.port,
-              let toNodeId = action.nodeId else {
+              let toNodeId = action.nodeId?.value else {
             return nil
         }
 
@@ -303,7 +304,7 @@ struct StepActionChangeNodeType: Equatable, Hashable, Codable {
     }
     
     static func fromStep(_ action: Step) -> Self? {
-        if let nodeId = action.nodeId,
+        if let nodeId = action.nodeId?.value,
            let nodeType = action.nodeType {
             return .init(nodeId: nodeId,
                          nodeType: nodeType)
@@ -332,7 +333,7 @@ struct StepActionSetInput: Equatable, Hashable, Codable {
     }
     
     static func fromStep(_ action: Step) -> Self? {
-        if let nodeId = action.nodeId,
+        if let nodeId = action.nodeId?.value,
            let port = action.port,
            let nodeType = action.nodeType,
            let value = action.value {

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StepTypeAction.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StepTypeAction.swift
@@ -274,14 +274,14 @@ struct StepActionConnectionAdded: Equatable, Hashable, Codable {
     }
     
     static func fromStep(_ action: Step) -> Self? {
-        guard let fromNodeId = action.nodeId?.value,
+        guard let fromNodeId = action.fromNodeId?.value,
               let toPort = action.port,
-              let toNodeId = action.nodeId?.value else {
+              let toNodeId = action.toNodeId?.value else {
             return nil
         }
 
         // default to 0 for some legacy actions ?
-        let fromPort = action.fromPort ?? 0
+        let fromPort = action.fromPort?.value ?? 0
         
         return .init(port: toPort,
                      toNodeId: toNodeId,

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StitchAICodableTypes.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StitchAICodableTypes.swift
@@ -52,6 +52,14 @@ protocol StitchAIStringConvertable: Codable, Hashable {
 
 
 extension StitchAIStringConvertable {
+    init?(value: T?) {
+        guard let value = value else {
+            return nil
+        }
+        
+        self.init(value: value)
+    }
+    
     /// Encodes the value as a string
     func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StitchAICodableTypes.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StitchAICodableTypes.swift
@@ -20,6 +20,10 @@ struct StitchAIPosition: Codable {
 
 // TODO: will delete below when LLM is more reliable at producing number types when expected.
 
+struct StitchAIInt: StitchAIStringConvertable {
+    var value: Int
+}
+
 struct StitchAINumber: StitchAIStringConvertable {
     var value: Double
 }
@@ -76,22 +80,22 @@ extension StitchAIStringConvertable {
         
         // Try decoding as different types, converting each to string
         if let value = try? container.decode(Self.T.self) {
-            log("StringOrNumber: Decoder: tried double")
+            log("StitchAIStringConvertable: Decoder: tried double")
             self.init(value: value)
         } else if let stringValue = try? container.decode(String.self),
                   let valueFromString = Self.T(stringValue) {
-            log("StringOrNumber: Decoder: tried string")
+            log("StitchAIStringConvertable: Decoder: tried string")
             self.init(value: valueFromString)
         } else if let jsonValue = try? container.decode(JSON.self),
                   let valueFromJson = Self.T(jsonValue.description) {
-            log("StringOrNumber: Decoder: had json \(jsonValue)")
+            log("StitchAIStringConvertable: Decoder: had json \(jsonValue)")
             self.init(value: valueFromJson)
         } else {
             throw DecodingError.typeMismatch(
                 String.self,
                 DecodingError.Context(
                     codingPath: decoder.codingPath,
-                    debugDescription: "Unexpected type for \(Self.T.self)"
+                    debugDescription: "StitchAIStringConvertable: unexpected type for \(Self.T.self)"
                 )
             )
         }

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StitchAICodableTypes.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StitchAICodableTypes.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import StitchSchemaKit
+import SwiftyJSON
 
 /**
  Saves JSON-friendly versions of data structures saved in `PortValue`.
@@ -17,3 +18,74 @@ struct StitchAIPosition: Codable {
     var y: Double
 }
 
+// TODO: will delete below when LLM is more reliable at producing number types when expected.
+
+struct StitchAINumber: StitchAIStringConvertable {
+    var value: Double
+}
+
+struct StitchAIUUID: StitchAIStringConvertable {
+    var value: UUID
+}
+
+extension UUID: LosslessStringConvertible {
+    public init?(_ description: String) {
+        self.init(uuidString: description)
+    }
+}
+
+typealias StitchAIValueStringConvertable = Codable & CustomStringConvertible & LosslessStringConvertible & Hashable
+
+//extension StitchAIStringConvertable {
+//    init(_ value: T) {
+//        self.value =
+//    }
+//}
+
+protocol StitchAIStringConvertable: Codable, Hashable {
+    associatedtype T: StitchAIValueStringConvertable
+    
+    var value: T { get set }
+    
+    init(value: T)
+}
+
+
+extension StitchAIStringConvertable {
+    /// Encodes the value as a string
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        
+        // LLM expects string type
+        try container.encode(self.value.description)
+    }
+    
+    /// Decodes a value that could be string, int, double, or JSON
+    /// - Parameter decoder: The decoder to read from
+    /// - Throws: DecodingError if value cannot be converted to string
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        
+        // Try decoding as different types, converting each to string
+        if let value = try? container.decode(Self.T.self) {
+            log("StringOrNumber: Decoder: tried double")
+            self.init(value: value)
+        } else if let stringValue = try? container.decode(String.self),
+                  let valueFromString = Self.T(stringValue) {
+            log("StringOrNumber: Decoder: tried string")
+            self.init(value: valueFromString)
+        } else if let jsonValue = try? container.decode(JSON.self),
+                  let valueFromJson = Self.T(jsonValue.description) {
+            log("StringOrNumber: Decoder: had json \(jsonValue)")
+            self.init(value: valueFromJson)
+        } else {
+            throw DecodingError.typeMismatch(
+                String.self,
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Unexpected type for \(Self.T.self)"
+                )
+            )
+        }
+    }
+}

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StitchAICodableTypes.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StitchAICodableTypes.swift
@@ -40,12 +40,6 @@ extension UUID: LosslessStringConvertible {
 
 typealias StitchAIValueStringConvertable = Codable & CustomStringConvertible & LosslessStringConvertible & Hashable
 
-//extension StitchAIStringConvertable {
-//    init(_ value: T) {
-//        self.value =
-//    }
-//}
-
 protocol StitchAIStringConvertable: Codable, Hashable {
     associatedtype T: StitchAIValueStringConvertable
     

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StitchAITypeCasting.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StitchAITypeCasting.swift
@@ -17,9 +17,9 @@ extension PortValue {
         case .bool(let x):
             return x
         case .int(let x):
-            return "\(x)"
+            return StitchAINumber(value: Double(x))
         case .number(let x):
-            return "\(x)"
+            return StitchAINumber(value: x)
         case .layerDimension(let x):
             return x
         case .transform(let x):
@@ -143,7 +143,7 @@ extension UserVisibleType {
         case .bool:
             return Bool.self
         case .int, .number:
-            return String.self
+            return StitchAINumber.self
         case .layerDimension:
             return LayerDimension.self
         case .transform:

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StitchAITypeCasting.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StitchAITypeCasting.swift
@@ -264,16 +264,15 @@ extension UserVisibleType {
             }
             return .bool(x)
         case .int:
-            guard let x = anyValue as? String,
-                  let xInt = Int(x) else {
+            guard let x = anyValue as? StitchAINumber else {
                 throw StitchAICodingError.typeCasting
             }
-            return .int(xInt)
+            return .int(Int(x.value))
         case .number:
-            guard let x = anyValue as? Double else {
+            guard let x = anyValue as? StitchAINumber else {
                 throw StitchAICodingError.typeCasting
             }
-            return .number(x)
+            return .number(x.value)
         case .layerDimension:
             guard let x = anyValue as? LayerDimension else {
                 throw StitchAICodingError.typeCasting

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StitchAITypeCasting.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StitchAITypeCasting.swift
@@ -264,10 +264,10 @@ extension UserVisibleType {
             }
             return .bool(x)
         case .int:
-            guard let x = anyValue as? StitchAINumber else {
+            guard let x = anyValue as? StitchAIInt else {
                 throw StitchAICodingError.typeCasting
             }
-            return .int(Int(x.value))
+            return .int(x.value)
         case .number:
             guard let x = anyValue as? StitchAINumber else {
                 throw StitchAICodingError.typeCasting


### PR DESCRIPTION
Pseudo revert, we use a protocol called `StitchAIStringConvertable` instead of `StringOrNumber`, which uses the logic from the latter but allows for flexibility with more types than just numbers. Possibly useful if this strategy proves necessary.