### PR TITLE
Properly de-assign an interaction from a layer

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -155,7 +155,6 @@
 		B569E58B2B06A8B100C7435B /* NodeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B569E58A2B06A8B100C7435B /* NodeInfo.swift */; };
 		B56EA8A62C409898003D39E2 /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = B56EA8A52C409898003D39E2 /* StitchEngine */; };
 		B56F36252D3C1A2E0051C80E /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = B56F36242D3C1A2E0051C80E /* StitchEngine */; };
-		B56F36282D3C29BA0051C80E /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = B56F36272D3C29BA0051C80E /* StitchEngine */; };
 		B56FFB212C18B4F600623CC7 /* AnimationUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56FFB202C18B4F600623CC7 /* AnimationUtils.swift */; };
 		B56FFB242C18B53C00623CC7 /* StitchHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56FFB232C18B53C00623CC7 /* StitchHostingController.swift */; };
 		B56FFB2A2C18B72500623CC7 /* MediaImportUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56FFB292C18B72500623CC7 /* MediaImportUtils.swift */; };
@@ -1514,6 +1513,7 @@
 		EC609DD329357C0A00BF60A5 /* EqualsExactly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualsExactly.swift; sourceTree = "<group>"; };
 		EC60B8642C18044D00984FC8 /* ProjectThumbnailActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectThumbnailActions.swift; sourceTree = "<group>"; };
 		EC60E57B27178DDD00AABE71 /* LayerUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerUtils.swift; sourceTree = "<group>"; };
+		EC6225BB2D5BF4F5000059E8 /* StitchEngineClosedSource */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = StitchEngineClosedSource; path = "/Users/christianjclampitt/Local Documents/wissenschaft/StitchEngine-ACTUAL-CODE/StitchEngineClosedSource"; sourceTree = "<absolute>"; };
 		EC631401265C418D00BD45B2 /* LoopSelectNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopSelectNode.swift; sourceTree = "<group>"; };
 		EC63B97929FB0D8800C65A95 /* ExistingEdgesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExistingEdgesView.swift; sourceTree = "<group>"; };
 		EC650BD826864DF200C4CCC9 /* SoundImportNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundImportNode.swift; sourceTree = "<group>"; };
@@ -1895,7 +1895,6 @@
 				EC1137382719F9B400ADCA72 /* OrderedCollections in Frameworks */,
 				B51D8A022CD13D420016CCDA /* StitchEngine in Frameworks */,
 				E42AAE4C2D4844EE002D187D /* Sentry in Frameworks */,
-				B56F36282D3C29BA0051C80E /* StitchEngine in Frameworks */,
 				EC91034A29109DF3007C548E /* SoulverCore in Frameworks */,
 				B5380E312CF8E51600E6D801 /* StitchEngine in Frameworks */,
 				B560CE812CF1C93100F31905 /* StitchEngine in Frameworks */,
@@ -1960,6 +1959,7 @@
 		200BD859254F66EB00692903 /* Stitch */ = {
 			isa = PBXGroup;
 			children = (
+				EC6225BB2D5BF4F5000059E8 /* StitchEngineClosedSource */,
 				EC15E425260271C6006F2E08 /* Stitch.entitlements */,
 				200BD863254F66EE00692903 /* Info.plist */,
 				B5617A7B2C175C3C00B53DAF /* App */,
@@ -4584,7 +4584,6 @@
 				E4A848AA2D32FCFA0029AFDE /* PostgREST */,
 				E4A848AC2D32FCFA0029AFDE /* Storage */,
 				B56F36242D3C1A2E0051C80E /* StitchEngine */,
-				B56F36272D3C29BA0051C80E /* StitchEngine */,
 				E42AAE4B2D4844EE002D187D /* Sentry */,
 			);
 			productName = prototype;
@@ -4672,7 +4671,6 @@
 				B5FBE3C22C4195B3006DA0A7 /* XCRemoteSwiftPackageReference "DirectoryWatcher" */,
 				E463E7ED2C6FC7090008E318 /* XCRemoteSwiftPackageReference "StitchSchemaKit" */,
 				E4A848A92D32FCFA0029AFDE /* XCRemoteSwiftPackageReference "supabase-swift" */,
-				B56F36262D3C29BA0051C80E /* XCRemoteSwiftPackageReference "StitchEngine" */,
 				E42AAE4A2D4844EE002D187D /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 			);
 			productRefGroup = 200BD858254F66EB00692903 /* Products */;
@@ -6498,14 +6496,6 @@
 				revision = b36ffff23f8a14e3f8fae4f335482b731c5deffb;
 			};
 		};
-		B56F36262D3C29BA0051C80E /* XCRemoteSwiftPackageReference "StitchEngine" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/StitchDesign/StitchEngine";
-			requirement = {
-				kind = revision;
-				revision = 7a2e98214b6602a2f276d52d3f48d5be0898cad2;
-			};
-		};
 		B5FBE3C22C4195B3006DA0A7 /* XCRemoteSwiftPackageReference "DirectoryWatcher" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GianniCarlo/DirectoryWatcher.git";
@@ -6647,11 +6637,6 @@
 		};
 		B56F36242D3C1A2E0051C80E /* StitchEngine */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = StitchEngine;
-		};
-		B56F36272D3C29BA0051C80E /* StitchEngine */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = B56F36262D3C29BA0051C80E /* XCRemoteSwiftPackageReference "StitchEngine" */;
 			productName = StitchEngine;
 		};
 		B58612AE2C68681600C64313 /* StitchEngine */ = {

--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -1513,7 +1513,6 @@
 		EC609DD329357C0A00BF60A5 /* EqualsExactly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualsExactly.swift; sourceTree = "<group>"; };
 		EC60B8642C18044D00984FC8 /* ProjectThumbnailActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectThumbnailActions.swift; sourceTree = "<group>"; };
 		EC60E57B27178DDD00AABE71 /* LayerUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerUtils.swift; sourceTree = "<group>"; };
-		EC6225BB2D5BF4F5000059E8 /* StitchEngineClosedSource */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = StitchEngineClosedSource; path = "/Users/christianjclampitt/Local Documents/wissenschaft/StitchEngine-ACTUAL-CODE/StitchEngineClosedSource"; sourceTree = "<absolute>"; };
 		EC631401265C418D00BD45B2 /* LoopSelectNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopSelectNode.swift; sourceTree = "<group>"; };
 		EC63B97929FB0D8800C65A95 /* ExistingEdgesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExistingEdgesView.swift; sourceTree = "<group>"; };
 		EC650BD826864DF200C4CCC9 /* SoundImportNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundImportNode.swift; sourceTree = "<group>"; };
@@ -1959,7 +1958,6 @@
 		200BD859254F66EB00692903 /* Stitch */ = {
 			isa = PBXGroup;
 			children = (
-				EC6225BB2D5BF4F5000059E8 /* StitchEngineClosedSource */,
 				EC15E425260271C6006F2E08 /* Stitch.entitlements */,
 				200BD863254F66EE00692903 /* Info.plist */,
 				B5617A7B2C175C3C00B53DAF /* App */,
@@ -4672,6 +4670,7 @@
 				E463E7ED2C6FC7090008E318 /* XCRemoteSwiftPackageReference "StitchSchemaKit" */,
 				E4A848A92D32FCFA0029AFDE /* XCRemoteSwiftPackageReference "supabase-swift" */,
 				E42AAE4A2D4844EE002D187D /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
+				ECFCBEF02D5C03ED00AD677B /* XCRemoteSwiftPackageReference "StitchEngine" */,
 			);
 			productRefGroup = 200BD858254F66EB00692903 /* Products */;
 			projectDirPath = "";
@@ -6590,6 +6589,14 @@
 			requirement = {
 				branch = master;
 				kind = branch;
+			};
+		};
+		ECFCBEF02D5C03ED00AD677B /* XCRemoteSwiftPackageReference "StitchEngine" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/StitchDesign/StitchEngine.git";
+			requirement = {
+				kind = revision;
+				revision = d7da03a9b3cb45aaf0ba2950fd985e98b62ab9b0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2f217b3ebd4ed4fdf06f7fad2cbf55899cf913fe0a1916b4eb705be2ef0cd05d",
+  "originHash" : "906ea53775f320cbbf1349503a463e5e89cc8a926639156d5273d631e3d7c8ee",
   "pins" : [
     {
       "identity" : "audiokit",
@@ -52,14 +52,6 @@
       "state" : {
         "revision" : "ef309cda2d2f426476181ae294f3b899eac83af4",
         "version" : "2.6.3"
-      }
-    },
-    {
-      "identity" : "stitchengine",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StitchDesign/StitchEngine",
-      "state" : {
-        "revision" : "7a2e98214b6602a2f276d52d3f48d5be0898cad2"
       }
     },
     {

--- a/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "7bc6d60cb599493d0ae6a2e8dd9fdc8ec70d26d605f0be0daab33a1734d85dab",
   "pins" : [
     {
       "identity" : "audiokit",
@@ -51,6 +52,14 @@
       "state" : {
         "revision" : "ef309cda2d2f426476181ae294f3b899eac83af4",
         "version" : "2.6.3"
+      }
+    },
+    {
+      "identity" : "stitchengine",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/StitchDesign/StitchEngine.git",
+      "state" : {
+        "revision" : "d7da03a9b3cb45aaf0ba2950fd985e98b62ab9b0"
       }
     },
     {
@@ -178,5 +187,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "906ea53775f320cbbf1349503a463e5e89cc8a926639156d5273d631e3d7c8ee",
   "pins" : [
     {
       "identity" : "audiokit",
@@ -179,5 +178,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Stitch/Graph/Node/Port/Util/NodeRowObserverUtil.swift
+++ b/Stitch/Graph/Node/Port/Util/NodeRowObserverUtil.swift
@@ -105,6 +105,7 @@ extension NodeRowObserver {
             if let firstOriginalValues = oldValues.first {
                 self.coerceUpdate(these: newValues,
                                   to: firstOriginalValues,
+                                  oldValues: oldValues,
                                   currentGraphTime: graphTime)
             } else {
                 fatalErrorIfDebug()

--- a/Stitch/Graph/Node/Port/Util/PortValue/CoercerUtils.swift
+++ b/Stitch/Graph/Node/Port/Util/PortValue/CoercerUtils.swift
@@ -208,7 +208,7 @@ extension NodeRowObserver {
     @MainActor
     func coerceUpdate(these values: PortValues,
                       to thisType: PortValue,
-
+                      oldValues: PortValues, // ALL old values
                       // Additional data used for input coercion:
                       currentGraphTime: TimeInterval) {
 
@@ -216,6 +216,7 @@ extension NodeRowObserver {
                                       currentGraphTime: currentGraphTime)
 
         // Update new values to input observer
-        self.updateValues(newValues)
+        self.updateValues(newValues,
+                          oldValues: oldValues)
     }
 }

--- a/Stitch/Graph/Node/Port/Util/TypeChange/NodeTypeChangedHelpers.swift
+++ b/Stitch/Graph/Node/Port/Util/TypeChange/NodeTypeChangedHelpers.swift
@@ -34,8 +34,7 @@ extension NodeRowObserver {
                          isVisible: Bool) {
 
         if let portId = self.id.portId,
-           nodeKind.rowIsTypeStatic(nodeType: newType,
-                                    portId: portId) {
+           nodeKind.rowIsTypeStatic(nodeType: newType, portId: portId) {
             log("NodeRowObserver: coerceInput: had static node row, so nothing to do")
             return
         }
@@ -66,9 +65,9 @@ extension NodeRowObserver {
         // If we had preserved values for this node type,
         // do we really need to coerce again?
         // They're already same type.
-
         self.coerceUpdate(these: valuesToUse,
                           to: newType.defaultPortValue,
+                          oldValues: values, // treat self.loopedValues as oldValues ?
                           currentGraphTime: currentGraphTime)
         
         // Update port views

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -66,8 +66,20 @@ final class InputNodeRowObserver: NodeRowObserver, InputNodeRowCalculatable {
     let id: NodeIOCoordinate
     
     // Data-side for values
+    // THIS IS GETTING SET BEFORE WE ACTUALLY CALL updateValues
     @MainActor
     var allLoopedValues: PortValues = .init()
+//    {
+//        didSet {
+//            if let x = allLoopedValues.first,
+//               case let .assignedLayer(layerId) = x {
+//                log("allLoopedValues didSet: oldValue \(oldValue) and new value \(allLoopedValues)")
+//                if layerId == nil {
+//                    fatalErrorIfDebug() // see when this was set nil
+//                }
+//            }
+//        }
+//    }
     
     // Connected upstream node, if input
     @MainActor
@@ -114,12 +126,18 @@ final class InputNodeRowObserver: NodeRowObserver, InputNodeRowCalculatable {
     
     @MainActor
     func didValuesUpdate() { }
+    
+    func updateOutputValues(_ values: [StitchSchemaKit.CurrentPortValue.PortValue]) {
+        fatalErrorIfDebug("Should never be called for InputNodeRowObserver")
+    }
+    
 }
 
 extension NodeIOCoordinate: Sendable { }
 
 @Observable
 final class OutputNodeRowObserver: NodeRowObserver {
+    
     static let nodeIOType: NodeIO = .output
     let containsUpstreamConnection = false  // always false
 
@@ -168,6 +186,10 @@ final class OutputNodeRowObserver: NodeRowObserver {
             .getPulseReversionEffects(id: self.id,
                                       graphTime: graphTime)
             .processEffects()
+    }
+    
+    func updateOutputValues(_ values: [StitchSchemaKit.CurrentPortValue.PortValue]) {
+        self.updateValues(values)
     }
 }
 
@@ -532,6 +554,7 @@ extension NodeRowObserver {
     
     @MainActor
     func initializeDelegate(_ node: NodeDelegate) {
+        log("initializeDelegate called")
         self.nodeDelegate = node
         self.postProcessing(oldValues: [], newValues: values)
     }

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -66,21 +66,9 @@ final class InputNodeRowObserver: NodeRowObserver, InputNodeRowCalculatable {
     let id: NodeIOCoordinate
     
     // Data-side for values
-    // THIS IS GETTING SET BEFORE WE ACTUALLY CALL updateValues
     @MainActor
     var allLoopedValues: PortValues = .init()
-//    {
-//        didSet {
-//            if let x = allLoopedValues.first,
-//               case let .assignedLayer(layerId) = x {
-//                log("allLoopedValues didSet: oldValue \(oldValue) and new value \(allLoopedValues)")
-//                if layerId == nil {
-//                    fatalErrorIfDebug() // see when this was set nil
-//                }
-//            }
-//        }
-//    }
-    
+
     // Connected upstream node, if input
     @MainActor
     var upstreamOutputCoordinate: NodeIOCoordinate? {
@@ -89,7 +77,6 @@ final class InputNodeRowObserver: NodeRowObserver, InputNodeRowCalculatable {
         }
     }
     
-    // TODO: an output row can NEVER have an `upstream output` (i.e. incoming edge)
     /// Tracks upstream output row observer for some input. Cached for perf.
     @MainActor
     var upstreamOutputObserver: OutputNodeRowObserver? {

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
@@ -14,7 +14,7 @@ import StitchEngine
 extension NodeRowObserver {
     
     /*
-     Note: StitchEngine's `setValuesInInput` has already updated an InputRowObserver's `allLoopedValues` by the time `updateValues` is called, therefore `allLoopedValues` already reflects "new values", so we must
+     Note: StitchEngine's `setValuesInInput` has already updated an InputRowObserver's `allLoopedValues` by the time `updateValues` is called, therefore `allLoopedValues` already reflects "new values", so we must rely on the explicitly passed-in `oldValues`
      TODO: separate `updateValues` functions for InputNodeRowObserver vs OutputNodeRowObserver, since `oldValues` only relevant for input updates' post-processing?
      */
     @MainActor

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
@@ -13,7 +13,11 @@ import StitchEngine
 
 extension NodeRowObserver {
     @MainActor
-    func updateValues(_ newValues: PortValues) {
+    func updateValues(_ newValues: PortValues,
+//                      // Note: StitchEngine's `setValuesInInput` has already updated an InputRowObserver's `allLoopedValues` by the time `updateValues` is called, therefore `allLoopedValues` already reflects "new values"
+//                      // TODO: separate `updateValues` functions for InputNodeRowObserver vs OutputNodeRowObserver ? ... force caller to pass in oldValues
+                      oldValues: PortValues? = nil)
+    {
         // Check if this port is for a packed layer input but the set mode is unpacked
         // Valid scenarios here--we use input row observer getters for all-up value getting
         if let layerId = self.id.keyPath,
@@ -32,10 +36,24 @@ extension NodeRowObserver {
         }
         
         // Save these for `postProcessing`
-        let oldValues = self.allLoopedValues
+        let oldValues = oldValues ?? self.allLoopedValues
+        
+        if let x = self.allLoopedValues.first
+//            ,
+//           case let PortValue.assignedLayer(k) = x
+        {
+            log("updateValues: self.allLoopedValues were: \(self.allLoopedValues)")
+        }
         
         // Always update the non-view data in the NodeRowObserver
         self.allLoopedValues = newValues
+        
+        if let x = self.allLoopedValues.first
+//            ,
+//           case let PortValue.assignedLayer(k) = x
+        {
+            log("updateValues: self.allLoopedValues are now: \(self.allLoopedValues)")
+        }
         
         // Always update "hasLoop", since offscreen node may have an onscreen edge.
         let hasLoop = newValues.hasLoop
@@ -118,6 +136,8 @@ extension NodeRowObserver {
     @MainActor
     func postProcessing(oldValues: PortValues,
                         newValues: PortValues) {
+        log("postProcessing: oldValues: \(oldValues)")
+        log("postProcessing: newValues: \(newValues)")
         // Update cached interactions data in graph
         self.updateInteractionNodeData(oldValues: oldValues,
                                        newValues: newValues)
@@ -134,9 +154,11 @@ extension NodeRowObserver {
                                    newValues: PortValues) {
         
         // Interaction nodes ignore loops of assigned layers and only use the first
+        // Note: may be nil when first initializing the graph
         let firstValueOld = oldValues.first
         let firstValueNew = newValues.first
-                
+               
+//        // We only want to
         guard let graphDelegate = self.nodeDelegate?.graphDelegate,
               let patch = self.nodeKind.getPatch,
               patch.isInteractionPatchNode,
@@ -145,37 +167,69 @@ extension NodeRowObserver {
             return
         }
         
-        // Remove old value from graph state
-        // Note: can be nil when first initializing the graph
-        if let oldLayerId = firstValueOld?.getInteractionId {
-            switch patch {
-            case .dragInteraction:
-                graphDelegate.dragInteractionNodes.removeValue(forKey: oldLayerId)
-            case .pressInteraction:
-                graphDelegate.pressInteractionNodes.removeValue(forKey: oldLayerId)
-            case .scrollInteraction:
-                graphDelegate.scrollInteractionNodes.removeValue(forKey: oldLayerId)
-            default:
-                fatalErrorIfDebug()
+        if let firstValueOld = firstValueOld,
+            case let .assignedLayer(oldLayerId) = firstValueOld {
+            log("updateInteractionNodeData: OLD: oldLayerId \(oldLayerId)")
+            // Note: `.assignedLayer(nil)` is for when the interaction patch has no assigned layer
+            if let oldLayerId = oldLayerId {
+                switch patch {
+                case .dragInteraction:
+                    graphDelegate.dragInteractionNodes.removeValue(forKey: oldLayerId)
+                case .pressInteraction:
+                    log("updateInteractionNodeData: OLD: will remove oldLayerId \(oldLayerId)")
+                    graphDelegate.pressInteractionNodes.removeValue(forKey: oldLayerId)
+                    log("updateInteractionNodeData: OLD: graphDelegate.pressInteractionNodes are now: \(graphDelegate.pressInteractionNodes)")
+                case .scrollInteraction:
+                    graphDelegate.scrollInteractionNodes.removeValue(forKey: oldLayerId)
+                default:
+                    fatalErrorIfDebug()
+                }
             }
         }
+        
+        // Remove old value from graph state
+        // Note: can be nil when first initializing the graph
+//        if let oldLayerId = firstValueOld?.getInteractionId {
+//            switch patch {
+//            case .dragInteraction:
+//                graphDelegate.dragInteractionNodes.removeValue(forKey: oldLayerId)
+//            case .pressInteraction:
+//                log("updateInteractionNodeData: OLD: will remove oldLayerId \(oldLayerId)")
+//                graphDelegate.pressInteractionNodes.removeValue(forKey: oldLayerId)
+//                log("updateInteractionNodeData: OLD: graphDelegate.pressInteractionNodes are now: \(graphDelegate.pressInteractionNodes)")
+//            case .scrollInteraction:
+//                graphDelegate.scrollInteractionNodes.removeValue(forKey: oldLayerId)
+//            default:
+//                fatalErrorIfDebug()
+//            }
+//        }
                 
-        if let newLayerId = firstValueNew?.getInteractionId {
-            switch patch {
-            case .dragInteraction:
-                var currentIds = graphDelegate.dragInteractionNodes.get(newLayerId) ?? NodeIdSet()
-                currentIds.insert(self.id.nodeId)
-                graphDelegate.dragInteractionNodes.updateValue(currentIds, forKey: newLayerId)
-            case .pressInteraction:
-                var currentIds = graphDelegate.pressInteractionNodes.get(newLayerId) ?? NodeIdSet()
-                currentIds.insert(self.id.nodeId)
-                graphDelegate.pressInteractionNodes.updateValue(currentIds, forKey: newLayerId)
-            case .scrollInteraction:
-                var currentIds = graphDelegate.scrollInteractionNodes.get(newLayerId) ?? NodeIdSet()
-                currentIds.insert(self.id.nodeId)
-                graphDelegate.scrollInteractionNodes.updateValue(currentIds, forKey: newLayerId)
-            default:
-                fatalErrorIfDebug()
+        // if we de-assign an interaction from a layer, then the interactionId will be nil
+//        if let newLayerId = firstValueNew?.getInteractionId {
+        if let firstValueNew = firstValueNew,
+            case let .assignedLayer(newLayerId) = firstValueNew {
+            log("updateInteractionNodeData: NEW: newLayerId \(newLayerId)")
+            
+            // Note: `.assignedLayer(nil)` is for when the interaction patch has no assigned layer
+            if let newLayerId = newLayerId {
+                switch patch {
+                case .dragInteraction:
+                    var currentIds = graphDelegate.dragInteractionNodes.get(newLayerId) ?? NodeIdSet()
+                    currentIds.insert(self.id.nodeId)
+                    graphDelegate.dragInteractionNodes.updateValue(currentIds, forKey: newLayerId)
+                case .pressInteraction:
+                    log("updateInteractionNodeData: NEW: will add newLayerId \(newLayerId)")
+                    var currentIds = graphDelegate.pressInteractionNodes.get(newLayerId) ?? NodeIdSet()
+                    currentIds.insert(self.id.nodeId)
+                    graphDelegate.pressInteractionNodes.updateValue(currentIds, forKey: newLayerId)
+                    log("updateInteractionNodeData: NEW: graphDelegate.pressInteractionNodes are now: \(graphDelegate.pressInteractionNodes)")
+                case .scrollInteraction:
+                    var currentIds = graphDelegate.scrollInteractionNodes.get(newLayerId) ?? NodeIdSet()
+                    currentIds.insert(self.id.nodeId)
+                    graphDelegate.scrollInteractionNodes.updateValue(currentIds, forKey: newLayerId)
+                default:
+                    fatalErrorIfDebug()
+                }
             }
         }
     }


### PR DESCRIPTION
We were not actually removing the interaction assignment for a given layer, leading to cases where a layer group's old interactions interfered with children's hit areas below.

TODO: write a thorough test for layer-assignments to interaction patches
