### PR TITLE
Different icon for ColorFill vs Oval

### DIFF
--- a/Stitch/Graph/Sidebar/Util/SidebarIcons.swift
+++ b/Stitch/Graph/Sidebar/Util/SidebarIcons.swift
@@ -51,8 +51,10 @@ extension SidebarItemGestureViewModel {
             return "photo"
         case .rectangle:
             return "rectangle"
-        case .oval, .colorFill:
+        case .oval:
             return "oval"
+        case .colorFill:
+            return "swatchpalette.fill"
         case .model3D:
             return "move.3d"
         case .realityView:


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/6947

<img width="1440" alt="Screenshot 2025-02-24 at 5 43 56 PM" src="https://github.com/user-attachments/assets/975dde74-bf72-4a34-ba3e-8468a3f739ea" />
