### PR TITLE
Pass GraphState to CanvasItem select and deselect methods

### DIFF
--- a/Stitch/Graph/Node/Group/GroupNodeCreationActions.swift
+++ b/Stitch/Graph/Node/Group/GroupNodeCreationActions.swift
@@ -236,7 +236,7 @@ extension StitchDocumentViewModel {
         self.visibleGraph.resetSelectedCanvasItems()
         
         // ... then select the GroupNode and its edges
-        newGroupNode.patchCanvasItem?.select()
+        newGroupNode.patchCanvasItem?.select(self.graph)
 
         // Stop any active node dragging etc.
         self.graphMovement.stopNodeMovement()

--- a/Stitch/Graph/Node/Util/Movement/NodePositionUtils.swift
+++ b/Stitch/Graph/Node/Util/Movement/NodePositionUtils.swift
@@ -43,9 +43,9 @@ extension CanvasItemViewModel {
             // toggle selection
             let isSelected = document.graphUI.selection.selectedNodeIds.contains(self.id)
             if isSelected {
-                self.deselect()
+                self.deselect(document.graph)
             } else {
-                self.select()
+                self.select(document.graph)
             }
         }
         

--- a/Stitch/Graph/Node/Util/NodeDeletedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeDeletedAction.swift
@@ -45,7 +45,7 @@ struct SelectedGraphNodesDeleted: GraphEventWithResponse {
         if state.selectedCanvasItems.isEmpty,
            let canvasItemId = canvasItemId,
            let canvasItem = state.getCanvasItem(canvasItemId) {
-            canvasItem.select()
+            canvasItem.select(state)
         }
 
         state.selectedGraphNodesDeleted(

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/TextField/PreviewTextFieldLayerUtils.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/TextField/PreviewTextFieldLayerUtils.swift
@@ -64,7 +64,7 @@ extension GraphState {
         
         // if we selected a canvas item, we also thereby selected it:
         if let canvasItemId = focusedField.canvasFieldId {
-            self.getCanvasItem(canvasItemId)?.select()
+            self.getCanvasItem(canvasItemId)?.select(self)
         }
     }
 }

--- a/Stitch/Graph/Sidebar/Util/JumpToCanvasItem.swift
+++ b/Stitch/Graph/Sidebar/Util/JumpToCanvasItem.swift
@@ -69,7 +69,7 @@ extension GraphState {
         
         self.graphUI.selection = GraphUISelectionState()
         self.resetSelectedCanvasItems()
-        canvasItem.select()
+        canvasItem.select(self)
         
         // Update focused group
         if let newGroup = canvasItem.parentGroupNodeId {

--- a/Stitch/Graph/StitchAI/DatasetRecording/LLMRecordingState.swift
+++ b/Stitch/Graph/StitchAI/DatasetRecording/LLMRecordingState.swift
@@ -218,7 +218,7 @@ extension StitchDocumentViewModel {
             if let node = self.graph.getNodeViewModel(nodeId) {
                 // Will select a patch node or a layer nodes' inputs/outputs on canvas
                 node.getAllCanvasObservers().forEach { (canvasItem: CanvasItemViewModel) in
-                    canvasItem.select()
+                    canvasItem.select(self.graph)
                 }
             }
         }

--- a/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
+++ b/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
@@ -353,7 +353,7 @@ extension GraphState {
                             if let canvas = inputData.canvasItem,
                                let canvasItem = self.getCanvasItem(.layerInput(.init(node: nodeEntity.id,
                                                                                      keyPath: layerId))) {
-                                canvasItem.select()
+                                canvasItem.select(self)
                             }
                         }
                     }
@@ -361,7 +361,7 @@ extension GraphState {
                 case .patch, .group, .component:
                     let stitch = self.getNodeViewModel(nodeEntity.id)
                     if let canvasItem = stitch?.patchCanvasItem {
-                        canvasItem.select()
+                        canvasItem.select(self)
                     }
                 }
         }

--- a/Stitch/Graph/Util/NodeSelection/NodeSelectionUtil.swift
+++ b/Stitch/Graph/Util/NodeSelection/NodeSelectionUtil.swift
@@ -123,7 +123,7 @@ func selectAllNodesAtTraversalLevel(_ state: GraphState) {
     state.resetSelectedCanvasItems()
     
     visibleNodes.forEach {
-        $0.select()
+        $0.select(state)
     }
 }
 

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -418,7 +418,7 @@ extension GraphState {
     func resetSelectedCanvasItems() {
         
         self.getCanvasItems().forEach {
-            $0.deselect()
+            $0.deselect(self)
         }
     }
 }
@@ -442,7 +442,7 @@ extension GraphState {
         // get reset when we select a single node.
         self.graphUI.selection = GraphUISelectionState()
         self.resetSelectedCanvasItems()
-        node.select()
+        node.select(self)
     }
     
     @MainActor
@@ -456,7 +456,7 @@ extension GraphState {
         // ie expansionBox, isSelecting, selected-comments etc.
         // get reset when we select a single canvasItem.
         self.deselectAllCanvasItems()
-        canvasItem.select()
+        canvasItem.select(self)
     }
     
     // TEST HELPER
@@ -466,28 +466,27 @@ extension GraphState {
             fatalErrorIfDebug()
             return
         }
-        node.select()
+        node.select(self)
     }
 }
 
 extension CanvasItemViewModel {
     @MainActor
-    func select() {
+    func select(_ graph: GraphState) {
+        log("CanvasItemViewModel: selecting called")
         // Prevent render cycles if already selected
-        guard !self.isSelected,
-              let graph = self.graphDelegate else { return }
+        guard !self.isSelected  else { return }
         
         graph.graphUI.selection.selectedNodeIds.insert(self.id)
         
         // Unfocus sidebar
-        self.graphDelegate?.isSidebarFocused = false
+        graph.isSidebarFocused = false
     }
     
     @MainActor
-    func deselect() {
+    func deselect(_ graph: GraphState) {
         // Prevent render cycles if already unselected
-        guard self.isSelected,
-              let graph = self.graphDelegate else { return }
+        guard self.isSelected else { return }
         graph.graphUI.selection.selectedNodeIds.remove(self.id)
     }
 }


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/6951

We were accessing GraphState via NodeDelegate; a separate issue arose where a canvas item's NodeDelegate would be nil and so we would fail to access GraphDelegate. 

In reality, every method that called canvas item's select or deselect had a GraphState available in its context. 

Passing down GraphState directly both makes the function more transparent (= inputs communicate more info about what is required) and means these functions won't fail in the future even if we somehow mess up NodeDelegate again.