### PR TITLE
Fixed regression for Stitch AI edit mode

### DIFF
--- a/Stitch/Graph/StitchAI/DatasetRecording/LLMRecordingState.swift
+++ b/Stitch/Graph/StitchAI/DatasetRecording/LLMRecordingState.swift
@@ -222,6 +222,10 @@ extension StitchDocumentViewModel {
                 }
             }
         }
+        
+        // Manually call graph update since hash may be the same
+        // Has to be a new ID since objects are cached in the view
+        self.visibleGraph.graphUpdaterId = .init()
     }
 }
 


### PR DESCRIPTION
Fixes connections and non-moving nodes. Issue was caused by action reapplying logic actually deleting nodes, which is an issue for the new system which caches objects locally. Those cached objects needed to be completely reset, which is why this fix works.