### PR TITLE
`getVisibleXYZ` now only refers to `isVisibleInFrame`

### DIFF
--- a/Stitch/Graph/CommentBox/Util/CommentBoxActions.swift
+++ b/Stitch/Graph/CommentBox/Util/CommentBoxActions.swift
@@ -27,7 +27,7 @@ extension GraphState {
         }
 
         let visibleNodes = self.visibleNodesViewModel
-            .getVisibleCanvasItems(at: self.graphUI.groupNodeFocused?.asNodeId)
+            .getCanvasItemsAtTraversalLevel(at: self.graphUI.groupNodeFocused?.asNodeId)
 
         let visibleSelectedNodes = visibleNodes
             .filter { selectedNodes.contains($0.id) }

--- a/Stitch/Graph/Edge/Util/EdgeEditingActions.swift
+++ b/Stitch/Graph/Edge/Util/EdgeEditingActions.swift
@@ -132,7 +132,7 @@ extension CanvasItemViewModel {
         
         // this looks at ALL nodes' inputs -- need to look only at
         
-        nodes.getVisibleCanvasItems(at: focusedGroupId)
+        nodes.getCanvasItemsAtTraversalLevel(at: focusedGroupId)
             .flatMap { canvasItem -> [InputPortViewData] in
                 
                 guard let nodeId = self.nodeDelegate?.id,
@@ -223,7 +223,7 @@ extension GraphState {
         // log("getNodesToTheEastFromClosestToFarthest: for originOutputNode \(originOutputNode.id), hoveredOutputLocation: \(hoveredOutputLocation)")
                 
         let nodes = self.visibleNodesViewModel
-            .getVisibleCanvasItems(at: self.graphUI.groupNodeFocused?.asNodeId)
+            .getCanvasItemsAtTraversalLevel(at: self.graphUI.groupNodeFocused?.asNodeId)
             .filter { node in
                 // "Nearby node" for edge-edit mode can never be a wireless receiver node
                 node.nodeDelegate?.kind.getPatch != .wirelessReceiver

--- a/Stitch/Graph/Node/Group/GroupNodeCreationActions.swift
+++ b/Stitch/Graph/Node/Group/GroupNodeCreationActions.swift
@@ -27,7 +27,7 @@ extension GraphState {
         for id in selectedGroupNodes {
             
             let visibleCanvasItemsForSelectedGroupNode = self.visibleNodesViewModel
-                .getVisibleCanvasItems(at: id)
+                .getCanvasItemsAtTraversalLevel(at: id)
                 .reduce(into: CanvasItemIdSet(), { $0.insert($1.id) })
             
             impliedIds = impliedIds.union(visibleCanvasItemsForSelectedGroupNode)
@@ -180,7 +180,7 @@ extension StitchDocumentViewModel {
         let center = self.viewPortCenter
 
         // Every selected node must belong to this traversal level.
-        let nodesAtThisLevel = self.visibleGraph.getVisibleCanvasItems().map(\.id).toSet
+        let nodesAtThisLevel = self.visibleGraph.getCanvasItemsAtTraversalLevel().map(\.id).toSet
         
         assertInDebug(!self.visibleGraph.selectedNodeIds.contains(where: { selectedNodeId in !nodesAtThisLevel.contains(selectedNodeId) }))
         

--- a/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
+++ b/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
@@ -400,7 +400,7 @@ extension GraphState {
         let currentTraversalLevel = self.graphUI.groupNodeFocused?.asNodeId
 
         // Only check nodes on this current traversal level
-        let visibleNodes = self.getVisibleCanvasItems()
+        let visibleNodes = self.getCanvasItemsAtTraversalLevel()
         let visibleCommentBoxes = self
             .commentBoxesDict.boxesForTraversalLevel(currentTraversalLevel)
 

--- a/Stitch/Graph/Node/View/NodesView.swift
+++ b/Stitch/Graph/Node/View/NodesView.swift
@@ -135,7 +135,7 @@ struct CanvasEdgesViewModifier: ViewModifier {
         // Moves expensive computation here to reduce render cycles
             .onChange(of: graph.graphUpdaterId, initial: true) {
                 self.allInputs = self.graph
-                    .getVisibleCanvasItems()
+                    .getCanvasItemsAtTraversalLevel()
                     .flatMap { canvasItem -> [InputNodeRowViewModel] in
                         canvasItem.inputViewModels
                     }

--- a/Stitch/Graph/Node/View/StitchUIScrollView.swift
+++ b/Stitch/Graph/Node/View/StitchUIScrollView.swift
@@ -376,7 +376,7 @@ final class StitchScrollCoordinator<Content: View>: NSObject, UIScrollViewDelega
         }
         
         // Only check borders if we have cached size and position data for canvas items
-        let canvasItemsInFrame = graph.getVisibleCanvasItems().filter({ $0.isVisibleInFrame(graph.visibleCanvasIds) })
+        let canvasItemsInFrame = graph.getCanvasItemsAtTraversalLevel().filter({ $0.isVisibleInFrame(graph.visibleCanvasIds) })
         
         guard let westNode = graph.westernMostNodeForBorderCheck(canvasItemsInFrame),
               let eastNode = graph.easternMostNodeForBorderCheck(canvasItemsInFrame),

--- a/Stitch/Graph/Sidebar/Util/JumpToCanvasItem.swift
+++ b/Stitch/Graph/Sidebar/Util/JumpToCanvasItem.swift
@@ -36,7 +36,7 @@ struct FindSomeCanvasItemOnGraph: GraphEvent {
     func handle(state: GraphState) {
         if let canvasItem = GraphState.westernMostNode(
             state.groupNodeFocused,
-            canvasItems: state.getVisibleCanvasItems()) {
+            canvasItems: state.getCanvasItemsAtTraversalLevel()) {
             
             state.panGraphToNodeLocation(id: canvasItem.id)
         }

--- a/Stitch/Graph/Util/GraphStateCardinalPoints.swift
+++ b/Stitch/Graph/Util/GraphStateCardinalPoints.swift
@@ -19,7 +19,7 @@ extension GraphState {
     @MainActor
     func canvasItemsAtTraversalLevel(_ focusedGroupNodeId: NodeId?) -> CanvasItemViewModels {
         self.visibleNodesViewModel
-            .getVisibleCanvasItems(at: focusedGroupNodeId )
+            .getCanvasItemsAtTraversalLevel(at: focusedGroupNodeId )
     }
 
     // eastern-most node is node with greatest x-position

--- a/Stitch/Graph/Util/GraphUIActions.swift
+++ b/Stitch/Graph/Util/GraphUIActions.swift
@@ -334,7 +334,7 @@ struct ActiveIndexChangedAction: GraphEvent {
         
         // Note: previously this logic was handled in the view (`NodeInputOutputView`);
         // the advantage was that only actively-rendered
-        state.getVisibleNodes().forEach { node in
+        state.getNodesAtThisTraversalLevel().forEach { node in
             node.updatePortViewModels(state)
         }
     }

--- a/Stitch/Graph/Util/NodeSelection/NodeSelectionUtil.swift
+++ b/Stitch/Graph/Util/NodeSelection/NodeSelectionUtil.swift
@@ -118,7 +118,7 @@ func selectAllNodesAtTraversalLevel(_ state: GraphState) {
     // Only select the visible nodes,
     // i.e. those at this traversal level.
     let visibleNodes = state.visibleNodesViewModel
-        .getVisibleCanvasItems(at: state.graphUI.groupNodeFocused?.asNodeId)
+        .getCanvasItemsAtTraversalLevel(at: state.graphUI.groupNodeFocused?.asNodeId)
 
     state.resetSelectedCanvasItems()
     

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -447,7 +447,7 @@ extension GraphState {
     
     @MainActor
     func getBroadcasterNodesAtThisTraversalLevel() -> [NodeDelegate] {
-        self.visibleNodesViewModel.getVisibleNodes(at: self.graphUI.groupNodeFocused?.groupNodeId)
+        self.visibleNodesViewModel.getNodesAtThisTraversalLevel(at: self.graphUI.groupNodeFocused?.groupNodeId)
             .compactMap { node in
                 guard node.kind == .patch(.wirelessBroadcaster) else {
                     return nil
@@ -481,7 +481,7 @@ extension GraphState {
         let nodeCount = nodes.keys.count
         
         // Track graph canvas items count
-        let canvasItems = self.getVisibleCanvasItems().count
+        let canvasItems = self.getCanvasItemsAtTraversalLevel().count
 
         // Tracks edge changes to reset cached data
         let upstreamConnections = allInputsObservers
@@ -719,15 +719,15 @@ extension GraphState {
     }
     
     @MainActor
-    func getVisibleNodes() -> [NodeDelegate] {
+    func getNodesAtThisTraversalLevel() -> [NodeDelegate] {
         self.visibleNodesViewModel
-            .getVisibleNodes(at: self.graphUI.groupNodeFocused?.groupNodeId)
+            .getNodesAtThisTraversalLevel(at: self.graphUI.groupNodeFocused?.groupNodeId)
     }
     
     @MainActor
-    func getVisibleCanvasItems() -> CanvasItemViewModels {
+    func getCanvasItemsAtTraversalLevel() -> CanvasItemViewModels {
         self.visibleNodesViewModel
-            .getVisibleCanvasItems(at: self.graphUI.groupNodeFocused?.groupNodeId)
+            .getCanvasItemsAtTraversalLevel(at: self.graphUI.groupNodeFocused?.groupNodeId)
     }
     
     @MainActor

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -544,7 +544,7 @@ extension GraphState {
 extension GraphState {
     @MainActor
     var selectedCanvasItems: CanvasItemViewModels {
-        self.getVisibleCanvasItems().filter { $0.isSelected(self) }
+        self.getCanvasItemsAtTraversalLevel().filter { $0.isSelected(self) }
     }
     
     @MainActor

--- a/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
+++ b/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
@@ -118,7 +118,7 @@ extension VisibleNodesViewModel {
             let westernMostNode: CanvasItemViewModel? = GraphState.westernMostNode(
                 incomingGroupId,
                 // Canvas items at this new group's traversal level
-                canvasItems: self.getVisibleCanvasItems(at: incomingGroupId))
+                canvasItems: self.getCanvasItemsAtTraversalLevel(at: incomingGroupId))
             
             var startOffset: CGPoint = ABSOLUTE_GRAPH_CENTER
             
@@ -217,8 +217,8 @@ extension VisibleNodesViewModel {
     }
 
     @MainActor
-    func getVisibleNodes(at focusedGroup: NodeId?) -> [NodeDelegate] {
-        self.getVisibleCanvasItems(at: focusedGroup)
+    func getNodesAtThisTraversalLevel(at focusedGroup: NodeId?) -> [NodeDelegate] {
+        self.getCanvasItemsAtTraversalLevel(at: focusedGroup)
             .filter { $0.parentGroupNodeId ==  focusedGroup }
             .compactMap { $0.nodeDelegate }
     }
@@ -241,7 +241,7 @@ extension VisibleNodesViewModel {
     
     // TODO: "visible" is ambiguous between "canvas item is on-screen" vs "canvas item is at this traversal level"
     @MainActor
-    func getVisibleCanvasItems(at focusedGroup: NodeId?) -> CanvasItemViewModels {
+    func getCanvasItemsAtTraversalLevel(at focusedGroup: NodeId?) -> CanvasItemViewModels {
         self.getCanvasItems()
             .filter { $0.parentGroupNodeId == focusedGroup }
     }


### PR DESCRIPTION
Renamed other methods to explicitly distinguish between nodes / canvas items at traversal level vs visible in frame.