### PR TITLE
add color support for multiply and divide

### DIFF
--- a/Stitch/Graph/Node/Eval/PatchEvaluateExtensions.swift
+++ b/Stitch/Graph/Node/Eval/PatchEvaluateExtensions.swift
@@ -27,9 +27,9 @@ extension Patch {
         case .convertPosition:
             return .graph(outputsOnlyGraphStateEval(convertPositionEval))
         case .multiply:
-            return .node(mathNodeTypeEval(multiplyEval))
+            return .node(mathNodeTypeWithColorEval(multiplyEval))
         case .divide:
-            return .node(mathNodeTypeEval(divideEval))
+            return .node(mathNodeTypeWithColorEval(divideEval))
         // Scroll interaction is a little different because scroll does animation stuff
         case .pressInteraction:
             // DOES NOT USE graph step

--- a/Stitch/Graph/Node/Patch/Util/PatchNodeTypeExtensions.swift
+++ b/Stitch/Graph/Node/Patch/Util/PatchNodeTypeExtensions.swift
@@ -106,10 +106,10 @@ extension Patch {
             return ArithmeticUVT.value
 
         // Updated to exclude text/string types
-        case .multiply, .divide, .power, .squareRoot:
+        case .power, .squareRoot:
             return MathUVT.value
             
-        case .subtract:
+        case .subtract, .multiply, .divide:
             return MathWithColorUVT.value
 
         // ANIMATION


### PR DESCRIPTION

[Color Multiply and Divide.origami.zip](https://github.com/user-attachments/files/19044143/Color.Multiply.and.Divide.origami.zip)
[Color Multiply and Divide.stitch.zip](https://github.com/user-attachments/files/19044144/Color.Multiply.and.Divide.stitch.zip)


![CleanShot 2025-03-02 at 09 48 01@2x](https://github.com/user-attachments/assets/a33a277c-cbb4-4eb4-8771-5a9a862e7175)

![CleanShot 2025-03-02 at 09 48 07@2x](https://github.com/user-attachments/assets/6af4b85b-03e8-4bc6-8070-8e4228c88a0c)
