### PR TITLE
Start at animation goal when graph opened

### DIFF
--- a/Stitch/Graph/Node/Patch/Type/Animation/ClassicAnimation.swift
+++ b/Stitch/Graph/Node/Patch/Type/Animation/ClassicAnimation.swift
@@ -97,7 +97,6 @@ struct ClassicAnimationNode: PatchNodeDefinition {
         // If we have existing inputs, then we're deserializing,
         // and should base internal state and starting outputs on those inputs.
         let state = ClassicAnimationState.defaultFromNodeType(.fromNodeType(Self._defaultUserVisibleType))
-
         return ComputedNodeState(classicAnimationState: state)
     }
 }
@@ -106,18 +105,13 @@ struct ClassicAnimationNode: PatchNodeDefinition {
 func classicAnimationEval(node: PatchNode,
                           state: GraphStepState) -> ImpureEvalResult {
     
-//    let inputs = node.inputs
-//    let outputs = node.outputs
-//    let animationStates: [ClassicAnimationState] = node.computedStates?.compactMap {
-//        $0.classicAnimationState
-//    } ?? []
     let fps = state.estimatedFPS
-
+    
     return node.loopedEval(ComputedNodeState.self) { values, computedState, index in
         
         // We must have a userVisibleType on a classic animation node
         guard let evalType: AnimationNodeType = node.userVisibleType.map(AnimationNodeType.fromNodeType) else {
-            log("classicAnimationEval: had invalide node type: \(node.userVisibleType)")
+            log("classicAnimationEval: had invalid node type: \(node.userVisibleType)")
             fatalErrorIfDebug() // we were assigned some false or bad type
             return ImpureEvalOpResult(outputs: [.number(.zero)])
         }

--- a/Stitch/Graph/Node/Patch/Type/Animation/spring+and+pop+animations/PopAnimationNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Animation/spring+and+pop+animations/PopAnimationNode.swift
@@ -63,11 +63,13 @@ func popAnimationEval(node: PatchNode,
             return springAnimationNumberOp(
                     values: values,
                     computedState: computedState,
+                    graphTime: graphStepState.graphTime,
                     isPopAnimation: true)
         case .position:
             return springAnimationPositionOp(
                     values: values,
                     computedState: computedState,
+                    graphTime: graphStepState.graphTime,
                     isPopAnimation: true)
         default:
             fatalError()

--- a/Stitch/Graph/Node/Patch/Type/Animation/spring+and+pop+animations/SpringAnimationNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Animation/spring+and+pop+animations/SpringAnimationNode.swift
@@ -69,11 +69,13 @@ func springAnimationEval(node: PatchNode,
             springAnimationNumberOp(
                 values: values,
                 computedState: computedState,
+                graphTime: graphStepState.graphTime,
                 isPopAnimation: false)
         case .position:
             springAnimationPositionOp(
                 values: values,
                 computedState: computedState,
+                graphTime: graphStepState.graphTime,
                 isPopAnimation: false)
         default:
             fatalError()

--- a/Stitch/Graph/Node/Patch/Type/Animation/spring+and+pop+animations/SpringAnimationNumberOp.swift
+++ b/Stitch/Graph/Node/Patch/Type/Animation/spring+and+pop+animations/SpringAnimationNumberOp.swift
@@ -12,6 +12,7 @@ import StitchSchemaKit
 // NOTE: Used by both pop and spring animation nodes.
 func springAnimationNumberOp(values: PortValues, // ie inputs and outputs
                              computedState: ComputedNodeState,
+                             graphTime: TimeInterval,
                              isPopAnimation: Bool) -> ImpureEvalOpResult {
         
     //    log("springAnimationNumberOp: eval called")
@@ -37,7 +38,7 @@ func springAnimationNumberOp(values: PortValues, // ie inputs and outputs
     let currentOutputIndex = isPopAnimation ? 3 : 4
     
     // i.e. current output
-    let position: Double = values[safe: currentOutputIndex]?.getNumber ?? toValue
+    let position: Double = graphTime.graphJustStarted ? toValue : values[safe: currentOutputIndex]?.getNumber ?? toValue
     
     //    log("springAnimationNumberOp: position: \(position)")
     //    log("springAnimationNumberOp: toValue: \(toValue)")

--- a/Stitch/Graph/Node/Patch/Type/Animation/spring+and+pop+animations/SpringAnimationPositionOp.swift
+++ b/Stitch/Graph/Node/Patch/Type/Animation/spring+and+pop+animations/SpringAnimationPositionOp.swift
@@ -11,6 +11,7 @@ import StitchSchemaKit
 
 func springAnimationPositionOp(values: PortValues, // ie inputs and outputs
                                computedState: ComputedNodeState,
+                               graphTime: TimeInterval,
                                isPopAnimation: Bool) -> ImpureEvalOpResult {
     
     //    log("springAnimationPositionOp: isPopAnimation: \(isPopAnimation)")
@@ -34,7 +35,7 @@ func springAnimationPositionOp(values: PortValues, // ie inputs and outputs
     // Spring node has 4 inputs, so current output will be 5th value, i.e. index = 4
     let currentOutputIndex = isPopAnimation ? 3 : 4
     
-    let currentOutput: StitchPosition = values[safe: currentOutputIndex]?.getPosition ?? toValue
+    let currentOutput: StitchPosition = graphTime.graphJustStarted ? toValue : values[safe: currentOutputIndex]?.getPosition ?? toValue
     let currentOutputX = currentOutput.x
     let currentOutputY = currentOutput.y
     

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Animation/ClassicAnimation/Eval/ClassicAnimationColor.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Animation/ClassicAnimation/Eval/ClassicAnimationColor.swift
@@ -34,7 +34,7 @@ func classicAnimationEvalOpColor(values: PortValues,
 
     // Our current output is always the 'starting point'
     // of a given animation step.
-    let currentOutput: RGBA = values.last?.getColor?.asRGBA ?? RGBA(red: 0, green: 0, blue: 0, alpha: 1)
+    let currentOutput: RGBA = graphTime.graphJustStarted ? toValue : values.last?.getColor?.asRGBA ?? RGBA(red: 0, green: 0, blue: 0, alpha: 1)
 
     let equivalentRed = areEquivalent(n: currentOutput.red,
                                       n2: toValue.red)

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Animation/ClassicAnimation/Eval/ClassicAnimationOpAnchoring.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Animation/ClassicAnimation/Eval/ClassicAnimationOpAnchoring.swift
@@ -20,7 +20,7 @@ func classicAnimationEvalOpAnchoring(values: PortValues,
 
     // Our current output is always the 'starting point'
     // of a given animation step.
-    let currentOutput: Anchoring = values.last?.getAnchoring ?? .topLeft
+    let currentOutput: Anchoring = graphTime.graphJustStarted ? toValue : values.last?.getAnchoring ?? .topLeft
     log("\n \n classicAnimationEvalOpSize: TOP: currentOutput: \(currentOutput)")
     
     let equivalentX = areEquivalent(n: currentOutput.x,

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Animation/ClassicAnimation/Eval/ClassicAnimationOpSize.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Animation/ClassicAnimation/Eval/ClassicAnimationOpSize.swift
@@ -21,7 +21,7 @@ func classicAnimationEvalOpSize(values: PortValues,
 
     // Our current output is always the 'starting point'
     // of a given animation step.
-    let currentOutput: LayerSize = values.last?.getSize ?? .zero
+    let currentOutput: LayerSize = graphTime.graphJustStarted ? toValue : values.last?.getSize ?? .zero
     log("\n \n classicAnimationEvalOpSize: TOP: currentOutput: \(currentOutput)")
     
     let equivalentX = areEquivalent(n: currentOutput.width.asNumber,

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Animation/ClassicAnimation/Eval/ClassicAnimationPoint3D.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Animation/ClassicAnimation/Eval/ClassicAnimationPoint3D.swift
@@ -34,7 +34,7 @@ func classicAnimationEvalOpPoint3D(values: PortValues,
 
     // Our current output is always the 'starting point'
     // of a given animation step.
-    let currentOutput: Point3D = values.last?.getPoint3D ?? .zero
+    let currentOutput: Point3D = graphTime.graphJustStarted ? toValue : values.last?.getPoint3D ?? .zero
 
     let equivalentX = areEquivalent(n: currentOutput.x,
                                     n2: toValue.x)

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Animation/ClassicAnimation/Eval/ClassicAnimationPoint4D.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Animation/ClassicAnimation/Eval/ClassicAnimationPoint4D.swift
@@ -21,7 +21,7 @@ func classicAnimationEvalOpPoint4D(values: PortValues,
 
     // Our current output is always the 'starting point'
     // of a given animation step.
-    let currentOutput: Point4D = values.last?.getPoint4D ?? .zero
+    let currentOutput: Point4D = graphTime.graphJustStarted ? toValue : values.last?.getPoint4D ?? .zero
 
     let equivalentX = areEquivalent(n: currentOutput.x,
                                       n2: toValue.x)

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Animation/ClassicAnimation/Eval/ClassicAnimationPosition.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Animation/ClassicAnimation/Eval/ClassicAnimationPosition.swift
@@ -34,7 +34,7 @@ func classicAnimationEvalOpPosition(values: PortValues,
 
     // Our current output is always the 'starting point'
     // of a given animation step.
-    let currentOutput: StitchPosition = values.last?.getPosition ?? .zero
+    let currentOutput: StitchPosition = graphTime.graphJustStarted ? toValue : values.last?.getPosition ?? .zero
     log("\n \n classicAnimationEvalOpPosition: TOP: currentOutput: \(currentOutput)")
 
     let equivalentX = areEquivalent(n: currentOutput.x,


### PR DESCRIPTION
We had inconsistent behavior across Graph Open vs Graph Reset, since the first provided non-empty default outputs and the second set the outputs empty. 

We now treat both Graph Open and Reset as "graph time is zero."

https://github.com/user-attachments/assets/4fd05a4e-0a40-4899-923b-a05a857101e7

