### PR TITLE
Reduced render cycles to NodesOnlyView

### DIFF
--- a/Stitch/Graph/Node/View/NodeViewType.swift
+++ b/Stitch/Graph/Node/View/NodeViewType.swift
@@ -20,7 +20,6 @@ struct NodeTypeView: View {
     let atleastOneCommentBoxSelected: Bool
     let activeIndex: ActiveIndex
     let groupNodeFocused: GroupNodeType?
-    let adjustmentBarSessionId: AdjustmentBarSessionId
     let isSelected: Bool
 
     var boundsReaderDisabled: Bool = false
@@ -78,7 +77,7 @@ struct NodeTypeView: View {
                                      node: node,
                                      canvas: canvasNode,
                                      isNodeSelected: isSelected,
-                                     adjustmentBarSessionId: adjustmentBarSessionId)
+                                     adjustmentBarSessionId: document.graphUI.adjustmentBarSessionId)
             }
         }
     }
@@ -96,7 +95,7 @@ struct NodeTypeView: View {
                                       node: node,
                                       canvas: canvasNode,
                                       isNodeSelected: isSelected,
-                                      adjustmentBarSessionId: adjustmentBarSessionId)
+                                      adjustmentBarSessionId: document.graphUI.adjustmentBarSessionId)
             }
         }
     }


### PR DESCRIPTION
Fixes perf by moving expensive logic out of `var body`