### PR TITLE
Color Arithmetic: Add, Subtract, Length

### DIFF
--- a/Stitch/Graph/Node/Eval/EvalKindNodeEvaluationHelpers.swift
+++ b/Stitch/Graph/Node/Eval/EvalKindNodeEvaluationHelpers.swift
@@ -56,6 +56,10 @@ let pureNodeEval = { (_ eval: @escaping PureEval) in { (node: PatchNode) in
     outputsOnlyEvalT(eval, \.asMathEval)
 }
 
+@MainActor let mathNodeTypeWithColorEval = { (_ eval: @escaping OutputsOnlyPureEvalT<MathNodeTypeWithColor>) in
+    outputsOnlyEvalT(eval, \.asMathWithColorEval)
+}
+
 // Default helper for now
 let stringOp: Operation = { (_: PortValues) -> PortValue in .string(.init("")) }
 

--- a/Stitch/Graph/Node/Eval/PatchEvaluateExtensions.swift
+++ b/Stitch/Graph/Node/Eval/PatchEvaluateExtensions.swift
@@ -199,7 +199,7 @@ extension Patch {
         case .optionEquals:
             return .node(outputsOnlyEval(optionEqualsEval))
         case .subtract:
-            return .node(mathNodeTypeEval(subtractEval))
+            return .node(mathNodeTypeWithColorEval(subtractEval))
         case .squareRoot:
             return .node(mathNodeTypeEval(squareRootEval))
         case .length:

--- a/Stitch/Graph/Node/Eval/PatchNodeType.swift
+++ b/Stitch/Graph/Node/Eval/PatchNodeType.swift
@@ -80,12 +80,12 @@ enum NumberNodeType: PatchNodeTypeSet {
 
 struct ArithmeticUVT: NodeTypeEnummable {
     typealias NT = ArithmeticNodeType
-    static let value = UVTSet([.string, .number, .position, .size, .point3D])
+    static let value = UVTSet([.string, .number, .position, .size, .point3D, .color])
 }
 
 // For Add, Substract nodes
 enum ArithmeticNodeType: PatchNodeTypeSet {
-    case number, position, size, point3D
+    case number, position, size, point3D, color
 
     static func fromNodeType(_ nodeType: UserVisibleType) -> ArithmeticNodeType {
         switch nodeType {
@@ -93,6 +93,7 @@ enum ArithmeticNodeType: PatchNodeTypeSet {
         case .position: return .position
         case .size: return .size
         case .point3D: return .point3D
+        case .color: return .color
         default:
             log("ArithmeticNodeType: unsupported nodeType: \(nodeType)")
             return .number

--- a/Stitch/Graph/Node/Eval/PatchNodeType.swift
+++ b/Stitch/Graph/Node/Eval/PatchNodeType.swift
@@ -114,6 +114,17 @@ struct MathUVT: NodeTypeEnummable {
     ])
 }
 
+struct MathWithColorUVT: NodeTypeEnummable {
+    typealias NT = MathNodeTypeWithColor
+    static let value = UVTSet([
+        .number,
+        .position,
+        .size,
+        .point3D,
+        .color
+    ])
+}
+
 enum MathNodeType: PatchNodeTypeSet {
     case number, position, size, point3D
 
@@ -123,6 +134,21 @@ enum MathNodeType: PatchNodeTypeSet {
         case .position: return .position
         case .size: return .size
         case .point3D: return .point3D
+        default: return .number
+        }
+    }
+}
+
+enum MathNodeTypeWithColor: PatchNodeTypeSet {
+    case number, position, size, point3D, color
+
+    static func fromNodeType(_ nodeType: UserVisibleType) -> MathNodeTypeWithColor {
+        switch nodeType {
+        case .number: return .number
+        case .position: return .position
+        case .size: return .size
+        case .point3D: return .point3D
+        case .color: return .color
         default: return .number
         }
     }

--- a/Stitch/Graph/Node/Eval/UserVisibleTypeSet.swift
+++ b/Stitch/Graph/Node/Eval/UserVisibleTypeSet.swift
@@ -24,6 +24,10 @@ extension UVTSet {
     func asMath(_ uvt: UserVisibleType) -> MathNodeType? {
         self == MathUVT.value ? MathUVT.choices(uvt) : nil
     }
+    
+    func asMathWithColor(_ uvt: UserVisibleType) -> MathNodeTypeWithColor? {
+        self == MathUVT.value ? MathWithColorUVT.choices(uvt) : nil
+    }
 
     func asPack(_ uvt: UserVisibleType) -> PackNodeType? {
         self == PackUVT.value ? PackUVT.choices(uvt) : nil
@@ -49,6 +53,11 @@ extension PatchNodeViewModel {
     @MainActor
     var asMathEval: MathNodeType? {
         return self.userVisibleType.flatMap(patch.availableNodeTypes.asMath)
+    }
+    
+    @MainActor
+    var asMathWithColorEval: MathNodeTypeWithColor? {
+        return self.userVisibleType.flatMap(patch.availableNodeTypes.asMathWithColor)
     }
 
     @MainActor

--- a/Stitch/Graph/Node/Eval/UserVisibleTypeSet.swift
+++ b/Stitch/Graph/Node/Eval/UserVisibleTypeSet.swift
@@ -26,7 +26,7 @@ extension UVTSet {
     }
     
     func asMathWithColor(_ uvt: UserVisibleType) -> MathNodeTypeWithColor? {
-        self == MathUVT.value ? MathWithColorUVT.choices(uvt) : nil
+        self == MathWithColorUVT.value ? MathWithColorUVT.choices(uvt) : nil
     }
 
     func asPack(_ uvt: UserVisibleType) -> PackNodeType? {

--- a/Stitch/Graph/Node/Patch/Type/Math/AddNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Math/AddNode.swift
@@ -160,10 +160,10 @@ struct AddEvalOps {
             let colorRGBA = color.asRGBA
             
             let newRGBA = RGBA(
-                red: min(accRGBA.red + colorRGBA.red, 1.0),
-                green: min(accRGBA.green + colorRGBA.green, 1.0),
-                blue: min(accRGBA.blue + colorRGBA.blue, 1.0),
-                alpha: min(accRGBA.alpha + colorRGBA.alpha, 1.0)
+                red: accRGBA.red + colorRGBA.red,
+                green: accRGBA.green + colorRGBA.green,
+                blue: accRGBA.blue + colorRGBA.blue,
+                alpha: accRGBA.alpha + colorRGBA.alpha
             )
             
             return newRGBA.toColor

--- a/Stitch/Graph/Node/Patch/Type/Math/AddNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Math/AddNode.swift
@@ -40,10 +40,10 @@ func addPatchNode(nodeId: NodeId = NodeId(),
 //// This has an output of .none during `insert-node-animation` ?
 //struct AddPatchNode: PatchNodeDefinition {
 //    static let patch = Patch.add
-//    
+//
 //    static private let _defaultUserVisibleType: UserVisibleType = .number
 //    static let defaultUserVisibleType: UserVisibleType? = Self._defaultUserVisibleType
-//    
+//
 //    static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
 //        .init(
 //            inputs: [
@@ -71,7 +71,7 @@ func addEval(inputs: PortValuesList,
     
     let result = resultsMaker(inputs)
     
-    // Check if any input is a string
+    // Check if any input is a string or color
     let hasStringInput = inputs.contains { portValues in
         portValues.contains { portValue in
             if case .string(_) = portValue {
@@ -81,8 +81,21 @@ func addEval(inputs: PortValuesList,
         }
     }
     
+    let hasColorInput = inputs.contains { portValues in
+        portValues.contains { portValue in
+            if case .color(_) = portValue {
+                return true
+            }
+            return false
+        }
+    }
+    
     if hasStringInput {
         return result(AddEvalOps.stringOperation)
+    }
+    
+    if hasColorInput {
+        return result(AddEvalOps.colorOperation)
     }
     
     switch evalKind {
@@ -94,6 +107,8 @@ func addEval(inputs: PortValuesList,
         return result(AddEvalOps.positionOperation)
     case .point3D:
         return result(AddEvalOps.point3DOperation)
+    case .color:
+        return result(AddEvalOps.colorOperation)
     }
 }
 
@@ -134,5 +149,26 @@ struct AddEvalOps {
             .point3D(values.reduce(.additionIdentity) { (acc: Point3D, value: PortValue) -> Point3D in
                 acc + (value.getPoint3D ?? .additionIdentity)
             })
+    }
+    
+    static let colorOperation: Operation = { (values: PortValues) -> PortValue in
+        let colors = values.compactMap { $0.getColor }
+        guard !colors.isEmpty else { return .color(.clear) }
+        
+        let result = colors.reduce(Color.clear) { (acc: Color, color: Color) -> Color in
+            let accRGBA = acc.asRGBA
+            let colorRGBA = color.asRGBA
+            
+            let newRGBA = RGBA(
+                red: min(accRGBA.red + colorRGBA.red, 1.0),
+                green: min(accRGBA.green + colorRGBA.green, 1.0),
+                blue: min(accRGBA.blue + colorRGBA.blue, 1.0),
+                alpha: min(accRGBA.alpha + colorRGBA.alpha, 1.0)
+            )
+            
+            return newRGBA.toColor
+        }
+        
+        return .color(result)
     }
 }

--- a/Stitch/Graph/Node/Patch/Type/Math/LengthNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Math/LengthNode.swift
@@ -89,6 +89,19 @@ func lengthEval(inputs: PortValuesList,
         return .number(Double(length)) // Return the length as a number
     }
 
+    let colorOp: Operation = { (values: PortValues) -> PortValue in
+        guard let color = values[0].getColor else { return .number(1) } // Default to 1 for no color
+        let rgba = color.asRGBA
+        // Scale factor is (2/√3 * 1.33) to get our target values
+        let scaleToWhite = (2.0 / sqrt(3.0)) * 1.33
+        let length = sqrt(
+            rgba.red * rgba.red +
+            rgba.green * rgba.green +
+            rgba.blue * rgba.blue
+        ) * scaleToWhite
+        return .number(length)
+    }
+
     let result = resultsMaker(inputs)
         
     if hasStringInput {
@@ -104,5 +117,7 @@ func lengthEval(inputs: PortValuesList,
         return result(sizeOp)
     case .point3D:
         return result(point3DOp)
+    case .color:
+        return result(colorOp)
     }
 }

--- a/Stitch/Graph/Node/Patch/Type/Math/LengthNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Math/LengthNode.swift
@@ -90,15 +90,16 @@ func lengthEval(inputs: PortValuesList,
     }
 
     let colorOp: Operation = { (values: PortValues) -> PortValue in
-        guard let color = values[0].getColor else { return .number(1) } // Default to 1 for no color
+        guard let color = values[0].getColor else { return .number(0) } // Default to 0 for no color
         let rgba = color.asRGBA
-        // Scale factor is (2/√3 * 1.33) to get our target values
-        let scaleToWhite = (2.0 / sqrt(3.0)) * 1.33
+        
+        // Calculate normalized vector length in RGB space
         let length = sqrt(
             rgba.red * rgba.red +
             rgba.green * rgba.green +
             rgba.blue * rgba.blue
-        ) * scaleToWhite
+        ) / sqrt(3.0) // Normalize by dividing by √3 so white has length 1
+        
         return .number(length)
     }
 

--- a/Stitch/Graph/Node/Patch/Type/Math/SubtractNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Math/SubtractNode.swift
@@ -20,13 +20,13 @@ func subtractNode(id: NodeId,
 
 
     let inputs = toInputs(id: id,
-                          values:
-                            (nil, n1Loop ?? [.number(n1)]),
-                          (nil, n2Loop ?? [.number(n2)]))
+                            values:
+                              (nil, n1Loop ?? [.number(n1)]),
+                            (nil, n2Loop ?? [.number(n2)]))
 
     let outputs = toOutputs(id: id, offset: inputs.count,
-                            values: (nil, [.number(n1 + n2)]))
-
+                              values: (nil, [.number(n1 + n2)]))
+    
     return PatchNode(
         position: position,
         zIndex: zIndex,

--- a/Stitch/Graph/Node/Patch/Type/Math/SubtractNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Math/SubtractNode.swift
@@ -16,12 +16,15 @@ func subtractNode(id: NodeId,
                   position: CGSize = .zero,
                   zIndex: Double = 0,
                   n1Loop: PortValues? = nil,
-                  n2Loop: PortValues? = nil) -> PatchNode {
+                  n2Loop: PortValues? = nil,
+                  userVisibleType: UserVisibleType = .number) -> PatchNode {
+
+    let defaultValue: PortValue = userVisibleType == .color ? .color(.clear) : .number(0.0)
 
     let inputs = toInputs(id: id,
                           values:
-                            (nil, n1Loop ?? [.number(n1)]),
-                          (nil, n2Loop ?? [.number(n2)]))
+                            (nil, n1Loop ?? [defaultValue]),
+                          (nil, n2Loop ?? [defaultValue]))
 
     let outputs = toOutputs(id: id, offset: inputs.count,
                             values: (nil, [.number(n1 + n2)]))
@@ -31,7 +34,7 @@ func subtractNode(id: NodeId,
         zIndex: zIndex,
         id: id,
         patchName: .subtract,
-        userVisibleType: .number,
+        userVisibleType: userVisibleType,
         inputs: inputs,
         outputs: outputs)
 }

--- a/Stitch/Graph/Node/Patch/Type/Math/SubtractNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Math/SubtractNode.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import StitchSchemaKit
+import SwiftUI
 
 @MainActor
 func subtractNode(id: NodeId,
@@ -37,7 +38,7 @@ func subtractNode(id: NodeId,
 
 @MainActor
 func subtractEval(inputs: PortValuesList,
-                  evalKind: MathNodeType) -> PortValuesList {
+                  evalKind: MathNodeTypeWithColor) -> PortValuesList {
 
     let numberOperation: Operation = { (values: PortValues) -> PortValue in
 
@@ -86,7 +87,46 @@ func subtractEval(inputs: PortValuesList,
         })
     }
 
+    let colorOperation: Operation = { (values: PortValues) -> PortValue in
+        guard let firstColor = values.first?.getColor else {
+            return .color(.clear)
+        }
+        
+        let tail = values.tail
+        
+        let result = tail.reduce(firstColor) { (acc: Color, value: PortValue) -> Color in
+            guard let colorToSubtract = value.getColor else { return acc }
+            
+            let accRGBA = acc.asRGBA
+            let subtractRGBA = colorToSubtract.asRGBA
+            
+            let newRGBA = RGBA(
+                red: max(0, accRGBA.red - subtractRGBA.red),
+                green: max(0, accRGBA.green - subtractRGBA.green),
+                blue: max(0, accRGBA.blue - subtractRGBA.blue),
+                alpha: max(0, accRGBA.alpha - subtractRGBA.alpha)
+            )
+            
+            return newRGBA.toColor
+        }
+        
+        return .color(result)
+    }
+
     let result = resultsMaker(inputs)
+
+    let hasColorInput = inputs.contains { portValues in
+        portValues.contains { portValue in
+            if case .color(_) = portValue {
+                return true
+            }
+            return false
+        }
+    }
+
+    if hasColorInput {
+        return result(colorOperation)
+    }
 
     switch evalKind {
     case .number:
@@ -97,5 +137,7 @@ func subtractEval(inputs: PortValuesList,
         return result(positionOperation)
     case .point3D:
         return result(point3DOperation)
+    case .color:
+        return result(colorOperation)
     }
 }

--- a/Stitch/Graph/Node/Patch/Type/Math/SubtractNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Math/SubtractNode.swift
@@ -116,19 +116,6 @@ func subtractEval(inputs: PortValuesList,
 
     let result = resultsMaker(inputs)
 
-    let hasColorInput = inputs.contains { portValues in
-        portValues.contains { portValue in
-            if case .color(_) = portValue {
-                return true
-            }
-            return false
-        }
-    }
-
-    if hasColorInput {
-        return result(colorOperation)
-    }
-
     switch evalKind {
     case .number:
         return result(numberOperation)

--- a/Stitch/Graph/Node/Patch/Type/Math/SubtractNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Math/SubtractNode.swift
@@ -16,15 +16,13 @@ func subtractNode(id: NodeId,
                   position: CGSize = .zero,
                   zIndex: Double = 0,
                   n1Loop: PortValues? = nil,
-                  n2Loop: PortValues? = nil,
-                  userVisibleType: UserVisibleType = .number) -> PatchNode {
+                  n2Loop: PortValues? = nil) -> PatchNode {
 
-    let defaultValue: PortValue = userVisibleType == .color ? .color(.clear) : .number(0.0)
 
     let inputs = toInputs(id: id,
                           values:
-                            (nil, n1Loop ?? [defaultValue]),
-                          (nil, n2Loop ?? [defaultValue]))
+                            (nil, n1Loop ?? [.number(n1)]),
+                          (nil, n2Loop ?? [.number(n2)]))
 
     let outputs = toOutputs(id: id, offset: inputs.count,
                             values: (nil, [.number(n1 + n2)]))
@@ -34,7 +32,7 @@ func subtractNode(id: NodeId,
         zIndex: zIndex,
         id: id,
         patchName: .subtract,
-        userVisibleType: userVisibleType,
+        userVisibleType: .number,
         inputs: inputs,
         outputs: outputs)
 }

--- a/Stitch/Graph/Node/Patch/Util/PatchNodeTypeExtensions.swift
+++ b/Stitch/Graph/Node/Patch/Util/PatchNodeTypeExtensions.swift
@@ -106,8 +106,11 @@ extension Patch {
             return ArithmeticUVT.value
 
         // Updated to exclude text/string types
-        case .subtract, .multiply, .divide, .power, .squareRoot:
+        case .multiply, .divide, .power, .squareRoot:
             return MathUVT.value
+            
+        case .subtract:
+            return MathWithColorUVT.value
 
         // ANIMATION
         // TODO: add .size, .anchor etc.?

--- a/Stitch/Graph/Node/Patch/Util/PatchNodeTypeExtensions.swift
+++ b/Stitch/Graph/Node/Patch/Util/PatchNodeTypeExtensions.swift
@@ -102,7 +102,6 @@ extension Patch {
 
         // ARITHMETIC
         case .add, .length:
-            // LATER: color
             return ArithmeticUVT.value
 
         // Updated to exclude text/string types


### PR DESCRIPTION
**Test Projects**
[Color Arithmetic.stitch.zip](https://github.com/user-attachments/files/18946939/Color.Arithmetic.stitch.zip)
[ColorsTestProject.zip](https://github.com/user-attachments/files/18951405/ColorsTestProject.zip)

_Note_: length seems a bit different in OrigamI? ChatGPT could not make sense of what formula it was using when provided examples of calculating color length from Origami; I decided to go with calculating normalized vector length in RGB space
 

**Add Node:**

![CleanShot 2025-02-23 at 09 35 40@2x](https://github.com/user-attachments/assets/41cf25c4-770f-4cd4-815c-2120edbe6ec8)
![CleanShot 2025-02-23 at 09 35 50@2x](https://github.com/user-attachments/assets/b2c4437f-4d24-49b0-910b-609dc2d060a2)


**Subtract Node**
![CleanShot 2025-02-24 at 08 47 00@2x](https://github.com/user-attachments/assets/15d04b0e-5ec2-4158-be46-9f777ea0b641)

**All Nodes**
![CleanShot 2025-02-24 at 08 48 57@2x](https://github.com/user-attachments/assets/08bcceaf-31b4-475b-93b5-33db62f2c273)