### PR TITLE
Remove SwiftUI MagnificationGesture and UIKit PinchGesture on graph

### DIFF
--- a/Stitch/Graph/Gesture/Util/GraphUIZoomedActions.swift
+++ b/Stitch/Graph/Gesture/Util/GraphUIZoomedActions.swift
@@ -27,32 +27,6 @@ extension GraphZoom {
 
 extension StitchDocumentViewModel {
     @MainActor
-    func graphPinchToZoom( amount: CGFloat) {
-        let graphZoom = self.graphMovement.zoomData
-
-        // Scale zoom based on current device zoom--makes pinch to zoom feel more natural
-        var newAmount = (amount - 1) * graphZoom.final
-        
-        newAmount = GraphZoom.throttleGraphZoom(zoomAmount: newAmount,
-                                                currentScale: graphZoom.final)
-        
-        graphZoom.current = newAmount
-    }
-    
-    @MainActor
-    func graphZoomEnded() {
-        // set new zoom final to current + final of last zoom state
-        self.graphMovement.zoomData.final += self.graphMovement.zoomData.current
-        
-        if self.graphMovement.zoomData.current != 0 {
-            self.graphMovement.zoomData.current = 0
-        }
-
-        // Wipe comment box bounds
-        self.wipeCommentBoxBounds()
-    }
-
-    @MainActor
     func graphZoomedIn(_ manualZoom: GraphManualZoom) {
         // Set `true` here; set `false` by the UIScrollView
         self.graphUI.canvasZoomedIn = manualZoom

--- a/Stitch/Graph/Gesture/View/GraphMovementViewModifier.swift
+++ b/Stitch/Graph/Gesture/View/GraphMovementViewModifier.swift
@@ -52,6 +52,7 @@ struct GraphMovementViewModifier: ViewModifier {
             }
             .onChange(of: graphMovement.zoomData.current) { _, newValue in
                 currentNodePage.zoomData.current = graphMovement.zoomData.current
+                self.graph.updateVisibleNodes()
             }
             .onChange(of: graphMovement.zoomData.final) { _, newValue in
                 currentNodePage.zoomData.final = graphMovement.zoomData.final

--- a/Stitch/Graph/Gesture/View/GraphMovementViewModifier.swift
+++ b/Stitch/Graph/Gesture/View/GraphMovementViewModifier.swift
@@ -23,8 +23,6 @@ struct GraphMovementViewModifier: ViewModifier {
                 // curentNodePage local position is default rather than persisted local position when graph first opened
                 self.graphMovement.localPosition = currentNodePage.localPosition
                 self.graphMovement.localPreviousPosition = currentNodePage.localPosition
-                
-                self.graphMovement.zoomData.current = currentNodePage.zoomData.current
                 self.graphMovement.zoomData.final = currentNodePage.zoomData.final
                 
                 /*
@@ -48,10 +46,6 @@ struct GraphMovementViewModifier: ViewModifier {
             .onChange(of: graphMovement.localPosition) { _, newValue in
                 currentNodePage.localPosition = graphMovement.localPosition
                 
-                self.graph.updateVisibleNodes()
-            }
-            .onChange(of: graphMovement.zoomData.current) { _, newValue in
-                currentNodePage.zoomData.current = graphMovement.zoomData.current
                 self.graph.updateVisibleNodes()
             }
             .onChange(of: graphMovement.zoomData.final) { _, newValue in

--- a/Stitch/Graph/View/Gesture/GraphBackgroundGestureView.swift
+++ b/Stitch/Graph/View/Gesture/GraphBackgroundGestureView.swift
@@ -60,14 +60,6 @@ struct GraphGestureBackgroundView<T: View>: UIViewControllerRepresentable {
         longPressGesture.delegate = delegate
         vc.view.addGestureRecognizer(longPressGesture)
 
-        // Now pinch only available on graph background
-        let pinchGesture = UIPinchGestureRecognizer(
-            target: delegate,
-            action: #selector(delegate.pinchInView))
-        pinchGesture.delegate = delegate
-        pinchGesture.allowedTouchTypes = [SCREEN_TOUCH_ID]
-        vc.view.addGestureRecognizer(pinchGesture)
-
         return vc
     }
 
@@ -137,17 +129,4 @@ final class NodeSelectionGestureRecognizer: NSObject, UIGestureRecognizerDelegat
             gestureState: gestureRecognizer.state,
             shiftHeld: self.shiftHeld)
     }
-
-    @MainActor
-    @objc func pinchInView(_ gestureRecognizer: UIPinchGestureRecognizer) {
-        switch gestureRecognizer.state {
-        case .changed:
-            self.document?.graphPinchToZoom(amount: gestureRecognizer.scale)
-        case .cancelled, .ended:
-            self.document?.graphZoomEnded()
-        default:
-            break
-        }
-    }
-
 }

--- a/Stitch/Graph/View/GraphBaseView.swift
+++ b/Stitch/Graph/View/GraphBaseView.swift
@@ -32,17 +32,7 @@ struct GraphBaseView: View {
         // so our touch-responsive interfaces must ignore them to.
 
         nodesAndCursor
-            .simultaneousGesture(
-                MagnifyGesture()
-                    .onChanged { value in
-                        self.document.graphPinchToZoom(amount: value.magnification)
-                    }
-                    .onEnded { _ in
-                        self.document.graphZoomEnded()
-                    }
-            )
             .onAppear {
-
                 #if targetEnvironment(macCatalyst)
                 if self.spaceHeld || document.keypressState.isSpacePressed {
                     NSCursor.openHand.push()

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -501,11 +501,10 @@ final class GraphZoom {
     // Shortcut
     static let zoomCommandRate = 0.1 // 0.25 // 0.175
     
-    var current: CGFloat = 0
     var final: CGFloat = 1
 
     var zoom: CGFloat {
-        self.current + self.final
+        self.final
     }
 }
 


### PR DESCRIPTION
Noticed that we were sometimes updating zoomData.current but not calling `updateVisibleNodes`; `GraphScrollDataUpdated` does not update `zoomData.current`; we no longer need SwiftUI MagnificationGesture and UIKit PinchGesture for the graph, since we use UIScrollView.