### PR TITLE
When creating example from scratch, show LLM Edit Modal before submitting; Supabase submissions have proper correction vs from-scratch

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -839,7 +839,7 @@
 		ECD7FA8D29D73E2D0073ACAC /* ComponentActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD7FA8C29D73E2D0073ACAC /* ComponentActions.swift */; };
 		ECD83E9E2D4D87AD002B7A3E /* LLMActionPositionNodeUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD83E9D2D4D87AC002B7A3E /* LLMActionPositionNodeUtil.swift */; };
 		ECD83F0E2C19ED0800722AD7 /* LLMRecordingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD83F0D2C19ED0800722AD7 /* LLMRecordingState.swift */; };
-		ECD83F1B2C1A0C5F00722AD7 /* LLMPromptModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD83F1A2C1A0C5F00722AD7 /* LLMPromptModalView.swift */; };
+		ECD83F1B2C1A0C5F00722AD7 /* LLMAssignPromptToScratchLLMExampleModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD83F1A2C1A0C5F00722AD7 /* LLMAssignPromptToScratchLLMExampleModalView.swift */; };
 		ECD8871C29410BF500003B47 /* LoopFilterNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD8871B29410BF500003B47 /* LoopFilterNode.swift */; };
 		ECD8871F2941417900003B47 /* LayerInfoNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD8871E2941417900003B47 /* LayerInfoNode.swift */; };
 		ECD887232941494800003B47 /* LayerNodeId.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD887222941494800003B47 /* LayerNodeId.swift */; };
@@ -1793,7 +1793,7 @@
 		ECD7FA8C29D73E2D0073ACAC /* ComponentActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentActions.swift; sourceTree = "<group>"; };
 		ECD83E9D2D4D87AC002B7A3E /* LLMActionPositionNodeUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMActionPositionNodeUtil.swift; sourceTree = "<group>"; };
 		ECD83F0D2C19ED0800722AD7 /* LLMRecordingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMRecordingState.swift; sourceTree = "<group>"; };
-		ECD83F1A2C1A0C5F00722AD7 /* LLMPromptModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMPromptModalView.swift; sourceTree = "<group>"; };
+		ECD83F1A2C1A0C5F00722AD7 /* LLMAssignPromptToScratchLLMExampleModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMAssignPromptToScratchLLMExampleModalView.swift; sourceTree = "<group>"; };
 		ECD8871B29410BF500003B47 /* LoopFilterNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopFilterNode.swift; sourceTree = "<group>"; };
 		ECD8871E2941417900003B47 /* LayerInfoNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerInfoNode.swift; sourceTree = "<group>"; };
 		ECD887222941494800003B47 /* LayerNodeId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerNodeId.swift; sourceTree = "<group>"; };
@@ -3949,7 +3949,7 @@
 			isa = PBXGroup;
 			children = (
 				E4D0D2D62CE6B4B000E482E4 /* LLM_ACTIONS_TO_ADD_LATER.swift */,
-				ECD83F1A2C1A0C5F00722AD7 /* LLMPromptModalView.swift */,
+				ECD83F1A2C1A0C5F00722AD7 /* LLMAssignPromptToScratchLLMExampleModalView.swift */,
 				ECD83F0D2C19ED0800722AD7 /* LLMRecordingState.swift */,
 				ECD83E9D2D4D87AC002B7A3E /* LLMActionPositionNodeUtil.swift */,
 				EC5C6C392C2DAE690023D0C0 /* LLMActionRecording.swift */,
@@ -4842,7 +4842,7 @@
 				EC0B8A7F2953C4C500AA01B6 /* RoundedRectanglePatchNode.swift in Sources */,
 				EC2614452B89605700BEB066 /* PositionPackNode.swift in Sources */,
 				B51C67512C6441A5002F83D1 /* UnpackedValueCoercer.swift in Sources */,
-				ECD83F1B2C1A0C5F00722AD7 /* LLMPromptModalView.swift in Sources */,
+				ECD83F1B2C1A0C5F00722AD7 /* LLMAssignPromptToScratchLLMExampleModalView.swift in Sources */,
 				ECA92A54260A6BB700281B52 /* Output.swift in Sources */,
 				ECCE40E327E29B5D0068484B /* ICloudSyncStatus.swift in Sources */,
 				EC08D55B28988C4D00FEE846 /* AdjustmentBarPopoverView.swift in Sources */,

--- a/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
@@ -114,6 +114,7 @@ struct OutputValueView: View {
                 readOnlyView(string.string)
                 
             case .number, .layerDimension, .spacing:
+                logInView("OutValueView: body: fieldValue.stringValue: \(fieldValue.stringValue)")
                 readOnlyView(fieldValue.stringValue)
                 
             case .bool(let bool):

--- a/Stitch/Graph/Node/View/NodesOnlyView.swift
+++ b/Stitch/Graph/Node/View/NodesOnlyView.swift
@@ -86,7 +86,7 @@ struct NodesOnlyView: View {
             }
         }
         .onChange(of: self.graph.graphUpdaterId, initial: true) {
-            log("NodesOnlyView: .onChange(of: self.graph.graphUpdaterId)")
+            // log("NodesOnlyView: .onChange(of: self.graph.graphUpdaterId)")
             self.refreshCanvasNodes()
         }
         .onChange(of: self.activeIndex) {

--- a/Stitch/Graph/Node/View/NodesOnlyView.swift
+++ b/Stitch/Graph/Node/View/NodesOnlyView.swift
@@ -86,6 +86,7 @@ struct NodesOnlyView: View {
             }
         }
         .onChange(of: self.graph.graphUpdaterId, initial: true) {
+            log("NodesOnlyView: .onChange(of: self.graph.graphUpdaterId)")
             self.refreshCanvasNodes()
         }
         .onChange(of: self.activeIndex) {

--- a/Stitch/Graph/Node/View/NodesView.swift
+++ b/Stitch/Graph/Node/View/NodesView.swift
@@ -134,7 +134,7 @@ struct CanvasEdgesViewModifier: ViewModifier {
         return content
         // Moves expensive computation here to reduce render cycles
             .onChange(of: graph.graphUpdaterId, initial: true) {
-                log("CanvasEdgesViewModifier: .onChange(of: self.graph.graphUpdaterId)")
+                // log("CanvasEdgesViewModifier: .onChange(of: self.graph.graphUpdaterId)")
                 self.allInputs = self.graph
                     .getCanvasItemsAtTraversalLevel()
                     .flatMap { canvasItem -> [InputNodeRowViewModel] in

--- a/Stitch/Graph/Node/View/NodesView.swift
+++ b/Stitch/Graph/Node/View/NodesView.swift
@@ -134,6 +134,7 @@ struct CanvasEdgesViewModifier: ViewModifier {
         return content
         // Moves expensive computation here to reduce render cycles
             .onChange(of: graph.graphUpdaterId, initial: true) {
+                log("CanvasEdgesViewModifier: .onChange(of: self.graph.graphUpdaterId)")
                 self.allInputs = self.graph
                     .getCanvasItemsAtTraversalLevel()
                     .flatMap { canvasItem -> [InputNodeRowViewModel] in

--- a/Stitch/Graph/StitchAI/DatasetRecording/LLMActionHelpers.swift
+++ b/Stitch/Graph/StitchAI/DatasetRecording/LLMActionHelpers.swift
@@ -59,7 +59,7 @@ extension StitchDocumentViewModel {
         self.llmRecording.isRecording = true
         
         //       Always treat edit modal as an augmentation
-        //       state.llmRecording.mode = .augmentation
+        self.llmRecording.mode = .augmentation
         
         self.llmRecording.modal = .editBeforeSubmit
     }

--- a/Stitch/Graph/StitchAI/DatasetRecording/LLMActionHelpers.swift
+++ b/Stitch/Graph/StitchAI/DatasetRecording/LLMActionHelpers.swift
@@ -161,8 +161,8 @@ struct LLMActionDeleted: StitchDocumentEvent {
     let deletedAction: StepTypeAction
     
     func handle(state: StitchDocumentViewModel) {
-        log("LLMActionsUpdated: deletedAction: \(deletedAction)")
-        log("LLMActionsUpdated: state.llmRecording.actions was: \(state.llmRecording.actions)")
+        log("LLMActionDeleted: deletedAction: \(deletedAction)")
+        log("LLMActionDeleted: state.llmRecording.actions was: \(state.llmRecording.actions)")
         
         // Note: fine to do equality check because not editing actions per se here
         // TODO: what if we change the `value` of
@@ -186,11 +186,15 @@ struct LLMActionDeleted: StitchDocumentEvent {
         case .connectNodes, .changeValueType, .setInput:
             // deleting these LLMActions does not require us to delete any other LLMActions;
             // we just 'wipe and replay LLMActions'
-            log("do not need to delete any other other LLMActions")
+            log("LLMActionDeleted: Do not need to delete any other other LLMActions")
         }
                 
-        // If immediately "de-apply" the removed action(s) from graph,
+        // We immediately "de-apply" the removed action(s) from graph,
         // so that user instantly sees what changed.
-        try? state.reapplyActions()
+        do {
+            try state.reapplyActions()
+        } catch {
+            log("LLMActionDeleted: when reapplying actions, encountered: \(error)")
+        }
     }
 }

--- a/Stitch/Graph/StitchAI/DatasetRecording/LLMActionHelpers.swift
+++ b/Stitch/Graph/StitchAI/DatasetRecording/LLMActionHelpers.swift
@@ -49,13 +49,19 @@ struct ShowLLMApprovalModal: StitchDocumentEvent {
 struct ShowLLMEditModal: StitchDocumentEvent {
     func handle(state: StitchDocumentViewModel) {
         log("ShowLLMEditModal called")
+        state.showLLMEditModal()
+    }
+}
 
-        state.llmRecording.isRecording = true
+extension StitchDocumentViewModel {
+    @MainActor
+    func showLLMEditModal() {
+        self.llmRecording.isRecording = true
         
-        // Always treat edit modal as an augmentation
-//        state.llmRecording.mode = .augmentation
+        //       Always treat edit modal as an augmentation
+        //       state.llmRecording.mode = .augmentation
         
-        state.llmRecording.modal = .editBeforeSubmit
+        self.llmRecording.modal = .editBeforeSubmit
     }
 }
 
@@ -88,10 +94,11 @@ struct SubmitLLMActionsToSupabase: StitchDocumentEvent {
                     prompt: state.llmRecording.promptState.prompt,
                     finalActions: actionsAsSteps,
                     deviceUUID: deviceUUID,
-                    isCorrection: state.llmRecording.mode == .augmentation)
+                    isCorrection: state.llmRecording.mode == .augmentation && state.llmRecording.recentOpenAIRequestCompleted)
                 
                 log("📼 ✅ Data successfully saved locally and uploaded to Supabase ✅ 📼")
                 state.llmRecording = .init()
+                state.llmRecording.recentOpenAIRequestCompleted = false
             }
             
         } catch let encodingError as EncodingError {

--- a/Stitch/Graph/StitchAI/DatasetRecording/LLMActionRecording.swift
+++ b/Stitch/Graph/StitchAI/DatasetRecording/LLMActionRecording.swift
@@ -130,13 +130,15 @@ extension StitchDocumentViewModel {
             return
         }
         
-        // Only show the edit modal if we're in augmentation mode
-        if currentMode == .augmentation {
-            dispatch(ShowLLMEditModal())
-        } else {
-            // For normal mode, proceed directly to approve and submit
-            dispatch(ShowLLMApprovalModal())
-        }
+        self.showLLMEditModal()
+        
+//        // Only show the edit modal if we're in augmentation mode
+//        if currentMode == .augmentation {
+//            dispatch(ShowLLMEditModal())
+//        } else {
+//            // For normal mode, proceed directly to approve and submit
+//            dispatch(ShowLLMApprovalModal())
+//        }
     }
 }
 

--- a/Stitch/Graph/StitchAI/DatasetRecording/LLMAssignPromptToScratchLLMExampleModalView.swift
+++ b/Stitch/Graph/StitchAI/DatasetRecording/LLMAssignPromptToScratchLLMExampleModalView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import SwiftyJSON
 
 // User has recorded some LLM Steps in the app and now assigns a prompt to them
-struct LLMPromptModalView: View {
+struct LLMAssignPromptToScratchLLMExampleModalView: View {
         
     @State var prompt: String = ""
     

--- a/Stitch/Graph/StitchAI/DatasetRecording/LLMRecordingState.swift
+++ b/Stitch/Graph/StitchAI/DatasetRecording/LLMRecordingState.swift
@@ -31,6 +31,8 @@ enum LLMRecordinModal: Equatable, Hashable {
 
 struct LLMRecordingState: Equatable {
     
+    // Set true just when we have received and successfully validated and applied an OpenAI request
+    // Set false when make another request or submit a correction
     var recentOpenAIRequestCompleted: Bool = false {
         didSet {
             // When a request is completed and we're recording, switch to augmentation mode
@@ -103,7 +105,7 @@ extension StitchDocumentViewModel {
     
     @MainActor
     func validateAndApplyActions(_ actions: [StepTypeAction]) throws {
-        
+                
         // Wipe old error reason
         self.llmRecording.actionsError = nil
         
@@ -247,14 +249,3 @@ struct LLMJsonEntryState: Equatable {
 }
 
 typealias LLMNodeIdMapping = [String: NodeId]
-
-extension StitchDocumentViewModel {
-    @MainActor
-    var llmNodeIdMapping: LLMNodeIdMapping {
-        get {
-            self.llmRecording.jsonEntryState.llmNodeIdMapping
-        } set(newValue) {
-            self.llmRecording.jsonEntryState.llmNodeIdMapping = newValue
-        }
-    }
-}

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StepActionToStateChange.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StepActionToStateChange.swift
@@ -37,7 +37,7 @@ extension StitchDocumentViewModel {
             guard let _ = self.nodeCreated(choice: x.nodeName.asNodeKind,
                                            nodeId: x.nodeId) else {
                 self.llmRecording.isApplyingActions = false
-                fatalErrorIfDebug()
+                // fatalErrorIfDebug()
                 throw StitchAIManagerError.actionValidationError("Could not create node \(x.nodeId.debugFriendlyId) \(x.nodeName)")
             }
             self.llmRecording.isApplyingActions = false
@@ -54,7 +54,7 @@ extension StitchDocumentViewModel {
                let destinationNode = graph.getNodeViewModel(x.toNodeId),
                let layerNode = destinationNode.layerNode {
                 guard let keyPath = x.port.keyPath else {
-                    fatalErrorIfDebug()
+                    // fatalErrorIfDebug()
                     throw StitchAIManagerError.actionValidationError("expected layer node keypath but got: \(x.port)")
                 }
                 
@@ -82,7 +82,7 @@ extension StitchDocumentViewModel {
             guard let input = self.graph.getInputObserver(coordinate: inputCoordinate) else {
                 log("applyAction: could not apply setInput")
                 self.llmRecording.isApplyingActions = false
-                fatalErrorIfDebug()
+                // fatalErrorIfDebug()
                 throw StitchAIManagerError.actionValidationError("Could not retrieve input \(inputCoordinate)")
             }
             

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StepActionToStateChange.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StepActionToStateChange.swift
@@ -37,6 +37,7 @@ extension StitchDocumentViewModel {
             guard let _ = self.nodeCreated(choice: x.nodeName.asNodeKind,
                                            nodeId: x.nodeId) else {
                 self.llmRecording.isApplyingActions = false
+                fatalErrorIfDebug()
                 throw StitchAIManagerError.actionValidationError("Could not create node \(x.nodeId.debugFriendlyId) \(x.nodeName)")
             }
             self.llmRecording.isApplyingActions = false
@@ -53,6 +54,7 @@ extension StitchDocumentViewModel {
                let destinationNode = graph.getNodeViewModel(x.toNodeId),
                let layerNode = destinationNode.layerNode {
                 guard let keyPath = x.port.keyPath else {
+                    fatalErrorIfDebug()
                     throw StitchAIManagerError.actionValidationError("expected layer node keypath but got: \(x.port)")
                 }
                 
@@ -80,6 +82,7 @@ extension StitchDocumentViewModel {
             guard let input = self.graph.getInputObserver(coordinate: inputCoordinate) else {
                 log("applyAction: could not apply setInput")
                 self.llmRecording.isApplyingActions = false
+                fatalErrorIfDebug()
                 throw StitchAIManagerError.actionValidationError("Could not retrieve input \(inputCoordinate)")
             }
             
@@ -90,6 +93,11 @@ extension StitchDocumentViewModel {
             
             self.llmRecording.isApplyingActions = false
         }
+
+        self.graph.visibleNodesViewModel.setAllNodesVisible()
+        
+        // Finally, updateGraphData ?
+        self.graph.refreshGraphUpdaterId()
     }
 }
 

--- a/Stitch/Graph/View/ContentView.swift
+++ b/Stitch/Graph/View/ContentView.swift
@@ -155,7 +155,7 @@ struct ContentView: View, KeyboardReadable {
                      titleLabel: "LLM Recording",
                      hideAction: document.closedLLMRecordingPrompt,
                      sheetBody: {
-            LLMPromptModalView()
+            LLMAssignPromptToScratchLLMExampleModalView()
         })
     }
 

--- a/Stitch/Graph/View/ProjectNavigationView.swift
+++ b/Stitch/Graph/View/ProjectNavigationView.swift
@@ -32,6 +32,7 @@ struct ProjectNavigationView: View {
             })
         }
         .onChange(of: document.visibleGraph.graphUpdaterId) {
+            log("NodesOnlyView: .onChange(of: document.visibleGraph.graphUpdaterId)")
             document.visibleGraph.updateGraphData()
         }
         .onChange(of: document.graphUI.groupNodeFocused) {

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -382,11 +382,11 @@ extension GraphState {
      
     @MainActor
     func refreshGraphUpdaterId() {
-        log("refreshGraphUpdaterId called")
+        // log("refreshGraphUpdaterId called")
         let newId = self.calculateGraphUpdaterId()
         
         if self.graphUpdaterId != newId {
-            log("refreshGraphUpdaterId: newId: \(newId)")
+            // log("refreshGraphUpdaterId: newId: \(newId)")
             self.graphUpdaterId = newId
         }
     }
@@ -472,9 +472,9 @@ extension GraphState {
     /// Creases a unique hash based on view data which if changes, requires graph data update.
     @MainActor
     func calculateGraphUpdaterId() -> Int {
-//        let randomInt = Int.random(in: -999999999999999...999999999999)
-//        log("calculateGraphUpdaterId: randomInt: \(randomInt)")
-//        return randomInt
+        //        let randomInt = Int.random(in: -999999999999999...999999999999)
+        //        log("calculateGraphUpdaterId: randomInt: \(randomInt)")
+        //        return randomInt
         
         var hasher = Hasher()
         
@@ -513,9 +513,10 @@ extension GraphState {
         hasher.combine(groupNodeIdFocused)
         
         let newGraphUpdaterId = hasher.finalize()
-        log("calculateGraphUpdaterId: newGraphUpdaterId: \(newGraphUpdaterId)")
+        // log("calculateGraphUpdaterId: newGraphUpdaterId: \(newGraphUpdaterId)")
         return newGraphUpdaterId
-//        return hasher.finalize()
+        
+        // return hasher.finalize()
     }
     
     @MainActor

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -382,9 +382,11 @@ extension GraphState {
      
     @MainActor
     func refreshGraphUpdaterId() {
+        log("refreshGraphUpdaterId called")
         let newId = self.calculateGraphUpdaterId()
         
         if self.graphUpdaterId != newId {
+            log("refreshGraphUpdaterId: newId: \(newId)")
             self.graphUpdaterId = newId
         }
     }
@@ -470,6 +472,10 @@ extension GraphState {
     /// Creases a unique hash based on view data which if changes, requires graph data update.
     @MainActor
     func calculateGraphUpdaterId() -> Int {
+//        let randomInt = Int.random(in: -999999999999999...999999999999)
+//        log("calculateGraphUpdaterId: randomInt: \(randomInt)")
+//        return randomInt
+        
         var hasher = Hasher()
         
         let nodes = self.nodes
@@ -506,7 +512,10 @@ extension GraphState {
         hasher.combine(manualEdits)
         hasher.combine(groupNodeIdFocused)
         
-        return hasher.finalize()
+        let newGraphUpdaterId = hasher.finalize()
+        log("calculateGraphUpdaterId: newGraphUpdaterId: \(newGraphUpdaterId)")
+        return newGraphUpdaterId
+//        return hasher.finalize()
     }
     
     @MainActor


### PR DESCRIPTION
Eventually would be nice to clean up this code a bit more.

<img width="1133" alt="Screenshot 2025-02-27 at 3 10 57 PM" src="https://github.com/user-attachments/assets/0830e3f3-56ee-4abd-9c50-637519481db0" />
