### PR TITLE
Do not count `nil` `upstreamOutputCoordinates` as valid upstreamConnections in `calculateGraphUpdaterId`

### DIFF
--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -491,7 +491,8 @@ extension GraphState {
 
         // Tracks edge changes to reset cached data
         let upstreamConnections = allInputsObservers
-            .map { $0.upstreamOutputCoordinate }
+        // Important: use compactMap, otherwise `nil` (i.e. non-existence connections) will be counted as a valid connection
+            .compactMap { $0.upstreamOutputCoordinate }
         
         // Tracks manual edits
         let manualEdits: [PortValue] = allInputsObservers


### PR DESCRIPTION
Our algorithm got around this because we also hash based on `manualEdits`, which looks at nil vs non-nil.

Really, `manualEdits` is just counting non-connected inputs. `manualEdits` and `upstreamConnections` always add up to the total number of inputs on the graph, so we only need one, not both?