### PR TITLE
Prefer passing down `GraphState` directly

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -1753,7 +1753,6 @@
 		ECC558A6294A9B340025BB42 /* ScrollInteractionUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollInteractionUtils.swift; sourceTree = "<group>"; };
 		ECC558A8294A9B3A0025BB42 /* DragInteractionUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragInteractionUtils.swift; sourceTree = "<group>"; };
 		ECC6F00828BFBBC600535493 /* LayerNamesDropDownChoiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerNamesDropDownChoiceView.swift; sourceTree = "<group>"; };
-		ECC732152D6E4DF800F62474 /* StitchEngineClosedSource */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = StitchEngineClosedSource; path = "/Users/christianjclampitt/Local Documents/wissenschaft/StitchEngine-ACTUAL-CODE/StitchEngineClosedSource"; sourceTree = "<absolute>"; };
 		ECC7382C2BB6093100A680B5 /* ClassicAnimationOpAnchoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassicAnimationOpAnchoring.swift; sourceTree = "<group>"; };
 		ECC738302BB6360B00A680B5 /* AnchorGridIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnchorGridIconView.swift; sourceTree = "<group>"; };
 		ECCA95942899CFFC002D241F /* FocusedUserEditField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusedUserEditField.swift; sourceTree = "<group>"; };
@@ -1985,7 +1984,6 @@
 			children = (
 				EC15E425260271C6006F2E08 /* Stitch.entitlements */,
 				200BD863254F66EE00692903 /* Info.plist */,
-				ECC732152D6E4DF800F62474 /* StitchEngineClosedSource */,
 				B5617A7B2C175C3C00B53DAF /* App */,
 				ECB33C5926F12F5E0069885B /* Home */,
 				B56FFB522C195EA000623CC7 /* Graph */,
@@ -4724,6 +4722,7 @@
 				E463E7ED2C6FC7090008E318 /* XCRemoteSwiftPackageReference "StitchSchemaKit" */,
 				E4A848A92D32FCFA0029AFDE /* XCRemoteSwiftPackageReference "supabase-swift" */,
 				E42AAE4A2D4844EE002D187D /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
+				EC9A48DA2D6E694F006A1FC9 /* XCRemoteSwiftPackageReference "StitchEngine" */,
 			);
 			productRefGroup = 200BD858254F66EB00692903 /* Products */;
 			projectDirPath = "";
@@ -6646,6 +6645,14 @@
 			requirement = {
 				kind = exactVersion;
 				version = 2.6.3;
+			};
+		};
+		EC9A48DA2D6E694F006A1FC9 /* XCRemoteSwiftPackageReference "StitchEngine" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/StitchDesign/StitchEngine.git";
+			requirement = {
+				kind = revision;
+				revision = ad4468add9702f55d96bbbfd09943f8fec819b6a;
 			};
 		};
 		ECD5438C29A003F8009D0A30 /* XCRemoteSwiftPackageReference "DisplayLink" */ = {

--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -1753,6 +1753,7 @@
 		ECC558A6294A9B340025BB42 /* ScrollInteractionUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollInteractionUtils.swift; sourceTree = "<group>"; };
 		ECC558A8294A9B3A0025BB42 /* DragInteractionUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragInteractionUtils.swift; sourceTree = "<group>"; };
 		ECC6F00828BFBBC600535493 /* LayerNamesDropDownChoiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerNamesDropDownChoiceView.swift; sourceTree = "<group>"; };
+		ECC732152D6E4DF800F62474 /* StitchEngineClosedSource */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = StitchEngineClosedSource; path = "/Users/christianjclampitt/Local Documents/wissenschaft/StitchEngine-ACTUAL-CODE/StitchEngineClosedSource"; sourceTree = "<absolute>"; };
 		ECC7382C2BB6093100A680B5 /* ClassicAnimationOpAnchoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassicAnimationOpAnchoring.swift; sourceTree = "<group>"; };
 		ECC738302BB6360B00A680B5 /* AnchorGridIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnchorGridIconView.swift; sourceTree = "<group>"; };
 		ECCA95942899CFFC002D241F /* FocusedUserEditField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusedUserEditField.swift; sourceTree = "<group>"; };
@@ -1984,6 +1985,7 @@
 			children = (
 				EC15E425260271C6006F2E08 /* Stitch.entitlements */,
 				200BD863254F66EE00692903 /* Info.plist */,
+				ECC732152D6E4DF800F62474 /* StitchEngineClosedSource */,
 				B5617A7B2C175C3C00B53DAF /* App */,
 				ECB33C5926F12F5E0069885B /* Home */,
 				B56FFB522C195EA000623CC7 /* Graph */,
@@ -4722,7 +4724,6 @@
 				E463E7ED2C6FC7090008E318 /* XCRemoteSwiftPackageReference "StitchSchemaKit" */,
 				E4A848A92D32FCFA0029AFDE /* XCRemoteSwiftPackageReference "supabase-swift" */,
 				E42AAE4A2D4844EE002D187D /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
-				EC5BC3DD2D67B76D000DF722 /* XCRemoteSwiftPackageReference "StitchEngine" */,
 			);
 			productRefGroup = 200BD858254F66EB00692903 /* Products */;
 			projectDirPath = "";
@@ -6629,14 +6630,6 @@
 			requirement = {
 				kind = exactVersion;
 				version = 1.0.2;
-			};
-		};
-		EC5BC3DD2D67B76D000DF722 /* XCRemoteSwiftPackageReference "StitchEngine" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/StitchDesign/StitchEngine.git";
-			requirement = {
-				kind = revision;
-				revision = 5b1f619ff730214e4b4e50b47510f3bdc9211beb;
 			};
 		};
 		EC7784CD27053D9700B662DD /* XCRemoteSwiftPackageReference "ZIPFoundation" */ = {

--- a/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0407b3ec7cff6449cce7c4d57d62ce4b05fed89382fdeb8d0e4e7e3c039452dc",
+  "originHash" : "906ea53775f320cbbf1349503a463e5e89cc8a926639156d5273d631e3d7c8ee",
   "pins" : [
     {
       "identity" : "audiokit",
@@ -52,14 +52,6 @@
       "state" : {
         "revision" : "ef309cda2d2f426476181ae294f3b899eac83af4",
         "version" : "2.6.3"
-      }
-    },
-    {
-      "identity" : "stitchengine",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StitchDesign/StitchEngine.git",
-      "state" : {
-        "revision" : "5b1f619ff730214e4b4e50b47510f3bdc9211beb"
       }
     },
     {

--- a/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "906ea53775f320cbbf1349503a463e5e89cc8a926639156d5273d631e3d7c8ee",
+  "originHash" : "0407b3ec7cff6449cce7c4d57d62ce4b05fed89382fdeb8d0e4e7e3c039452dc",
   "pins" : [
     {
       "identity" : "audiokit",
@@ -52,6 +52,14 @@
       "state" : {
         "revision" : "ef309cda2d2f426476181ae294f3b899eac83af4",
         "version" : "2.6.3"
+      }
+    },
+    {
+      "identity" : "stitchengine",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/StitchDesign/StitchEngine.git",
+      "state" : {
+        "revision" : "ad4468add9702f55d96bbbfd09943f8fec819b6a"
       }
     },
     {

--- a/Stitch/Graph/Edge/Util/PortActions.swift
+++ b/Stitch/Graph/Edge/Util/PortActions.swift
@@ -89,7 +89,8 @@ extension GraphState {
 
         // Removes edge and checks for media to remove
         downstreamNode.removeIncomingEdge(at: input,
-                                          activeIndex: self.activeIndex)
+                                          activeIndex: self.activeIndex,
+                                          graph: self)
     }
 
     @MainActor
@@ -154,10 +155,11 @@ extension NodeViewModel {
     // or when we add a new edge to an input that already has an edge
     @MainActor
     func removeIncomingEdge(at coordinate: NodeIOCoordinate,
-                            activeIndex: ActiveIndex) {
+                            activeIndex: ActiveIndex,
+                            graph: GraphState) {
         self.getInputRowObserver(for: coordinate.portType)?
             .removeUpstreamConnection(activeIndex: activeIndex,
-                                      isVisible: self.isVisibleInFrame)
+                                      isVisible: self.isVisibleInFrame(graph))
     }
 }
 

--- a/Stitch/Graph/Edge/Util/PortActions.swift
+++ b/Stitch/Graph/Edge/Util/PortActions.swift
@@ -159,7 +159,7 @@ extension NodeViewModel {
                             graph: GraphState) {
         self.getInputRowObserver(for: coordinate.portType)?
             .removeUpstreamConnection(activeIndex: activeIndex,
-                                      isVisible: self.isVisibleInFrame(graph))
+                                      isVisible: self.isVisibleInFrame(graph.visibleCanvasIds, graph.selectedSidebarLayers))
     }
 }
 

--- a/Stitch/Graph/GraphStep/GraphStepIncrementer.swift
+++ b/Stitch/Graph/GraphStep/GraphStepIncrementer.swift
@@ -86,7 +86,7 @@ extension GraphState {
 
         self.nodes.values.forEach { node in
             // Checks for transform updates each graph step--needed due to lack of transform publishers
-            node.checkARTransformUpdate()
+            node.checkARTransformUpdate(self)
         }
         
         if nodesToRunOnGraphStep.isEmpty {
@@ -114,7 +114,7 @@ extension NodeViewModel {
     /// Checks if some 3D model's transform was changed due to external event like gestures.
     /// Solves problem where gestures won't update fields directly, and without available publishers we have to manually check on graph step.
     @MainActor
-    func checkARTransformUpdate() {
+    func checkARTransformUpdate(_ graph: GraphState) {
         guard let layerNode = self.nodeType.layerNode,
               Layer.layers3D.contains(layerNode.layer) else {
             return
@@ -145,20 +145,20 @@ extension NodeViewModel {
             let newValues = layerNode.previewLayerViewModels
                 .map { $0.transform3D }
             layerNode.transform3DPort.updatePortValues(newValues)
-            layerNode.transform3DPort.updateAllRowObserversPortViewModels()
+            layerNode.transform3DPort.updateAllRowObserversPortViewModels(graph)
         }
     }
 }
 
 extension LayerInputObserver {
     @MainActor
-    func updateAllRowObserversPortViewModels() {
+    func updateAllRowObserversPortViewModels(_ graph: GraphState) {
         switch self.mode {
         case .packed:
-            self._packedData.rowObserver.updatePortViewModels()
+            self._packedData.rowObserver.updatePortViewModels(graph)
         case .unpacked:
             self._unpackedData.allPorts.forEach {
-                $0.rowObserver.updatePortViewModels()
+                $0.rowObserver.updatePortViewModels(graph)
             }
         }
     }

--- a/Stitch/Graph/Node/Patch/Type/Value/SplitterTypeActions.swift
+++ b/Stitch/Graph/Node/Patch/Type/Value/SplitterTypeActions.swift
@@ -62,12 +62,12 @@ extension GraphState {
             // we need to remove some edges.
             if currentType == .output {
                 self.removeConnections(from: outputPort,
-                                       isNodeVisible: splitterNode.isVisibleInFrame)
+                                       isNodeVisible: splitterNode.isVisibleInFrame(self.visibleCanvasIds, self.selectedSidebarLayers))
             } else if currentType == .input {
                 if let inputObserver = splitterNode.getInputRowObserver(for: .portIndex(0)) {
                     inputObserver
                         .removeUpstreamConnection(activeIndex: self.activeIndex,
-                                                  isVisible: splitterNode.isVisibleInFrame)
+                                                  isVisible: splitterNode.isVisibleInFrame(self.visibleCanvasIds, self.selectedSidebarLayers))
                 }
             }
 
@@ -76,7 +76,7 @@ extension GraphState {
             // then need to remove outgoing edges.
             if currentType == .output {
                 self.removeConnections(from: outputPort,
-                                       isNodeVisible: splitterNode.isVisibleInFrame)
+                                       isNodeVisible: splitterNode.isVisibleInFrame(self.visibleCanvasIds, self.selectedSidebarLayers))
             }
 
         case .output:
@@ -86,7 +86,7 @@ extension GraphState {
                 if let inputObserver = splitterNode.getInputRowObserver(for: .portIndex(0)) {
                     inputObserver
                         .removeUpstreamConnection(activeIndex: self.activeIndex,
-                                                  isVisible: splitterNode.isVisibleInFrame)
+                                                  isVisible: splitterNode.isVisibleInFrame(self.visibleCanvasIds, self.selectedSidebarLayers))
                 }
             }
         }

--- a/Stitch/Graph/Node/Patch/Type/WirelessBroadcasterNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/WirelessBroadcasterNode.swift
@@ -58,7 +58,8 @@ extension GraphState {
                 // we want to update the node type and inputs types
                 node.updateNodeTypeAndInputs(newType: newNodeType,
                                              currentGraphTime: graphTime,
-                                             activeIndex: activeIndex)
+                                             activeIndex: activeIndex,
+                                             graph: self)
                 
                 /*
                  When a Wireless Broadcaster's node-type changes, we updates its inputs (and thus outputs, since Wireless node's evals are just `identity`),

--- a/Stitch/Graph/Node/Patch/Util/WirelessReceiver.swift
+++ b/Stitch/Graph/Node/Patch/Util/WirelessReceiver.swift
@@ -37,8 +37,10 @@ struct SetBroadcastForWirelessReceiver: ProjectEnvironmentEvent {
             // Note 1: we may not have actually had an edge, e.g. if we were already on a nil broadcaster.
             // Note 2: removeAnyEdges already recalculates the graph from the `to` node of the removed edge.
 
-            receiverNodeInputObserver.removeUpstreamConnection(activeIndex: graphState.activeIndex,
-                                                               isVisible: receiverNode.isVisibleInFrame)
+            receiverNodeInputObserver.removeUpstreamConnection(
+                activeIndex: graphState.activeIndex,
+                isVisible: receiverNode.isVisibleInFrame(graphState.visibleCanvasIds, graphState.selectedSidebarLayers))
+            
             graphState.scheduleForNextGraphStep(receiverNodeId)
             
             return .init(willPersist: true)
@@ -60,7 +62,8 @@ struct SetBroadcastForWirelessReceiver: ProjectEnvironmentEvent {
         receiverNode.updateNodeTypeAndInputs(
             newType: broadcasterNode.userVisibleType!,
             currentGraphTime: graphTime,
-            activeIndex: graphState.activeIndex)
+            activeIndex: graphState.activeIndex,
+            graph: graphState)
 
         // Then recalculate the graph from the broadcaster onward:
         graphState.scheduleForNextGraphStep(broadcasterNodeId)

--- a/Stitch/Graph/Node/Port/Util/InputEdit/InputCommittedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/InputEdit/InputCommittedActions.swift
@@ -148,7 +148,7 @@ extension GraphState {
             // that field must be 'visible in frame.'
             // If the field is not visible, log this to Sentry and manually set the canvas item visible.
             if let canvasItem = rowViewModel.canvasItemDelegate,
-               !canvasItem.isVisibleInFrame(self) {
+               !canvasItem.isVisibleInFrame(self.visibleCanvasIds) {
                 
                 // TODO: we are firing input edit events merely when an item is added to the canvas
 //                // On dev debug, crash

--- a/Stitch/Graph/Node/Port/Util/InputEdit/InputCommittedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/InputEdit/InputCommittedActions.swift
@@ -107,7 +107,8 @@ extension GraphState {
         }
         
         nodeViewModel.removeIncomingEdge(at: input.id,
-                                         activeIndex: self.activeIndex)
+                                         activeIndex: self.activeIndex,
+                                         graph: self)
         
         // Block or unblock certain layer inputs
         if let layerInputType: LayerInputType = input.id.keyPath,
@@ -147,7 +148,7 @@ extension GraphState {
             // that field must be 'visible in frame.'
             // If the field is not visible, log this to Sentry and manually set the canvas item visible.
             if let canvasItem = rowViewModel.canvasItemDelegate,
-               !canvasItem.isVisibleInFrame {
+               !canvasItem.isVisibleInFrame(self) {
                 
                 // TODO: we are firing input edit events merely when an item is added to the canvas
 //                // On dev debug, crash

--- a/Stitch/Graph/Node/Port/Util/InputEdit/InputEditedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/InputEdit/InputEditedActions.swift
@@ -68,7 +68,8 @@ extension InputNodeRowObserver {
 
             // MARK: very important to remove edges before input changes
             node.removeIncomingEdge(at: self.id,
-                                    activeIndex: graph.activeIndex)
+                                    activeIndex: graph.activeIndex,
+                                    graph: graph)
 
             self.setValuesInInput([newValue])
         }

--- a/Stitch/Graph/Node/Port/Util/TypeChange/NodeTypeChangedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/TypeChange/NodeTypeChangedActions.swift
@@ -96,7 +96,8 @@ extension GraphState {
             node.updateNodeTypeAndInputs(
                 newType: newType,
                 currentGraphTime: graphTime,
-                activeIndex: activeIndex)
+                activeIndex: activeIndex,
+                graph: self)
         } else {
             // For network request node, we just change the user-visible-type manually.
             patchNode.userVisibleType = newType

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -61,6 +61,7 @@ extension NodeRowObserver {
 
 @Observable
 final class InputNodeRowObserver: NodeRowObserver, InputNodeRowCalculatable {
+    
     static let nodeIOType: NodeIO = .input
 
     let id: NodeIOCoordinate

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverCachedViewDataExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverCachedViewDataExtensions.swift
@@ -22,7 +22,7 @@ extension NodeRowViewModel {
         let canvasItems = nodeDelegate.getAllCanvasObservers()
         
         return canvasItems.compactMap { canvasItem in
-            guard canvasItem.isVisibleInFrame(graph) else {
+            guard canvasItem.isVisibleInFrame(graph.visibleCanvasIds) else {
                 return nil
             }
             

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverCachedViewDataExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverCachedViewDataExtensions.swift
@@ -14,7 +14,7 @@ extension NodeRowViewModel {
     /// Gets node ID for currently visible node. Covers edge cause where group nodes use splitter nodes,
     /// which save a differnt node ID.
     @MainActor
-    var visibleNodeIds: Set<CanvasItemId> {
+    func visibleNodeIds(_ graph: GraphState) -> Set<CanvasItemId> {
         guard let nodeDelegate = self.nodeDelegate else {
             return []
         }
@@ -22,15 +22,15 @@ extension NodeRowViewModel {
         let canvasItems = nodeDelegate.getAllCanvasObservers()
         
         return canvasItems.compactMap { canvasItem in
-            guard canvasItem.isVisibleInFrame else {
+            guard canvasItem.isVisibleInFrame(graph) else {
                 return nil
             }
             
             // We use the group node ID only if it isn't in focus
             if nodeDelegate.splitterType == .input &&
-                 nodeDelegate.graphDelegate?.groupNodeFocused != canvasItem.parentGroupNodeId,
+                graph.groupNodeFocused != canvasItem.parentGroupNodeId,
                let parentNodeId = canvasItem.parentGroupNodeId,
-               let parentNode = self.graphDelegate?.getNodeViewModel(parentNodeId),
+               let parentNode = graph.getNodeViewModel(parentNodeId),
                let parentCanvasItem = parentNode.patchCanvasItem {
                 return parentCanvasItem.id
             }

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
@@ -63,21 +63,46 @@ extension NodeRowObserver {
     /// Updates port view models when the backend port observer has been updated.
     /// Also invoked when nodes enter the viewframe incase they need to be udpated.
     @MainActor
-    func updatePortViewModels(_ graph: GraphState) {
-        guard (self.nodeDelegate?.isVisibleInFrame(graph) ?? false) else {
+//    func updatePortViewModels(_ graph: GraphState) {
+    func updatePortViewModels(_ graph: any GraphCalculatable) {
+        
+        // TODO: this actually works? We don't have to extend the GraphCalculatable protocol to have `visibleCanvasIds`, `selectedSidebarLayers`, `isFullScreenMode` and `groupNodeFocused`? ... Swift is tracking the concrete type?
+        guard let graph = graph as? GraphState else {
+            log("updatePortViewModels: could not ")
             return
         }
         
-        self.getVisibleRowViewModels(graph, showsLayerInspector: graph.graphUI.showsLayerInspector).forEach { rowViewModel in
+        guard let node: NodeViewModel = self.nodeDelegate else {
+            // Should this be a fatalError?
+//            fatalErrorIfDebug("updatePortViewModels: no node delegate")
+            log("updatePortViewModels: no node delegate")
+            return
+        }
+        
+        guard node.isVisibleInFrame(graph.visibleCanvasIds,
+                                    graph.selectedSidebarLayers) else {
+            // Node not visible, so nothing to do
+            return
+        }
+        
+        let visibleRowViewModels = self.getVisibleRowViewModels(
+            visibleCanvasIds: graph.visibleCanvasIds,
+            isFullScreenMode: graph.isFullScreenMode,
+            groupNodeFocused: graph.groupNodeFocused)
+        
+        visibleRowViewModels.forEach { rowViewModel in
             rowViewModel.didPortValuesUpdate(values: self.allLoopedValues)
         }
     }
     
+    // Just reads GraphState, does not modify it?
     @MainActor
-    func getVisibleRowViewModels(_ graph: GraphState,
-                                 showsLayerInspector: Bool) -> [Self.RowViewModelType] {
+    func getVisibleRowViewModels(visibleCanvasIds: CanvasItemIdSet,
+                                 isFullScreenMode: Bool,
+                                 groupNodeFocused: NodeId?) -> [Self.RowViewModelType] {
         // Make sure we're not in full screen mode
-        guard !graph.isFullScreenMode else {
+//        guard !graph.isFullScreenMode else {
+        guard !isFullScreenMode else {
             return []
         }
         
@@ -88,11 +113,12 @@ extension NodeRowObserver {
             // A row for a layer inspector is visible just if layer inspector is open
             case .layerInspector:
                 
-                let layerFocused = graph.sidebarSelectionState.all.contains(rowViewModel.id.nodeId)
-                
                 // TODO: why can't we the proper condition here? Why must we always return `true`? For perf, we only want to update inspector UI-fields if that inspector is open and this row observer's layer is actually focused; otherwise it's same as if we're updating an off-screen node
+                // let showsLayerInspector = graph.graphUI.showsLayerInspector
+                // let layerFocused = graph.sidebarSelectionState.all.contains(rowViewModel.id.nodeId)
                 // return showsLayerInspector && layerFocused
                 return true
+                
                 
             case .node:
                 
@@ -101,7 +127,8 @@ extension NodeRowObserver {
                     return false
                 }
                 
-                let isVisibleInCurrentGroup = canvas.isVisibleInFrame(graph) && canvas.parentGroupNodeId == graph.groupNodeFocused
+//                let isVisibleInCurrentGroup = canvas.isVisibleInFrame(graph) && canvas.parentGroupNodeId == graph.groupNodeFocused
+                let isVisibleInCurrentGroup = canvas.isVisibleInFrame(visibleCanvasIds) && canvas.parentGroupNodeId == groupNodeFocused
              
                 // always update group node, whose row view models don't otherwise update
                 let isGroupNode = canvas.nodeDelegate?.nodeType.groupNode.isDefined ?? false

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
@@ -63,23 +63,21 @@ extension NodeRowObserver {
     /// Updates port view models when the backend port observer has been updated.
     /// Also invoked when nodes enter the viewframe incase they need to be udpated.
     @MainActor
-    func updatePortViewModels() {
-        guard (self.nodeDelegate?.isVisibleInFrame ?? false) else {
+    func updatePortViewModels(_ graph: GraphState) {
+        guard (self.nodeDelegate?.isVisibleInFrame(graph) ?? false) else {
             return
         }
         
-        self.getVisibleRowViewModels().forEach { rowViewModel in
+        self.getVisibleRowViewModels(graph, showsLayerInspector: graph.graphUI.showsLayerInspector).forEach { rowViewModel in
             rowViewModel.didPortValuesUpdate(values: self.allLoopedValues)
         }
     }
     
     @MainActor
-    func getVisibleRowViewModels() -> [Self.RowViewModelType] {
-        guard let graph = self.nodeDelegate?.graphDelegate,
-              // Make sure we're not in full screen mode
-              !graph.isFullScreenMode,
-              // Make sure we have can access whether inspector is open or not
-              let showsLayerInspector = graph.documentDelegate?.graphUI.showsLayerInspector else {
+    func getVisibleRowViewModels(_ graph: GraphState,
+                                 showsLayerInspector: Bool) -> [Self.RowViewModelType] {
+        // Make sure we're not in full screen mode
+        guard !graph.isFullScreenMode else {
             return []
         }
         
@@ -103,7 +101,7 @@ extension NodeRowObserver {
                     return false
                 }
                 
-                let isVisibleInCurrentGroup = canvas.isVisibleInFrame && canvas.parentGroupNodeId == self.nodeDelegate?.graphDelegate?.groupNodeFocused
+                let isVisibleInCurrentGroup = canvas.isVisibleInFrame(graph) && canvas.parentGroupNodeId == graph.groupNodeFocused
              
                 // always update group node, whose row view models don't otherwise update
                 let isGroupNode = canvas.nodeDelegate?.nodeType.groupNode.isDefined ?? false

--- a/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
+++ b/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
@@ -97,7 +97,7 @@ extension GraphState {
             }
             
             // If we drag a canvas item that is not yet selected, we'll select it and deselect all the others.
-            if !canvasItem.isSelected {
+            if !canvasItem.isSelected(state) {
                 // log("NodeDuplicateDraggedAction: \(canvasItem.id) was NOT already selected")
                 // select the canvas item and de-select all the others
                 state.selectSingleCanvasItem(canvasItem)
@@ -220,7 +220,7 @@ extension GraphState {
 
         // Dragging an unselected node selects that node
         // and de-selects all other nodes.
-        let alreadySelected = canvasItem.isSelected
+        let alreadySelected = canvasItem.isSelected(self)
 
         if !alreadySelected {
             // update node's position
@@ -286,7 +286,7 @@ extension StitchDocumentViewModel {
         
         let _update = { (canvasItem: CanvasItemViewModel) in
             
-            guard let nodeSize = canvasItem.graphBaseViewSize else {
+            guard let nodeSize = canvasItem.graphBaseViewSize(self.graphMovement) else {
                 return
             }
             

--- a/Stitch/Graph/Node/Util/Movement/NodePositionUtils.swift
+++ b/Stitch/Graph/Node/Util/Movement/NodePositionUtils.swift
@@ -23,11 +23,12 @@ extension CGPoint {
 // Note: previously we had a side-effect delay to work around some issues with `.buttonStyle(.plain)`'s auto animation and a GraphSchema-update interrupting double tap. These issues now seem to be resolved.
 extension CanvasItemViewModel {
     @MainActor
-    var graphBaseViewSize: CGSize? {
-        guard let nodeSize = self.sizeByLocalBounds,
-              let denominator = self.graphDelegate?.documentDelegate?.graphMovement.zoomData.zoom else {
+    func graphBaseViewSize(_ graphMovement: GraphMovementObserver) -> CGSize? {
+        guard let nodeSize = self.sizeByLocalBounds else {
             return nil
         }
+        
+        let denominator = graphMovement.zoomData.zoom
         
         return .init(width: nodeSize.width / denominator,
                      height: nodeSize.height / denominator)

--- a/Stitch/Graph/Node/Util/NodeViewModelUtils.swift
+++ b/Stitch/Graph/Node/Util/NodeViewModelUtils.swift
@@ -161,7 +161,8 @@ extension NodeViewModel {
     @MainActor
     func updateNodeTypeAndInputs(newType: UserVisibleType,
                                  currentGraphTime: TimeInterval,
-                                 activeIndex: ActiveIndex) {
+                                 activeIndex: ActiveIndex,
+                                 graph: GraphState) {
 
         self.userVisibleType = newType
         
@@ -172,7 +173,7 @@ extension NodeViewModel {
                 currentGraphTime: currentGraphTime,
                 computedState: self.computedStates?[safe: index],
                 activeIndex: activeIndex,
-                isVisible: self.isVisibleInFrame)
+                isVisible: self.isVisibleInFrame(graph.visibleCanvasIds, graph.selectedSidebarLayers))
         }
     }
     

--- a/Stitch/Graph/Node/View/NodeView.swift
+++ b/Stitch/Graph/Node/View/NodeView.swift
@@ -56,10 +56,10 @@ struct NodeView<InputsViews: View, OutputsViews: View>: View {
             nodeBody
                 .opacity(node.viewCache.isDefined ? 1 : 0)
             .onAppear {
-                self.node.updateVisibilityStatus(with: true)
+                self.node.updateVisibilityStatus(with: true, graph: graph)
             }
             .onDisappear {
-                self.node.updateVisibilityStatus(with: false)
+                self.node.updateVisibilityStatus(with: false, graph: graph)
             }
             .onChange(of: self.isSelected) {
                 self.stitch.updatePortColorDataUponNodeSelection()

--- a/Stitch/Graph/Node/View/StitchUIScrollView.swift
+++ b/Stitch/Graph/Node/View/StitchUIScrollView.swift
@@ -324,18 +324,13 @@ final class StitchScrollCoordinator<Content: View>: NSObject, UIScrollViewDelega
     func checkBorder(_ scrollView: UIScrollView) {
                 
         let scale = scrollView.zoomScale
-        let cache = self.document?.graph.visibleNodesViewModel.infiniteCanvasCache ?? .init()
         
-        let jumpLocationDefined = self.document?.graphUI.canvasJumpLocation.isDefined ?? false
-        
-        let activelyZooming = self.document?.graphUI.canvasZoomedIn.zoomAmount.isDefined ?? self.document?.graphUI.canvasZoomedOut.zoomAmount.isDefined ?? false
-
         guard let document = self.document else {
             log("checkBorder: no document, exiting early")
             return
         }
-        
         let graph = document.graph
+        let cache = graph.visibleNodesViewModel.infiniteCanvasCache
 
         // Do not check borders for ~1 second after (1) jumping to an item on the canvas or (2) zooming in/out
         
@@ -346,7 +341,7 @@ final class StitchScrollCoordinator<Content: View>: NSObject, UIScrollViewDelega
         }
         
         // Only check borders if we have cached size and position data for canvas items
-        let canvasItemsInFrame = graph.getVisibleCanvasItems().filter({ $0.isVisibleInFrame(graph) })
+        let canvasItemsInFrame = graph.getVisibleCanvasItems().filter({ $0.isVisibleInFrame(graph.visibleCanvasIds) })
         
         guard let westNode = graph.westernMostNodeForBorderCheck(canvasItemsInFrame),
               let eastNode = graph.easternMostNodeForBorderCheck(canvasItemsInFrame),
@@ -364,8 +359,8 @@ final class StitchScrollCoordinator<Content: View>: NSObject, UIScrollViewDelega
             return
         }
         
-        let screenWidth = document.graphUI.frame.width ?? .zero
-        let screenHeight = document.graphUI.frame.height ?? .zero
+        let screenWidth = document.graphUI.frame.width
+        let screenHeight = document.graphUI.frame.height
         
         let westernMostNodeCachedBoundsOriginX: CGFloat = westBounds.origin.x
         let easternMostNodeCachedBoundsOriginX: CGFloat = eastBounds.origin.x
@@ -499,16 +494,22 @@ final class StitchScrollCoordinator<Content: View>: NSObject, UIScrollViewDelega
     func graphScroll(_ gesture: UIPanGestureRecognizer,
                      translation: CGPoint,
                      scrollView: UIScrollView) {
+        
+        guard let document = self.document else {
+            log("graphScroll: no document")
+            return
+        }
+        
         switch gesture.state {
         case .began:
             initialContentOffset = scrollView.contentOffset
-            document?.graphUI.activeSpacebarClickDrag = true
+            document.graphUI.activeSpacebarClickDrag = true
             
         case .changed:
-            document?.graphUI.activeSpacebarClickDrag = true
+            document.graphUI.activeSpacebarClickDrag = true
             
-            let screenHeight = self.document?.graphUI.frame.height ?? .zero
-            let screenWidth = self.document?.graphUI.frame.width ?? .zero
+            let screenHeight = document.graphUI.frame.height
+            let screenWidth = document.graphUI.frame.width
             
             // UIScrollView's contentOffset can never be negative
             let minOffset: CGFloat = 0
@@ -552,7 +553,7 @@ final class StitchScrollCoordinator<Content: View>: NSObject, UIScrollViewDelega
             log("StitchUIScrollView: handlePan: possible")
             
         case .ended, .cancelled, .failed:
-            document?.graphUI.activeSpacebarClickDrag = false
+            document.graphUI.activeSpacebarClickDrag = false
             scrollView.setContentOffset(scrollView.contentOffset,
                                         animated: false)
             Self.updateGraphScrollData(scrollView, shouldPersist: true)

--- a/Stitch/Graph/Node/View/StitchUIScrollView.swift
+++ b/Stitch/Graph/Node/View/StitchUIScrollView.swift
@@ -329,22 +329,33 @@ final class StitchScrollCoordinator<Content: View>: NSObject, UIScrollViewDelega
         let jumpLocationDefined = self.document?.graphUI.canvasJumpLocation.isDefined ?? false
         
         let activelyZooming = self.document?.graphUI.canvasZoomedIn.zoomAmount.isDefined ?? self.document?.graphUI.canvasZoomedOut.zoomAmount.isDefined ?? false
-        
 
-        guard
-            // Do not check borders for ~1 second after (1) jumping to an item on the canvas or (2) zooming in/out
-            !self.borderCheckingDisabled,
-            
-                // Only check borders if we have cached size and position data for canvas items
-            let canvasItemsInFrame = self.document?.graph.getVisibleCanvasItems().filter(\.isVisibleInFrame),
-            let westNode = self.document?.graph.westernMostNodeForBorderCheck(canvasItemsInFrame),
-            let eastNode = self.document?.graph.easternMostNodeForBorderCheck(canvasItemsInFrame),
-            let westBounds = cache.get(westNode.id),
-            let eastBounds = cache.get(eastNode.id),
-            let northNode = self.document?.graph.northernMostNodeForBorderCheck(canvasItemsInFrame),
-            let southNode = self.document?.graph.southernMostNodeForBorderCheck(canvasItemsInFrame),
-            let northBounds = cache.get(northNode.id),
-            let southBounds = cache.get(southNode.id) else {
+        guard let document = self.document else {
+            log("checkBorder: no document, exiting early")
+            return
+        }
+        
+        let graph = document.graph
+
+        // Do not check borders for ~1 second after (1) jumping to an item on the canvas or (2) zooming in/out
+        
+        guard !self.borderCheckingDisabled else {
+            log("checkBorder: border checking disabled")
+            Self.updateGraphScrollData(scrollView)
+            return
+        }
+        
+        // Only check borders if we have cached size and position data for canvas items
+        let canvasItemsInFrame = graph.getVisibleCanvasItems().filter({ $0.isVisibleInFrame(graph) })
+        
+        guard let westNode = graph.westernMostNodeForBorderCheck(canvasItemsInFrame),
+              let eastNode = graph.easternMostNodeForBorderCheck(canvasItemsInFrame),
+              let westBounds = cache.get(westNode.id),
+              let eastBounds = cache.get(eastNode.id),
+              let northNode = graph.northernMostNodeForBorderCheck(canvasItemsInFrame),
+              let southNode = graph.southernMostNodeForBorderCheck(canvasItemsInFrame),
+              let northBounds = cache.get(northNode.id),
+              let southBounds = cache.get(southNode.id) else {
             
             Self.updateGraphScrollData(scrollView)
             
@@ -353,8 +364,8 @@ final class StitchScrollCoordinator<Content: View>: NSObject, UIScrollViewDelega
             return
         }
         
-        let screenWidth = self.document?.graphUI.frame.width ?? .zero
-        let screenHeight = self.document?.graphUI.frame.height ?? .zero
+        let screenWidth = document.graphUI.frame.width ?? .zero
+        let screenHeight = document.graphUI.frame.height ?? .zero
         
         let westernMostNodeCachedBoundsOriginX: CGFloat = westBounds.origin.x
         let easternMostNodeCachedBoundsOriginX: CGFloat = eastBounds.origin.x

--- a/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
@@ -97,11 +97,6 @@ final class CanvasItemViewModel: Identifiable, StitchLayoutCachable, Sendable {
     @MainActor
     weak var nodeDelegate: NodeDelegate?
     
-//    @MainActor
-//    var graphDelegate: GraphDelegate? {
-//        self.nodeDelegate?.graphDelegate
-//    }
-    
     @MainActor
     init(id: CanvasItemId,
          position: CGPoint,

--- a/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
@@ -74,8 +74,7 @@ final class CanvasItemViewModel: Identifiable, StitchLayoutCachable, Sendable {
     @MainActor var parentGroupNodeId: NodeId?
     
     @MainActor
-    var isVisibleInFrame: Bool {
-        guard let graph = self.graphDelegate else { return false }
+    func isVisibleInFrame(_ graph: GraphState) -> Bool {
         return graph.visibleNodesViewModel.visibleCanvasIds.contains(self.id)
     }
     
@@ -89,19 +88,18 @@ final class CanvasItemViewModel: Identifiable, StitchLayoutCachable, Sendable {
     
     // Moved state here for render cycle perf on port view for colors
     @MainActor
-    var isSelected: Bool {
-        guard let graphDelegate = self.graphDelegate else { return false }
-        return graphDelegate.graphUI.selection.selectedNodeIds.contains(self.id)
+    func isSelected(_ graph: GraphState) -> Bool {
+        return graph.graphUI.selection.selectedNodeIds.contains(self.id)
     }
     
     // Reference back to the parent node entity
     @MainActor
     weak var nodeDelegate: NodeDelegate?
     
-    @MainActor
-    var graphDelegate: GraphDelegate? {
-        self.nodeDelegate?.graphDelegate
-    }
+//    @MainActor
+//    var graphDelegate: GraphDelegate? {
+//        self.nodeDelegate?.graphDelegate
+//    }
     
     @MainActor
     init(id: CanvasItemId,

--- a/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
@@ -74,8 +74,9 @@ final class CanvasItemViewModel: Identifiable, StitchLayoutCachable, Sendable {
     @MainActor var parentGroupNodeId: NodeId?
     
     @MainActor
-    func isVisibleInFrame(_ graph: GraphState) -> Bool {
-        return graph.visibleNodesViewModel.visibleCanvasIds.contains(self.id)
+//    func isVisibleInFrame(_ graph: GraphState) -> Bool {
+    func isVisibleInFrame(_ visibleCanvasIds: CanvasItemIdSet) -> Bool {
+        return visibleCanvasIds.contains(self.id)
     }
     
     // View specific port value data
@@ -256,10 +257,10 @@ extension CanvasItemViewModel {
     }
 
     @MainActor
-    func updateVisibilityStatus(with newValue: Bool) {
+    func updateVisibilityStatus(with newValue: Bool, graph: GraphState) {
         if newValue {
             self.updatePortLocations()
-            self.nodeDelegate?.updatePortViewModels()
+            self.nodeDelegate?.updatePortViewModels(graph)
         }
         
 //        let oldValue = self.isVisibleInFrame

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
@@ -342,16 +342,15 @@ extension NodeViewModel {
     
     /// Checks if any canvas entity for this node is visible.
     @MainActor
-    var isVisibleInFrame: Bool {
+    func isVisibleInFrame(_ graph: GraphState) -> Bool {
         for canvasObserver in self.getAllCanvasObservers() {
-            if canvasObserver.isVisibleInFrame {
+            if canvasObserver.isVisibleInFrame(graph) {
                 return true
             }
         }
         
         // Check for visible layer inspectors
         if let layerId = self.layerNode?.id,
-           let graph = self.graphDelegate,
            graph.layersSidebarViewModel.selectionState.primary.contains(layerId) {
             return true
         }

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
@@ -342,16 +342,17 @@ extension NodeViewModel {
     
     /// Checks if any canvas entity for this node is visible.
     @MainActor
-    func isVisibleInFrame(_ graph: GraphState) -> Bool {
+    func isVisibleInFrame(_ visibleCanvasIds: CanvasItemIdSet,
+                          _ selectedSidebarLayers: SidebarLayerIdSet) -> Bool {
         for canvasObserver in self.getAllCanvasObservers() {
-            if canvasObserver.isVisibleInFrame(graph) {
+            if canvasObserver.isVisibleInFrame(visibleCanvasIds) {
                 return true
             }
         }
         
         // Check for visible layer inspectors
         if let layerId = self.layerNode?.id,
-           graph.layersSidebarViewModel.selectionState.primary.contains(layerId) {
+           selectedSidebarLayers.contains(layerId) {
             return true
         }
         

--- a/Stitch/Graph/Util/GraphUIActions.swift
+++ b/Stitch/Graph/Util/GraphUIActions.swift
@@ -335,7 +335,7 @@ struct ActiveIndexChangedAction: GraphEvent {
         // Note: previously this logic was handled in the view (`NodeInputOutputView`);
         // the advantage was that only actively-rendered
         state.getVisibleNodes().forEach { node in
-            node.updatePortViewModels()
+            node.updatePortViewModels(state)
         }
     }
 }

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -473,9 +473,8 @@ extension GraphState {
 extension CanvasItemViewModel {
     @MainActor
     func select(_ graph: GraphState) {
-        log("CanvasItemViewModel: selecting called")
         // Prevent render cycles if already selected
-        guard !self.isSelected  else { return }
+        guard !self.isSelected(graph)  else { return }
         
         graph.graphUI.selection.selectedNodeIds.insert(self.id)
         
@@ -486,7 +485,7 @@ extension CanvasItemViewModel {
     @MainActor
     func deselect(_ graph: GraphState) {
         // Prevent render cycles if already unselected
-        guard self.isSelected else { return }
+        guard self.isSelected(graph) else { return }
         graph.graphUI.selection.selectedNodeIds.remove(self.id)
     }
 }
@@ -533,7 +532,7 @@ extension GraphState {
             .flatMap { node in
                 node.getAllCanvasObservers()
                     .compactMap { canvas in
-                        guard canvas.isSelected else {
+                        guard canvas.isSelected(self) else {
                             return nil
                         }
                         return canvas.id
@@ -546,7 +545,7 @@ extension GraphState {
 extension GraphState {
     @MainActor
     var selectedCanvasItems: CanvasItemViewModels {
-        self.getVisibleCanvasItems().filter(\.isSelected)
+        self.getVisibleCanvasItems().filter { $0.isSelected(self) }
     }
     
     @MainActor

--- a/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
+++ b/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
@@ -16,7 +16,7 @@ final class VisibleNodesViewModel: Sendable {
     // Saves location and zoom-specific data for groups
     @MainActor var nodesByPage: NodesPagingDict // = [.root: .init()]
     
-    @MainActor var visibleCanvasIds = Set<CanvasItemId>()
+    @MainActor var visibleCanvasIds = CanvasItemIdSet()
     
     // Signals to SwiftUI layout when new sizing data is needed;
     // tracked here to fix stutter that exists if we reset cache before
@@ -26,6 +26,33 @@ final class VisibleNodesViewModel: Sendable {
     
     @MainActor init(localPosition: CGPoint) {
         self.nodesByPage = [.root: .init(localPosition: localPosition)]
+    }
+}
+
+/*
+ //        let x: Set<LayersSidebarViewModel.ItemID> = graph.sidebarSelectionState.primary
+ //        let k: SidebarLayerIdSet = graph.sidebarSelectionState.primary
+ */
+typealias SidebarLayerIdSet = Set<LayersSidebarViewModel.ItemID>
+
+extension GraphState {
+    
+    @MainActor
+    var visibleCanvasIds: CanvasItemIdSet {
+        get {
+            self.visibleNodesViewModel.visibleCanvasIds
+        } set(newValue) {
+            self.visibleNodesViewModel.visibleCanvasIds = newValue
+        }
+    }
+    
+    @MainActor
+    var selectedSidebarLayers: SidebarLayerIdSet {
+        get {
+            self.sidebarSelectionState.primary
+        } set(newValue) {
+            self.sidebarSelectionState.primary = newValue
+        }
     }
 }
 

--- a/StitchTests/evalTests.swift
+++ b/StitchTests/evalTests.swift
@@ -570,7 +570,8 @@ class EvalTests: XCTestCase {
         // node =
         node.updateNodeTypeAndInputs(newType: .string,
                                      currentGraphTime: fakeGraphTime,
-                                     activeIndex: .init(.zero))
+                                     activeIndex: .init(.zero),
+                                     graph: .createEmpty())
         
         let newInputs = node.inputs
         
@@ -612,7 +613,8 @@ class EvalTests: XCTestCase {
         node.updateNodeTypeAndInputs(
             newType: .point3D,
             currentGraphTime: fakeGraphTime,
-            activeIndex: .init(.zero))
+            activeIndex: .init(.zero),
+            graph: .createEmpty())
         let newInputs = node.inputs
         
         let expectedCoercedInputs: PortValuesList = [


### PR DESCRIPTION
Noticed we were relying on NodeDelegate for GraphState in the CanvasItem's select and deselect methods. We still need to fix the bug that caused NodeDelegate to be missing, but with this change we no longer expose other parts of the app to that failure (more maintainable).

This change only removes `GraphDelegate` from `CanvasItemViewModel`. `NodeDelegate` still has `GraphDelegate` etc.

It ended up being small because in every context where we were accessing NodeDelegate.graphDelegate, we had `graph` in the parent caller.

We get:
1. **consistency**: one way to access GraphState (via GraphState method / action handler); we no longer do weird things where a function is called in context where GraphState exists yet we access the optional GraphDelegate
2. **greater function transparency**: e.g. if a method requires GraphState (or some of its data), that's made clear by passing down GraphState; function signatures should communicate requirements
3. **greater type expressiveness**:  CanvasItemViewModel's `weak var graphDelegate` was always Optional, which was confusing in contexts where we know we _must_ have GraphState.

QA'd all the larger projects, did not find any issues, but will keep eyes open.

Note existing failing test: https://github.com/StitchDesign/Stitch--Old/issues/6955