### PR TITLE
Any edited field must be 'visible in frame'

### DIFF
--- a/Stitch/Graph/Node/Port/Util/InputEdit/InputEditedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/InputEdit/InputEditedActions.swift
@@ -50,6 +50,8 @@ extension InputNodeRowObserver {
             return
         }
     
+        graph.confirmInputIsVisibleInFrame(self)
+        
         let parentPortValue = self.activeValue
 
         //        log("inputEdited: fieldValue: \(fieldValue)")


### PR DESCRIPTION
Log to Sentry if the field was not visible in frame when edited.