### PR TITLE
Fixed regression where new nodes couldn't establish edges

### DIFF
--- a/Stitch/Graph/Util/GraphActions.swift
+++ b/Stitch/Graph/Util/GraphActions.swift
@@ -40,6 +40,12 @@ extension GraphState: DocumentEncodableDelegate {
     }
     
     func willEncodeProject(schema: GraphEntity) {
+        // Updates graph data when changed
+        let newViewId = self.calculateGraphUpdaterId()
+        if self.graphUpdaterId != newViewId {
+            self.graphUpdaterId = newViewId
+        }
+        
         // Updates thumbnail
          if let document = self.documentDelegate {
              document.encodeProjectInBackground(willUpdateUndoHistory: false)

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -505,12 +505,6 @@ extension GraphState {
                                                                 temporaryUrl: temporaryURL,
                                                                 willUpdateUndoHistory: willUpdateUndoHistory)
         
-        // Updates graph data when changed
-        let newViewId = self.calculateGraphUpdaterId()
-        if self.graphUpdaterId != newViewId {
-            self.graphUpdaterId = newViewId
-        }
-        
         // If debug mode, make sure fields are updated as we aren't using calculate
         // to update them
         // MARK: should move to delegate, however this works fine for now

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -172,6 +172,12 @@ extension StitchDocumentViewModel: DocumentEncodableDelegate {
         
         // Blocks thumbnail from being selected until encoding completes
         self.projectLoader?.loadingDocument = .loading
+        
+        // Updates graph data when changed
+        let newViewId = self.visibleGraph.calculateGraphUpdaterId()
+        if self.visibleGraph.graphUpdaterId != newViewId {
+            self.visibleGraph.graphUpdaterId = newViewId
+        }
     }
     
     func didEncodeProject(schema: StitchDocument) {


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/6937

The issue is caused by persistence from node creation using a different flow than the new UI updating logic was leveraging. Logic has been moved to places which are consistently called on encoding.