### PR TITLE
Use offset and zoom per traversal level; use graph-center if entering level for first time

### DIFF
--- a/Stitch/Graph/CommentBox/Util/CommentBoxActions.swift
+++ b/Stitch/Graph/CommentBox/Util/CommentBoxActions.swift
@@ -34,7 +34,7 @@ extension GraphState {
 
         let box = CommentBoxViewModel(
             zIndex: self.highestZIndex + 1,
-            scale: self.graphMovement.zoomData.zoom,
+            scale: self.graphMovement.zoomData,
             nodes: visibleSelectedNodes)
 
         self.commentBoxesDict.updateValue(box, forKey: box.id)

--- a/Stitch/Graph/CommentBox/Util/CommentBoxGestureActions.swift
+++ b/Stitch/Graph/CommentBox/Util/CommentBoxGestureActions.swift
@@ -40,7 +40,7 @@ extension StitchDocumentViewModel {
                                    value: DragGesture.Value) {
 
         // log("CommentBoxPositionDragged called")
-        let zoom: CGFloat = self.graphMovement.zoomData.zoom
+        let zoom: CGFloat = self.graphMovement.zoomData
 
         // log("CommentBoxPositionDragged: value.translation: \(value.translation)")
         // log("CommentBoxPositionDragged: value.translation / zoom: \(value.translation / zoom)")
@@ -160,7 +160,7 @@ extension StitchDocumentViewModel {
                                     value: DragGesture.Value) {
         self.graphUI.selection.selectedCommentBoxes = Set([box.id])
 
-        let zoom = self.graphMovement.zoomData.zoom
+        let zoom = self.graphMovement.zoomData
 
         // STEP 1: UPDATE THE COMMENT BOX ITSELF
         box.expansionBox.startPoint = box.position

--- a/Stitch/Graph/Gesture/Util/GraphUIScrollActions.swift
+++ b/Stitch/Graph/Gesture/Util/GraphUIScrollActions.swift
@@ -667,10 +667,8 @@ extension StitchDocumentViewModel {
     @MainActor
     var localPosition: CGPoint {
         get {
-            log("StitchDocument: localPosition: get: \(self.graphMovement.localPosition)")
             return self.graphMovement.localPosition
         } set {
-            log("StitchDocument: localPosition: set newValue: \(newValue)")
             self.graphMovement.localPosition = newValue
         }
     }

--- a/Stitch/Graph/Gesture/Util/GraphUIScrollActions.swift
+++ b/Stitch/Graph/Gesture/Util/GraphUIScrollActions.swift
@@ -54,15 +54,6 @@ extension StitchDocumentViewModel {
             gestureTranslation: translation.toCGSize,
             wasTrackpadScroll: wasTrackpadScroll)
     }
-
-    /// Fixes issue where tap gestures need to be registered in UKit to stop a graph jumpiness bug.
-    /// Tapping the graph should stop momentum.
-    @MainActor
-    func graphTappedDuringMouseScroll() {
-        log("GraphTappedDuringMouseScroll called")
-        self.graphMovement.resetGraphMovement()
-        self.graphUI.selection.graphDragState = .none
-    }
 }
 
 extension GraphMovementObserver {
@@ -549,7 +540,7 @@ extension StitchDocumentViewModel {
 //
 //        // Always update the graph offset,
 //        // regardless whether there is another active gesture.
-//        self.graphMovement.localPosition = self.localPreviousPosition + (translation.toCGPoint / self.graphMovement.zoomData.zoom)
+//        self.graphMovement.localPosition = self.localPreviousPosition + (translation.toCGPoint / self.graphMovement.zoomData)
 
         //    log("handleGraphScrolled: state.graphUI.graphMovement.localPosition is now: \(state.graphUI.graphMovement.localPosition)")
 
@@ -583,7 +574,7 @@ extension StitchDocumentViewModel {
                 node.updateNodeOnGraphDragged(
                     translation,
                     self.visibleGraph.highestZIndex + 1,
-                    zoom: self.graphMovement.zoomData.zoom,
+                    zoom: self.graphMovement.zoomData,
                     state: self.graphMovement)
             }
 
@@ -659,7 +650,7 @@ extension StitchDocumentViewModel {
 
         // TODO: factor out zoom level
         
-        let scale = self.graphMovement.zoomData.zoom
+        let scale = self.graphMovement.zoomData
         
         // UIScrollView's contentOffset is based on contentSize, which is a function zoomScale;
         // but we do not persist zoom;
@@ -676,8 +667,10 @@ extension StitchDocumentViewModel {
     @MainActor
     var localPosition: CGPoint {
         get {
-            self.graphMovement.localPosition
+            log("StitchDocument: localPosition: get: \(self.graphMovement.localPosition)")
+            return self.graphMovement.localPosition
         } set {
+            log("StitchDocument: localPosition: set newValue: \(newValue)")
             self.graphMovement.localPosition = newValue
         }
     }
@@ -750,7 +743,7 @@ extension StitchDocumentViewModel {
 
         // Only add to `accumulated` if we're indeed dragging at least one node
         if graphMovement.canvasItemIsDragged {
-            graphMovement.accumulatedGraphTranslation += (graphMovement.runningGraphTranslation ?? .zero) / graphMovement.zoomData.zoom
+            graphMovement.accumulatedGraphTranslation += (graphMovement.runningGraphTranslation ?? .zero) / graphMovement.zoomData
         }
 
         graphMovement.runningGraphTranslation = nil
@@ -775,13 +768,13 @@ extension StitchDocumentViewModel {
 
             graphMovement
                 .momentumState = startMomentum(graphMovement.momentumState,
-                                               graphMovement.zoomData.zoom,
+                                               graphMovement.zoomData,
                                                velocity)
 
             // also set graphOrigins; JUST FOR GRAPH DRAG AND GRAPH MOMENTUM
             if let nodesPositionalData = self.graphMovement.boundaryNodes {
                 let momentumOrigin = self.visibleGraph
-                    .graphBounds(graphMovement.zoomData.zoom,
+                    .graphBounds(graphMovement.zoomData,
                                  graphView: graphUIState.frame,
                                  graphOffset: graphMovement.localPosition,
                                  positionalData: nodesPositionalData)

--- a/Stitch/Graph/Gesture/Util/GraphUITappedActions.swift
+++ b/Stitch/Graph/Gesture/Util/GraphUITappedActions.swift
@@ -35,14 +35,3 @@ struct GraphDoubleTappedAction: StitchDocumentEvent {
         // log("GraphDoubleTappedAction: state.doubleTapLocation is now: \(state.doubleTapLocation)")
     }
 }
-
-extension GraphMovementObserver {
-    @MainActor func centerViewOnNode(frame: CGRect,
-                          position: CGPoint) {
-
-        // the size of the screen and nodeView
-        let newLocation = calculateMove(frame, position)
-        self.localPosition = newLocation
-        self.localPreviousPosition = newLocation
-    }
-}

--- a/Stitch/Graph/Gesture/Util/GraphUIZoomedActions.swift
+++ b/Stitch/Graph/Gesture/Util/GraphUIZoomedActions.swift
@@ -9,22 +9,6 @@ import Foundation
 import SwiftUI
 import StitchSchemaKit
 
-extension GraphZoom {
-    // Keep current zoom bound to allowed thresholds
-    @MainActor
-    static func throttleGraphZoom(zoomAmount: CGFloat, currentScale: CGFloat) -> CGFloat {
-        let newScale = currentScale + zoomAmount
-        if newScale < 0 || newScale.magnitude < MIN_GRAPH_SCALE {
-            // log("throttleGraphZoom: too small: \(newScale)")
-            return MIN_GRAPH_SCALE - currentScale
-        } else if newScale.magnitude > MAX_GRAPH_SCALE {
-            // log("throttleGraphZoom: too big: \(newScale)")
-            return MAX_GRAPH_SCALE - currentScale
-        }
-        return zoomAmount
-    }
-}
-
 extension StitchDocumentViewModel {
     @MainActor
     func graphZoomedIn(_ manualZoom: GraphManualZoom) {

--- a/Stitch/Graph/Gesture/View/GraphMovementViewModifier.swift
+++ b/Stitch/Graph/Gesture/View/GraphMovementViewModifier.swift
@@ -20,56 +20,19 @@ struct GraphMovementViewModifier: ViewModifier {
 
             // Note: `initial: true` seemed to fire only upon first opening of a given project after app re-opened, and not upon every opening of the project?
             .onChange(of: groupNodeFocused) { oldValue, newValue in
-                
-                log("onChange of groupNodeFocused: oldValue: \(oldValue)")
-                log("onChange of groupNodeFocused: newValue: \(newValue)")
-                log("onChange of groupNodeFocused: self.graphMovement.localPosition; was \(self.graphMovement.localPosition) )")
-                log("onChange of groupNodeFocused: currentNodePage.localPosition: \(currentNodePage.localPosition))")
-                log("onChange of groupNodeFocused: currentNodePage.zoomData: \(currentNodePage.zoomData))")
-                
                 dispatch(SetGraphScrollDataUponPageChange(
                     newPageLocalPosition: currentNodePage.localPosition,
                     newPageZoom: currentNodePage.zoomData
                 ))
-                
-                
-                // curentNodePage local position is default rather than persisted local position when graph first opened
-//                self.graphMovement.localPosition = currentNodePage.localPosition
-//                self.graphMovement.localPreviousPosition = currentNodePage.localPosition
-//                self.graphMovement.zoomData = currentNodePage.zoomData
-                
-                /*
-                 Set all nodes visible for the field updates, since when we enter the new traversal level
-                 our infiniteCanvasCache may not yet have entries for canvas items at this level.
-                 
-                 Then, do the actual determination of onscreen nodes.
-                 
-                 (Similar to how, when first loading a project, we set all nodes visible before we call updateVisibleNodes to actually determine on- vs offscreen nodes.)
-                 
-                 Resolves:
-                 - https://github.com/StitchDesign/Stitch--Old/issues/6787
-                 - https://github.com/StitchDesign/Stitch--Old/issues/6779
-                 
-                 */
-//                self.graph.visibleNodesViewModel.setAllNodesVisible()
-//                
-//                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak graph] in
-//                    graph?.updateVisibleNodes()
-//                }
             }
-        
-        //  these should only be updated by `GraphScrollDataUpdated` ?
+
+            // TODO: either update these `graphMovement: GraphMovementObserver` in `GraphScrollDataUpdated` OR get rid of GraphMovementObserver completely and merely rely on node-page's offset and zoom
             .onChange(of: graphMovement.localPosition) { _, newValue in
-                log("onChange of graphMovement.localPosition: \(graphMovement.localPosition)")
-                log("onChange of graphMovement.localPosition: level \(graph.graphUI.groupNodeFocused)")
-                
                 currentNodePage.localPosition = graphMovement.localPosition
-                
                 self.graph.updateVisibleNodes()
             }
             .onChange(of: graphMovement.zoomData) { _, newValue in
                 currentNodePage.zoomData = graphMovement.zoomData
-                
                 self.graph.updateVisibleNodes()
             }
     }

--- a/Stitch/Graph/Gesture/View/GraphMovementViewModifier.swift
+++ b/Stitch/Graph/Gesture/View/GraphMovementViewModifier.swift
@@ -20,10 +20,23 @@ struct GraphMovementViewModifier: ViewModifier {
 
             // Note: `initial: true` seemed to fire only upon first opening of a given project after app re-opened, and not upon every opening of the project?
             .onChange(of: groupNodeFocused) { oldValue, newValue in
+                
+                log("onChange of groupNodeFocused: oldValue: \(oldValue)")
+                log("onChange of groupNodeFocused: newValue: \(newValue)")
+                log("onChange of groupNodeFocused: self.graphMovement.localPosition; was \(self.graphMovement.localPosition) )")
+                log("onChange of groupNodeFocused: currentNodePage.localPosition: \(currentNodePage.localPosition))")
+                log("onChange of groupNodeFocused: currentNodePage.zoomData: \(currentNodePage.zoomData))")
+                
+                dispatch(SetGraphScrollDataUponPageChange(
+                    newPageLocalPosition: currentNodePage.localPosition,
+                    newPageZoom: currentNodePage.zoomData
+                ))
+                
+                
                 // curentNodePage local position is default rather than persisted local position when graph first opened
-                self.graphMovement.localPosition = currentNodePage.localPosition
-                self.graphMovement.localPreviousPosition = currentNodePage.localPosition
-                self.graphMovement.zoomData.final = currentNodePage.zoomData.final
+//                self.graphMovement.localPosition = currentNodePage.localPosition
+//                self.graphMovement.localPreviousPosition = currentNodePage.localPosition
+//                self.graphMovement.zoomData = currentNodePage.zoomData
                 
                 /*
                  Set all nodes visible for the field updates, since when we enter the new traversal level
@@ -36,20 +49,26 @@ struct GraphMovementViewModifier: ViewModifier {
                  Resolves:
                  - https://github.com/StitchDesign/Stitch--Old/issues/6787
                  - https://github.com/StitchDesign/Stitch--Old/issues/6779
+                 
                  */
-                self.graph.visibleNodesViewModel.setAllNodesVisible()
-                
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak graph] in
-                    graph?.updateVisibleNodes()
-                }
+//                self.graph.visibleNodesViewModel.setAllNodesVisible()
+//                
+//                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak graph] in
+//                    graph?.updateVisibleNodes()
+//                }
             }
+        
+        //  these should only be updated by `GraphScrollDataUpdated` ?
             .onChange(of: graphMovement.localPosition) { _, newValue in
+                log("onChange of graphMovement.localPosition: \(graphMovement.localPosition)")
+                log("onChange of graphMovement.localPosition: level \(graph.graphUI.groupNodeFocused)")
+                
                 currentNodePage.localPosition = graphMovement.localPosition
                 
                 self.graph.updateVisibleNodes()
             }
-            .onChange(of: graphMovement.zoomData.final) { _, newValue in
-                currentNodePage.zoomData.final = graphMovement.zoomData.final
+            .onChange(of: graphMovement.zoomData) { _, newValue in
+                currentNodePage.zoomData = graphMovement.zoomData
                 
                 self.graph.updateVisibleNodes()
             }
@@ -63,7 +82,7 @@ extension GraphState {
     @MainActor
     func updateVisibleNodes() {
         
-        let zoom = self.graphMovement.zoomData.zoom
+        let zoom = self.graphMovement.zoomData
         
         // How much that content is offset from the UIScrollView's top-left corner;
         // can never be negative.

--- a/Stitch/Graph/Gesture/ViewModel/GraphMovementObserver.swift
+++ b/Stitch/Graph/Gesture/ViewModel/GraphMovementObserver.swift
@@ -77,11 +77,11 @@ struct BoundaryNodesPositions {
 
 @Observable
 final class GraphMovementObserver: Sendable {
-    @MainActor var localPosition: CGPoint = ABSOLUTE_GRAPH_CENTER
     
-    @MainActor var zoomData: GraphZoom = .init()
-
+    @MainActor var localPosition: CGPoint = ABSOLUTE_GRAPH_CENTER
     @MainActor var localPreviousPosition: CGPoint = ABSOLUTE_GRAPH_CENTER
+    
+    @MainActor var zoomData: CGFloat = 1.0
 
     let graphMultigesture = GraphMultigesture()
 
@@ -167,12 +167,6 @@ extension GraphMovementObserver {
         momentumState.delta
     }
 
-    @MainActor
-    func resetGraphMovement() {
-        self.localPreviousPosition = self.localPosition
-        self.momentumState = resetMomentum(self.momentumState)
-    }
-    
     @MainActor
     func stopNodeMovement() {
         self.draggedCanvasItem = nil

--- a/Stitch/Graph/GraphStep/GraphStepIncrementer.swift
+++ b/Stitch/Graph/GraphStep/GraphStepIncrementer.swift
@@ -24,7 +24,7 @@ extension StitchDocumentViewModel: GraphStepManagerDelegate {
         
         // Update fields every 30 frames
         if !self.visibleGraph.portsToUpdate.isEmpty &&
-            frameCount % Self.fieldsFrequency(from: self.graphMovement.zoomData.zoom) == 0 {
+            frameCount % Self.fieldsFrequency(from: self.graphMovement.zoomData) == 0 {
             self.visibleGraph.updatePortViews()
         }
     }

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWrapper.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWrapper.swift
@@ -20,7 +20,7 @@ struct InsertNodeMenuWrapper: View {
     }
     
     var graphScale: CGFloat {
-        graphMovement.zoomData.zoom
+        graphMovement.zoomData
     }
     
     // menu and animating-node start in middle

--- a/Stitch/Graph/Node/Patch/Type/DeviceInfoNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/DeviceInfoNode.swift
@@ -183,7 +183,7 @@ func deviceInfoEval(node: PatchNode,
 
     let outputs: PortValuesList = [
         [.size(deviceSize.toLayerSize)],
-        [.number(state.graphMovement.zoomData.zoom)],
+        [.number(state.graphMovement.zoomData)],
         [.deviceOrientation(orientation.toStitchDeviceOrientation)],
         [.string(.init(deviceType.rawValue))],
         [.string(.init(state.graphUI.colorScheme.description))],

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
@@ -127,7 +127,7 @@ extension GraphState {
                               store: StitchStore) {
         var droppedLocation = nodeLocation
         let localPosition = self.localPosition
-        let graphScale = self.graphMovement.zoomData.zoom
+        let graphScale = self.graphMovement.zoomData
 
         let originalNodeLocation = nodeLocation.toCGSize
 

--- a/Stitch/Graph/Node/Port/View/PortView.swift
+++ b/Stitch/Graph/Node/Port/View/PortView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 import StitchSchemaKit
 
+typealias GraphZoom = CGFloat
+
 let EXTENDED_HITBOX_WIDTH: CGFloat = 32 // 68 // 48 // 40 // 32
 let EXTENDED_HITBOX_HEIGHT: CGFloat = 24
 
@@ -23,7 +25,7 @@ struct PortEntryView<NodeRowViewModelType: NodeRowViewModel>: View {
     @Bindable var rowViewModel: NodeRowViewModelType
     @Bindable var graph: GraphState
     @Bindable var graphMultigesture: GraphMultigesture
-    @Bindable var zoomData: GraphZoom
+    var zoomData: CGFloat
     let coordinate: NodeIOPortType
 
     @MainActor

--- a/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
+++ b/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
@@ -17,7 +17,7 @@ extension GraphState {
                                    translation: CGSize) {
         canvasItem.updateCanvasItemOnDragged(translation: translation,
                                              highestZIndex: self.highestZIndex + 1,
-                                             zoom: self.graphMovement.zoomData.zoom,
+                                             zoom: self.graphMovement.zoomData,
                                              state: self.graphMovement)
     }
 }
@@ -211,7 +211,7 @@ extension GraphState {
                 log("canvasItemMoved: setting runningGraphTranslationBeforeNodeDragged to be self.graphMovement.runningGraphTranslation: \(self.graphMovement.runningGraphTranslation)")
                 self.graphMovement
                     .runningGraphTranslationBeforeNodeDragged = (
-                        self.graphMovement.runningGraphTranslation ?? .zero) / self.graphMovement.zoomData.zoom
+                        self.graphMovement.runningGraphTranslation ?? .zero) / self.graphMovement.zoomData
             }
         }
 

--- a/Stitch/Graph/Node/Util/Movement/NodePositionUtils.swift
+++ b/Stitch/Graph/Node/Util/Movement/NodePositionUtils.swift
@@ -28,7 +28,7 @@ extension CanvasItemViewModel {
             return nil
         }
         
-        let denominator = graphMovement.zoomData.zoom
+        let denominator = graphMovement.zoomData
         
         return .init(width: nodeSize.width / denominator,
                      height: nodeSize.height / denominator)

--- a/Stitch/Graph/Node/Util/NodeCreatedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeCreatedAction.swift
@@ -113,7 +113,7 @@ extension StitchDocumentViewModel {
     @MainActor
     var viewPortCenter: CGPoint {
         let localPosition = self.graphMovement.localPosition
-        let scale = self.graphMovement.zoomData.final
+        let scale = self.graphMovement.zoomData
         let viewPortFrame = self.graphUI.frame
         
         // Apply scale to the viewPort-centering

--- a/Stitch/Graph/Node/View/NodesOnlyView.swift
+++ b/Stitch/Graph/Node/View/NodesOnlyView.swift
@@ -64,8 +64,8 @@ struct NodesOnlyView: View {
             Circle().fill(.black.opacity(0.95))
                 .frame(width: 60, height: 60)
                 .position(
-                    x: self.document.graphMovement.localPosition.x / self.document.graphMovement.zoomData.final,
-                    y: self.document.graphMovement.localPosition.y / self.document.graphMovement.zoomData.final
+                    x: self.document.graphMovement.localPosition.x / self.document.graphMovement.zoomData,
+                    y: self.document.graphMovement.localPosition.y / self.document.graphMovement.zoomData
                 )
                 .zIndex(999999999999999)
 #endif

--- a/Stitch/Graph/Node/View/NodesView.swift
+++ b/Stitch/Graph/Node/View/NodesView.swift
@@ -44,9 +44,9 @@ struct NodesView: View {
     }
     
     var body: some View {
-        let nodePageData = self.graph.visibleNodesViewModel
+        let currentNodePageData = self.graph.visibleNodesViewModel
             .getViewData(groupNodeFocused: graphUI.groupNodeFocused?.groupNodeId) ?? .init(localPosition: graph.localPosition)
-        
+                
         // CommentBox needs to be affected by graph offset and zoom
 //         but can live somewhere else?
         InfiniteCanvas(graph: graph,
@@ -55,7 +55,7 @@ struct NodesView: View {
             
             //                        commentBoxes
             
-            nodesOnlyView(nodePageData: nodePageData)
+            nodesOnlyView(nodePageData: currentNodePageData)
         }
            .modifier(CanvasEdgesViewModifier(document: document,
                                              graph: graph,
@@ -68,7 +68,7 @@ struct NodesView: View {
            .coordinateSpace(name: Self.coordinateNameSpace)
         
            .modifier(GraphMovementViewModifier(graphMovement: graph.graphMovement,
-                                               currentNodePage: nodePageData,
+                                               currentNodePage: currentNodePageData,
                                                graph: graph,
                                                groupNodeFocused: graphUI.groupNodeFocused))
         // should come after edges, so that edges are offset, scaled etc.

--- a/Stitch/Graph/Node/View/StitchUIScrollHelpers.swift
+++ b/Stitch/Graph/Node/View/StitchUIScrollHelpers.swift
@@ -8,6 +8,38 @@
 import SwiftUI
 import UIKit
 
+struct SetGraphScrollDataUponPageChange: GraphEvent {
+    let newPageLocalPosition: CGPoint
+    let newPageZoom: CGFloat
+    
+    func handle(state: GraphState) {
+        //        log("SetGraphScrollDataUponPageChange: newPageLocalPosition: \(newPageLocalPosition)")
+        //        log("SetGraphScrollDataUponPageChange: newPageZoom: \(newPageZoom)")
+        state.graphUI.canvasPageOffsetChanged = newPageLocalPosition
+        state.graphUI.canvasPageZoomScaleChanged = newPageZoom
+        
+        /*
+         Set all nodes visible for the field updates, since when we enter the new traversal level
+         our infiniteCanvasCache may not yet have entries for canvas items at this level.
+         
+         Then, do the actual determination of onscreen nodes.
+         
+         (Similar to how, when first loading a project, we set all nodes visible before we call updateVisibleNodes to actually determine on- vs offscreen nodes.)
+         
+         Resolves:
+         - https://github.com/StitchDesign/Stitch--Old/issues/6787
+         - https://github.com/StitchDesign/Stitch--Old/issues/6779
+         
+         */
+        // TODO: doesn't actually fix the issue? The above-level nodes are still *sometimes* what we see when we first enter the lower-level
+        state.visibleNodesViewModel.setAllNodesVisible()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak state] in
+            state?.updateVisibleNodes()
+        }
+    }
+}
+
 
 // UIScrollView's zooming also updates contentOffset,
 // so we prefer to update both localPosition and zoomData at same time.

--- a/Stitch/Graph/Node/View/StitchUIScrollHelpers.swift
+++ b/Stitch/Graph/Node/View/StitchUIScrollHelpers.swift
@@ -17,10 +17,10 @@ struct GraphScrollDataUpdated: StitchDocumentEvent {
     var shouldPersist: Bool = false // true just when e.g. we stopped decelerating
     
     func handle(state: StitchDocumentViewModel) {
-        // log("GraphScrolledViaUIScrollView: newOffset: \(newOffset)")
-        // log("GraphZoomUpdated: newZoom: \(newZoom)")
+        log("GraphScrollDataUpdated: newOffset: \(newOffset)")
+        log("GraphScrollDataUpdated: newZoom: \(newZoom)")
         state.graphMovement.localPosition = newOffset
-        state.graphMovement.zoomData.final = newZoom
+        state.graphMovement.zoomData = newZoom
         
         if shouldPersist {
             log("GraphScrollDataUpdated: will persist")

--- a/Stitch/Graph/Node/ViewModel/NodePageData.swift
+++ b/Stitch/Graph/Node/ViewModel/NodePageData.swift
@@ -14,22 +14,11 @@ typealias NodesPagingDict = [NodePageType: NodePageData]
 final class NodePageData {
     // The graph's movement (offset, momentum, etc.) for this traversal level
     // TODO: for root page data, should always be same as the persisted localPosition of GraphEntity; currently we only persist a single localPosition on the document entity
-    var localPosition: CGPoint {
-        didSet {
-            log("NodePageData: didSet: localPosition \(self.localPosition)")
-        }
-    }
+    var localPosition: CGPoint
 
-    // TODO: you probably only need to save the zoomData, since that's roughly equivalent during a magnification gesture to localPosition during a graph scroll gesture
-    var zoomData: CGFloat {
-        didSet {
-            log("NodePageData: zoomData: zoomData \(self.zoomData)")
-        }
-    }
+    var zoomData: CGFloat
 
     init(localPosition: CGPoint, zoomFinal: Double = 1) {
-        log("NodePageData: init: localPosition: \(localPosition)")
-        log("NodePageData: init: zoomFinal: \(zoomFinal)")
         self.localPosition = localPosition
         self.zoomData = zoomFinal
     }

--- a/Stitch/Graph/Node/ViewModel/NodePageData.swift
+++ b/Stitch/Graph/Node/ViewModel/NodePageData.swift
@@ -14,14 +14,24 @@ typealias NodesPagingDict = [NodePageType: NodePageData]
 final class NodePageData {
     // The graph's movement (offset, momentum, etc.) for this traversal level
     // TODO: for root page data, should always be same as the persisted localPosition of GraphEntity; currently we only persist a single localPosition on the document entity
-    var localPosition: CGPoint
+    var localPosition: CGPoint {
+        didSet {
+            log("NodePageData: didSet: localPosition \(self.localPosition)")
+        }
+    }
 
-    // TODO: you probably only need to save the zoomData.final, since that's roughly equivalent during a magnification gesture to localPosition during a graph scroll gesture
-    let zoomData = GraphZoom()
+    // TODO: you probably only need to save the zoomData, since that's roughly equivalent during a magnification gesture to localPosition during a graph scroll gesture
+    var zoomData: CGFloat {
+        didSet {
+            log("NodePageData: zoomData: zoomData \(self.zoomData)")
+        }
+    }
 
     init(localPosition: CGPoint, zoomFinal: Double = 1) {
+        log("NodePageData: init: localPosition: \(localPosition)")
+        log("NodePageData: init: zoomFinal: \(zoomFinal)")
         self.localPosition = localPosition
-        self.zoomData.final = zoomFinal
+        self.zoomData = zoomFinal
     }
 }
 

--- a/Stitch/Graph/Sidebar/Util/JumpToCanvasItem.swift
+++ b/Stitch/Graph/Sidebar/Util/JumpToCanvasItem.swift
@@ -57,7 +57,7 @@ extension GraphState {
             return
         }
         
-        let scale: CGFloat = self.documentDelegate?.graphMovement.zoomData.final ?? 1
+        let scale: CGFloat = self.documentDelegate?.graphMovement.zoomData ?? 1
         
         let jumpPosition = CGPoint(
             // TODO: why do we have to SUBTRACT rather than add?

--- a/Stitch/Graph/Sidebar/Util/JumpToCanvasItem.swift
+++ b/Stitch/Graph/Sidebar/Util/JumpToCanvasItem.swift
@@ -47,24 +47,17 @@ extension GraphState {
     // TODO: anywhere this isn't being used but should be?
     @MainActor
     func panGraphToNodeLocation(id: CanvasItemId) {
+        
         guard let canvasItem = self.getCanvasItem(id) else {
             fatalErrorIfDebug("panGraphToNodeLocation: no canvasItem found")
             return
         }
         
-        guard let cachedBounds = self.visibleNodesViewModel.infiniteCanvasCache.get(id) else {
-            fatalErrorIfDebug("Could not find cached bounds for canvas item \(id)")
+        guard let jumpPosition = self.getNodeGraphPanLocation(id: id) else {
+            log("panGraphToNodeLocation: could not retrieve jump location")
             return
         }
         
-        let scale: CGFloat = self.documentDelegate?.graphMovement.zoomData ?? 1
-        
-        let jumpPosition = CGPoint(
-            // TODO: why do we have to SUBTRACT rather than add?
-            x: (cachedBounds.origin.x * scale) - self.graphUI.frame.size.width/2,
-            y: (cachedBounds.origin.y * scale) - self.graphUI.frame.size.height/2
-        )
-                
         self.graphUI.canvasJumpLocation = jumpPosition
         
         self.graphUI.selection = GraphUISelectionState()
@@ -77,28 +70,22 @@ extension GraphState {
             self.graphUI.groupNodeBreadcrumbs.append(.groupNode(newGroup))
         }
     }
-}
-
-// graphViewFrame is same for screen and nodeView.size;
-// we're actually calculate how the nodeView will be moved
-// to bring the child into center of screen.
-func calculateMove(_ graphViewFrame: CGRect,
-                   // the location of child
-                   _ childPosition: CGPoint) -> CGPoint {
-
-    // you always know the absolute center
-    let center = CGPoint(x: graphViewFrame.midX,
-                         y: graphViewFrame.midY)
-
-    let distance = CGPoint(x: center.x - childPosition.x,
-                           y: center.y - childPosition.y)
-
-    let newOffset = CGPoint(x: distance.x,
-                            y: distance.y)
-
-    // log("calculateMove: childPosition: \(childPosition)")
-    // log("calculateMove: distance: \(distance)")
-    // log("calculateMove: newOffset: \(newOffset)")
-
-    return newOffset
+    
+    // nil could not be be found
+    @MainActor
+    func getNodeGraphPanLocation(id: CanvasItemId) -> CGPoint? {
+                
+        guard let cachedBounds = self.visibleNodesViewModel.infiniteCanvasCache.get(id) else {
+            // Can be `nil` when called for a canvas item that has never yet been on-screen
+            return nil
+        }
+        
+        let scale: CGFloat = self.documentDelegate?.graphMovement.zoomData ?? 1
+        
+        return CGPoint(
+            // TODO: why do we have to SUBTRACT rather than add?
+            x: (cachedBounds.origin.x * scale) - self.graphUI.frame.size.width/2,
+            y: (cachedBounds.origin.y * scale) - self.graphUI.frame.size.height/2
+        )
+    }
 }

--- a/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
+++ b/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
@@ -189,7 +189,7 @@ extension GraphState {
             component: component,
             destinationGraphInfo: isCopyPaste ? .init(destinationGraphOffset: self.localPosition,
                                                       destinationGraphFrame: self.graphUI.frame,
-                                                      destinationGraphScale: self.graphMovement.zoomData.zoom,
+                                                      destinationGraphScale: self.graphMovement.zoomData,
                                                       destinationGraphTraversalLevel: self.groupNodeFocused) : nil
         )
         

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -169,7 +169,8 @@ extension GraphState {
         self.visibleNodesViewModel
             .updateNodesPagingDict(components: self.components,
                                    graphFrame: self.graphUI.frame,
-                                   parentGraphPath: self.saveLocation)
+                                   parentGraphPath: self.saveLocation,
+                                   graph: self)
         
         // Update connected port data
         self.visibleNodesViewModel.updateAllNodeViewData()

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -17,6 +17,7 @@ import Vision
 
 @Observable
 final class GraphState: Sendable {
+    
     typealias CachedPortUI = NodePortType<NodeViewModel>
     typealias NodePortCacheSet = Set<CachedPortUI>
     

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -34,23 +34,6 @@ enum FocusedFieldChangedByArrowKey: Equatable, Hashable {
          downArrow // decrement
 }
 
-struct SetGraphScrollDataUponPageChange: GraphEvent {
-    let newPageLocalPosition: CGPoint
-    let newPageZoom: CGFloat
-    
-    func handle(state: GraphState) {
-        log("SetGraphScrollDataUponPageChange: newPageLocalPosition: \(newPageLocalPosition)")
-        log("SetGraphScrollDataUponPageChange: newPageZoom: \(newPageZoom)")
-        state.graphUI.canvasPageOffsetChanged = newPageLocalPosition
-        state.graphUI.canvasPageZoomScaleChanged = newPageZoom
-        
-        state.visibleNodesViewModel.setAllNodesVisible()
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak state] in
-            state?.updateVisibleNodes()
-        }
-    }
-}
 
 @Observable
 final class GraphUIState: Sendable {

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -55,17 +55,15 @@ struct SetGraphScrollDataUponPageChange: GraphEvent {
 @Observable
 final class GraphUIState: Sendable {
     
-    // Set true / non-nil in redux-actions
-    // Set false in StitchUIScrollView
+    // Set true / non-nil in methods or action handlers
+    // Set false / nil in StitchUIScrollView
     // TODO: combine canvasZoomedIn and canvasZoomedOut? can never have both at same time? or we can, and they cancel each other?
     @MainActor var canvasZoomedIn: GraphManualZoom = .noZoom
     @MainActor var canvasZoomedOut: GraphManualZoom = .noZoom
     @MainActor var canvasJumpLocation: CGPoint? = nil
-    
-    // non-nil when we have just change
     @MainActor var canvasPageOffsetChanged: CGPoint? = nil
     @MainActor var canvasPageZoomScaleChanged: CGFloat? = nil
-    
+
     
     @MainActor var nodeMenuHeight: CGFloat = INSERT_NODE_MENU_MAX_HEIGHT
     

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -12,21 +12,8 @@ import StitchEngine
 
 let STITCH_PROJECT_DEFAULT_NAME = StitchDocument.defaultName
 
-//final class StitchUIScrollViewWrapper: NSObject {
-//    // Should this be nil
-//    let scrollView: UIScrollView?
-//    
-//    init(_ scrollView: UIScrollView?) {
-//        self.scrollView = scrollView
-//    }
-//}
-
 @Observable
 final class StitchDocumentViewModel: Sendable {
-//    
-//    var stitchUIScrollView = StitchUIScrollViewWrapper(nil)
-//
-    
     let rootId: UUID
     let isDebugMode: Bool
     let graph: GraphState

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -12,8 +12,21 @@ import StitchEngine
 
 let STITCH_PROJECT_DEFAULT_NAME = StitchDocument.defaultName
 
+//final class StitchUIScrollViewWrapper: NSObject {
+//    // Should this be nil
+//    let scrollView: UIScrollView?
+//    
+//    init(_ scrollView: UIScrollView?) {
+//        self.scrollView = scrollView
+//    }
+//}
+
 @Observable
 final class StitchDocumentViewModel: Sendable {
+//    
+//    var stitchUIScrollView = StitchUIScrollViewWrapper(nil)
+//
+    
     let rootId: UUID
     let isDebugMode: Bool
     let graph: GraphState
@@ -336,7 +349,7 @@ extension StitchDocumentViewModel {
                        previewWindowBackgroundColor: self.previewWindowBackgroundColor,
                        // Important: `StitchDocument.localPosition` currently represents only the root level's graph-offset
                        localPosition: self.localPositionToPersist,
-                       zoomData: self.graphMovement.zoomData.zoom,
+                       zoomData: self.graphMovement.zoomData,
                        cameraSettings: self.cameraSettings)
     }
     


### PR DESCRIPTION
In the future, might be nice to: 
1. completely remove GraphMovementObserver and just rely on NodePageData's offset and zoom
2. have a way to subscribe directly to UIScrollView's zoomScale and contentOffset, without intermediate state (attempted this but `UIScrollView` is not Sendable? Also weird imo to store the view in state...)

Note: large number of files changed because I removed `class GraphZoom` since zoom gesture now longer needs `current` vs ` final`. 

https://github.com/user-attachments/assets/61e0007b-c04e-4a55-b6bb-d486679f308e

