### PR TITLE
Use inputs if outputs are empty for LoopInsert node

### DIFF
--- a/Stitch/Graph/Node/Patch/Type/Loop/LoopInsert.swift
+++ b/Stitch/Graph/Node/Patch/Type/Loop/LoopInsert.swift
@@ -92,16 +92,24 @@ func loopInsertEval(node: PatchNode,
 
     let defaultFirstInputs: PortValues = [.color(.red), .color(.yellow), .color(.blue), .color(.green)]
 
-    let inputsValues = node.inputs
-    let outputsValues = node.outputs
+    //if the outputs are empty (when we reset/open a graph); just provide the inputs instead
+    //outputs = inputs
+    //to match origimai
+    
+    let inputsValues: PortValuesList = node.inputs
+    var outputsValues: PortValuesList = node.outputs
+    
+    let firstOutput: PortValues? = outputsValues.first
+    
+    if (firstOutput?.isEmpty == true) || (firstOutput?.first == nil) {
+        outputsValues = inputsValues
+    }
+    
     let graphTime = graphStep.graphTime
 
     // Apparently: If ANY indices pulsed, then we insert.
-    let shouldPulse: Bool = (inputsValues[safe: 3] ?? []).contains { (value: PortValue) -> Bool in
-        if let pulseAt = value.getPulse {
-            return pulseAt.shouldPulse(graphTime)
-        }
-        return false
+    let shouldPulse: Bool = (inputsValues[safe: 3] ?? []).contains { value in
+        value.getPulse?.shouldPulse(graphTime) ?? false
     }
 
     let currentInput = inputsValues.first ?? defaultFirstInputs


### PR DESCRIPTION
Previously:
![IMG_2786](https://github.com/user-attachments/assets/43b7562b-45c6-42bb-80e6-fe66f6b66237)

Now:
https://github.com/user-attachments/assets/24ba267c-da40-455d-b3e9-7da9c7e681e5

