### PR TITLE
LayerInspector: properly handle unpacked Margin and Padding layer inputs

### DIFF
--- a/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
@@ -77,7 +77,7 @@ struct GenericFlyoutView: View {
             nodeId: node.id,
             forPropertySidebar: true,
             forFlyout: true,
-            blockedFields: layerInputObserver.blockedFields) { inputFieldViewModel, isMultifield in
+            layerInputObserver: layerInputObserver) { inputFieldViewModel, isMultifield in
                 GenericFlyoutRowView(
                     graph: graph,
                     graphUI: graphUI,

--- a/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
@@ -22,6 +22,7 @@ struct NodeFieldsView<FieldType, ValueEntryView>: View where FieldType: FieldVie
     let isMultiField: Bool
     let forPropertySidebar: Bool
     let forFlyout: Bool
+    let layerInputObserver: LayerInputObserver?
     
     let blockedFields: Set<LayerInputKeyPathType>?
     
@@ -44,9 +45,10 @@ struct NodeFieldsView<FieldType, ValueEntryView>: View where FieldType: FieldVie
     
     var displaysNarrowMultifields: Bool {
         switch layerInput {
-        case .layerPadding, .layerMargin, .transform3D:
+        case .transform3D:
             return true
-            
+        case .layerPadding, .layerMargin:
+            return layerInputObserver?.mode == .packed
         default:
             return false
         }
@@ -54,6 +56,11 @@ struct NodeFieldsView<FieldType, ValueEntryView>: View where FieldType: FieldVie
     
     @ViewBuilder
     var constrainedMultifieldsView: some View {
+        
+        if layerInput == .layerMargin { // || layerInput == .padding {
+            logInView("had margin")
+        }
+        
         let p0 = fieldGroupViewModel.fieldObservers[safe: 0]
         let p1 = fieldGroupViewModel.fieldObservers[safe: 1]
         let p2 = fieldGroupViewModel.fieldObservers[safe: 2]
@@ -67,7 +74,8 @@ struct NodeFieldsView<FieldType, ValueEntryView>: View where FieldType: FieldVie
                 self.valueEntry(p2)
             }
         }
-        
+  
+        // See note in `NodeInputView`: this use assumes Margin and Padding are in a Packed state, i.e. one row observer and 4 field models
         else if fieldGroupViewModel.fieldObservers.count == 4 {
             VStack {
                 HStack {
@@ -117,7 +125,7 @@ struct NodeFieldsView<FieldType, ValueEntryView>: View where FieldType: FieldVie
         
         else if forPropertySidebar,
                 !forFlyout,
-                isMultiField,
+                // isMultiField,
                 displaysNarrowMultifields {
             HStack {
                 Spacer()

--- a/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
@@ -56,11 +56,6 @@ struct NodeFieldsView<FieldType, ValueEntryView>: View where FieldType: FieldVie
     
     @ViewBuilder
     var constrainedMultifieldsView: some View {
-        
-        if layerInput == .layerMargin { // || layerInput == .padding {
-            logInView("had margin")
-        }
-        
         let p0 = fieldGroupViewModel.fieldObservers[safe: 0]
         let p1 = fieldGroupViewModel.fieldObservers[safe: 1]
         let p2 = fieldGroupViewModel.fieldObservers[safe: 2]

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
@@ -107,6 +107,19 @@ extension LayerInputType {
 
 extension LayerInputObserver {
     
+    // "Does this layer input use multifield fields?"
+    // Regardless of packed vs unpacked mode.
+    @MainActor
+    var usesMultifields: Bool {
+        //        log("LayerInputObserver: usesMultifields: for layer input \(self.port)")
+        switch self.mode {
+        case .packed:
+            return (self.fieldValueTypes.first?.fieldObservers.count ?? 0) > 1
+        case .unpacked:
+            return self.fieldValueTypes.count > 1
+        }
+    }
+    
     // The overall-label for the port, e.g. "Size" (not "W" or "H") for the size property
     @MainActor
     func overallPortLabel(usesShortLabel: Bool,


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/6973

Note: we can give this area more love in the future; need some way to abstract over "packed = 1 field group with n field models" vs "unpacked = n groups with 1 field model each"


<img width="1430" alt="Screenshot 2025-03-03 at 12 56 56 PM" src="https://github.com/user-attachments/assets/39bf494d-5475-46f4-b39a-c7b052b745b0" />
