### PR TITLE
Reduced render counts for media views

### DIFF
--- a/Stitch/Graph/Node/Eval/LoopedEval.swift
+++ b/Stitch/Graph/Node/Eval/LoopedEval.swift
@@ -39,7 +39,7 @@ extension NodeViewModel {
 
         guard let interactionLayerId = inputs.first?.first?.getInteractionId,
               let layerNode = graphState.getNodeViewModel(interactionLayerId.id)?.layerNode else {
-            log("loopedEval: could not retrieve interactive layer id and layer node")
+//            log("loopedEval: could not retrieve interactive layer id and layer node")
             return [0..<loopCount].map { _ in
                 return .init(from: self.defaultOutputs)
             }

--- a/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
@@ -422,30 +422,20 @@ struct InputValueView: View {
                 
                 
             case .media(let media):
-                let loopIndex = graph.activeIndex.adjustedIndex(viewModel.rowViewModelDelegate?.rowDelegate?.allLoopedValues.count ?? .zero)
-                
-                let mediaObserver = viewModel.rowViewModelDelegate?.nodeDelegate?
-                    .getInputMediaObserver(inputCoordinate: rowObserverId,
-                                           loopIndex: loopIndex,
-                                           // nil mediaId ensures observer is returned
-                                           mediaId: nil)
-                
-                if let mediaObserver = mediaObserver {
-                    MediaFieldValueView(
-                        inputCoordinate: rowObserverId,
-                        layerInputObserver: layerInputObserver,
-                        isUpstreamValue: isUpstreamValue,
-                        media: media,
-                        mediaName: media.name,
-                        mediaObserver: mediaObserver,
-                        nodeKind: nodeKind,
-                        isInput: true,
-                        fieldIndex: fieldIndex,
-                        isNodeSelected: isCanvasItemSelected,
-                        isFieldInsideLayerInspector: isFieldInsideLayerInspector,
-                        isSelectedInspectorRow: isSelectedInspectorRow,
-                        graph: graph)
-                }
+                MediaFieldValueView(
+                    viewModel: viewModel,
+                    coordinate: rowObserverId,
+                    layerInputObserver: layerInputObserver,
+                    isUpstreamValue: isUpstreamValue,
+                    media: media,
+                    mediaName: media.name,
+                    nodeKind: nodeKind,
+                    isInput: true,
+                    fieldIndex: fieldIndex,
+                    isNodeSelected: isCanvasItemSelected,
+                    isFieldInsideLayerInspector: isFieldInsideLayerInspector,
+                    isSelectedInspectorRow: isSelectedInspectorRow,
+                    graph: graph)
                 
             case .color(let color):
                 ColorOrbValueButtonView(fieldViewModel: viewModel,

--- a/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
@@ -113,10 +113,6 @@ struct MediaFieldLabelView<Field: FieldViewModel>: View {
     let isNodeSelected: Bool
     let isMultiselectInspectorInputWithHeterogenousValues: Bool
     
-    var media: GraphMediaValue? {
-        self.mediaObserver?.currentMedia
-    }
-    
     @MainActor
     func updateMediaObserver() {
         self.mediaObserver = viewModel.getMediaObserver()

--- a/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
@@ -122,9 +122,10 @@ struct MediaFieldLabelView<Field: FieldViewModel>: View {
         self.mediaObserver = viewModel.getMediaObserver()
     }
     
-    var loopCount: Int {
-        self.viewModel.rowViewModelDelegate?.rowDelegate?.allLoopedValues.count ?? .zero
-    }
+    // MARK: commented logic below causes render cycles, cheating with 0 for now
+//    var loopCount: Int {
+//        self.viewModel.rowViewModelDelegate?.rowDelegate?.allLoopedValues.count ?? .zero
+//    }
     
     // An image/video input or output shows a placeholder 'blank image' if it currently contains no image/video.
     // TODO: update FieldValueMedia (or even PortValue ?) to distinguish between visual media and other types?
@@ -187,8 +188,8 @@ struct MediaFieldLabelView<Field: FieldViewModel>: View {
         .onChange(of: graph.activeIndex, initial: true) {
             self.updateMediaObserver()
         }
-        .onChange(of: self.loopCount) {
-            self.updateMediaObserver()
-        }
+//        .onChange(of: self.loopCount) {
+//            self.updateMediaObserver()
+//        }
     }
 }

--- a/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
@@ -163,8 +163,5 @@ struct MediaFieldLabelView<Field: FieldViewModel>: View {
         .onChange(of: graph.activeIndex, initial: true) {
             self.updateMediaObserver()
         }
-//        .onChange(of: self.loopCount) {
-//            self.updateMediaObserver()
-//        }
     }
 }

--- a/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
@@ -225,28 +225,19 @@ struct OutputValueView: View {
                        alignment: .leading)
                 
             case .media(let media):
-                // No keypaths ever used for output
-                let portIndex = coordinate.portId!
-                let mediaObserver = viewModel.rowViewModelDelegate?.nodeDelegate?
-                    .getVisibleMediaObserver(outputPortId: portIndex,
-                                             // nil mediaId ensures observer is returned
-                                             mediaId: nil)
-                
-                if let mediaObserver = mediaObserver {
-                    MediaFieldValueView(inputCoordinate: coordinate,
-                                        layerInputObserver: nil,
-                                        isUpstreamValue: false,     // only valid for inputs
-                                        media: media,
-                                        mediaName: media.name,
-                                        mediaObserver: mediaObserver,
-                                        nodeKind: nodeKind,
-                                        isInput: false,
-                                        fieldIndex: fieldIndex,
-                                        isNodeSelected: isCanvasItemSelected,
-                                        isFieldInsideLayerInspector: false,
-                                        isSelectedInspectorRow: isSelectedInspectorRow,
-                                        graph: graph)
-                }
+                MediaFieldValueView(viewModel: viewModel,
+                                    coordinate: coordinate,
+                                    layerInputObserver: nil,
+                                    isUpstreamValue: false,     // only valid for inputs
+                                    media: media,
+                                    mediaName: media.name,
+                                    nodeKind: nodeKind,
+                                    isInput: false,
+                                    fieldIndex: fieldIndex,
+                                    isNodeSelected: isCanvasItemSelected,
+                                    isFieldInsideLayerInspector: false,
+                                    isSelectedInspectorRow: isSelectedInspectorRow,
+                                    graph: graph)
                 
             case .color(let color):
                 StitchColorPickerOrb(chosenColor: color,

--- a/Stitch/Graph/Node/Port/ViewModel/FieldViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/FieldViewModel.swift
@@ -93,7 +93,9 @@ final class InputFieldViewModel: FieldViewModel {
     
     func getMediaObserver() -> MediaViewModel? {
         let inputCoordinate = id.rowId.asNodeIOCoordinate
-        let loopCount = self.rowViewModelDelegate?.rowDelegate?.allLoopedValues.count ?? .zero
+        
+        // MARK: cheating with 0 since logic causes render cycles
+        let loopCount = 0 //self.rowViewModelDelegate?.rowDelegate?.allLoopedValues.count ?? .zero
         
         let loopIndex = self.rowViewModelDelegate?.graphDelegate?.activeIndex.adjustedIndex(loopCount) ?? .zero
         

--- a/Stitch/Graph/Node/Port/ViewModel/FieldViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/FieldViewModel.swift
@@ -30,6 +30,9 @@ protocol FieldViewModel: StitchLayoutCachable, Observable, AnyObject, Identifiab
          fieldIndex: Int,
          fieldLabel: String,
          rowViewModelDelegate: NodeRowType?)
+    
+    @MainActor
+    func getMediaObserver() -> MediaViewModel?
 }
 
 extension FieldViewModel {
@@ -87,6 +90,21 @@ final class InputFieldViewModel: FieldViewModel {
         self.fieldLabel = fieldLabel
         self.rowViewModelDelegate = rowViewModelDelegate
     }
+    
+    func getMediaObserver() -> MediaViewModel? {
+        let inputCoordinate = id.rowId.asNodeIOCoordinate
+        let loopCount = self.rowViewModelDelegate?.rowDelegate?.allLoopedValues.count ?? .zero
+        
+        let loopIndex = self.rowViewModelDelegate?.graphDelegate?.activeIndex.adjustedIndex(loopCount) ?? .zero
+        
+        let mediaObserver = self.rowViewModelDelegate?.nodeDelegate?
+            .getInputMediaObserver(inputCoordinate: inputCoordinate,
+                                   loopIndex: loopIndex,
+                                   // nil mediaId ensures observer is returned
+                                   mediaId: nil)
+        
+        return mediaObserver
+    }
 }
 
 @Observable
@@ -110,6 +128,17 @@ final class OutputFieldViewModel: FieldViewModel {
         self.fieldIndex = fieldIndex
         self.fieldLabel = fieldLabel
         self.rowViewModelDelegate = rowViewModelDelegate
+    }
+    
+    func getMediaObserver() -> MediaViewModel? {
+        // No keypaths ever used for output
+        let portIndex = self.id.rowId.portId
+        let mediaObserver = self.rowViewModelDelegate?.nodeDelegate?
+            .getVisibleMediaObserver(outputPortId: portIndex,
+                                     // nil mediaId ensures observer is returned
+                                     mediaId: nil)
+        
+        return mediaObserver
     }
 }
 

--- a/Stitch/Graph/Node/View/NodeLayout.swift
+++ b/Stitch/Graph/Node/View/NodeLayout.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 /// Used by view models to cache local data.
-protocol StitchLayoutCachable: AnyObject, Sendable {
+protocol StitchLayoutCachable: AnyObject, Sendable, Identifiable {
     @MainActor var viewCache: NodeLayoutCache? { get set }
 }
 
@@ -41,7 +41,7 @@ struct NodeLayoutView<T: StitchLayoutCachable, Content: View>: View {
 }
 
 struct NodeLayout<T: StitchLayoutCachable>: Layout, Sendable {
-    typealias Cache = ()
+    typealias Cache = NodeLayoutCache
     
     // Check that prevents loop of cache updates given dispatch
     // updating cache on next cycle
@@ -53,15 +53,17 @@ struct NodeLayout<T: StitchLayoutCachable>: Layout, Sendable {
     // IMPORTANT
     func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout Cache) -> CGSize {
         
-        let isMarkedForUpdate = existingCache?.needsUpdating ?? true
+//        let isMarkedForUpdate = existingCache?.needsUpdating ?? true
+//        
+//        // Condition for needing new cache
+//        if isMarkedForUpdate && !self.isUpdatingCache {
+//            let newCache = self.recreateCache(subviews: subviews)
+//            return newCache.sizeThatFits
+//        }
+//        
+//        return existingCache?.sizeThatFits ?? .zero
         
-        // Condition for needing new cache
-        if isMarkedForUpdate && !self.isUpdatingCache {
-            let newCache = self.recreateCache(subviews: subviews)
-            return newCache.sizeThatFits
-        }
-        
-        return existingCache?.sizeThatFits ?? .zero
+        cache.sizeThatFits
     }
     
     func recreateCache(subviews: Subviews) -> NodeLayoutCache {
@@ -111,16 +113,17 @@ struct NodeLayout<T: StitchLayoutCachable>: Layout, Sendable {
                        proposal: ProposedViewSize,
                        subviews: Subviews,
                        cache: inout Cache) {
+        print("Place subview: \(observer.id)")
         
         guard !subviews.isEmpty else { return }
         
-        let cache = self.existingCache ?? self.createCache(subviews: subviews)
+//        let cache = self.existingCache ?? self.createCache(subviews: subviews)
             
-        if self.existingCache == nil {
-            DispatchQueue.main.async {
-                self.observer.viewCache = cache
-            }
-        }
+//        if self.existingCache == nil {
+//            DispatchQueue.main.async {
+//                self.observer.viewCache = cache
+//            }
+//        }
         
         for index in subviews.indices {
             let subview = subviews[index]
@@ -139,10 +142,10 @@ struct NodeLayout<T: StitchLayoutCachable>: Layout, Sendable {
     }
     
     func spacing(subviews: Self.Subviews, cache: inout Cache) -> ViewSpacing {
-        guard let cache = self.existingCache else {
-            let newCache = self.createCache(subviews: subviews)
-            return newCache.spacing
-        }
+//        guard let cache = self.existingCache else {
+//            let newCache = self.createCache(subviews: subviews)
+//            return newCache.spacing
+//        }
         
         return cache.spacing
     }
@@ -161,10 +164,12 @@ struct NodeLayout<T: StitchLayoutCachable>: Layout, Sendable {
     }
     
     // MARK: we don't use SwiftUI Layout's native cache as it doesn't resize properly for our needs.
-//    func makeCache(subviews: Subviews) -> Cache { }
+    func makeCache(subviews: Subviews) -> Cache {
+        self.recreateCache(subviews: subviews)
+    }
     
     // Keep this empty for perf
-//    func updateCache(_ cache: inout Cache, subviews: Subviews) { }
+    func updateCache(_ cache: inout Cache, subviews: Subviews) { }
     
     func explicitAlignment(of guide: HorizontalAlignment,
                            in bounds: CGRect,


### PR DESCRIPTION
Removing more expensive logic in `var body`, now moved to event handlers and called much less frequently.