### PR TITLE
Refactored GraphUI to reduce weak var usage for improved perf

### DIFF
--- a/Stitch/App/Shortcut/ProjectsHomeCommands.swift
+++ b/Stitch/App/Shortcut/ProjectsHomeCommands.swift
@@ -21,7 +21,7 @@ struct ProjectsHomeCommands: Commands {
     }
         
     var isSidebarFocused: Bool {
-        self.graph?.graphUI.isSidebarFocused ?? false
+        store.currentDocument?.isSidebarFocused ?? false
     }
     
     var graph: GraphState? {

--- a/Stitch/App/Util/Action/GraphReducer.swift
+++ b/Stitch/App/Util/Action/GraphReducer.swift
@@ -20,13 +20,14 @@ struct MediaCopiedToNewNode: StitchStoreEvent {
     }
 }
 
-struct MediaCopiedToExistingNode: GraphEvent {
+struct MediaCopiedToExistingNode: StitchDocumentEvent {
     let url: URL
     let nodeMediaImportPayload: NodeMediaImportPayload
     
-    func handle(state: GraphState) {
-        state.mediaCopiedToExistingNode(nodeImportPayload: nodeMediaImportPayload,
-                                        newURL: url)
+    func handle(state: StitchDocumentViewModel) {
+        state.visibleGraph.mediaCopiedToExistingNode(nodeImportPayload: nodeMediaImportPayload,
+                                                     newURL: url,
+                                                     activeIndex: state.activeIndex)
     }
 }
 
@@ -48,14 +49,14 @@ struct ImportFileToNewNode: GraphEventWithResponse {
     }
 }
 
-struct GraphZoomedIn: StitchDocumentEvent {
-    func handle(state: StitchDocumentViewModel) {
+struct GraphZoomedIn: GraphEvent {
+    func handle(state: GraphState) {
         state.graphZoomedIn(.shortcutKey)
     }
 }
 
-struct GraphZoomedOut: StitchDocumentEvent {
-    func handle(state: StitchDocumentViewModel) {
+struct GraphZoomedOut: GraphEvent {
+    func handle(state: GraphState) {
         state.graphZoomedOut(.shortcutKey)
     }
 }

--- a/Stitch/App/Util/Action/ReSwift/ReframeEvent.swift
+++ b/Stitch/App/Util/Action/ReSwift/ReframeEvent.swift
@@ -17,7 +17,6 @@ typealias GraphEventWithResponse = Action & GraphActionWithResponseHandler
 typealias ProjectEnvironmentEvent = Action & ProjectEnvironmentActionHandler
 typealias AppEvent = Action & AppActionHandler
 typealias AppEnvironmentEvent = Action & AppEnvironmentActionHandler
-typealias GraphUIEvent = Action & GraphUIActionHandler
 typealias ProjectAlertEvent = Action & ProjectAlertActionHandler
 typealias FileManagerEvent = Action & FileManagerEffectHandler
 //typealias LogEvent = Action & LogListenerEffectHandler
@@ -59,11 +58,6 @@ protocol AppEnvironmentActionHandler {
     @MainActor
     func handle(state: AppState,
                 environment: StitchEnvironment) -> AppResponse
-}
-
-protocol GraphUIActionHandler {
-    @MainActor
-    func handle(state: GraphUIState)
 }
 
 protocol ProjectAlertActionHandler {

--- a/Stitch/App/Util/Action/ReSwift/legacy+action+conversions/LegacyActionConversionUtils.swift
+++ b/Stitch/App/Util/Action/ReSwift/legacy+action+conversions/LegacyActionConversionUtils.swift
@@ -82,14 +82,6 @@ func _getResponse(from legacyAction: Action,
         return response
     }
 
-    // GraphUIEvents
-    else if let graphUIAction = (legacyAction as? GraphUIEvent),
-            let graphState = graphState {
-        // Mutates GraphState.graphUI in-place
-        graphUIAction.handle(state: graphState.graphUI)
-        return .noChange
-    }
-
     // Project Alert Events
     else if let projectAlertAction = (legacyAction as? ProjectAlertEvent) {
         projectAlertAction.handle(state: store.alertState)

--- a/Stitch/App/View/Component/StitchTextEditingField.swift
+++ b/Stitch/App/View/Component/StitchTextEditingField.swift
@@ -173,30 +173,31 @@ struct StitchTextEditingBindingField: View {
                 }
             }
         // When an input's field is focused, we treat an up- or down-arrow as a user "increment" or "decrement" input
-            .onChange(of: self.store.currentDocument?.graphUI.reduxFocusedFieldChangedByArrowKey) { _, _ in
-                if let numberEdit = self.store.currentDocument?.graph.handleArrowKeyInput(self.currentEdit) {
+            .onChange(of: self.store.currentDocument?.reduxFocusedFieldChangedByArrowKey) { _, _ in
+                if let numberEdit = self.store.currentDocument?
+                    .handleArrowKeyInput(self.currentEdit) {
                     self.currentEdit = numberEdit
                 }
             }
     }
 }
 
-extension GraphState {
+extension StitchDocumentViewModel {
     
     @MainActor
     func handleArrowKeyInput(_ currentEdit: String) -> String? {
         
-        guard self.graphUI.reduxFocusedField?.getTextInputEdit.isDefined ?? false, // only for an input's fields, not node title etc.
-              let arrowKey = self.graphUI.reduxFocusedFieldChangedByArrowKey else {
+        guard self.reduxFocusedField?.getTextInputEdit.isDefined ?? false, // only for an input's fields, not node title etc.
+              let arrowKey = self.reduxFocusedFieldChangedByArrowKey else {
             
             log("handleArrowKeyInput: no text field focused or no relevant arrow key")
-            self.graphUI.reduxFocusedFieldChangedByArrowKey = nil
+            self.reduxFocusedFieldChangedByArrowKey = nil
             
             return nil
         }
         
         // Always wipe
-        self.graphUI.reduxFocusedFieldChangedByArrowKey = nil
+        self.reduxFocusedFieldChangedByArrowKey = nil
                 
         // If we had a regular, non-percentage number:
         if let n: Double = toNumber(currentEdit) {
@@ -224,8 +225,8 @@ struct TextFieldDisappeared: StitchDocumentEvent {
     let focusedField: FocusedUserEditField
     
     func handle(state: StitchDocumentViewModel) {
-        if state.graphUI.reduxFocusedField == focusedField {
-            state.graphUI.reduxFocusedField = nil
+        if state.reduxFocusedField == focusedField {
+            state.reduxFocusedField = nil
         }
         
         /*

--- a/Stitch/App/View/StitchNavStack.swift
+++ b/Stitch/App/View/StitchNavStack.swift
@@ -18,7 +18,6 @@ struct StitchNavStack: View {
                     if let document = projectLoader.documentViewModel {
                         StitchProjectView(store: store,
                                           document: document,
-                                          graphUI: document.graphUI,
                                           alertState: store.alertState)
                         .onDisappear {
                             // Remove document from project loader

--- a/Stitch/Graph/CommentBox/Util/CommentBoxActions.swift
+++ b/Stitch/Graph/CommentBox/Util/CommentBoxActions.swift
@@ -18,7 +18,8 @@ extension GraphState {
      in which case we use the passed in `nodeId`
      */
     @MainActor
-    func commentBoxCreated(nodeId: CanvasItemId) {
+    func commentBoxCreated(nodeId: CanvasItemId,
+                           groupNodeFocused: NodeId?) {
         var selectedNodes = self.selectedNodeIds
 
         // Alternatively?: always add this id to selectedNodes in GraphUIState, so that we start it selected.
@@ -27,7 +28,7 @@ extension GraphState {
         }
 
         let visibleNodes = self.visibleNodesViewModel
-            .getCanvasItemsAtTraversalLevel(at: self.graphUI.groupNodeFocused?.asNodeId)
+            .getCanvasItemsAtTraversalLevel(at: groupNodeFocused)
 
         let visibleSelectedNodes = visibleNodes
             .filter { selectedNodes.contains($0.id) }

--- a/Stitch/Graph/CommentBox/View/CommentBoxTagMenuButtonsView.swift
+++ b/Stitch/Graph/CommentBox/View/CommentBoxTagMenuButtonsView.swift
@@ -10,7 +10,6 @@ import StitchSchemaKit
 
 struct CommentBoxTagMenuButtonsView: View {
     @Bindable var graph: GraphState
-    @Bindable var graphUI: GraphUIState
     @Bindable var box: CommentBoxViewModel
     let atleastOneNodeSelected: Bool
 
@@ -18,7 +17,7 @@ struct CommentBoxTagMenuButtonsView: View {
         deleteButton
         duplicateButton
         Button("Edit Title") {
-            graphUI.commentBoxTitleEditStarted(id: box.id)
+            graph.commentBoxTitleEditStarted(id: box.id)
         }
         commentBoxColorPicker
     }

--- a/Stitch/Graph/CommentBox/View/CommentBoxTitleEditView.swift
+++ b/Stitch/Graph/CommentBox/View/CommentBoxTitleEditView.swift
@@ -10,7 +10,7 @@ import StitchSchemaKit
 
 let superLongString = "Some SwiftUI views have a default background color that overrides whatever you try to apply yourself, but if you use the scrollContentBackground() modifier you can hide that default background and replace it with something else. At the time of writing, this works for List, TextEditor, and Form, so you can remove or change their background colors."
 
-extension GraphUIState {
+extension GraphState {
     @MainActor func commentBoxTitleEditStarted(id: CommentBoxId) {
         self.activelyEditedCommentBoxTitle = id
     }

--- a/Stitch/Graph/Edge/Model/EdgeEditingState.swift
+++ b/Stitch/Graph/Edge/Model/EdgeEditingState.swift
@@ -95,7 +95,8 @@ extension EdgeEditingState {
     @MainActor
     func canvasItemIndexChanged(edgeEditState: EdgeEditingState,
                                 graph: GraphState,
-                                wasIncremented: Bool) -> Self {
+                                wasIncremented: Bool,
+                                groupNodeFocused: NodeId?) -> Self {
         
         var edgeEditState = edgeEditState._indexChanged(
             edgeEditState: edgeEditState,
@@ -113,7 +114,8 @@ extension EdgeEditingState {
         let (alreadyShownEdges,
              possibleEdges) = graph.getShownAndPossibleEdges(
             nearbyNode: newNearbyNode,
-            outputCoordinate: edgeEditState.originOutput)
+            outputCoordinate: edgeEditState.originOutput,
+            groupNodeFocused: groupNodeFocused)
         
         edgeEditState.shownIds = alreadyShownEdges
         edgeEditState.possibleEdges = possibleEdges

--- a/Stitch/Graph/Edge/Util/EdgeUtils.swift
+++ b/Stitch/Graph/Edge/Util/EdgeUtils.swift
@@ -106,7 +106,8 @@ extension GraphState {
     /// Removes edges which root from some output coordinate.
     @MainActor
     func removeConnections(from outputCoordinate: NodeIOCoordinate,
-                           isNodeVisible: Bool) {
+                           isNodeVisible: Bool,
+                           activeIndex: ActiveIndex) {
         guard let connectedInputs = self.connections.get(outputCoordinate) else {
             return
         }
@@ -116,7 +117,7 @@ extension GraphState {
                 return
             }
             
-            inputObserver.removeUpstreamConnection(activeIndex: self.activeIndex,
+            inputObserver.removeUpstreamConnection(activeIndex: activeIndex,
                                                    isVisible: isNodeVisible)
         }
     }

--- a/Stitch/Graph/Edge/Util/PortActions.swift
+++ b/Stitch/Graph/Edge/Util/PortActions.swift
@@ -75,21 +75,24 @@ extension GraphState {
     // Note: this removes ANY incoming edge to the `edge.to` input; whereas in some use-cases e.g. group node creation, we had expected only to remove the specific passed-in edge if it existed.
     // Hence the rename from `edgeRemoved` to `removesEdgeAt`
     @MainActor
-    func removeEdgeAt(input: InputPortViewData) {
+    func removeEdgeAt(input: InputPortViewData,
+                      activeIndex: ActiveIndex) {
         if let inputCoordinate = self.getInputCoordinate(from: input) {
-            self.removeEdgeAt(input: inputCoordinate)
+            self.removeEdgeAt(input: inputCoordinate,
+                              activeIndex: activeIndex)
         }
     }
     
     @MainActor
-    func removeEdgeAt(input: InputCoordinate) {
+    func removeEdgeAt(input: InputCoordinate,
+                      activeIndex: ActiveIndex) {
         guard let downstreamNode = self.getNodeViewModel(input.nodeId) else {
             return
         }
 
         // Removes edge and checks for media to remove
         downstreamNode.removeIncomingEdge(at: input,
-                                          activeIndex: self.activeIndex,
+                                          activeIndex: activeIndex,
                                           graph: self)
     }
 

--- a/Stitch/Graph/Edge/View/EditMode/EdgeEditModeLabelsView.swift
+++ b/Stitch/Graph/Edge/View/EditMode/EdgeEditModeLabelsView.swift
@@ -11,12 +11,12 @@ import StitchSchemaKit
 struct EdgeInputLabelsView: View {
     let inputs: [InputNodeRowViewModel]
     @Bindable var document: StitchDocumentViewModel
-    @Bindable var graphUI: GraphUIState
+    @Bindable var graph: GraphState
 
     var body: some View {
-        let showLabels = document.graphUI.edgeEditingState?.labelsShown ?? false
+        let showLabels = graph.edgeEditingState?.labelsShown ?? false
         
-        if let nearbyCanvasItem: CanvasItemId = document.graphUI.edgeEditingState?.nearbyCanvasItem {
+        if let nearbyCanvasItem: CanvasItemId = graph.edgeEditingState?.nearbyCanvasItem {
             ForEach(inputs) { inputRowViewModel in
                 
                 // Doesn't seem to be needed? Checking the canvasItemDelegate seems to work well

--- a/Stitch/Graph/Edge/View/EditMode/EdgeEditModeOutputHoverView.swift
+++ b/Stitch/Graph/Edge/View/EditMode/EdgeEditModeOutputHoverView.swift
@@ -15,6 +15,7 @@ extension Double {
 struct EdgeEditModeOutputHoverViewModifier: ViewModifier {
 
     @Bindable var graph: GraphState
+    let document: StitchDocumentViewModel
     let outputCoordinate: OutputPortViewData
     
     var isDraggingOutput: Bool {
@@ -76,7 +77,8 @@ struct EdgeEditModeOutputHoverViewModifier: ViewModifier {
                 }
 
                 // immediately enable edge-edit mode
-                graph.outputHovered(outputCoordinate: outputCoordinate)
+                graph.outputHovered(outputCoordinate: outputCoordinate,
+                                    groupNodeFocused: document.groupNodeFocused?.groupNodeId)
 
                 if !self.hoverStartTime.isDefined {
                     self.hoverStartTime = Date.now.timeIntervalSince1970

--- a/Stitch/Graph/Edge/View/ExistingEdgesView.swift
+++ b/Stitch/Graph/Edge/View/ExistingEdgesView.swift
@@ -10,19 +10,18 @@ import StitchSchemaKit
 
 struct GraphConnectedEdgesView: View {
     @Bindable var graph: GraphState
-    @Bindable var graphUI: GraphUIState
     let allConnectedInputs: [InputNodeRowViewModel]
     
     var animatingEdges: PossibleEdgeSet {
-        graphUI.edgeEditingState?.possibleEdges ?? .init()
+        graph.edgeEditingState?.possibleEdges ?? .init()
     }
     
     var edgeAnimationEnabled: Bool {
-        graphUI.edgeAnimationEnabled
+        graph.edgeAnimationEnabled
     }
     
     var shownPossibleEdgeIds: Set<PossibleEdgeId> {
-        graphUI.edgeEditingState?.shownIds ?? .init()
+        graph.edgeEditingState?.shownIds ?? .init()
     }
     
     @MainActor
@@ -171,12 +170,13 @@ struct ConnectedEdgeView: View {
 // If we tap an edge specifically,
 // then deselect all other edges and nodes,
 // and select only that tapped edge.
-struct EdgeTapped: GraphEvent {
+struct EdgeTapped: StitchDocumentEvent {
     let edge: PortEdgeUI
 
-    func handle(state: GraphState) {
-        state.resetAlertAndSelectionState(graphUI: state.graphUI)
-        state.selectedEdges = Set([edge])
+    func handle(state: StitchDocumentViewModel) {
+        let graph = state.visibleGraph
+        graph.resetAlertAndSelectionState(document: state)
+        graph.selectedEdges = Set([edge])
     }
 }
 

--- a/Stitch/Graph/Gesture/Util/GestureUtils.swift
+++ b/Stitch/Graph/Gesture/Util/GestureUtils.swift
@@ -30,7 +30,7 @@ extension NodeSelectionGestureRecognizer {
 //                log("Graph pan disabled during LLM Recording")
 //                return
 //            }
-            self.document?.graphScrollBegan()
+            self.document?.visibleGraph.graphScrollBegan()
             
         case .changed:
             
@@ -40,10 +40,13 @@ extension NodeSelectionGestureRecognizer {
 //            }
             // Should only have a single touch
             if gestureRecognizer.numberOfTouches == 1 {
-                self.document?.graphDragged(
-                    // not an accurate translation?
-                    translation: translation.toCGSize,
-                    location: location)
+                if let document = document {
+                    document.visibleGraph.graphDragged(
+                        // not an accurate translation?
+                        translation: translation.toCGSize,
+                        location: location,
+                        document: document)
+                }
             }
         
         case .ended, .cancelled:
@@ -57,11 +60,13 @@ extension NodeSelectionGestureRecognizer {
             //        log("handleScreenGraphPanGesture: screenPanInView: translation: \(translation)")
             //        log("handleScreenGraphPanGesture: screenPanInView: velocity: \(velocity)")
             // should have no touches
-            if gestureRecognizer.numberOfTouches == 0 {
-                self.document?.graphDragEnded(
+            if gestureRecognizer.numberOfTouches == 0,
+               let document = self.document {
+                document.visibleGraph.graphDragEnded(
                     location: location,
                     velocity: velocity,
-                    wasScreenDrag: true)
+                    wasScreenDrag: true,
+                    frame: document.frame)
             }
             
         default:

--- a/Stitch/Graph/Gesture/Util/GraphUITappedActions.swift
+++ b/Stitch/Graph/Gesture/Util/GraphUITappedActions.swift
@@ -12,9 +12,9 @@ import StitchSchemaKit
 // More like: `ResetGraphUIEdits`
 extension GraphState {
     @MainActor
-    func graphTapped(graphUI: GraphUIState) {
+    func graphTapped(document: StitchDocumentViewModel) {
         log("GraphTappedAction called")
-        self.resetAlertAndSelectionState(graphUI: graphUI)
+        self.resetAlertAndSelectionState(document: document)
     }
 }
 
@@ -24,11 +24,11 @@ struct GraphDoubleTappedAction: StitchDocumentEvent {
     func handle(state: StitchDocumentViewModel) {
         log("GraphDoubleTappedAction: location: \(location)")
         
-        state.graphUI.toggleInsertNodeMenu()
+        state.toggleInsertNodeMenu()
         
 //        if !state.llmRecording.isRecording {
         // Do not set double-tap location if we're actively recording
-        state.graphUI.doubleTapLocation = location
+        state.insertNodeMenuState.doubleTapLocation = location
 //        }
         
         // log("GraphDoubleTappedAction: state.doubleTapLocation is now: \(state.doubleTapLocation)")

--- a/Stitch/Graph/Gesture/Util/GraphUIZoomedActions.swift
+++ b/Stitch/Graph/Gesture/Util/GraphUIZoomedActions.swift
@@ -9,11 +9,11 @@ import Foundation
 import SwiftUI
 import StitchSchemaKit
 
-extension StitchDocumentViewModel {
+extension GraphState {
     @MainActor
     func graphZoomedIn(_ manualZoom: GraphManualZoom) {
         // Set `true` here; set `false` by the UIScrollView
-        self.graphUI.canvasZoomedIn = manualZoom
+        self.canvasZoomedIn = manualZoom
         
         // Wipe comment box bounds
         self.wipeCommentBoxBounds()
@@ -21,7 +21,7 @@ extension StitchDocumentViewModel {
 
     @MainActor
     func graphZoomedOut(_ manualZoom: GraphManualZoom) {
-        self.graphUI.canvasZoomedOut = manualZoom
+        self.canvasZoomedOut = manualZoom
         
         // Wipe comment box bounds
         self.wipeCommentBoxBounds()

--- a/Stitch/Graph/Gesture/View/GraphMovementViewModifier.swift
+++ b/Stitch/Graph/Gesture/View/GraphMovementViewModifier.swift
@@ -45,6 +45,8 @@ extension GraphState {
     @MainActor
     func updateVisibleNodes() {
         
+        guard let document = self.documentDelegate else { return }
+        
         let zoom = self.graphMovement.zoomData
         
         // How much that content is offset from the UIScrollView's top-left corner;
@@ -54,7 +56,7 @@ extension GraphState {
         let scaledOffset = CGPoint(x: originOffset.x / zoom,
                                    y: originOffset.y / zoom)
 
-        let viewPortSize = self.graphUI.frame.size
+        let viewPortSize = document.frame.size
                 
         let scaledSize = CGSize(width: viewPortSize.width * 1/zoom,
                                 height: viewPortSize.height * 1/zoom)

--- a/Stitch/Graph/GraphStep/GraphStepIncrementer.swift
+++ b/Stitch/Graph/GraphStep/GraphStepIncrementer.swift
@@ -52,7 +52,7 @@ extension GraphState {
             .compactMap { $0.nodeType.componentNode }
         
         // If we have actively-interacted-with mouse nodes, we may need reset their velocity outputs
-        if let lastMouseMovement = self.graphUI.lastMouseNodeMovement,
+        if let lastMouseMovement = self.documentDelegate?.lastMouseNodeMovement,
            (graphTime - lastMouseMovement) > DRAG_NODE_VELOCITY_RESET_STEP {
             
             let mouseNodeIds = self.mouseNodes

--- a/Stitch/Graph/LayerInspector/ColorFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/ColorFlyoutView.swift
@@ -23,11 +23,12 @@ struct ColorFlyoutView: View {
     
     let rowObserver: InputNodeRowObserver
     let layerInputObserver: LayerInputObserver
+    let activeIndex: ActiveIndex
     
     @State var chosenColor: Color = .white
 
     var activeColor: Color {
-        if let color = layerInputObserver.activeValue.getColor {
+        if let color = layerInputObserver.getActiveValue(activeIndex: activeIndex).getColor {
             return color
         } else {
             fatalErrorIfDebug()
@@ -45,6 +46,7 @@ struct ColorFlyoutView: View {
                 isFieldInsideLayerInspector: true, // true for purposes of editing multiple layers
                 isForPreviewWindowBackgroundPicker: false,
                 isForIPhone: false,
+                activeIndex: activeIndex,
                 // i.e. the current active value
                 chosenColor: self.$chosenColor,
                 graph: graph)
@@ -58,6 +60,7 @@ struct ColorFlyoutView: View {
                 graph.pickerOptionSelected(
                     rowObserver: rowObserver,
                     choice: .color(newColor),
+                    activeIndex: activeIndex,
                     isFieldInsideLayerInspector: true,
                     // Lots of small changes so don't persist everything
                     isPersistence: false)

--- a/Stitch/Graph/LayerInspector/FlyoutUtils.swift
+++ b/Stitch/Graph/LayerInspector/FlyoutUtils.swift
@@ -44,21 +44,21 @@ extension LayerInputPort {
 
 // Used by a given flyout view to update its read-height in state,
 // for proper positioning.
-struct UpdateFlyoutSize: GraphUIEvent {
+struct UpdateFlyoutSize: GraphEvent {
     let size: CGSize
     
-    func handle(state: GraphUIState) {
+    func handle(state: GraphState) {
         state.propertySidebar.flyoutState?.flyoutSize = size
     }
 }
 
-struct FlyoutClosed: GraphUIEvent {
-    func handle(state: GraphUIState) {
+struct FlyoutClosed: GraphEvent {
+    func handle(state: GraphState) {
         state.closeFlyout()
     }
 }
 
-extension GraphUIState {
+extension GraphState {
     @MainActor
     func closeFlyout() {
 //        withAnimation {
@@ -74,35 +74,32 @@ struct FlyoutToggled: StitchDocumentEvent {
     let fieldToFocus: FocusedUserEditField?
     
     func handle(state: StitchDocumentViewModel) {
-        if let flyoutState = state.graphUI.propertySidebar.flyoutState,
+        let graph = state.visibleGraph
+        
+        if let flyoutState = graph.propertySidebar.flyoutState,
            flyoutState.flyoutInput == flyoutInput,
            flyoutState.flyoutNode == flyoutNodeId {
-            state.graphUI.closeFlyout()
+            graph.closeFlyout()
         } else {
-//            withAnimation {
-            state.graphUI.propertySidebar.flyoutState = .init(
+            graph.propertySidebar.flyoutState = .init(
                     // TODO: assuming flyout state is packed here
                     flyoutInput: flyoutInput,
                     flyoutNode: flyoutNodeId)
             
             if let fieldToFocus = fieldToFocus {
-                state.visibleGraph
-                    .reduxFieldFocused(focusedField: fieldToFocus,
-                                       graphUI: state.graphUI)
+                state.reduxFieldFocused(focusedField: fieldToFocus)
             }
-            
-//            }
         }
     }
 }
 
-struct LeftSidebarSet: GraphUIEvent {
+struct LeftSidebarSet: StitchDocumentEvent {
     
     let open: Bool
     
-    func handle(state: GraphUIState) {
+    func handle(state: StitchDocumentViewModel) {
         // Reset flyout
-        state.closeFlyout()
+        state.visibleGraph.closeFlyout()
         
         state.leftSidebarOpen = open
     }

--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -271,13 +271,13 @@ extension StitchDocumentViewModel {
 
             // On Catalyst, use hover-only, never row-selection.
             #if !targetEnvironment(macCatalyst)
-            let alreadySelected = self.propertySidebar.selectedProperty == layerInspectorRowId
+            let alreadySelected = graph.propertySidebar.selectedProperty == layerInspectorRowId
             
             withAnimation {
                 if alreadySelected {
-                    self.propertySidebar.selectedProperty = nil
+                    graph.propertySidebar.selectedProperty = nil
                 } else {
-                    self.propertySidebar.selectedProperty = layerInspectorRowId
+                    graph.propertySidebar.selectedProperty = layerInspectorRowId
                 }
             }
             #endif

--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -11,7 +11,7 @@ import StitchSchemaKit
 struct LayerInspectorInputPortView: View {
     @Bindable var layerInputObserver: LayerInputObserver
     @Bindable var graph: GraphState
-    @Bindable var graphUI: GraphUIState
+    @Bindable var graphUI: StitchDocumentViewModel
     let node: NodeViewModel
     
     var fieldValueTypes: [FieldGroupTypeData<InputNodeRowViewModel.FieldType>] {
@@ -67,6 +67,7 @@ struct LayerInspectorInputPortView: View {
                               // Inspector Row always uses the overall input label, never an individual field label
                               label: layerInputObserver
                     .overallPortLabel(usesShortLabel: true,
+                                      currentTraversalLevel: graphUI.groupNodeFocused?.groupNodeId,
                                       node: node,
                                       graph: graph)
                 )
@@ -86,7 +87,7 @@ struct LayerInspectorOutputPortView: View {
     @Bindable var rowViewModel: OutputNodeRowViewModel
     @Bindable var rowObserver: OutputNodeRowObserver
     @Bindable var graph: GraphState
-    @Bindable var graphUI: GraphUIState
+    @Bindable var graphUI: StitchDocumentViewModel
     
     let canvasItemId: CanvasItemId?
     
@@ -123,6 +124,7 @@ struct LayerInspectorOutputPortView: View {
                                label: rowObserver
                     .label(useShortLabel: true,
                            node: node,
+                           currentTraversalLevel: graphUI.groupNodeFocused?.groupNodeId,
                            graph: graph)
                 )
             }
@@ -160,7 +162,7 @@ struct LayerInspectorPortView<RowView>: View where RowView: View {
     // Is this property-row selected?
     @MainActor
     var propertyRowIsSelected: Bool {
-        graphUI.propertySidebar.selectedProperty == layerInspectorRowId
+        graph.propertySidebar.selectedProperty == layerInspectorRowId
     }
     
     var isOnGraphAlready: Bool {
@@ -253,7 +255,7 @@ struct LayerInspectorPortViewTapModifier: ViewModifier {
     }
 }
 
-extension GraphUIState {
+extension StitchDocumentViewModel {
     @MainActor
     func onLayerPortRowTapped(layerInspectorRowId: LayerInspectorRowId,
                               canvasItemId: CanvasItemId?,
@@ -261,7 +263,7 @@ extension GraphUIState {
         // Defined canvas item id = we're already on the canvas
         if let canvasItemId = canvasItemId {
             graph.jumpToCanvasItem(id: canvasItemId,
-                                   graphUI: self)
+                                   document: self)
         }
         
         // Else select/de-select the property

--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -140,7 +140,6 @@ struct LayerInspectorView: View {
 struct LayerPropertyRowOriginReader: ViewModifier {
     
     @Bindable var graph: GraphState
-    @Bindable var graphUI: GraphUIState
     let layerInput: LayerInputPort
     
     func body(content: Content) -> some View {
@@ -153,7 +152,7 @@ struct LayerPropertyRowOriginReader: ViewModifier {
                     
                     // Guide for where to place the flyout;
                     // we read the origin even if this row doesn't support flyout.
-                    graphUI.propertySidebar.propertyRowOrigins
+                    graph.propertySidebar.propertyRowOrigins
                         .updateValue(newValue.origin, forKey: layerInput)
                 }
             } // GeometryReader
@@ -161,10 +160,10 @@ struct LayerPropertyRowOriginReader: ViewModifier {
     }
 }
 
-struct LayerInspectorSectionToggled: GraphUIEvent {
+struct LayerInspectorSectionToggled: GraphEvent {
     let section: LayerInspectorSection
     
-    func handle(state: GraphUIState) {
+    func handle(state: GraphState) {
         let alreadyClosed = state.propertySidebar.collapsedSections.contains(section)
         if alreadyClosed {
             state.propertySidebar.collapsedSections.remove(section)
@@ -219,7 +218,6 @@ struct LayerInspectorInputView: View {
                                         graphUI: graphUI,
                                         node: node)
             .modifier(LayerPropertyRowOriginReader(graph: graph,
-                                                   graphUI: graphUI,
                                                    layerInput: layerInput.layerInput))
         } else {
             EmptyView()
@@ -293,9 +291,9 @@ struct LayerInspectorInputsSectionView: View {
                     dispatch(LayerInspectorSectionToggled(section: section))
                     
                     layerInputs.layerInputs.forEach { layerInput in
-                        if case let .layerInput(x) = graphUI.propertySidebar.selectedProperty,
+                        if case let .layerInput(x) = graph.propertySidebar.selectedProperty,
                            x.layerInput == layerInput.layerInput {
-                            graphUI.propertySidebar.selectedProperty = nil
+                            graph.propertySidebar.selectedProperty = nil
                         }
                     }
                 }

--- a/Stitch/Graph/LayerInspector/ShadowFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/ShadowFlyoutView.swift
@@ -84,7 +84,7 @@ struct ShadowFlyoutRowView: View {
     }
     
     var propertyRowIsSelected: Bool {
-        graphUI.propertySidebar.selectedProperty == layerInspectorRowId
+        graph.propertySidebar.selectedProperty == layerInspectorRowId
     }
     
     var isShadowOffsetRow: Bool {
@@ -127,6 +127,7 @@ struct ShadowFlyoutRowView: View {
                           label: layerInputData.rowObserver
                 .label(useShortLabel: true,
                        node: node,
+                       currentTraversalLevel: graphUI.groupNodeFocused?.groupNodeId,
                        graph: graph),
                           forFlyout: true)
         } // HStack

--- a/Stitch/Graph/Menu/NumberAdjustmentBar/AdjustmentBarPopoverView.swift
+++ b/Stitch/Graph/Menu/NumberAdjustmentBar/AdjustmentBarPopoverView.swift
@@ -33,6 +33,7 @@ struct AdjustmentBarPopoverView: View {
     let fieldCoordinate: FieldCoordinate
     let rowObserver: InputNodeRowObserver
     let isFieldInsideLayerInspector: Bool
+    let activeIndex: ActiveIndex
     
     @Binding var isPopoverOpen: Bool
 
@@ -98,6 +99,7 @@ struct AdjustmentBarPopoverView: View {
                 graph.inputEditedFromUI(
                     fieldValue: .layerDimension(.auto),
                     fieldIndex: fieldCoordinate.fieldIndex,
+                    activeIndex: activeIndex,
                     rowObserver: rowObserver,
                     isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                     isCommitting: false)

--- a/Stitch/Graph/Menu/NumberAdjustmentBar/AdjustmentBarPopoverView.swift
+++ b/Stitch/Graph/Menu/NumberAdjustmentBar/AdjustmentBarPopoverView.swift
@@ -202,6 +202,7 @@ struct AdjustmentBarPopoverView: View {
             fieldCoordinate: fieldCoordinate,
             rowObserver: rowObserver,
             isFieldInsideLayerInspector: isFieldInsideLayerInspector, 
+            activeIndex: activeIndex,
             currentlySelectedNumber: barNumber,
             numberLineMiddle: barNumber)
     }

--- a/Stitch/Graph/Menu/NumberAdjustmentBar/WideAdjustmentBarView.swift
+++ b/Stitch/Graph/Menu/NumberAdjustmentBar/WideAdjustmentBarView.swift
@@ -50,6 +50,7 @@ struct WideAdjustmentBarView: View {
     let fieldCoordinate: FieldCoordinate
     let rowObserver: InputNodeRowObserver
     let isFieldInsideLayerInspector: Bool
+    let activeIndex: ActiveIndex
 
     // Starts out same as `middleNumber`,
     // but unlike `middleNumber` is updated whenever we
@@ -149,6 +150,7 @@ struct WideAdjustmentBarView: View {
                                 graph.inputEditedFromUI(
                                     fieldValue: fieldValueNumberType.createFieldValueForAdjustmentBar(from: n.number),
                                     fieldIndex: self.fieldCoordinate.fieldIndex,
+                                    activeIndex: activeIndex,
                                     rowObserver: rowObserver,
                                     isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                                     isCommitting: false)
@@ -373,6 +375,7 @@ struct WideAdjustmentBarView: View {
                     graph?.inputEditedFromUI(
                         fieldValue: fieldValue,
                         fieldIndex: pref.field.fieldIndex,
+                        activeIndex: activeIndex,
                         rowObserver: rowObserver,
                         isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                         // We don't persist changes from auto-selectiong the center value during scroll

--- a/Stitch/Graph/Menu/ProjectSettingsView.swift
+++ b/Stitch/Graph/Menu/ProjectSettingsView.swift
@@ -241,7 +241,9 @@ struct ProjectSettingsView: View {
             isForFlyout: false,
             isForPreviewWindowBackgroundPicker: true,
             isForIPhone: isPhoneDevice(),
-            chosenColor: binding, 
+            isMultiselectInspectorInputWithHeterogenousValues: false,
+            activeIndex: .init(.zero),
+            chosenColor: binding,
             graph: graph)
     }
 }
@@ -258,24 +260,23 @@ struct PreviewWindowBackgroundColorSet: StitchDocumentEvent {
 
 
 // TODO: create an inner view that still receives this data
-struct ProjectSettingsView_Previews: PreviewProvider {
-    @State static var show = true
-    static let graph = GraphState.createEmpty()
-    static let graphUI = GraphUIState(isPhoneDevice: false)
-
-    static var previews: some View {
-        ProjectSettingsView(previewWindowSize: PreviewWindowDevice.DEFAULT_PREVIEW_SIZE,
-                            previewSizeDevice: .custom,
-                            previewWindowBackgroundColor: DEFAULT_FLOATING_WINDOW_COLOR, 
-                            graph: graph,
-                            graphUI: graphUI)
-            .previewDevice(PreviewDevice(rawValue: "iPad Pro (11-inch) (3rd generation)"))
-
-        ProjectSettingsView(previewWindowSize: PreviewWindowDevice.DEFAULT_PREVIEW_SIZE,
-                            previewSizeDevice: .custom,
-                            previewWindowBackgroundColor: DEFAULT_FLOATING_WINDOW_COLOR, 
-                            graph: graph,
-                            graphUI: graphUI)
-            .previewDevice(PreviewDevice(rawValue: "iPhone 13"))
-    }
-}
+//struct ProjectSettingsView_Previews: PreviewProvider {
+//    @State static var show = true
+//    static let graph = GraphState.createEmpty()
+//
+//    static var previews: some View {
+//        ProjectSettingsView(previewWindowSize: PreviewWindowDevice.DEFAULT_PREVIEW_SIZE,
+//                            previewSizeDevice: .custom,
+//                            previewWindowBackgroundColor: DEFAULT_FLOATING_WINDOW_COLOR, 
+//                            graph: graph,
+//                            graphUI: graphUI)
+//            .previewDevice(PreviewDevice(rawValue: "iPad Pro (11-inch) (3rd generation)"))
+//
+//        ProjectSettingsView(previewWindowSize: PreviewWindowDevice.DEFAULT_PREVIEW_SIZE,
+//                            previewSizeDevice: .custom,
+//                            previewWindowBackgroundColor: DEFAULT_FLOATING_WINDOW_COLOR, 
+//                            graph: graph,
+//                            graphUI: graphUI)
+//            .previewDevice(PreviewDevice(rawValue: "iPhone 13"))
+//    }
+//}

--- a/Stitch/Graph/Menu/ProjectSettingsView.swift
+++ b/Stitch/Graph/Menu/ProjectSettingsView.swift
@@ -257,26 +257,3 @@ struct PreviewWindowBackgroundColorSet: StitchDocumentEvent {
         state.visibleGraph.encodeProjectInBackground()
     }
 }
-
-
-// TODO: create an inner view that still receives this data
-//struct ProjectSettingsView_Previews: PreviewProvider {
-//    @State static var show = true
-//    static let graph = GraphState.createEmpty()
-//
-//    static var previews: some View {
-//        ProjectSettingsView(previewWindowSize: PreviewWindowDevice.DEFAULT_PREVIEW_SIZE,
-//                            previewSizeDevice: .custom,
-//                            previewWindowBackgroundColor: DEFAULT_FLOATING_WINDOW_COLOR, 
-//                            graph: graph,
-//                            graphUI: graphUI)
-//            .previewDevice(PreviewDevice(rawValue: "iPad Pro (11-inch) (3rd generation)"))
-//
-//        ProjectSettingsView(previewWindowSize: PreviewWindowDevice.DEFAULT_PREVIEW_SIZE,
-//                            previewSizeDevice: .custom,
-//                            previewWindowBackgroundColor: DEFAULT_FLOATING_WINDOW_COLOR, 
-//                            graph: graph,
-//                            graphUI: graphUI)
-//            .previewDevice(PreviewDevice(rawValue: "iPhone 13"))
-//    }
-//}

--- a/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
+++ b/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
@@ -58,17 +58,17 @@ final class InputLayerNodeRowData: LayerNodeRowData, Identifiable {
     // which could be for a field on the canvas or in the layer inspector
     @MainActor
     func fieldHasHeterogenousValues(_ fieldIndex: Int,
-                                    isFieldInsideLayerInspector: Bool) -> Bool {
+                                    isFieldInsideLayerInspector: Bool,
+                                    graph: GraphState) -> Bool {
 
         // Only relevant when this layer-input field is in the layer inspector and multiple layers are selected
         guard isFieldInsideLayerInspector,
-              let graphDelegate = self.inspectorRowViewModel.graphDelegate,
-              graphDelegate.multiselectInputs.isDefined else {
+              graph.multiselectInputs.isDefined else {
             return false
         }
     
          return self.id.layerInput
-            .fieldsInMultiselectInputWithHeterogenousValues(graphDelegate)
+            .fieldsInMultiselectInputWithHeterogenousValues(graph)
             .contains(fieldIndex)
     }
     

--- a/Stitch/Graph/Node/Layer/Util/LayerGroups.swift
+++ b/Stitch/Graph/Node/Layer/Util/LayerGroups.swift
@@ -9,56 +9,6 @@ import Foundation
 import SwiftUI
 import StitchSchemaKit
 
-extension GraphState {
-    // Assumes:
-    // - all selected nodes have either same parent or no parent ('top level')
-//    @MainActor
-//    func getParentSizeForSelectedNodes(selectedNodes: NodeIdSet,
-//                                       activeIndex: ActiveIndex) -> CGSize {
-//
-//        if let firstSelectedNode = selectedNodes.first,
-//           let layerNode = self.getNodeViewModel(firstSelectedNode)?.layerNode,
-//           let parentId = layerNode.layerGroupId {
-//            return self.parentSizeHelper(id: parentId,
-//                                         activeIndex: activeIndex)
-//        }
-//        // had no parent, so is just a top level item
-//        else {
-//            return previewWindowSize
-//        }
-//    }
-
-//     Find the CGSize (not LayerSize)
-//    @MainActor
-//    private func parentSizeHelper(id: NodeId,
-//                                  activeIndex: ActiveIndex) -> CGSize {
-//
-//        guard let node = self.getNodeViewModel(id),
-//              let nodeLayerSize = node.layerNode?.layerSize(activeIndex) else {
-//            return .zero
-//        }
-//
-//        // if this layer node has a directly usable size,
-//        // just return that
-//        if let size = nodeLayerSize.asCGSize {
-//            return size
-//        }
-//        // else, if this layer-node has its own parent-node, try to find that
-//        // parent-node's size, and provide it to LayerSize
-//        else if let layerNode = self.getNodeViewModel(id)?.layerNode,
-//                let parentId = layerNode.layerGroupId {
-//            let sizeFromAbove = self.parentSizeHelper(id: parentId,
-//                                                      activeIndex: activeIndex)
-//            return nodeLayerSize.asCGSize(sizeFromAbove)
-//        }
-//        // else this layer node is already top level
-//        else {
-//            let sizeFromPreviewWindow = nodeLayerSize.asCGSize(previewWindowSize)
-//            return nodeLayerSize.asCGSize(sizeFromPreviewWindow)
-//        }
-//    }
-}
-
 struct LayerGroupFit {
     // size for the Group Layer node
     let size: LayerSize
@@ -78,24 +28,3 @@ struct LayerGroupFit {
         self.childAdjustment = childAdjustment
     }
 }
-
-//extension NodeViewModel {
-//    @MainActor
-//    func updateLayerNodePositionInput(offset: CGSize,
-//                                      activeIndex: ActiveIndex) {
-//
-//        guard let layerViewModel = self.layerNode else {
-//            log("updateLayerNodePositionInput: called for layer that did not have position", .logToServer)
-//            return
-//        }
-//        
-//        let inputPort = layerViewModel.positionPort
-//        let updatedPositions: PortValues = inputPort.allLoopedValues.map { $0.getPoint ?? .zero }
-//            .map {
-//                updatePosition(position: $0, offset: offset.toCGPoint)
-//            }
-//            .map(PortValue.position)
-//
-//        inputPort.updatePortValues(updatedPositions)
-//    }
-//}

--- a/Stitch/Graph/Node/Layer/Util/LayerGroups.swift
+++ b/Stitch/Graph/Node/Layer/Util/LayerGroups.swift
@@ -12,47 +12,51 @@ import StitchSchemaKit
 extension GraphState {
     // Assumes:
     // - all selected nodes have either same parent or no parent ('top level')
-    @MainActor
-    func getParentSizeForSelectedNodes(selectedNodes: NodeIdSet) -> CGSize {
+//    @MainActor
+//    func getParentSizeForSelectedNodes(selectedNodes: NodeIdSet,
+//                                       activeIndex: ActiveIndex) -> CGSize {
+//
+//        if let firstSelectedNode = selectedNodes.first,
+//           let layerNode = self.getNodeViewModel(firstSelectedNode)?.layerNode,
+//           let parentId = layerNode.layerGroupId {
+//            return self.parentSizeHelper(id: parentId,
+//                                         activeIndex: activeIndex)
+//        }
+//        // had no parent, so is just a top level item
+//        else {
+//            return previewWindowSize
+//        }
+//    }
 
-        if let firstSelectedNode = selectedNodes.first,
-           let layerNode = self.getNodeViewModel(firstSelectedNode)?.layerNode,
-           let parentId = layerNode.layerGroupId {
-            return self.parentSizeHelper(id: parentId)
-        }
-        // had no parent, so is just a top level item
-        else {
-            return previewWindowSize
-        }
-    }
-
-    // Find the CGSize (not LayerSize)
-    @MainActor
-    private func parentSizeHelper(id: NodeId) -> CGSize {
-
-        guard let node = self.getNodeViewModel(id),
-              let nodeLayerSize = node.layerNode?.layerSize(activeIndex) else {
-            return .zero
-        }
-
-        // if this layer node has a directly usable size,
-        // just return that
-        if let size = nodeLayerSize.asCGSize {
-            return size
-        }
-        // else, if this layer-node has its own parent-node, try to find that
-        // parent-node's size, and provide it to LayerSize
-        else if let layerNode = self.getNodeViewModel(id)?.layerNode,
-                let parentId = layerNode.layerGroupId {
-            let sizeFromAbove = self.parentSizeHelper(id: parentId)
-            return nodeLayerSize.asCGSize(sizeFromAbove)
-        }
-        // else this layer node is already top level
-        else {
-            let sizeFromPreviewWindow = nodeLayerSize.asCGSize(previewWindowSize)
-            return nodeLayerSize.asCGSize(sizeFromPreviewWindow)
-        }
-    }
+//     Find the CGSize (not LayerSize)
+//    @MainActor
+//    private func parentSizeHelper(id: NodeId,
+//                                  activeIndex: ActiveIndex) -> CGSize {
+//
+//        guard let node = self.getNodeViewModel(id),
+//              let nodeLayerSize = node.layerNode?.layerSize(activeIndex) else {
+//            return .zero
+//        }
+//
+//        // if this layer node has a directly usable size,
+//        // just return that
+//        if let size = nodeLayerSize.asCGSize {
+//            return size
+//        }
+//        // else, if this layer-node has its own parent-node, try to find that
+//        // parent-node's size, and provide it to LayerSize
+//        else if let layerNode = self.getNodeViewModel(id)?.layerNode,
+//                let parentId = layerNode.layerGroupId {
+//            let sizeFromAbove = self.parentSizeHelper(id: parentId,
+//                                                      activeIndex: activeIndex)
+//            return nodeLayerSize.asCGSize(sizeFromAbove)
+//        }
+//        // else this layer node is already top level
+//        else {
+//            let sizeFromPreviewWindow = nodeLayerSize.asCGSize(previewWindowSize)
+//            return nodeLayerSize.asCGSize(sizeFromPreviewWindow)
+//        }
+//    }
 }
 
 struct LayerGroupFit {
@@ -75,23 +79,23 @@ struct LayerGroupFit {
     }
 }
 
-extension NodeViewModel {
-    @MainActor
-    func updateLayerNodePositionInput(offset: CGSize,
-                                      activeIndex: ActiveIndex) {
-
-        guard let layerViewModel = self.layerNode else {
-            log("updateLayerNodePositionInput: called for layer that did not have position", .logToServer)
-            return
-        }
-        
-        let inputPort = layerViewModel.positionPort
-        let updatedPositions: PortValues = inputPort.allLoopedValues.map { $0.getPoint ?? .zero }
-            .map {
-                updatePosition(position: $0, offset: offset.toCGPoint)
-            }
-            .map(PortValue.position)
-
-        inputPort.updatePortValues(updatedPositions)
-    }
-}
+//extension NodeViewModel {
+//    @MainActor
+//    func updateLayerNodePositionInput(offset: CGSize,
+//                                      activeIndex: ActiveIndex) {
+//
+//        guard let layerViewModel = self.layerNode else {
+//            log("updateLayerNodePositionInput: called for layer that did not have position", .logToServer)
+//            return
+//        }
+//        
+//        let inputPort = layerViewModel.positionPort
+//        let updatedPositions: PortValues = inputPort.allLoopedValues.map { $0.getPoint ?? .zero }
+//            .map {
+//                updatePosition(position: $0, offset: offset.toCGPoint)
+//            }
+//            .map(PortValue.position)
+//
+//        inputPort.updatePortValues(updatedPositions)
+//    }
+//}

--- a/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
+++ b/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
@@ -519,11 +519,14 @@ extension LayerNodeViewModel {
                                           layer: self.layer)
         }
         
+        let activeIndex = node.graphDelegate?.documentDelegate?.activeIndex ?? .init(.zero)
+        
         // Set blocked fields after all fields have been initialized
         self.forEachInput { layerInput in
             self.blockOrUnblockFields(
-                newValue: layerInput.activeValue,
-                layerInput: layerInput.port)
+                newValue: layerInput.getActiveValue(activeIndex: activeIndex),
+                layerInput: layerInput.port,
+                activeIndex: activeIndex)
         }
     }
     
@@ -555,7 +558,7 @@ extension LayerNodeViewModel {
     
     @MainActor
     func layerSize(_ activeIndex: ActiveIndex) -> LayerSize? {
-        self.sizePort.activeValue.getSize
+        self.sizePort.getActiveValue(activeIndex: activeIndex).getSize
     }
     
     /// Updates one or more preview layers given some layer node.
@@ -678,16 +681,17 @@ extension Layer {
 extension LayerNodeViewModel {
     @MainActor
     func layerPosition(_ activeIndex: ActiveIndex) -> CGPoint? {
-        self.positionPort.activeValue.getPoint
+        self.positionPort.getActiveValue(activeIndex: activeIndex).getPoint
     }
     
     @MainActor
     func scaledLayerSize(for nodeId: NodeId,
                          parentSize: CGSize,
                          activeIndex: ActiveIndex) -> ScaledSize? {
-        let scale = self.scalePort.activeValue.getNumber ?? .zero
+        let scale = self.scalePort.getActiveValue(activeIndex: activeIndex)
+            .getNumber ?? .zero
         
-        return self.sizePort.activeValue
+        return self.sizePort.getActiveValue(activeIndex: activeIndex)
             .getSize?.asCGSize(parentSize)
             .asScaledSize(scale)
     }

--- a/Stitch/Graph/Node/Model/GraphCopyable.swift
+++ b/Stitch/Graph/Node/Model/GraphCopyable.swift
@@ -511,11 +511,14 @@ extension GraphState {
     /// Synchronous caller for node copying, used for Option + drag.
     @MainActor
     func copyAndPasteSelectedNodes(selectedNodeIds: NodeIdSet,
-                                   isOptionDragInSidebar: Bool = false) {
+                                   isOptionDragInSidebar: Bool = false,
+                                   document: StitchDocumentViewModel) {
+        let groupNodeFocused = document.groupNodeFocused
+        
         log("copyAndPasteSelectedNodes: selectedNodeIds: \(selectedNodeIds)")
         // Copy nodes if no drag started yet
         let copiedComponentResult = self
-            .createCopiedComponent(groupNodeFocused: self.graphUI.groupNodeFocused,
+            .createCopiedComponent(groupNodeFocused: groupNodeFocused,
                                    selectedNodeIds: selectedNodeIds)
         
         // creates new ids for nodes and sidebar layers; updates nodes' positions (staggering for duplication)
@@ -531,7 +534,7 @@ extension GraphState {
         // Update top-level nodes to match current focused group
         let newNodes: [NodeEntity] = Self.createNewNodes(
             from: newComponent,
-            focusedGroupNode: self.graphUI.groupNodeFocused?.asNodeId)
+            focusedGroupNode: groupNodeFocused?.groupNodeId)
         
         let graph = self.addComponentToGraph(newComponent: newComponent,
                                              newNodes: newNodes,
@@ -540,14 +543,16 @@ extension GraphState {
 
         self.updateSync(from: graph)
         
-        self.updateGraphAfterPaste(newNodes: newNodes)
+        self.updateGraphAfterPaste(newNodes: newNodes,
+                                   document: document)
     }
 
     @MainActor
-    func copyToClipboard(selectedNodeIds: NodeIdSet) {
+    func copyToClipboard(selectedNodeIds: NodeIdSet,
+                         groupNodeFocused: GroupNodeType?) {
         // Copy selected nodes
         let copiedComponentResult = self
-            .createCopiedComponent(groupNodeFocused: self.graphUI.groupNodeFocused,
+            .createCopiedComponent(groupNodeFocused: groupNodeFocused,
                                    selectedNodeIds: selectedNodeIds)
 
         Task { [weak self] in

--- a/Stitch/Graph/Node/Patch/Type/DeviceInfoNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/DeviceInfoNode.swift
@@ -169,6 +169,8 @@ func deviceInfoEval(node: PatchNode,
     // TODO: rewrite the SO code to get around this linter warning?
     let deviceType = UIDevice().type // UIDevice.current.model
 
+    let safeAreaInsets = state.documentDelegate?.safeAreaInsets ?? .init()
+    
     //    #if DEV_DEBUG
     //    log("deviceInfoEval: deviceSize: \(deviceSize)")
     //
@@ -186,12 +188,12 @@ func deviceInfoEval(node: PatchNode,
         [.number(state.graphMovement.zoomData)],
         [.deviceOrientation(orientation.toStitchDeviceOrientation)],
         [.string(.init(deviceType.rawValue))],
-        [.string(.init(state.graphUI.colorScheme.description))],
+        [.string(.init(state.documentDelegate?.colorScheme.description ?? ""))],
         [
-            .number(state.safeAreaInsets.top)
+            .number(safeAreaInsets.top)
         ],
         [
-            .number(state.safeAreaInsets.bottom)
+            .number(safeAreaInsets.bottom)
         ]
     ]
 

--- a/Stitch/Graph/Node/Patch/Type/Math/MathExpressionNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Math/MathExpressionNode.swift
@@ -37,6 +37,7 @@ func mathExpressionEval(node: PatchNode) -> EvalResult {
     
     let labels = node.getAllInputsObservers().map { $0
         .label(node: node,
+               currentTraversalLevel: graph.documentDelegate?.groupNodeFocused?.groupNodeId,
                graph: graph)
     }
 

--- a/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
+++ b/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
@@ -117,7 +117,8 @@ extension PatchNodeViewModel: SchemaObserver {
                 // call the changeType helper
                 let _ = graph.changeType(for: node,
                                          oldType: oldType,
-                                         newType: newType)
+                                         newType: newType,
+                                         activeIndex: graph.documentDelegate?.activeIndex ?? .init(.zero))
             }
         }
         if self.splitterNode != schema.splitterNode {

--- a/Stitch/Graph/Node/Port/Model/Field/FieldValueMedia.swift
+++ b/Stitch/Graph/Node/Port/Model/Field/FieldValueMedia.swift
@@ -57,10 +57,12 @@ extension FieldValueMedia {
     func handleSelection(rowObserver: InputNodeRowObserver,
                          mediaType: SupportedMediaFormat,
                          isFieldInsideLayerInspector: Bool,
+                         activeIndex: ActiveIndex,
                          graph: GraphState) {
         switch self {
         case .none:
             graph.mediaPickerNoneChanged(rowObserver: rowObserver,
+                                         activeIndex: activeIndex,
                                          isFieldInsideLayerInspector: isFieldInsideLayerInspector)
         
         case .importButton:
@@ -88,6 +90,7 @@ extension FieldValueMedia {
             graph.mediaPickerChanged(selectedValue: .asyncMedia(mediaValue),
                                      mediaType: mediaType,
                                      rowObserver: rowObserver,
+                                     activeIndex: activeIndex,
                                      isFieldInsideLayerInspector: isFieldInsideLayerInspector)
             
         case .defaultMedia(let defaultMedia):
@@ -99,6 +102,7 @@ extension FieldValueMedia {
             graph.mediaPickerChanged(selectedValue: portValue,
                                      mediaType: mediaType,
                                      rowObserver: rowObserver,
+                                     activeIndex: activeIndex,
                                      isFieldInsideLayerInspector: isFieldInsideLayerInspector)
         }
     }

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Layer/LayerDimensionUtils.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Layer/LayerDimensionUtils.swift
@@ -81,7 +81,8 @@ extension GraphState {
     @MainActor
     func getFilteredLayerDimensionChoices(nodeId: NodeId,
                                           nodeKind: NodeKind,
-                                          layerInputObserver: LayerInputObserver?) -> [NonNumberLayerDimension] {
+                                          layerInputObserver: LayerInputObserver?,
+                                          activeIndex: ActiveIndex) -> [NonNumberLayerDimension] {
         
         let allChoices = LayerDimension.choicesAsNonNumberLayerDimension
         
@@ -109,7 +110,9 @@ extension GraphState {
             case .hug:
                 // Show `hug` just if this is a layer group AND the layer group has orientation != ZStack
                 let isLayerGroup = layer == .group
-                let canUseHug = self.getLayerNode(id: nodeId)?.layerNode?.orientationPort.activeValue.getOrientation?.canUseHug ?? false
+                let canUseHug = self.getLayerNode(id: nodeId)?.layerNode?.orientationPort
+                    .getActiveValue(activeIndex: activeIndex)
+                    .getOrientation?.canUseHug ?? false
                 return isLayerGroup && canUseHug
             }
         }

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/CameraFeed/Util/CameraUtil.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/CameraFeed/Util/CameraUtil.swift
@@ -34,6 +34,8 @@ extension GraphState {
             .filter {
                 $0.kind == .layer(.realityView)
             }
+        
+        let activeIndex = self.documentDelegate?.activeIndex ?? .init(.zero)
 
         // Update all camera nodes
         cameraFeedNodes.forEach { node in
@@ -41,6 +43,7 @@ extension GraphState {
             self.handleInputEditCommitted(
                 input: coordinate,
                 value: value,
+                activeIndex: activeIndex,
                 // TODO: is this accurate? Can we change camera direction via any of the layers (i.e. via layer inspector)?
                 isFieldInsideLayerInspector: false)
         }
@@ -52,6 +55,7 @@ extension GraphState {
             self.handleInputEditCommitted(
                 input: coordinate,
                 value: value,
+                activeIndex: activeIndex,
                 // TODO: is this accurate? Can we change camera direction via any of the layers (i.e. via layer inspector)?
                 isFieldInsideLayerInspector: false)
         }

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
@@ -125,6 +125,8 @@ extension GraphState {
     func mediaCopiedToNewNode(newURL: URL,
                               nodeLocation: CGPoint,
                               store: StitchStore) {
+        guard let document = store.currentDocument else { return }
+        
         var droppedLocation = nodeLocation
         let localPosition = self.localPosition
         let graphScale = self.graphMovement.zoomData
@@ -153,7 +155,7 @@ extension GraphState {
                                patch: nil,
                                position: droppedLocation.toCGSize,
                                zIndex: self.highestZIndex + 1,
-                               activeIndex: self.activeIndex,
+                               activeIndex: document.activeIndex,
                                graphDelegate: self) {
         case .success(let patchNode):
             guard let patchViewModel = patchNode.patchNode else {
@@ -162,7 +164,7 @@ extension GraphState {
             }
 
             // Update group state if node created inside group
-            patchViewModel.parentGroupNodeId = self.graphUI.groupNodeFocused?.asNodeId
+            patchViewModel.parentGroupNodeId = document.groupNodeFocused?.asNodeId
 
             // Must also add the media patch node to graphState,
             // so that it can be found when we evaluate the graph.
@@ -179,7 +181,8 @@ extension GraphState {
     /// Takes some imported media and applies it directly to the input of some node.
     @MainActor
     func mediaCopiedToExistingNode(nodeImportPayload: NodeMediaImportPayload,
-                                   newURL: URL) {
+                                   newURL: URL,
+                                   activeIndex: ActiveIndex) {
         let mediaKey = newURL.mediaKey
         let destinationInputs = nodeImportPayload.destinationInputs
         
@@ -207,7 +210,8 @@ extension GraphState {
             let portValue = PortValue.asyncMedia(newMedia)
 
             self.mediaInputEditCommitted(input: destinationInput,
-                                         value: portValue)
+                                         value: portValue,
+                                         activeIndex: activeIndex)
 
             self.encodeProjectInBackground()       
         } // for destinationInput in ...        
@@ -344,10 +348,12 @@ extension GraphState {
     func mediaPickerChanged(selectedValue: PortValue,
                             mediaType: SupportedMediaFormat,
                             rowObserver: InputNodeRowObserver,
+                            activeIndex: ActiveIndex,
                             isFieldInsideLayerInspector: Bool) {
         // Commit the new media to the selector input
         self.handleInputEditCommitted(input: rowObserver,
                                       value: selectedValue,
+                                      activeIndex: activeIndex,
                                       isFieldInsideLayerInspector: isFieldInsideLayerInspector)
         
         self.encodeProjectInBackground()
@@ -355,10 +361,12 @@ extension GraphState {
     
     @MainActor
     func mediaPickerNoneChanged(rowObserver: InputNodeRowObserver,
+                                activeIndex: ActiveIndex,
                                 isFieldInsideLayerInspector: Bool) {
             let emptyPortValue = PortValue.asyncMedia(nil)
         self.handleInputEditCommitted(input: rowObserver,
                                       value: emptyPortValue,
+                                      activeIndex: activeIndex,
                                       isFieldInsideLayerInspector: isFieldInsideLayerInspector)
             
         self.encodeProjectInBackground()

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
@@ -373,8 +373,6 @@ extension GraphState {
     }
 }
 
-
-
 // TODO: video-import node should also show resource size output?
 /// Creates node specifically from some imported media URL.
 @MainActor

--- a/Stitch/Graph/Node/Port/Util/Field/TabKeyPressActions.swift
+++ b/Stitch/Graph/Node/Port/Util/Field/TabKeyPressActions.swift
@@ -13,7 +13,7 @@ import OrderedCollections
 
 // TODO: can likely consolidate a lot of the portId vs layerInput, tab vs shift+tab logic
 
-extension GraphState {
+extension StitchDocumentViewModel {
     @MainActor
     func tabPressed(focusedField: FieldCoordinate,
                     node: NodeViewModel) {
@@ -23,10 +23,10 @@ extension GraphState {
         
         let newFocusedField = node.nextInput(focusedField,
                                              layerInput: layerInputOnCanvas,
-                                             propertySidebarState: self.graphUI.propertySidebar)
+                                             propertySidebarState: self.visibleGraph.propertySidebar)
 
         log("tabPressed: newFocusedField: \(newFocusedField)")
-        self.graphUI.reduxFocusedField = .textInput(newFocusedField)
+        self.reduxFocusedField = .textInput(newFocusedField)
     }
     
     @MainActor
@@ -38,10 +38,10 @@ extension GraphState {
         
         let newFocusedField = node.previousInput(focusedField,
                                                  layerInputOnCanvas: layerInputOnCanvas,
-                                                 propertySidebarState: self.graphUI.propertySidebar)
+                                                 propertySidebarState: self.visibleGraph.propertySidebar)
         
         log("shiftTabPressed: newFocusedField: \(newFocusedField)")
-        self.graphUI.reduxFocusedField = .textInput(newFocusedField)
+        self.reduxFocusedField = .textInput(newFocusedField)
     }
 }
 

--- a/Stitch/Graph/Node/Port/Util/InputEdit/InputEditedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/InputEdit/InputEditedActions.swift
@@ -15,6 +15,7 @@ extension GraphState {
     func inputEditedFromUI(fieldValue: FieldValue,
                            // Single-fields always 0, multi-fields are like size or position inputs
                            fieldIndex: Int,
+                           activeIndex: ActiveIndex,
                            rowObserver: InputNodeRowObserver,
                            isFieldInsideLayerInspector: Bool,
                            isCommitting: Bool = true) {
@@ -28,6 +29,7 @@ extension GraphState {
         rowObserver.handleInputEdited(graph: self,
                                       fieldValue: fieldValue,
                                       fieldIndex: fieldIndex,
+                                      activeIndex: activeIndex,
                                       isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                                       isCommitting: isCommitting)
     }
@@ -39,7 +41,8 @@ extension InputNodeRowObserver {
                      fieldValue: FieldValue,
                      // Single-fields always 0, multi-fields are like size or position inputs
                      fieldIndex: Int,
-                     isCommitting: Bool = true) {        
+                     activeIndex: ActiveIndex,
+                     isCommitting: Bool = true) {
         guard let node = graph.getNodeViewModel(self.id.nodeId) else {
             fatalErrorIfDebug()
             return
@@ -47,7 +50,7 @@ extension InputNodeRowObserver {
     
         graph.confirmInputIsVisibleInFrame(self)
         
-        let parentPortValue = self.activeValue
+        let parentPortValue = self.getActiveValue(activeIndex: activeIndex)
 
         //        log("inputEdited: fieldValue: \(fieldValue)")
         //        log("inputEdited: fieldIndex: \(fieldIndex)")
@@ -63,7 +66,7 @@ extension InputNodeRowObserver {
 
             // MARK: very important to remove edges before input changes
             node.removeIncomingEdge(at: self.id,
-                                    activeIndex: graph.activeIndex,
+                                    activeIndex: activeIndex,
                                     graph: graph)
 
             self.setValuesInInput([newValue])
@@ -86,6 +89,7 @@ extension InputNodeRowObserver {
                            fieldValue: FieldValue,
                            // Single-fields always 0, multi-fields are like size or position inputs
                            fieldIndex: Int,
+                           activeIndex: ActiveIndex,
                            isFieldInsideLayerInspector: Bool,
                            isCommitting: Bool = true) {
                 
@@ -99,6 +103,7 @@ extension InputNodeRowObserver {
                 observer.rowObserver.inputEdited(graph: graph,
                                                  fieldValue: fieldValue,
                                                  fieldIndex: fieldIndex,
+                                                 activeIndex: activeIndex,
                                                  isCommitting: isCommitting)
             }
         }
@@ -108,6 +113,7 @@ extension InputNodeRowObserver {
             self.inputEdited(graph: graph,
                              fieldValue: fieldValue,
                              fieldIndex: fieldIndex,
+                             activeIndex: activeIndex,
                              isCommitting: isCommitting)
         }
         

--- a/Stitch/Graph/Node/Port/Util/InputEdit/PickerActions.swift
+++ b/Stitch/Graph/Node/Port/Util/InputEdit/PickerActions.swift
@@ -15,6 +15,7 @@ extension GraphState {
     @MainActor
     func pickerOptionSelected(rowObserver: InputNodeRowObserver,
                               choice: PortValue,
+                              activeIndex: ActiveIndex,
                               isFieldInsideLayerInspector: Bool,
                               isPersistence: Bool = true) {
         //        log("PickerOptionSelected: input: \(input)")`
@@ -22,6 +23,7 @@ extension GraphState {
         self.handleInputEditCommitted(
             input: rowObserver,
             value: choice,
+            activeIndex: activeIndex,
             isFieldInsideLayerInspector: isFieldInsideLayerInspector)
         
         if isPersistence {

--- a/Stitch/Graph/Node/Port/Util/PulseActions.swift
+++ b/Stitch/Graph/Node/Port/Util/PulseActions.swift
@@ -29,7 +29,7 @@ extension GraphState {
         // Select canvas if associated here
         if let canvasItem = canvasItem { // inputPort.canvasItemDelegate {
             self.selectSingleNode(canvasItem,
-                                  graphUI: graphUI)
+                                  document: graphUI)
         }
         
         inputObserver.updateValues([.pulse(self.graphStepState.graphTime)])

--- a/Stitch/Graph/Node/Port/View/Field/InputView/AnchorEntitiesDropdownView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/AnchorEntitiesDropdownView.swift
@@ -25,6 +25,7 @@ struct AnchorEntitiesDropdownView: View {
     let graph: GraphState
     let value: PortValue
     let isFieldInsideLayerInspector: Bool
+    let activeIndex: ActiveIndex
     
     var choices: [AnchorDropdownChoice] {
         let initialChoices: [AnchorDropdownChoice] = [.none]
@@ -43,6 +44,7 @@ struct AnchorEntitiesDropdownView: View {
         
         graph.handleInputEditCommitted(input: rowObserver,
                                        value: .anchorEntity(selectedId),
+                                       activeIndex: activeIndex,
                                        isFieldInsideLayerInspector: false)
         graph.encodeProjectInBackground()
     }

--- a/Stitch/Graph/Node/Port/View/Field/InputView/AnchorPopoverView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/AnchorPopoverView.swift
@@ -26,6 +26,7 @@ struct AnchorPopoverView: View {
     
     let rowObserver: InputNodeRowObserver
     let graph: GraphState
+    let document: StitchDocumentViewModel
     let selection: Anchoring
     let layerInputObserver: LayerInputObserver?
     let isFieldInsideLayerInspector: Bool
@@ -57,6 +58,7 @@ struct AnchorPopoverView: View {
             graph.pickerOptionSelected(
                 rowObserver: rowObserver,
                 choice: .anchoring(option),
+                activeIndex: document.activeIndex,
                 isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                 isPersistence: true)
 

--- a/Stitch/Graph/Node/Port/View/Field/InputView/BoolCheckboxView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/BoolCheckboxView.swift
@@ -15,25 +15,12 @@ struct BoolCheckboxView: View {
     
     let rowObserver: InputNodeRowObserver? // nil = used in output
     let graph: GraphState
+    let document: StitchDocumentViewModel
     let layerInputObserver: LayerInputObserver?
     let value: Bool
     let isFieldInsideLayerInspector: Bool
     let isSelectedInspectorRow: Bool
-
-    @MainActor
-    var isMultiselectInspectorInputWithHeterogenousValues: Bool {
-        
-        if let layerInputObserver = layerInputObserver {
-            @Bindable var layerInputObserver = layerInputObserver
-                        
-            return layerInputObserver.fieldHasHeterogenousValues(
-                0,
-                isFieldInsideLayerInspector: isFieldInsideLayerInspector,
-                graph: graph)
-        } else {
-            return false
-        }
-    }
+    let isMultiselectInspectorInputWithHeterogenousValues: Bool
     
     @MainActor
     var iconName: String {
@@ -72,6 +59,7 @@ struct BoolCheckboxView: View {
                     graph.pickerOptionSelected(
                         rowObserver: rowObserver,
                         choice: .bool(toggled),
+                        activeIndex: document.activeIndex,
                         isFieldInsideLayerInspector: isFieldInsideLayerInspector)
                 }
             }

--- a/Stitch/Graph/Node/Port/View/Field/InputView/CommonEditingView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/CommonEditingView.swift
@@ -144,7 +144,7 @@ struct CommonEditingView: View {
     
     @MainActor
     var multiselectInputs: LayerInputPortSet? {
-        graphUI.propertySidebar.inputsCommonToSelectedLayers
+        graph.propertySidebar.inputsCommonToSelectedLayers
     }
             
     @MainActor
@@ -393,6 +393,7 @@ struct CommonEditingView: View {
         self.graph.inputEditedFromUI(
             fieldValue: .string(.init(newEdit)),
             fieldIndex: fieldIndex,
+            activeIndex: graphUI.activeIndex,
             rowObserver: rowObserver,
             isFieldInsideLayerInspector: self.isFieldInsideLayerInspector,
             isCommitting: isCommitting)

--- a/Stitch/Graph/Node/Port/View/Field/InputView/CommonEditingViewWrapper.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/CommonEditingViewWrapper.swift
@@ -35,19 +35,6 @@ struct CommonEditingViewWrapper: View {
         self.fieldViewModel.fieldIndex
     }
     
-    @MainActor
-    var fieldHasHeterogenousValues: Bool {
-        if let layerInputObserver = layerInputObserver {
-            @Bindable var layerInputObserver = layerInputObserver
-            return layerInputObserver.fieldHasHeterogenousValues(
-                fieldIndex,
-                isFieldInsideLayerInspector: forPropertySidebar,
-                graph: graph)
-        } else {
-            return false
-        }
-    }
-    
     var isFieldInMultifieldInspectorInputAndNotFlyout: Bool {
         isFieldInMultifieldInput && forPropertySidebar && !isForFlyout
     }
@@ -58,7 +45,9 @@ struct CommonEditingViewWrapper: View {
     @MainActor
     var isPaddingFieldInsideInspector: Bool {
         isFieldInMultifieldInspectorInputAndNotFlyout
-        && (layerInputObserver?.activeValue.getPadding.isDefined ?? false)
+        && (layerInputObserver?
+            .getActiveValue(activeIndex: graphUI.activeIndex)
+            .getPadding.isDefined ?? false)
     }
     
     @MainActor

--- a/Stitch/Graph/Node/Port/View/Field/InputView/DropDownChoiceView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/DropDownChoiceView.swift
@@ -24,6 +24,7 @@ struct DropDownChoiceView: View {
     let isFieldInsideLayerInspector: Bool
     let isSelectedInspectorRow: Bool
     let hasHeterogenousValues: Bool
+    let activeIndex: ActiveIndex
 
     @MainActor
     var finalChoiceDisplay: String {
@@ -36,7 +37,8 @@ struct DropDownChoiceView: View {
                              graph: graph,
                              choices: choices,
                              choiceDisplay: finalChoiceDisplay,
-                             isFieldInsideLayerInspector: isFieldInsideLayerInspector)
+                             isFieldInsideLayerInspector: isFieldInsideLayerInspector,
+                             activeIndex: activeIndex)
         } label: {
             StitchTextView(string: finalChoiceDisplay,
                            fontColor: isSelectedInspectorRow ? theme.fontColor : STITCH_FONT_GRAY_COLOR)
@@ -62,6 +64,7 @@ struct StitchPickerView: View {
     let choices: PortValues
     let choiceDisplay: String // current choice
     let isFieldInsideLayerInspector: Bool
+    let activeIndex: ActiveIndex
 
     var pickerLabel: String {
         // slightly different Picker label logic for Catalyst vs iPad
@@ -84,6 +87,7 @@ struct StitchPickerView: View {
         if let _selection = _selection {
             graph.pickerOptionSelected(rowObserver: input,
                                        choice: _selection,
+                                       activeIndex: activeIndex,
                                        isFieldInsideLayerInspector: isFieldInsideLayerInspector)
         } else {
             log("StitchPickerView: could not create PortValue from string: \(selection) ... in choices: \(choices)")

--- a/Stitch/Graph/Node/Port/View/Field/InputView/EditJSONEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/EditJSONEntry.swift
@@ -22,6 +22,7 @@ struct EditJSONEntry: View {
     let rowObserver: InputNodeRowObserver
     let json: StitchJSON? // nil helps with perf?
     let isSelectedInspectorRow: Bool
+    let activeIndex: ActiveIndex
     @Binding var isPressed: Bool
 
     var body: some View {
@@ -63,6 +64,7 @@ struct EditJSONEntry: View {
                             graph.handleInputEditCommitted(
                                 input: rowObserver,
                                 value: .json(edit.toStitchJSON),
+                                activeIndex: activeIndex,
                                 // TODO: currently we never use json input for a layer input; but should pass down proper values here
                                 isFieldInsideLayerInspector: false)
                             

--- a/Stitch/Graph/Node/Port/View/Field/InputView/LayerGroupAlignmentChoicesView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/LayerGroupAlignmentChoicesView.swift
@@ -135,6 +135,7 @@ struct LayerGroupHorizontalAlignmentPickerFieldValueView: View {
     let layerInputObserver: LayerInputObserver?
     let isFieldInsideLayerInspector: Bool
     let hasHeterogenousValues: Bool
+    let activeIndex: ActiveIndex
     
     var body: some View {
         Picker("", selection: $currentChoice) {
@@ -149,6 +150,7 @@ struct LayerGroupHorizontalAlignmentPickerFieldValueView: View {
             graph.pickerOptionSelected(
                 rowObserver: rowObserver,
                 choice: .anchoring(newValue.asAnchoring),
+                activeIndex: activeIndex,
                 isFieldInsideLayerInspector: isFieldInsideLayerInspector)
         }
         .onAppear {
@@ -162,6 +164,7 @@ struct LayerGroupVerticalAlignmentPickerFieldValueView: View {
     
     let rowObserver: InputNodeRowObserver
     let graph: GraphState
+    let activeIndex: ActiveIndex
     let value: Anchoring
     let layerInputObserver: LayerInputObserver?
     let isFieldInsideLayerInspector: Bool
@@ -180,6 +183,7 @@ struct LayerGroupVerticalAlignmentPickerFieldValueView: View {
             graph.pickerOptionSelected(
                 rowObserver: rowObserver,
                 choice: .anchoring(newValue.asAnchoring),
+                activeIndex: activeIndex,
                 isFieldInsideLayerInspector: isFieldInsideLayerInspector)
         }
         .onAppear {

--- a/Stitch/Graph/Node/Port/View/Field/InputView/LayerGroupOrientationDropDownChoiceView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/LayerGroupOrientationDropDownChoiceView.swift
@@ -43,6 +43,7 @@ struct LayerGroupOrientationDropDownChoiceView: View {
     let layerInputObserver: LayerInputObserver?
     let isFieldInsideLayerInspector: Bool
     let hasHeterogenousValues: Bool
+    let activeIndex: ActiveIndex
     
     var choices: [StitchOrientation] {
         StitchOrientation.choices.compactMap(\.getOrientation)
@@ -66,6 +67,7 @@ struct LayerGroupOrientationDropDownChoiceView: View {
         .onChange(of: self.currentChoice) { oldValue, newValue in
             graph.pickerOptionSelected(rowObserver: rowObserver,
                                        choice: .orientation(newValue),
+                                       activeIndex: activeIndex,
                                        isFieldInsideLayerInspector: isFieldInsideLayerInspector)
         }
         .onAppear {

--- a/Stitch/Graph/Node/Port/View/Field/InputView/LayerNamesDropDownChoiceView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/LayerNamesDropDownChoiceView.swift
@@ -125,6 +125,7 @@ struct LayerNamesDropDownChoiceView: View {
     let isSelectedInspectorRow: Bool
     let choices: LayerDropdownChoices
     let hasHeterogenousValues: Bool
+    let activeIndex: ActiveIndex
     
     @MainActor
     func onSet(_ choice: LayerDropdownChoice) {
@@ -136,6 +137,7 @@ struct LayerNamesDropDownChoiceView: View {
         graph.pickerOptionSelected(
             rowObserver: rowObserver,
             choice: value,
+            activeIndex: activeIndex,
             isFieldInsideLayerInspector: isFieldInsideLayerInspector)
     }
         

--- a/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerValueEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerValueEntry.swift
@@ -21,6 +21,7 @@ struct MediaPickerValueEntry: View {
     let graph: GraphState // Doesn't need to be @Bindable, since not directly relied on in the UI for a render-cycle
     let isMultiselectInspectorInputWithHeterogenousValues: Bool
     let isSelectedInspectorRow: Bool
+    let activeIndex: ActiveIndex
     
     var mediaType: SupportedMediaFormat {
         nodeKind.mediaType
@@ -40,7 +41,8 @@ struct MediaPickerValueEntry: View {
                                choices: [.importButton],
                                isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                                graph: graph,
-                               isSelectedInspectorRow: isSelectedInspectorRow)
+                               isSelectedInspectorRow: isSelectedInspectorRow,
+                               activeIndex: activeIndex)
             
             // Only show the incoming value as an option if there's an incoming edge
             if isUpstreamValue {
@@ -49,7 +51,8 @@ struct MediaPickerValueEntry: View {
                                    choices: [],
                                    isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                                    graph: graph,
-                                   isSelectedInspectorRow: isSelectedInspectorRow)
+                                   isSelectedInspectorRow: isSelectedInspectorRow,
+                                   activeIndex: activeIndex)
                 
             }
             
@@ -60,7 +63,8 @@ struct MediaPickerValueEntry: View {
                                    choices: [mediaValue],
                                    isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                                    graph: graph,
-                                   isSelectedInspectorRow: isSelectedInspectorRow)
+                                   isSelectedInspectorRow: isSelectedInspectorRow,
+                                   activeIndex: activeIndex)
             }
             
             Divider()
@@ -69,7 +73,8 @@ struct MediaPickerValueEntry: View {
                                choices: defaultOptions,
                                isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                                graph: graph,
-                               isSelectedInspectorRow: isSelectedInspectorRow)
+                               isSelectedInspectorRow: isSelectedInspectorRow,
+                               activeIndex: activeIndex)
         },
                    
                    contentIPad: {
@@ -77,6 +82,7 @@ struct MediaPickerValueEntry: View {
                 $0.handleSelection(rowObserver: rowObserver,
                                    mediaType: mediaType,
                                    isFieldInsideLayerInspector: isFieldInsideLayerInspector,
+                                   activeIndex: activeIndex,
                                    graph: graph)
             })) {
                 // Import button and any default media

--- a/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
@@ -44,8 +44,10 @@ struct MediaFieldValueView<Field: FieldViewModel>: View {
     let isNodeSelected: Bool
     let isFieldInsideLayerInspector: Bool
     let isSelectedInspectorRow: Bool
+    let isMultiselectInspectorInputWithHeterogenousValues: Bool
     
     @Bindable var graph: GraphState
+    let document: StitchDocumentViewModel
 
     var alignment: Alignment { isInput ? .leading : .trailing }
     
@@ -60,19 +62,6 @@ struct MediaFieldValueView<Field: FieldViewModel>: View {
         }
     }
 
-    @MainActor
-    var isMultiselectInspectorInputWithHeterogenousValues: Bool {
-        if let layerInputObserver = layerInputObserver {
-            @Bindable var layerInputObserver = layerInputObserver
-            return layerInputObserver.fieldHasHeterogenousValues(
-                fieldIndex,
-                isFieldInsideLayerInspector: isFieldInsideLayerInspector,
-                graph: graph)
-        } else {
-            return false
-        }
-    }
-    
     var body: some View {
         // MARK: using StitchMediaObject is more dangerous than GraphMediaValue as it won't refresh when media is changed, causing media to be retained
         
@@ -87,7 +76,8 @@ struct MediaFieldValueView<Field: FieldViewModel>: View {
                                       isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                                       graph: graph,
                                       isMultiselectInspectorInputWithHeterogenousValues: isMultiselectInspectorInputWithHeterogenousValues,
-                                      isSelectedInspectorRow: isSelectedInspectorRow)
+                                      isSelectedInspectorRow: isSelectedInspectorRow,
+                                      activeIndex: document.activeIndex)
                 .onChange(of: mediaName, initial: true) {
                     print("media name in inner value view: \(mediaName)")
                 }
@@ -97,6 +87,7 @@ struct MediaFieldValueView<Field: FieldViewModel>: View {
                                 rowViewModel: rowViewModel,
                                 node: node,
                                 graph: graph,
+                                document: document,
                                 coordinate: rowObserver.id,
                                 isInput: isInput,
                                 fieldIndex: fieldIndex,
@@ -113,6 +104,7 @@ struct MediaFieldLabelView<Field: FieldViewModel>: View {
     let rowViewModel: Field.NodeRowType
     let node: NodeViewModel
     let graph: GraphState
+    let document: StitchDocumentViewModel
     let coordinate: InputCoordinate
     let isInput: Bool
     let fieldIndex: Int
@@ -123,7 +115,8 @@ struct MediaFieldLabelView<Field: FieldViewModel>: View {
     func updateMediaObserver() {
         self.mediaObserver = Field.getMediaObserver(node: node,
                                                     rowViewModel: rowViewModel,
-                                                    graph: graph)
+                                                    graph: graph,
+                                                    activeIndex: document.activeIndex)
     }
     
     var isVisualMediaPort: Bool {
@@ -168,7 +161,7 @@ struct MediaFieldLabelView<Field: FieldViewModel>: View {
                 visualMediaView(mediaObserver: self.mediaObserver)
             }
         }
-        .onChange(of: graph.activeIndex, initial: true) {
+        .onChange(of: document.activeIndex, initial: true) {
             self.updateMediaObserver()
         }
     }

--- a/Stitch/Graph/Node/Port/View/Field/InputView/PickerValueEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/PickerValueEntry.swift
@@ -28,6 +28,7 @@ struct MediaPickerButtons: View {
     let isFieldInsideLayerInspector: Bool
     let graph: GraphState
     let isSelectedInspectorRow: Bool
+    let activeIndex: ActiveIndex
 
     var body: some View {
         ForEach(choices) { choice in
@@ -36,6 +37,7 @@ struct MediaPickerButtons: View {
                 choice.handleSelection(rowObserver: rowObserver,
                                        mediaType: mediaType,
                                        isFieldInsideLayerInspector: isFieldInsideLayerInspector,
+                                       activeIndex: activeIndex,
                                        graph: graph)
             } label: {
                 // We add a value for truncating text here to ensure that the title view in the picker does not stretch too long when importing a file with a long tiel

--- a/Stitch/Graph/Node/Port/View/Field/InputView/SpecialPickerFieldValueView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/SpecialPickerFieldValueView.swift
@@ -75,6 +75,7 @@ struct SpecialPickerFieldValueView: View {
     let layerInputObserver: LayerInputObserver?
     let isFieldInsideLayerInspector: Bool
     let hasHeterogenousValues: Bool
+    let activeIndex: ActiveIndex
     
     var body: some View {
         Picker("", selection: $currentChoice) {
@@ -89,6 +90,7 @@ struct SpecialPickerFieldValueView: View {
             graph.pickerOptionSelected(
                 rowObserver: rowObserver,
                 choice: newValue,
+                activeIndex: activeIndex,
                 isFieldInsideLayerInspector: isFieldInsideLayerInspector)
         }
         .onAppear {

--- a/Stitch/Graph/Node/Port/View/Field/InputView/StitchFontDropdown.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/StitchFontDropdown.swift
@@ -17,6 +17,7 @@ struct StitchFontDropdown: View {
     let isFieldInsideLayerInspector: Bool
     let propertyIsSelected: Bool
     let hasHeterogenousValues: Bool
+    let activeIndex: ActiveIndex
     
     @MainActor
     var finalChoiceDisplay: String {
@@ -63,6 +64,7 @@ struct StitchFontDropdown: View {
 
             graph.pickerOptionSelected(rowObserver: rowObserver,
                                        choice: PortValue.textFont(newStitchFont),
+                                       activeIndex: activeIndex,
                                        isFieldInsideLayerInspector: isFieldInsideLayerInspector)
         }
     }

--- a/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
@@ -132,10 +132,12 @@ struct OutputValueView: View {
             case .bool(let bool):
                 BoolCheckboxView(rowObserver: nil,
                                  graph: graph,
+                                 document: graphUI,
                                  layerInputObserver: nil,
                                  value: bool,
                                  isFieldInsideLayerInspector: false,
-                                 isSelectedInspectorRow: isSelectedInspectorRow)
+                                 isSelectedInspectorRow: isSelectedInspectorRow,
+                                 isMultiselectInspectorInputWithHeterogenousValues: false)
                 
             case .dropdown(let choiceDisplay, _):
                 // Values that use dropdowns for their inputs use instead a display-only view for their outputs
@@ -253,7 +255,9 @@ struct OutputValueView: View {
                                     isNodeSelected: isCanvasItemSelected,
                                     isFieldInsideLayerInspector: false,
                                     isSelectedInspectorRow: isSelectedInspectorRow,
-                                    graph: graph)
+                                    isMultiselectInspectorInputWithHeterogenousValues: false,
+                                    graph: graph,
+                                    document: graphUI)
                 
             case .color(let color):
                 StitchColorPickerOrb(chosenColor: color,

--- a/Stitch/Graph/Node/Port/View/Field/ValueButton/ColorOrbValueButtonView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/ValueButton/ColorOrbValueButtonView.swift
@@ -20,6 +20,8 @@ struct ColorOrbValueButtonView: View {
     let currentColor: Color // the current color, from input
     let hasIncomingEdge: Bool
     let graph: GraphState
+    let isMultiselectInspectorInputWithHeterogenousValues: Bool
+    let activeIndex: ActiveIndex
     
     var body: some View {
 
@@ -39,6 +41,7 @@ struct ColorOrbValueButtonView: View {
                 graph.pickerOptionSelected(
                     rowObserver: rowObserver,
                     choice: .color(newColor),
+                    activeIndex: activeIndex,
                     isFieldInsideLayerInspector: rowViewModel.isFieldInsideLayerInspector,
                     // Lots of small changes so don't persist everything
                     isPersistence: false)
@@ -50,6 +53,8 @@ struct ColorOrbValueButtonView: View {
                               fieldCoordinate: fieldViewModel.id,
                               isFieldInsideLayerInspector: rowViewModel.isFieldInsideLayerInspector,
                               isForFlyout: isForFlyout,
+                              isMultiselectInspectorInputWithHeterogenousValues: isMultiselectInspectorInputWithHeterogenousValues,
+                              activeIndex: activeIndex,
                               chosenColor: binding,
                               graph: graph)
         .onAppear {

--- a/Stitch/Graph/Node/Port/View/Field/ValueButton/NumberValueButtonView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/ValueButton/NumberValueButtonView.swift
@@ -60,7 +60,8 @@ struct NumberValueButtonView: View {
                 rowObserver: rowObserver,
                 isPressed: $isPressed,
                 fieldValueNumberType: fieldValueNumberType,
-                isFieldInsideLayerInspector: isFieldInsideLayerInspector))
+                isFieldInsideLayerInspector: isFieldInsideLayerInspector,
+                activeIndex: graphUI.activeIndex))
     }
 }
 
@@ -72,6 +73,7 @@ struct AdjustmentBarViewModifier: ViewModifier {
     @Binding var isPressed: Bool
     let fieldValueNumberType: FieldValueNumberType
     let isFieldInsideLayerInspector: Bool
+    let activeIndex: ActiveIndex
 
     func body(content: Content) -> some View {
         return content
@@ -86,6 +88,7 @@ struct AdjustmentBarViewModifier: ViewModifier {
                     fieldCoordinate: fieldCoordinate,
                     rowObserver: rowObserver,
                     isFieldInsideLayerInspector: isFieldInsideLayerInspector,
+                    activeIndex: activeIndex,
                     isPopoverOpen: self.$isPressed
                 )
                 #if !targetEnvironment(macCatalyst)

--- a/Stitch/Graph/Node/Port/View/Field/ValueButton/StitchColorPicker/StitchColorPickerView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/ValueButton/StitchColorPicker/StitchColorPickerView.swift
@@ -61,6 +61,8 @@ struct StitchColorPickerView: View {
     let isForFlyout: Bool
     var isForPreviewWindowBackgroundPicker: Bool = false
     var isForIPhone: Bool = false
+    let isMultiselectInspectorInputWithHeterogenousValues: Bool
+    let activeIndex: ActiveIndex
 
     //    @State var currentColor: Color = .clear
     //    @State var chosenColor: Color = .red
@@ -72,19 +74,6 @@ struct StitchColorPickerView: View {
 #else
     let isCatalyst: Bool = false
 #endif
-    
-    @MainActor
-    var isMultiselectInspectorInputWithHeterogenousValues: Bool {
-        if let layerInputObserver = layerInputObserver {
-            @Bindable var layerInputObserver = layerInputObserver
-            return layerInputObserver.fieldHasHeterogenousValues(
-                fieldCoordinate.fieldIndex,
-                isFieldInsideLayerInspector: isFieldInsideLayerInspector,
-                graph: graph)
-        } else {
-            return false
-        }
-    }
     
     var body: some View {
 
@@ -101,6 +90,7 @@ struct StitchColorPickerView: View {
                         isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                         isForPreviewWindowBackgroundPicker: isForPreviewWindowBackgroundPicker,
                         isForIPhone: isForIPhone,
+                        activeIndex: activeIndex,
                         chosenColor: self.$chosenColor,
                         graph: graph)
                     .padding()

--- a/Stitch/Graph/Node/Port/View/Field/ValueButton/StitchColorPicker/StitchCustomColorPickerView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/ValueButton/StitchColorPicker/StitchCustomColorPickerView.swift
@@ -14,6 +14,7 @@ struct StitchCustomColorPickerView: View {
     let isFieldInsideLayerInspector: Bool
     let isForPreviewWindowBackgroundPicker: Bool
     let isForIPhone: Bool
+    let activeIndex: ActiveIndex
     
     @Binding var chosenColor: Color
     let graph: GraphState
@@ -174,6 +175,7 @@ struct StitchCustomColorPickerView: View {
                     graph.pickerOptionSelected(
                         rowObserver: rowObserver,
                         choice: .color(color),
+                        activeIndex: activeIndex,
                         isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                         // Lots of small changes so don't persist everything
                         isPersistence: true)

--- a/Stitch/Graph/Node/Port/View/Field/WirelessPortView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/WirelessPortView.swift
@@ -25,7 +25,8 @@ struct WirelessPortView: View {
             .offset(x: isOutput ? -12 : 12)
             .onTapGesture {
                 if !isOutput {
-                    graph.jumpToAssignedBroadcaster(wirelessReceiverNodeId: id, graphUI: graphUI)
+                    graph.jumpToAssignedBroadcaster(wirelessReceiverNodeId: id,
+                                                    document: graphUI)
                 }
             }
         #if targetEnvironment(macCatalyst)

--- a/Stitch/Graph/Node/Port/View/LayerInspectorRowButton.swift
+++ b/Stitch/Graph/Node/Port/View/LayerInspectorRowButton.swift
@@ -12,7 +12,7 @@ struct LayerInspectorRowButton: View {
     @Environment(\.appTheme) var theme
     
     @Bindable var graph: GraphState
-    @Bindable var graphUI: GraphUIState
+    @Bindable var graphUI: StitchDocumentViewModel
     let layerInputObserver: LayerInputObserver?
     let layerInspectorRowId: LayerInspectorRowId
     let coordinate: NodeIOCoordinate
@@ -83,7 +83,7 @@ struct LayerInspectorRowButton: View {
             // If we're already on the canvas, jump to that canvas item
             if let canvasItemId = canvasItemId {
                 graph.jumpToCanvasItem(id: canvasItemId,
-                                       graphUI: graphUI)
+                                       document: graphUI)
             }
             
             // Else we're adding an input (whole or field) or an output to the canvas

--- a/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
+++ b/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
@@ -18,7 +18,7 @@ struct NodeInputView: View {
     @Environment(\.appTheme) var theme
     
     @Bindable var graph: GraphState
-    @Bindable var graphUI: GraphUIState
+    @Bindable var graphUI: StitchDocumentViewModel
     
     let node: NodeViewModel
     let hasIncomingEdge: Bool
@@ -238,7 +238,7 @@ struct NodeOutputView: View {
             if isOutputSplitter {
                 // See `NodeRowObserver.label()` for similar logic for *inputs*
                 let parentGroupNode = node.patchNodeViewModel?.parentGroupNodeId
-                let currentTraversalLevel = graph.groupNodeFocused
+                let currentTraversalLevel = graphUI.groupNodeFocused?.groupNodeId
                 return parentGroupNode != currentTraversalLevel
             }
             

--- a/Stitch/Graph/Node/Port/ViewModel/FieldViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/FieldViewModel.swift
@@ -34,7 +34,8 @@ protocol FieldViewModel: StitchLayoutCachable, Observable, AnyObject, Identifiab
     @MainActor
     static func getMediaObserver(node: NodeViewModel,
                                  rowViewModel: Self.NodeRowType,
-                                 graph: GraphState) -> MediaViewModel?
+                                 graph: GraphState,
+                                 activeIndex: ActiveIndex) -> MediaViewModel?
 }
 
 extension FieldViewModel {
@@ -96,13 +97,14 @@ final class InputFieldViewModel: FieldViewModel {
     @MainActor
     static func getMediaObserver(node: NodeViewModel,
                                  rowViewModel: InputNodeRowViewModel,
-                                 graph: GraphState) -> MediaViewModel? {
+                                 graph: GraphState,
+                                 activeIndex: ActiveIndex) -> MediaViewModel? {
         let inputCoordinate = rowViewModel.id.asNodeIOCoordinate
         
         // MARK: cheating with 0 since logic causes render cycles
         let loopCount = 0 //self.rowViewModelDelegate?.rowDelegate?.allLoopedValues.count ?? .zero
         
-        let loopIndex = graph.activeIndex.adjustedIndex(loopCount)
+        let loopIndex = activeIndex.adjustedIndex(loopCount)
         
         let mediaObserver = node
             .getInputMediaObserver(inputCoordinate: inputCoordinate,
@@ -137,16 +139,18 @@ final class OutputFieldViewModel: FieldViewModel {
         self.rowViewModelDelegate = rowViewModelDelegate
     }
     
-    static func getMediaObserver(node: NodeViewModel,
-                                 rowViewModel: OutputNodeRowViewModel,
-                                 graph: GraphState) -> MediaViewModel? {
+    @MainActor static func getMediaObserver(node: NodeViewModel,
+                                            rowViewModel: OutputNodeRowViewModel,
+                                            graph: GraphState,
+                                            activeIndex: ActiveIndex) -> MediaViewModel? {
         // No keypaths ever used for output
         let portIndex = rowViewModel.id.portId
         let mediaObserver = node
             .getVisibleMediaObserver(outputPortId: portIndex,
                                      // nil mediaId ensures observer is returned
                                      mediaId: nil,
-                                     graph: graph)
+                                     graph: graph,
+                                     activeIndex: activeIndex)
         return mediaObserver
     }
 }

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
@@ -123,16 +123,14 @@ extension LayerInputObserver {
     // The overall-label for the port, e.g. "Size" (not "W" or "H") for the size property
     @MainActor
     func overallPortLabel(usesShortLabel: Bool,
+                          currentTraversalLevel: NodeId?,
                           node: NodeViewModel,
                           graph: GraphState) -> String {
-        guard let label = self._packedData.inspectorRowViewModel.rowDelegate?
+        self._packedData.rowObserver
             .label(useShortLabel: true,
                    node: node,
-                   graph: graph) else {
-            fatalErrorIfDebug("Did not have rowDelegate?")
-            return "NO LABEL"
-        }
-        return label
+                   currentTraversalLevel: currentTraversalLevel,
+                   graph: graph)
     }
         
     @MainActor
@@ -253,8 +251,7 @@ extension LayerInputObserver {
     }
     
     @MainActor
-    var activeValue: PortValue {
-        let activeIndex = self.graphDelegate?.activeIndex ?? .init(.zero)
+    func getActiveValue(activeIndex: ActiveIndex) -> PortValue {
         let values = self.values
         
         guard let value = values[safe: activeIndex.adjustedIndex(values.count)] else {

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -510,7 +510,8 @@ extension NodeRowViewModel {
            let layerInputForThisRow = rowDelegate.id.keyPath {
             
             layerNode.blockOrUnblockFields(newValue: newValue, 
-                                           layerInput: layerInputForThisRow.layerInput)
+                                           layerInput: layerInputForThisRow.layerInput,
+                                           activeIndex: self.graphDelegate?.documentDelegate?.activeIndex ?? .init(.zero))
         }
     }
 }
@@ -569,7 +570,7 @@ extension NodeRowObserver {
             // is for node (rather than layer inspector)
             $0.id.isNode &&
             // is currently visible in selected group
-            $0.graphDelegate?.groupNodeFocused == $0.canvasItemDelegate?.parentGroupNodeId
+            $0.graphDelegate?.documentDelegate?.groupNodeFocused?.groupNodeId == $0.canvasItemDelegate?.parentGroupNodeId
         }
     }
 }

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverCachedViewDataExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverCachedViewDataExtensions.swift
@@ -11,34 +11,34 @@ import StitchSchemaKit
 // MARK: derived/cached data: PortViewData, ActiveValue, PortColor
 
 extension NodeRowViewModel {
-    /// Gets node ID for currently visible node. Covers edge cause where group nodes use splitter nodes,
-    /// which save a differnt node ID.
-    @MainActor
-    func visibleNodeIds(_ graph: GraphState) -> Set<CanvasItemId> {
-        guard let nodeDelegate = self.nodeDelegate else {
-            return []
-        }
-        
-        let canvasItems = nodeDelegate.getAllCanvasObservers()
-        
-        return canvasItems.compactMap { canvasItem in
-            guard canvasItem.isVisibleInFrame(graph.visibleCanvasIds) else {
-                return nil
-            }
-            
-            // We use the group node ID only if it isn't in focus
-            if nodeDelegate.splitterType == .input &&
-                graph.groupNodeFocused != canvasItem.parentGroupNodeId,
-               let parentNodeId = canvasItem.parentGroupNodeId,
-               let parentNode = graph.getNodeViewModel(parentNodeId),
-               let parentCanvasItem = parentNode.patchCanvasItem {
-                return parentCanvasItem.id
-            }
-            
-            return canvasItem.id
-        }
-        .toSet
-    }
+//    /// Gets node ID for currently visible node. Covers edge cause where group nodes use splitter nodes,
+//    /// which save a differnt node ID.
+//    @MainActor
+//    func visibleNodeIds(_ graph: GraphState) -> Set<CanvasItemId> {
+//        guard let nodeDelegate = self.nodeDelegate else {
+//            return []
+//        }
+//        
+//        let canvasItems = nodeDelegate.getAllCanvasObservers()
+//        
+//        return canvasItems.compactMap { canvasItem in
+//            guard canvasItem.isVisibleInFrame(graph.visibleCanvasIds) else {
+//                return nil
+//            }
+//            
+//            // We use the group node ID only if it isn't in focus
+//            if nodeDelegate.splitterType == .input &&
+//                graph.groupNodeFocused != canvasItem.parentGroupNodeId,
+//               let parentNodeId = canvasItem.parentGroupNodeId,
+//               let parentNode = graph.getNodeViewModel(parentNodeId),
+//               let parentCanvasItem = parentNode.patchCanvasItem {
+//                return parentCanvasItem.id
+//            }
+//            
+//            return canvasItem.id
+//        }
+//        .toSet
+//    }
    
    @MainActor
    func updateConnectedCanvasItems() {

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverCachedViewDataExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverCachedViewDataExtensions.swift
@@ -10,36 +10,7 @@ import StitchSchemaKit
 
 // MARK: derived/cached data: PortViewData, ActiveValue, PortColor
 
-extension NodeRowViewModel {
-//    /// Gets node ID for currently visible node. Covers edge cause where group nodes use splitter nodes,
-//    /// which save a differnt node ID.
-//    @MainActor
-//    func visibleNodeIds(_ graph: GraphState) -> Set<CanvasItemId> {
-//        guard let nodeDelegate = self.nodeDelegate else {
-//            return []
-//        }
-//        
-//        let canvasItems = nodeDelegate.getAllCanvasObservers()
-//        
-//        return canvasItems.compactMap { canvasItem in
-//            guard canvasItem.isVisibleInFrame(graph.visibleCanvasIds) else {
-//                return nil
-//            }
-//            
-//            // We use the group node ID only if it isn't in focus
-//            if nodeDelegate.splitterType == .input &&
-//                graph.groupNodeFocused != canvasItem.parentGroupNodeId,
-//               let parentNodeId = canvasItem.parentGroupNodeId,
-//               let parentNode = graph.getNodeViewModel(parentNodeId),
-//               let parentCanvasItem = parentNode.patchCanvasItem {
-//                return parentCanvasItem.id
-//            }
-//            
-//            return canvasItem.id
-//        }
-//        .toSet
-//    }
-   
+extension NodeRowViewModel {   
    @MainActor
    func updateConnectedCanvasItems() {
        self.connectedCanvasItems = self.getConnectedCanvasItems()

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowViewModel.swift
@@ -178,7 +178,7 @@ extension NodeRowViewModel {
             self.initializeValues(rowDelegate: rowDelegate,
                                   unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
                                   unpackedPortIndex: unpackedPortIndex,
-                                  initialValue: rowDelegate.activeValue)
+                                  initialValue: rowDelegate.getActiveValue(activeIndex: node.graphDelegate?.documentDelegate?.activeIndex ?? .init(.zero)))
         }
         
         self.portViewData = self.getPortViewData()
@@ -222,7 +222,7 @@ extension NodeRowViewModel {
             return
         }
         
-        let activeIndex = rowDelegate.nodeDelegate?.activeIndex ?? .init(.zero)
+        let activeIndex = rowDelegate.nodeDelegate?.graphDelegate?.documentDelegate?.activeIndex ?? .init(.zero)
         let isLayerFocusedInPropertySidebar = rowDelegate.nodeDelegate?.graphDelegate?.layerFocusedInPropertyInspector == rowDelegate.id.nodeId
         
         let oldViewValue = self.activeValue // the old cached

--- a/Stitch/Graph/Node/Title/View/CanvasItemTitleView.swift
+++ b/Stitch/Graph/Node/Title/View/CanvasItemTitleView.swift
@@ -21,7 +21,6 @@ struct CanvasItemTitleView: View {
     
     @Bindable var document: StitchDocumentViewModel
     @Bindable var graph: GraphState
-    @Bindable var graphUI: GraphUIState
     @Bindable var node: NodeViewModel
     let canvasItem: CanvasItemViewModel
     let isCanvasItemSelected: Bool
@@ -52,6 +51,7 @@ struct CanvasItemTitleView: View {
             if node.patch == .wirelessReceiver,
                let rowObserver = node.inputsObservers.first {
                 CanvasItemTitleWirelessReceiverMenuView(graph: graph,
+                                                        document: document,
                                                         node: node, rowObserver: rowObserver,
                                                         nodeName: self.name)
             } else {
@@ -62,7 +62,6 @@ struct CanvasItemTitleView: View {
                     }
                     NodeTitleTextField(document: document,
                                        graph: graph,
-                                       graphUI: graphUI,
                                        node: node,
                                        canvasItem: canvasItem,
                                        label: label,
@@ -75,7 +74,7 @@ struct CanvasItemTitleView: View {
                 .modifier(
                     MathExpressionPopoverViewModifier(
                         id: nodeId,
-                        graph: graph,
+                        document: document,
                         shouldDisplay: node.patch == .mathExpression,
                         mathExpression: mathExpression ?? "")
                 )
@@ -110,6 +109,7 @@ struct CanvasItemTitleWirelessReceiverMenuView: View {
     @State private var choice: BroadcastChoice = nilBroadcastChoice
     
     @Bindable var graph: GraphState
+    @Bindable var document: StitchDocumentViewModel
     @Bindable var node: NodeViewModel
     @Bindable var rowObserver: InputNodeRowObserver
     let nodeName: String
@@ -136,6 +136,7 @@ struct CanvasItemTitleWirelessReceiverMenuView: View {
     var body: some View {
         Menu {
             NodeWirelessBroadcastSubmenuView(graph: graph,
+                                             document: document,
                                              currentBroadcastChoice: self.choice,
                                              nodeId: node.id,
                                              forNodeTitle: true)

--- a/Stitch/Graph/Node/Title/View/MathExpressionSubmenuButtonView.swift
+++ b/Stitch/Graph/Node/Title/View/MathExpressionSubmenuButtonView.swift
@@ -30,23 +30,22 @@ struct MathExpressionFormulaEdited: GraphEvent {
     }
 }
 
-struct MathExpressionFocused: GraphUIEvent {
+struct MathExpressionFocused: StitchDocumentEvent {
     let id: NodeId
     
-    func handle(state: GraphUIState) {
+    func handle(state: StitchDocumentViewModel) {
         state.reduxFocusedField = .mathExpression(id)
     }
 }
 
-struct MathExpressionDefocused: GraphEventWithResponse {
+struct MathExpressionDefocused: StitchDocumentEvent {
     let id: NodeId
     
-    func handle(state: GraphState) -> GraphResponse {
-        if case state.graphUI.reduxFocusedField = .mathExpression(id) {
-            state.graphUI.reduxFocusedField = nil
-            return .persistenceResponse
+    func handle(state: StitchDocumentViewModel) {
+        if case state.reduxFocusedField = .mathExpression(id) {
+            state.reduxFocusedField = nil
+            state.encodeProjectInBackground()
         }
-        return .noChange
     }
 }
 
@@ -56,13 +55,13 @@ struct MathExpressionPopoverViewModifier: ViewModifier {
     @State private var expr = "" // Alternatively?: pass down a @Bindable mathExpression
     
     let id: NodeId
-    let graph: GraphState
+    let document: StitchDocumentViewModel
     let shouldDisplay: Bool
     let mathExpression: String
     
     // more like?: "is popover open"
     var isFocused: Bool {
-        graph.graphUI.reduxFocusedField == .mathExpression(id)
+        document.reduxFocusedField == .mathExpression(id)
     }
     
     func body(content: Content) -> some View {

--- a/Stitch/Graph/Node/Title/View/NodeTitleTextField.swift
+++ b/Stitch/Graph/Node/Title/View/NodeTitleTextField.swift
@@ -11,7 +11,6 @@ import StitchSchemaKit
 struct NodeTitleTextField: View {
     @Bindable var document: StitchDocumentViewModel
     @Bindable var graph: GraphState
-    @Bindable var graphUI: GraphUIState
     @Bindable var node: NodeViewModel
     @Bindable var canvasItem: CanvasItemViewModel
     let label: String
@@ -21,7 +20,6 @@ struct NodeTitleTextField: View {
     var body: some View {
         StitchTitleTextField(document: document,
                              graph: graph,
-                             graphUI: graphUI,
                              node: node,
                              canvasItem: canvasItem,
                              titleEditType: .canvas(canvasItem.id),
@@ -37,7 +35,6 @@ struct StitchTitleTextField: View {
     
     @Bindable var document: StitchDocumentViewModel
     @Bindable var graph: GraphState
-    @Bindable var graphUI: GraphUIState
     @Bindable var node: NodeViewModel
     @Bindable var canvasItem: CanvasItemViewModel
     let titleEditType: StitchTitleEdit
@@ -47,7 +44,7 @@ struct StitchTitleTextField: View {
     
     @MainActor
     var isFocused: Bool {
-        (graphUI.reduxFocusedField?.getNodeTitleEdit == titleEditType)
+        (document.reduxFocusedField?.getNodeTitleEdit == titleEditType)
         // && isCanvasItemSelected
     }
 
@@ -106,8 +103,7 @@ struct StitchTitleTextField: View {
                 // Better as global redux-state than local view-state: only one field in entire app can be focused at a time.
                 .onTapGesture {
                     // log("NodeTitleTextField tapped")
-                    graph.reduxFieldFocused(focusedField: .nodeTitle(titleEditType),
-                                            graphUI: self.graphUI)
+                    document.reduxFieldFocused(focusedField: .nodeTitle(titleEditType))
                 }
             }
         }

--- a/Stitch/Graph/Node/Util/Movement/NodePositionUtils.swift
+++ b/Stitch/Graph/Node/Util/Movement/NodePositionUtils.swift
@@ -35,32 +35,32 @@ extension CanvasItemViewModel {
     }
     
     @MainActor
-    func isTapped(document: StitchDocumentViewModel,
-                  graphUI: GraphUIState) {
+    func isTapped(document: StitchDocumentViewModel) {
         log("canvasItemTapped: id: \(self.id)")
+        let graph = document.visibleGraph
         
         // when holding CMD ...
         // TODO: pass this down from the gesture handler or fix key listening
         if document.keypressState.isCommandPressed {
             // toggle selection
-            let isSelected = document.graphUI.selection.selectedNodeIds.contains(self.id)
+            let isSelected = graph.selection.selectedNodeIds.contains(self.id)
             if isSelected {
-                self.deselect(document.graph,
-                              graphUI: graphUI)
+                self.deselect(graph)
             } else {
-                self.select(document.graph)
+                self.select(graph,
+                            document: document)
             }
         }
         
         // when not holding CMD ...
         else {
-            document.visibleGraph.selectSingleCanvasItem(self,
-                                                         graphUI: graphUI)
+            graph.selectSingleCanvasItem(self,
+                                         document: document)
         }
         
         // if we tapped a node, we're no longer moving it
         document.graphMovement.draggedCanvasItem = nil
         
-        self.zIndex = document.visibleGraph.highestZIndex + 1
+        self.zIndex = graph.highestZIndex + 1
     }
 }

--- a/Stitch/Graph/Node/Util/NodeCreatedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeCreatedAction.swift
@@ -35,7 +35,7 @@ extension StitchDocumentViewModel {
     /// Only for insert-node-menu creation of nodes; shortcut key creation of nodes uses `viewPortCenter`
     @MainActor
     var newNodeCenterLocation: CGPoint {
-        if let doubleTapLocation = self.graphUI.doubleTapLocation {
+        if let doubleTapLocation = self.doubleTapLocation {
             log("newNodeCenterLocation: had doubleTapLocation: \(doubleTapLocation)")
             return adjustPositionToMultipleOf(doubleTapLocation)
         } else {
@@ -114,7 +114,7 @@ extension StitchDocumentViewModel {
     var viewPortCenter: CGPoint {
         let localPosition = self.graphMovement.localPosition
         let scale = self.graphMovement.zoomData
-        let viewPortFrame = self.graphUI.frame
+        let viewPortFrame = self.frame
         
         // Apply scale to the viewPort-centering
         let scaledViewPortFrame = CGPoint(
@@ -149,7 +149,7 @@ extension StitchDocumentViewModel {
         // self.graphUI.insertNodeMenuState.activeSelection = InsertNodeMenuState.allSearchOptions.first
 
         node.getAllCanvasObservers().forEach {
-            $0.parentGroupNodeId = self.graphUI.groupNodeFocused?.groupNodeId
+            $0.parentGroupNodeId = self.groupNodeFocused?.groupNodeId
         }
         self.visibleGraph.visibleNodesViewModel.nodes.updateValue(node, forKey: node.id)
         
@@ -216,7 +216,7 @@ extension StitchDocumentViewModel {
             self.visibleGraph.layersSidebarViewModel.resetEditModeSelections()
             self.visibleGraph.layersSidebarViewModel.sidebarItemSelectedViaEditMode(sidebarLayerData.id)
             self.visibleGraph.layersSidebarViewModel.selectionState.lastFocused = sidebarLayerData.id
-            self.visibleGraph.deselectAllCanvasItems(graphUI: graphUI)
+            self.visibleGraph.deselectAllCanvasItems()
             
             return layerNode
 

--- a/Stitch/Graph/Node/Util/NodeDeletedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeDeletedAction.swift
@@ -10,48 +10,51 @@ import SwiftUI
 import StitchSchemaKit
 
 // Used for Delete key shortcut
-struct DeleteShortcutKeyPressed: GraphEventWithResponse {
+struct DeleteShortcutKeyPressed: StitchDocumentEvent {
     
-    func handle(state: GraphState) -> GraphResponse {
-
+    func handle(state: StitchDocumentViewModel) {
+        let graph = state.visibleGraph
+        
         // Check which we have focused: layers or canvas items
-        if state.graphUI.isSidebarFocused {
-            state.layersSidebarViewModel.deleteSelectedItems()
-            state.updateInspectorFocusedLayers()
+        if state.isSidebarFocused {
+            graph.layersSidebarViewModel.deleteSelectedItems()
+            graph.updateInspectorFocusedLayers()
         }
         
         // If no layers actively selected, then assume canvas items may be selected
         else {
             
             // delete comment boxes
-            state.deleteSelectedCommentBoxes()
+            graph.deleteSelectedCommentBoxes()
 
             // delete nodes
-            state.selectedGraphNodesDeleted(
-                selectedNodes: state.selectedNodeIds)
+            graph.selectedGraphNodesDeleted(
+                selectedNodes: graph.selectedNodeIds)
         }
                 
-        return .shouldPersist
+        state.encodeProjectInBackground()
     }
 }
 
 // Used by Node Tag Menu 'delete' option
-struct SelectedGraphNodesDeleted: GraphEventWithResponse {
+struct SelectedGraphNodesDeleted: StitchDocumentEvent {
 
     var canvasItemId: CanvasItemId? // for when node tag menu opened via right-click
 
-    func handle(state: GraphState) -> GraphResponse {
+    func handle(state: StitchDocumentViewModel) {
+        let graph = state.visibleGraph
         
-        if state.selectedCanvasItems.isEmpty,
+        if graph.getSelectedCanvasItems(groupNodeFocused: state.groupNodeFocused?.groupNodeId).isEmpty,
            let canvasItemId = canvasItemId,
-           let canvasItem = state.getCanvasItem(canvasItemId) {
-            canvasItem.select(state)
+           let canvasItem = graph.getCanvasItem(canvasItemId) {
+            canvasItem.select(graph,
+                              document: state)
         }
 
-        state.selectedGraphNodesDeleted(
-            selectedNodes: state.selectedNodeIds)
+        graph.selectedGraphNodesDeleted(
+            selectedNodes: graph.selectedNodeIds)
 
-        return .shouldPersist
+        state.encodeProjectInBackground()
     }
 }
 

--- a/Stitch/Graph/Node/Util/NodeMediaUtils.swift
+++ b/Stitch/Graph/Node/Util/NodeMediaUtils.swift
@@ -204,13 +204,15 @@ extension NodeViewModel {
     @MainActor
     func getVisibleMediaObserver(inputCoordinate: NodeIOCoordinate,
                                  mediaId: UUID,
-                                 graph: GraphState) -> MediaViewModel? {
+                                 graph: GraphState,
+                                 activeIndex: ActiveIndex) -> MediaViewModel? {
         guard let rowObserver = self.getInputRowObserver(for: inputCoordinate.portType) else {
             fatalErrorIfDebug()
             return nil
         }
         
-        let loopIndex = rowObserver.getActiveLoopIndex(graph: graph)
+        let loopIndex = rowObserver.getActiveLoopIndex(graph: graph,
+                                                       activeIndex: activeIndex)
         return self.getInputMediaObserver(inputCoordinate: inputCoordinate,
                                           loopIndex: loopIndex,
                                           mediaId: mediaId)
@@ -220,13 +222,15 @@ extension NodeViewModel {
     @MainActor
     func getVisibleMediaObserver(outputPortId: Int,
                                  mediaId: UUID?,
-                                 graph: GraphState) -> MediaViewModel? {
+                                 graph: GraphState,
+                                 activeIndex: ActiveIndex) -> MediaViewModel? {
         guard let rowObserver = self.getOutputRowObserver(outputPortId) else {
             fatalErrorIfDebug()
             return nil
         }
         
-        let loopIndex = rowObserver.getActiveLoopIndex(graph: graph)
+        let loopIndex = rowObserver.getActiveLoopIndex(graph: graph,
+                                                       activeIndex: activeIndex)
         return self.getComputedMediaObserver(loopIndex: loopIndex,
                                              mediaId: mediaId)
     }
@@ -317,8 +321,9 @@ extension NodeViewModel {
 
 extension NodeRowObserver {
     @MainActor
-    func getActiveLoopIndex(graph: GraphState) -> Int {
-        graph.activeIndex.adjustedIndex(self.allLoopedValues.count)
+    func getActiveLoopIndex(graph: GraphState,
+                            activeIndex: ActiveIndex) -> Int {
+        activeIndex.adjustedIndex(self.allLoopedValues.count)
     }
 }
 

--- a/Stitch/Graph/Node/View/CanvasItemPositionHandler.swift
+++ b/Stitch/Graph/Node/View/CanvasItemPositionHandler.swift
@@ -61,7 +61,8 @@ struct CanvasItemPositionHandler: ViewModifier {
                         } else {
                             document.visibleGraph.canvasItemMoved(for: node,
                                                                   translation: gesture.translation,
-                                                                  wasDrag: true)
+                                                                  wasDrag: true,
+                                                                  document: document)
                         }
                     }
                         .onEnded { _ in

--- a/Stitch/Graph/Node/View/NodeTag/NodeTagMenuButtonsView.swift
+++ b/Stitch/Graph/Node/View/NodeTag/NodeTagMenuButtonsView.swift
@@ -16,7 +16,6 @@ struct NodeTagMenuButtonsView: View {
     @Environment(StitchStore.self) private var store
     
     @Bindable var graph: GraphState
-    @Bindable var graphUI: GraphUIState
     @Bindable var document: StitchDocumentViewModel
     @Bindable var node: NodeViewModel
 
@@ -40,10 +39,15 @@ struct NodeTagMenuButtonsView: View {
     var _loopIndices: [Int] {
         loopIndices ?? self.node.getLoopIndices()
     }
+    
+    var graphUI: StitchDocumentViewModel {
+        self.document
+    }
 
     @MainActor
     var moreThanOneNodeSelected: Bool {
-        graph.selectedCanvasItems.count > 1
+        graph.getSelectedCanvasItems(groupNodeFocused: document.groupNodeFocused?.groupNodeId)
+            .count > 1
     }
 
     @MainActor
@@ -210,7 +214,7 @@ struct NodeTagMenuButtonsView: View {
            let assignedBroadcaster = node.currentBroadcastChoiceId {
             nodeTagMenuButton(label: "Jump to Assigned Broadcaster") {
                 graph.jumpToCanvasItem(id: .node(assignedBroadcaster),
-                                       graphUI: graphUI)
+                                       document: document)
             }
         }
     }
@@ -398,7 +402,7 @@ struct NodeTagMenuButtonsView: View {
         return nodeTagMenuButton(label: visitLabel) {
             if let nodeId = canvasItemId.nodeCase {
                 graph.groupNodeDoubleTapped(id: nodeId,
-                                            graphUI: graphUI)
+                                            document: document)
             }
         }
     }

--- a/Stitch/Graph/Node/View/NodeTag/NodeWirelessBroadcastSubmenuView.swift
+++ b/Stitch/Graph/Node/View/NodeTag/NodeWirelessBroadcastSubmenuView.swift
@@ -21,6 +21,7 @@ let nilBroadcastChoice = BroadcastChoice(
 struct NodeWirelessBroadcastSubmenuView: View {
 
     @Bindable var graph: GraphState
+    @Bindable var document: StitchDocumentViewModel
     
     @State var currentBroadcastChoice: BroadcastChoice
         
@@ -30,10 +31,12 @@ struct NodeWirelessBroadcastSubmenuView: View {
 
     // TODO: Picker's selection state (the checkmark) is incorrect; and .onChange for a manually passed in input value completely breaks Picker's selection state; and this explicit `init` does not help either
     init(graph: GraphState,
+         document: StitchDocumentViewModel,
          currentBroadcastChoice: BroadcastChoice,
          nodeId: NodeId,
          forNodeTitle: Bool = false) {
         self.graph = graph
+        self.document = document
         self.currentBroadcastChoice = currentBroadcastChoice
         self.nodeId = nodeId
         self.forNodeTitle = forNodeTitle
@@ -44,7 +47,7 @@ struct NodeWirelessBroadcastSubmenuView: View {
     @MainActor
     var choices: [BroadcastChoice] {
         [nilBroadcastChoice] + self.graph
-            .getBroadcasterNodesAtThisTraversalLevel()
+            .getBroadcasterNodesAtThisTraversalLevel(document: document)
             // Sort alphabetically
             .sorted(by: { $0.displayTitle < $1.displayTitle })
             .map { .init(title: $0.displayTitle, id: $0.id) }

--- a/Stitch/Graph/Node/View/NodeView.swift
+++ b/Stitch/Graph/Node/View/NodeView.swift
@@ -14,7 +14,6 @@ struct NodeView<InputsViews: View, OutputsViews: View>: View {
     @Bindable var stitch: NodeViewModel
     @Bindable var document: StitchDocumentViewModel
     @Bindable var graph: GraphState
-    @Bindable var graphUI: GraphUIState
     let nodeId: NodeId
     let isSelected: Bool
     let atleastOneCommentBoxSelected: Bool
@@ -70,7 +69,6 @@ struct NodeView<InputsViews: View, OutputsViews: View>: View {
             // Catalyst right-click to open node tag menu
                 .contextMenu {
                     NodeTagMenuButtonsView(graph: graph,
-                                           graphUI: graphUI,
                                            document: document,
                                            node: stitch,
                                            canvasItemId: node.id,
@@ -84,7 +82,6 @@ struct NodeView<InputsViews: View, OutputsViews: View>: View {
                 .modifier(
                     NodeViewTapGestureModifier(graph: graph,
                                                document: document,
-                                               graphUI: graphUI,
                                                stitch: stitch,
                                                node: node)
                 )
@@ -100,7 +97,6 @@ struct NodeView<InputsViews: View, OutputsViews: View>: View {
                     if isSelected {
                         CanvasItemTag(node: node,
                                       graph: graph,
-                                      graphUI: graphUI,
                                       document: document,
                                       stitch: stitch,
                                       activeGroupId: activeGroupId,
@@ -156,7 +152,6 @@ struct NodeView<InputsViews: View, OutputsViews: View>: View {
         HStack {
             CanvasItemTitleView(document: document,
                                 graph: graph,
-                                graphUI: graphUI,
                                 node: stitch,
                                 canvasItem: node,
                                 isCanvasItemSelected: isSelected)
@@ -278,7 +273,6 @@ struct CanvasItemBackground: ViewModifier {
 struct CanvasItemTag: View {
     @Bindable var node: CanvasItemViewModel
     @Bindable var graph: GraphState
-    @Bindable var graphUI: GraphUIState
     @Bindable var document: StitchDocumentViewModel
     @Bindable var stitch: NodeViewModel
     let activeGroupId: GroupNodeType?
@@ -289,7 +283,6 @@ struct CanvasItemTag: View {
     
     @ViewBuilder var nodeTagMenu: NodeTagMenuButtonsView {
         NodeTagMenuButtonsView(graph: graph,
-                               graphUI: graphUI,
                                document: document,
                                node: stitch,
                                canvasItemId: node.id,
@@ -348,7 +341,6 @@ struct NodeViewTapGestureModifier: ViewModifier {
     
     let graph: GraphState
     let document: StitchDocumentViewModel
-    let graphUI: GraphUIState
     let stitch: NodeViewModel
     let node: CanvasItemViewModel
     
@@ -359,18 +351,17 @@ struct NodeViewTapGestureModifier: ViewModifier {
     func onSingleTap() {
         // deselect any fields; NOTE: not used on GroupNodes due to .simultaneousGesture
         if !self.stitch.kind.isGroup,
-           graphUI.reduxFocusedField != nil {
-            graphUI.reduxFocusedField = nil
+           document.reduxFocusedField != nil {
+            document.reduxFocusedField = nil
         }
         
         // and select just the node
-        node.isTapped(document: document,
-                      graphUI: graphUI)
+        node.isTapped(document: document)
     }
     
     func onDoubleTap() {
         graph.groupNodeDoubleTapped(id: stitch.id,
-                                    graphUI: graphUI)
+                                    document: document)
     }
     
     func body(content: Content) -> some View {

--- a/Stitch/Graph/Node/View/NodeViewType.swift
+++ b/Stitch/Graph/Node/View/NodeViewType.swift
@@ -15,7 +15,6 @@ struct NodeTypeView: View {
     
     @Bindable var document: StitchDocumentViewModel
     @Bindable var graph: GraphState
-    @Bindable var graphUI: GraphUIState
     @Bindable var node: NodeViewModel
     @Bindable var canvasNode: CanvasItemViewModel
     let atleastOneCommentBoxSelected: Bool
@@ -47,7 +46,6 @@ struct NodeTypeView: View {
                  stitch: node,
                  document: document,
                  graph: graph,
-                 graphUI: graphUI,
                  nodeId: node.id,
                  isSelected: isSelected,
                  atleastOneCommentBoxSelected: atleastOneCommentBoxSelected,
@@ -74,13 +72,12 @@ struct NodeTypeView: View {
                spacing: SPACING_BETWEEN_NODE_ROWS) {
             if self.node.patch == .wirelessReceiver {
                 WirelessPortView(graph: graph,
-                                 graphUI: graphUI,
+                                 graphUI: document,
                                  isOutput: false,
                                  id: node.id)
                     .padding(.trailing, NODE_BODY_SPACING)
             } else {
                 DefaultNodeInputView(graph: graph,
-                                     graphUI: graphUI,
                                      document: document,
                                      node: node,
                                      canvas: canvasNode,
@@ -96,13 +93,12 @@ struct NodeTypeView: View {
 
             if self.node.patch == .wirelessBroadcaster {
                 WirelessPortView(graph: graph,
-                                 graphUI: graphUI,
+                                 graphUI: document,
                                  isOutput: true,
                                  id: node.id)
                     .padding(.leading, NODE_BODY_SPACING)
             } else {
                 DefaultNodeOutputView(graph: graph,
-                                      graphUI: graphUI,
                                       document: document,
                                       node: node,
                                       canvas: canvasNode,
@@ -115,7 +111,6 @@ struct NodeTypeView: View {
 struct DefaultNodeInputView: View {
     
     @Bindable var graph: GraphState
-    @Bindable var graphUI: GraphUIState
     @Bindable var document: StitchDocumentViewModel
     @Bindable var node: NodeViewModel
     @Bindable var canvas: CanvasItemViewModel
@@ -139,7 +134,7 @@ struct DefaultNodeInputView: View {
                                     rowViewModel: rowViewModel)
                     
                     NodeInputView(graph: graph,
-                                  graphUI: graphUI,
+                                  graphUI: document,
                                   node: node,
                                   hasIncomingEdge: rowObserver.upstreamOutputCoordinate.isDefined,
                                   rowObserver: rowObserver,
@@ -154,6 +149,7 @@ struct DefaultNodeInputView: View {
                                   isCanvasItemSelected: isNodeSelected,
                                   label: rowObserver
                         .label(node: node,
+                               currentTraversalLevel: document.groupNodeFocused?.groupNodeId,
                                graph: graph)
                     )
                 }
@@ -165,7 +161,6 @@ struct DefaultNodeInputView: View {
 struct DefaultNodeOutputView: View {
     
     @Bindable var graph: GraphState
-    @Bindable var graphUI: GraphUIState
     @Bindable var document: StitchDocumentViewModel
     @Bindable var node: NodeViewModel
     @Bindable var canvas: CanvasItemViewModel
@@ -180,7 +175,7 @@ struct DefaultNodeOutputView: View {
             if let rowObserver = node.getOutputRowObserver(for: rowViewModel.id.portType) {
                 HStack {
                     NodeOutputView(graph: graph,
-                                   graphUI: graphUI,
+                                   graphUI: document,
                                    node: node,
                                    rowObserver: rowObserver,
                                    rowViewModel: rowViewModel,
@@ -191,6 +186,7 @@ struct DefaultNodeOutputView: View {
                                    isCanvasItemSelected: isNodeSelected,
                                    label: rowObserver
                         .label(node: node,
+                               currentTraversalLevel: document.groupNodeFocused?.groupNodeId,
                                graph: graph)
                     )
                     
@@ -201,6 +197,7 @@ struct DefaultNodeOutputView: View {
                 }
                 .modifier(EdgeEditModeOutputHoverViewModifier(
                     graph: graph,
+                    document: document,
                     outputCoordinate: .init(portId: rowViewModel.id.portId,
                                             canvasId: canvas.id)))
             }

--- a/Stitch/Graph/Node/View/NodesOnlyView.swift
+++ b/Stitch/Graph/Node/View/NodesOnlyView.swift
@@ -13,19 +13,18 @@ struct NodesOnlyView: View {
     
     @Bindable var document: StitchDocumentViewModel
     @Bindable var graph: GraphState
-    @Bindable var graphUI: GraphUIState
     @Bindable var nodePageData: NodePageData
     
     var selection: GraphUISelectionState {
-        graphUI.selection
+        graph.selection
     }
     
     var activeIndex: ActiveIndex {
-        graphUI.activeIndex
+        document.activeIndex
     }
     
     var focusedGroup: GroupNodeType? {
-        self.graphUI.groupNodeFocused
+        document.groupNodeFocused
     }
     
     func refreshCanvasNodes() {
@@ -76,13 +75,12 @@ struct NodesOnlyView: View {
                 NodeTypeView(
                     document: document,
                     graph: graph,
-                    graphUI: graphUI,
                     node: canvasNode.nodeDelegate ?? .init(),
                     canvasNode: canvasNode,
                     atleastOneCommentBoxSelected: selection.selectedCommentBoxes.count >= 1,
                     activeIndex: activeIndex,
-                    groupNodeFocused: graphUI.groupNodeFocused,
-                    isSelected: graphUI.selection.selectedNodeIds.contains(canvasNode.id)
+                    groupNodeFocused: document.groupNodeFocused,
+                    isSelected: graph.selection.selectedNodeIds.contains(canvasNode.id)
                 )
             }
         }

--- a/Stitch/Graph/Node/View/StitchUIScrollHelpers.swift
+++ b/Stitch/Graph/Node/View/StitchUIScrollHelpers.swift
@@ -15,8 +15,8 @@ struct SetGraphScrollDataUponPageChange: GraphEvent {
     func handle(state: GraphState) {
         //        log("SetGraphScrollDataUponPageChange: newPageLocalPosition: \(newPageLocalPosition)")
         //        log("SetGraphScrollDataUponPageChange: newPageZoom: \(newPageZoom)")
-        state.graphUI.canvasPageOffsetChanged = newPageLocalPosition
-        state.graphUI.canvasPageZoomScaleChanged = newPageZoom
+        state.canvasPageOffsetChanged = newPageLocalPosition
+        state.canvasPageZoomScaleChanged = newPageZoom
         
         /*
          Set all nodes visible for the field updates, since when we enter the new traversal level

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
@@ -416,17 +416,17 @@ extension NodeViewModel {
     func getInputRowObserver(_ portId: Int) -> InputNodeRowObserver? {
         self.inputsObservers[safe: portId]
     }
-    
-    @MainActor
-    func getInputActivePortValue(for layerInputType: LayerInputPort) -> PortValue? {
-        guard let layerNode = self.layerNode else {
-            fatalErrorIfDebug()
-            return nil
-        }
-        
-        let portObserver = layerNode[keyPath: layerInputType.layerNodeKeyPath]
-        return portObserver.activeValue
-    }
+//    
+//    @MainActor
+//    func getInputActivePortValue(for layerInputType: LayerInputPort) -> PortValue? {
+//        guard let layerNode = self.layerNode else {
+//            fatalErrorIfDebug()
+//            return nil
+//        }
+//        
+//        let portObserver = layerNode[keyPath: layerInputType.layerNodeKeyPath]
+//        return portObserver.activeValue
+//    }
     
     @MainActor
     func getOutputRowObserver(for portType: NodeIOPortType) -> OutputNodeRowObserver? {
@@ -579,11 +579,6 @@ extension NodeViewModel {
     }
     
     @MainActor
-    var activeIndex: ActiveIndex {
-        graphDelegate?.activeIndex ?? .init(.zero)
-    }
-    
-    @MainActor
     var getMathExpression: String? {
         self.patchNode?.mathExpression
     }
@@ -694,7 +689,7 @@ extension NodeViewModel {
     @MainActor
     func activeIndexChanged(activeIndex: ActiveIndex) {
         self.getAllInputsObservers().forEach { observer in
-            let oldValue = observer.activeValue
+            let oldValue = observer.getActiveValue(activeIndex: activeIndex)
             let newValue = PortValue
                 .getActiveValue(allLoopedValues: observer.allLoopedValues,
                                 activeIndex: activeIndex)
@@ -705,7 +700,7 @@ extension NodeViewModel {
         }
 
         self.getAllOutputsObservers().forEach { observer in
-            let oldValue = observer.activeValue
+            let oldValue = observer.getActiveValue(activeIndex: activeIndex)
             let newValue = PortValue
                 .getActiveValue(allLoopedValues: observer.allLoopedValues,
                                 activeIndex: activeIndex)

--- a/Stitch/Graph/PrototypePreview/Frame/View/FloatingWindowView.swift
+++ b/Stitch/Graph/PrototypePreview/Frame/View/FloatingWindowView.swift
@@ -204,7 +204,7 @@ struct FloatingWindowView: View {
     
     var finalXOffset: CGFloat {
         
-        return document.graphUI.showsLayerInspector ? Self.xOffset - LayerInspectorView.LAYER_INSPECTOR_WIDTH : Self.xOffset
+        return document.showsLayerInspector ? Self.xOffset - LayerInspectorView.LAYER_INSPECTOR_WIDTH : Self.xOffset
         
         //        if showPreviewWindow {
         //            // Original

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonModifierWithoutFrame.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonModifierWithoutFrame.swift
@@ -110,7 +110,7 @@ struct PreviewCommonModifierWithoutFrame: ViewModifier {
                 viewModel: layerViewModel,
                 isPinnedViewRendering: isPinnedViewRendering,
                 nodeId: interactiveLayer.id.layerNodeId,
-                highlightedSidebarLayers: document.graphUI.highlightedSidebarLayers,
+                highlightedSidebarLayers: graph.highlightedSidebarLayers,
                 scale: scale))
         
             .modifier(PreviewLayerRotationModifier(

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
@@ -157,7 +157,7 @@ struct PreviewGroupLayer: View {
                 viewModel: layerViewModel,
                 isPinnedViewRendering: isPinnedViewRendering,
                 nodeId: interactiveLayer.id.layerNodeId,
-                highlightedSidebarLayers: document.graphUI.highlightedSidebarLayers,
+                highlightedSidebarLayers: graph.highlightedSidebarLayers,
                 scale: scale))
                         
         // .clipped modifier should come before the offset/position modifier,

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewShapeLayer.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewShapeLayer.swift
@@ -81,7 +81,7 @@ struct PreviewShapeLayer: View {
                     viewModel: layerViewModel,
                     isPinnedViewRendering: isPinnedViewRendering,
                     nodeId: interactiveLayer.id.layerNodeId,
-                    highlightedSidebarLayers: document.graphUI.highlightedSidebarLayers,
+                    highlightedSidebarLayers: graph.highlightedSidebarLayers,
                     scale: scale))
             // order of .blur vs other modiifers doesn't matter?
                 .blur(radius: blurRadius)

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/TextField/PreviewTextFieldLayerUtils.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/TextField/PreviewTextFieldLayerUtils.swift
@@ -12,9 +12,7 @@ struct ReduxFieldFocused: StitchDocumentEvent {
     let focusedField: FocusedUserEditField
 
     func handle(state: StitchDocumentViewModel) {
-        state.visibleGraph
-            .reduxFieldFocused(focusedField: focusedField,
-                               graphUI: state.graphUI)
+        state.reduxFieldFocused(focusedField: focusedField)
     }
 }
 
@@ -56,33 +54,25 @@ extension FocusedUserEditField {
     }
 }
 
-//extension GraphUIState {
-extension GraphState {
+extension StitchDocumentViewModel {
     @MainActor
-    func reduxFieldFocused(focusedField: FocusedUserEditField,
-                           graphUI: GraphUIState) {
+    func reduxFieldFocused(focusedField: FocusedUserEditField) {
         log("reduxFieldFocused: focusedField: \(focusedField)")
-        log("reduxFieldFocused: self.graphUI.reduxFocusedField was: \(graphUI.reduxFocusedField)")
-        if graphUI.reduxFocusedField != focusedField {
-            graphUI.reduxFocusedField = focusedField
+        log("reduxFieldFocused: self.graphUI.reduxFocusedField was: \(self.reduxFocusedField)")
+        let graph = self.visibleGraph
+        
+        if self.reduxFocusedField != focusedField {
+            self.reduxFocusedField = focusedField
         }
         
         // if we selected a canvas item, we also thereby selected it:
         if let canvasItemId = focusedField.canvasFieldId {
-            self.getCanvasItem(canvasItemId)?.select(self)
+            graph.getCanvasItem(canvasItemId)?
+                .select(graph,
+                        document: self)
         }
     }
-}
-
-struct ReduxFieldDefocused: GraphUIEvent {
-    let focusedField: FocusedUserEditField
     
-    func handle(state: GraphUIState) {
-        state.reduxFieldDefocused(focusedField: focusedField)
-    }
-}
-
-extension GraphUIState {
     @MainActor
     func reduxFieldDefocused(focusedField: FocusedUserEditField) {
         log("reduxFieldDefocused: focusedField: \(focusedField)")
@@ -90,6 +80,14 @@ extension GraphUIState {
         if self.reduxFocusedField == focusedField {
             self.reduxFocusedField = nil
         }
+    }
+}
+
+struct ReduxFieldDefocused: StitchDocumentEvent {
+    let focusedField: FocusedUserEditField
+    
+    func handle(state: StitchDocumentViewModel) {
+        state.reduxFieldDefocused(focusedField: focusedField)
     }
 }
 

--- a/Stitch/Graph/Sidebar/Util/Gesture/LegacySidebarActions.swift
+++ b/Stitch/Graph/Sidebar/Util/Gesture/LegacySidebarActions.swift
@@ -15,7 +15,7 @@ extension ProjectSidebarObservable {
     @MainActor
     func sidebarListItemLongPressed(itemId: Self.ItemID) {
         self.currentItemDragged = itemId
-        self.graphDelegate?.isSidebarFocused = true
+        self.graphDelegate?.documentDelegate?.isSidebarFocused = true
     }
 
     // Function to find the set item whose index in the list is the smallest
@@ -69,7 +69,8 @@ extension ProjectSidebarObservable {
                                 translation: CGSize) {
         
         // log("SidebarListItemDragged called: item \(itemId) ")
-        guard let graph = self.graphDelegate else {
+        guard let graph = self.graphDelegate,
+              let document = graph.documentDelegate else {
             fatalErrorIfDebug()
             return
         }
@@ -80,7 +81,7 @@ extension ProjectSidebarObservable {
         var draggedItem = item
         
         // Focus sidebar
-        graph.isSidebarFocused = true
+        document.isSidebarFocused = true
         
         // TODO: debug and reintroduce option-duge drag in sidebar
 //        if state.selectionState.optionDragInProgress {

--- a/Stitch/Graph/Sidebar/Util/Gesture/SidebarListItemActions.swift
+++ b/Stitch/Graph/Sidebar/Util/Gesture/SidebarListItemActions.swift
@@ -8,7 +8,7 @@
 import Foundation
 import StitchSchemaKit
 
-extension GraphUIState {
+extension GraphState {
     @MainActor
     func sidebarLayerHovered(layerId: LayerNodeId) {
         self.highlightedSidebarLayers.insert(layerId)

--- a/Stitch/Graph/Sidebar/Util/LayerGrouping/LayerGroupFit.swift
+++ b/Stitch/Graph/Sidebar/Util/LayerGrouping/LayerGroupFit.swift
@@ -17,111 +17,113 @@ import SwiftUI
 import StitchSchemaKit
 
 extension GraphState {
-    // create the group fitting first,
-    // then apply the position offset to all the children
-    @MainActor
-    func getLayerGroupFit(_ selectedNodes: NodeIdSet,
-                          parentSize: CGSize) -> LayerGroupFit {
-        
-        var north: CGFloat = .zero
-        var south: CGFloat = .zero
-        var west: CGFloat = .zero
-        var east: CGFloat = .zero
-        
-        var northAdjustment: CGFloat?
-        var westAdjustment: CGFloat?
-        
-        // TODO: should be ADJUSTED active-index
-        
-        for selectedId in selectedNodes {
-            
-            // Must compare against "absolute size",
-            // ie the layer's size after parentSize and layer's own scale
-            // have been taken into account.
-            guard let layerNode = self.getNodeViewModel(selectedId)?.layerNode,
-                  let layerSize = layerNode.scaledLayerSize(for: selectedId,
-                                                            parentSize: parentSize,
-                                                            activeIndex: self.activeIndex),
-                  let layerPosition = layerNode.layerPosition(activeIndex) else {
-                log("getLayerGroupFit: could not get layerSize or layerPosition for node \(selectedId)")
-                continue
-            }
-
-            let layerNorth = layerPosition.y - layerSize.id.height/2
-            if layerNorth.magnitude > north.magnitude {
-                north = layerNorth
-                
-                // Use the position of the
-                // northernmost layer for our north-adjustment;
-                // but only if position is negative.
-                if layerPosition.y < 0 {
-                    northAdjustment = layerPosition.y.magnitude
-                }
-            }
-            
-            let layerSouth = layerPosition.y + layerSize.id.height/2
-            if layerSouth.magnitude > south.magnitude {
-                south = layerSouth
-            }
-            
-            let layerWest = layerPosition.x - layerSize.id.width/2
-            if layerWest.magnitude > west.magnitude {
-                west = layerWest
-                
-                // Use the position of the
-                // westernmost layer for our west-adjustment;
-                // but only if position is negative.
-                if layerPosition.x < 0 {
-                    westAdjustment = layerPosition.x.magnitude
-                }
-            }
-            
-            let layerEast = layerPosition.x + layerSize.id.width/2
-            if layerEast.magnitude > east.magnitude {
-                east = layerEast
-            }
-        }
-        
-        let height = abs(north) + abs(south)
-        let width = abs(west) + abs(east)
-        
-        let groupSize = LayerSize(width: width, height: height)
-        
-        // Group position and adjustment are non-zero only when
-        // some child is north and/or west (ie -y and/or -x positions).
-        let groupPosition = CGPoint(
-            x: westAdjustment.map(\.flipSign) ?? .zero,
-            y: northAdjustment.map(\.flipSign) ?? .zero)
-        
-        // Always either .zero or positive
-        let adjustment = CGSize(width: westAdjustment ?? .zero,
-                                height: northAdjustment ?? .zero)
-        
-        return .init(groupSize, groupPosition, adjustment)
-    }
+//    // create the group fitting first,
+//    // then apply the position offset to all the children
+//    @MainActor
+//    func getLayerGroupFit(_ selectedNodes: NodeIdSet,
+//                          parentSize: CGSize,
+//                          activeIndex: ActiveIndex) -> LayerGroupFit {
+//        
+//        var north: CGFloat = .zero
+//        var south: CGFloat = .zero
+//        var west: CGFloat = .zero
+//        var east: CGFloat = .zero
+//        
+//        var northAdjustment: CGFloat?
+//        var westAdjustment: CGFloat?
+//        
+//        // TODO: should be ADJUSTED active-index
+//        
+//        for selectedId in selectedNodes {
+//            
+//            // Must compare against "absolute size",
+//            // ie the layer's size after parentSize and layer's own scale
+//            // have been taken into account.
+//            guard let layerNode = self.getNodeViewModel(selectedId)?.layerNode,
+//                  let layerSize = layerNode.scaledLayerSize(for: selectedId,
+//                                                            parentSize: parentSize,
+//                                                            activeIndex: activeIndex),
+//                  let layerPosition = layerNode.layerPosition(activeIndex) else {
+//                log("getLayerGroupFit: could not get layerSize or layerPosition for node \(selectedId)")
+//                continue
+//            }
+//
+//            let layerNorth = layerPosition.y - layerSize.id.height/2
+//            if layerNorth.magnitude > north.magnitude {
+//                north = layerNorth
+//                
+//                // Use the position of the
+//                // northernmost layer for our north-adjustment;
+//                // but only if position is negative.
+//                if layerPosition.y < 0 {
+//                    northAdjustment = layerPosition.y.magnitude
+//                }
+//            }
+//            
+//            let layerSouth = layerPosition.y + layerSize.id.height/2
+//            if layerSouth.magnitude > south.magnitude {
+//                south = layerSouth
+//            }
+//            
+//            let layerWest = layerPosition.x - layerSize.id.width/2
+//            if layerWest.magnitude > west.magnitude {
+//                west = layerWest
+//                
+//                // Use the position of the
+//                // westernmost layer for our west-adjustment;
+//                // but only if position is negative.
+//                if layerPosition.x < 0 {
+//                    westAdjustment = layerPosition.x.magnitude
+//                }
+//            }
+//            
+//            let layerEast = layerPosition.x + layerSize.id.width/2
+//            if layerEast.magnitude > east.magnitude {
+//                east = layerEast
+//            }
+//        }
+//        
+//        let height = abs(north) + abs(south)
+//        let width = abs(west) + abs(east)
+//        
+//        let groupSize = LayerSize(width: width, height: height)
+//        
+//        // Group position and adjustment are non-zero only when
+//        // some child is north and/or west (ie -y and/or -x positions).
+//        let groupPosition = CGPoint(
+//            x: westAdjustment.map(\.flipSign) ?? .zero,
+//            y: northAdjustment.map(\.flipSign) ?? .zero)
+//        
+//        // Always either .zero or positive
+//        let adjustment = CGSize(width: westAdjustment ?? .zero,
+//                                height: northAdjustment ?? .zero)
+//        
+//        return .init(groupSize, groupPosition, adjustment)
+//    }
+//    
+//    // The adjustment is only for 'NW' displacement;
+//    // ie we ALWAYS add the displacement to the group's children's positions,
+//    // (whereas we always SUBTRACT the displacement from the group's positions).
+//    @MainActor
+//    func adjustGroupChildrenToLayerFit(_ layerFit: LayerGroupFit,
+//                                       _ selectedNodes: NodeIdSet) {
+//        selectedNodes.forEach {
+//            self.updateLayerNodePositionInput(
+//                nodeId: $0,
+//                offset: layerFit.childAdjustment)
+//        }
+//    }
     
-    // The adjustment is only for 'NW' displacement;
-    // ie we ALWAYS add the displacement to the group's children's positions,
-    // (whereas we always SUBTRACT the displacement from the group's positions).
-    @MainActor
-    func adjustGroupChildrenToLayerFit(_ layerFit: LayerGroupFit,
-                                       _ selectedNodes: NodeIdSet) {
-        selectedNodes.forEach {
-            self.updateLayerNodePositionInput(
-                nodeId: $0,
-                offset: layerFit.childAdjustment)
-        }
-    }
-    
-    @MainActor
-    func updateLayerNodePositionInput(nodeId: NodeId,
-                                      offset: CGSize) {
-        guard let node = self.getNodeViewModel(id) else {
-            log("updateLayerNodePositionInput: called for layer that did not have position", .logToServer)
-            return
-        }
-        
-        node.updateLayerNodePositionInput(offset: offset,
-                                          activeIndex: self.activeIndex)
-    }
+//    @MainActor
+//    func updateLayerNodePositionInput(nodeId: NodeId,
+//                                      offset: CGSize,
+//                                      activeIndex: ActiveIndex) {
+//        guard let node = self.getNodeViewModel(id) else {
+//            log("updateLayerNodePositionInput: called for layer that did not have position", .logToServer)
+//            return
+//        }
+//        
+//        node.updateLayerNodePositionInput(offset: offset,
+//                                          activeIndex: activeIndex)
+//    }
 }

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarGroupCreated.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarGroupCreated.swift
@@ -61,7 +61,7 @@ extension LayersSidebarViewModel {
         self.selectionState.resetEditModeSelections()
         self.sidebarItemSelectedViaEditMode(newNode.id)
         self.selectionState.lastFocused = newNode.id
-        self.graphDelegate?.deselectAllCanvasItems(graphUI: graph.graphUI)
+        graph.deselectAllCanvasItems()
         
         // NOTE: must do this AFTER children have been assigned to the new layer node; else we return preview window size
         

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
@@ -98,7 +98,7 @@ extension ProjectSidebarObservable {
                 
                 self.editModeSelectTappedItems(tappedItems: self.selectionState.primary)
                 
-                graph.deselectAllCanvasItems(graphUI: graphUI)
+                graph.deselectAllCanvasItems()
                 
             } else {
                 // log("sidebarItemTapped: did not have itemsBetween")
@@ -114,7 +114,7 @@ extension ProjectSidebarObservable {
                     
                     self.editModeSelectTappedItems(tappedItems: self.selectionState.primary)
                     
-                    graph.deselectAllCanvasItems(graphUI: graphUI)
+                    graph.deselectAllCanvasItems()
                 }
             }
         }
@@ -139,7 +139,7 @@ extension ProjectSidebarObservable {
                 self.selectionState.primary.insert(id)
                 self.sidebarItemSelectedViaEditMode(id)
                 self.selectionState.lastFocused = id
-                graph.deselectAllCanvasItems(graphUI: graphUI)
+                graph.deselectAllCanvasItems()
             }
             
         } else {
@@ -151,13 +151,13 @@ extension ProjectSidebarObservable {
             self.selectionState.primary = .init([id])
             self.sidebarItemSelectedViaEditMode(id)
             self.selectionState.lastFocused = id
-            graph.deselectAllCanvasItems(graphUI: graphUI)
+            graph.deselectAllCanvasItems()
         }
         
         graph.updateInspectorFocusedLayers()
         
         // Reset selected row in property sidebar when focused-layers changes
-        graphUI.propertySidebar.selectedProperty = nil
+        graph.propertySidebar.selectedProperty = nil
     }
 }
 

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarSelectedItemsDuplicated.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarSelectedItemsDuplicated.swift
@@ -8,20 +8,22 @@
 import Foundation
 
 // TODO: what happens if you duplicate a video layer node?
-struct SidebarSelectedItemsDuplicated: GraphEventWithResponse {
+struct SidebarSelectedItemsDuplicated: StitchDocumentEvent {
 
-    func handle(state: GraphState) -> GraphResponse {
-        state.sidebarSelectedItemsDuplicated()
-        return .persistenceResponse
+    func handle(state: StitchDocumentViewModel) {
+        state.visibleGraph.sidebarSelectedItemsDuplicated(document: state)
+        state.encodeProjectInBackground()
     }
 }
 
 extension GraphState {
     @MainActor
-    func sidebarSelectedItemsDuplicated(isOptionDrag: Bool = false) {
+    func sidebarSelectedItemsDuplicated(isOptionDrag: Bool = false,
+                                        document: StitchDocumentViewModel) {
         let nodeIds = self.layersSidebarViewModel.selectionState.primary
         self.copyAndPasteSelectedNodes(selectedNodeIds: nodeIds,
-                                       isOptionDragInSidebar: isOptionDrag)
+                                       isOptionDragInSidebar: isOptionDrag,
+                                       document: document)
         
         // Move nodes
     }

--- a/Stitch/Graph/Sidebar/Util/SidebarIcons.swift
+++ b/Stitch/Graph/Sidebar/Util/SidebarIcons.swift
@@ -39,7 +39,7 @@ extension SidebarItemGestureViewModel {
     
     @MainActor var sidebarLeftSideIcon: String {
         guard let layerNode = self.graphDelegate?.getNodeViewModel(id)?.layerNode,
-              let activeIndex = self.graphDelegate?.activeIndex else {
+              let activeIndex = self.graphDelegate?.documentDelegate?.activeIndex else {
 //            fatalErrorIfDebug()
             return "oval"
         }

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
@@ -165,7 +165,8 @@ final class SidebarListGestureRecognizer<SidebarViewModel: ProjectSidebarObserva
     @objc func tapInView(_ gestureRecognizer: UITapGestureRecognizer) {
         guard let sidebarViewModel = self.sidebarViewModel,
               let gestureViewModel = self.gestureViewModel,
-              let graph = self.sidebarViewModel?.graphDelegate else { return }
+              let graph = self.sidebarViewModel?.graphDelegate,
+              let doucment = graph.documentDelegate else { return }
         
         if sidebarViewModel.isEditing || gestureViewModel.swipeSetting == .open {
             return
@@ -175,7 +176,7 @@ final class SidebarListGestureRecognizer<SidebarViewModel: ProjectSidebarObserva
                                                  shiftHeld: self.shiftHeldDown,
                                                  commandHeld: self.commandHeldDown,
                                                  graph: graph,
-                                                 graphUI: graph.graphUI)
+                                                 graphUI: doucment)
     }
     
     // finger on screen
@@ -268,13 +269,14 @@ final class SidebarListGestureRecognizer<SidebarViewModel: ProjectSidebarObserva
     
     func contextMenuInteraction(_ interaction: UIContextMenuInteraction,
                                 configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
-        guard let graph = self.graph else {
+        guard let graph = self.graph,
+              let document = graph.documentDelegate else {
             return nil
         }
         return self.gestureViewModel?
             .contextMenuInteraction(itemId: self.itemId,
                                     graph: graph,
-                                    graphUI: graph.graphUI)
+                                    graphUI: document)
     }
 }
 

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeView.swift
@@ -79,14 +79,16 @@ struct SidebarListItemSwipeView<SidebarViewModel>: View where SidebarViewModel: 
             theme.fontColor
                 .opacity(backgroundOpacity)
         }
-        .onHover { [weak gestureViewModel] hovering in
+        .onHover { [weak gestureViewModel, weak graph] hovering in
             // MARK: - SUPER DUPER IMPORTANT TO WEAKLY REFERENCE **EVERYTHING** ELSE SEE RETAIN CYCLES
             
-            guard let gestureViewModel = gestureViewModel else { return }
+            guard let gestureViewModel = gestureViewModel,
+                  let graph = graph else { return }
             
             gestureViewModel.isHovered = hovering
             if hovering {
-                gestureViewModel.sidebarLayerHovered(itemId: gestureViewModel.id)
+                gestureViewModel.sidebarLayerHovered(itemId: gestureViewModel.id,
+                                                     graph: graph)
             } else {
                 gestureViewModel.sidebarLayerHoverEnded(itemId: gestureViewModel.id)
             }

--- a/Stitch/Graph/Sidebar/ViewModel/SidebarItemGestureViewModel.swift
+++ b/Stitch/Graph/Sidebar/ViewModel/SidebarItemGestureViewModel.swift
@@ -50,7 +50,8 @@ final class SidebarItemGestureViewModel: SidebarItemSwipable {
     @MainActor weak var parentDelegate: SidebarItemGestureViewModel? {
         didSet {
             dispatch(AssignedLayerUpdated(changedLayerNode: self.id.asLayerNodeId))
-            dispatch(LayerGroupIdChanged(layerNodeId: self.id.asLayerNodeId))
+            dispatch(LayerGroupIdChanged(layerNodeId: self.id.asLayerNodeId,
+                                         activeIndex: sidebarDelegate?.graphDelegate?.documentDelegate?.activeIndex ?? .init(.zero)))
         }
     }
 
@@ -133,8 +134,9 @@ extension SidebarItemGestureViewModel {
     }
     
     @MainActor
-    func sidebarLayerHovered(itemId: SidebarListItemId) {
-        self.graphDelegate?.graphUI.sidebarLayerHovered(layerId: itemId.asLayerNodeId)
+    func sidebarLayerHovered(itemId: SidebarListItemId,
+                             graph: GraphState) {
+        graph.sidebarLayerHovered(layerId: itemId.asLayerNodeId)
     }
     
     @MainActor

--- a/Stitch/Graph/Sidebar/ViewModel/SidebarItemSwipable.swift
+++ b/Stitch/Graph/Sidebar/ViewModel/SidebarItemSwipable.swift
@@ -58,7 +58,8 @@ protocol SidebarItemSwipable: StitchNestedListElementObservable, Sendable, Ident
                                 graphUI: GraphUIState) -> UIContextMenuConfiguration?
     
     @MainActor
-    func sidebarLayerHovered(itemId: Self.ID)
+    func sidebarLayerHovered(itemId: Self.ID,
+                             graph: GraphState)
     
     @MainActor
     func sidebarLayerHoverEnded(itemId: Self.ID)

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/Node/StitchAINodeUtils.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/Node/StitchAINodeUtils.swift
@@ -74,8 +74,9 @@ extension StitchAINodeSectionDescription {
                 let inputs: [StitchAIPortValueDescription] = defaultNode.inputsObservers.map { inputObserver in
                     StitchAIPortValueDescription(label: inputObserver
                         .label(node: defaultNode,
+                               currentTraversalLevel: nil,
                                graph: graph),
-                                                 value: inputObserver.activeValue)
+                                                 value: inputObserver.getActiveValue(activeIndex: .init(.zero)))
                 }
                 
                 // Calculate node to get outputs values
@@ -87,8 +88,9 @@ extension StitchAINodeSectionDescription {
                 let outputs: [StitchAIPortValueDescription] = defaultNode.outputsObservers.map { outputObserver in
                     StitchAIPortValueDescription(label: outputObserver
                         .label(node: defaultNode,
+                               currentTraversalLevel: nil,
                                graph: graph),
-                                                 value: outputObserver.activeValue)
+                                                 value: outputObserver.getActiveValue(activeIndex: .init(.zero)))
                 }
                 
                 assertInDebug(inputs.first { $0.value == .none } == nil)

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StepTypeAction.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StepTypeAction.swift
@@ -291,7 +291,7 @@ struct StepActionConnectionAdded: StepActionable {
     }
     
     func removeAction(graph: GraphState) {
-        graph.removeEdgeAt(input: self.inputPort)
+        graph.removeEdgeAt(input: self.inputPort, activeIndex: .init(.zero))
     }
     
     func validate(createdNodes: inout [NodeId : PatchOrLayer]) throws {
@@ -350,7 +350,8 @@ struct StepActionChangeValueType: StepActionable {
     func applyAction(graph: GraphState) throws {
         // NodeType etc. for this patch was already validated in `[StepTypeAction].areValidLLMSteps`
         let _ = graph.nodeTypeChanged(nodeId: self.nodeId,
-                                      newNodeType: self.valueType)
+                                      newNodeType: self.valueType,
+                                      activeIndex: graph.documentDelegate?.activeIndex ?? .init(.zero))
     }
     
     func removeAction(graph: GraphState) {
@@ -430,7 +431,8 @@ struct StepActionSetInput: StepActionable {
         
         // Use the common input-edit-committed function, so that we remove edges, block or unblock fields, etc.
         graph.inputEditCommitted(input: input,
-                                 value: self.value)
+                                 value: self.value,
+                                 activeIndex: graph.documentDelegate?.activeIndex ?? .init(.zero))
     }
     
     func removeAction(graph: GraphState) {

--- a/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
+++ b/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
@@ -12,15 +12,14 @@ struct CatalystProjectTitleModalOpened: StitchDocumentEvent {
     func handle(state: StitchDocumentViewModel) {
         // log("CatalystProjectTitleModalOpened")
         withAnimation {
-            state.graphUI.showCatalystProjectTitleModal = true
+            state.showCatalystProjectTitleModal = true
         }
-        state.visibleGraph.reduxFieldFocused(focusedField: .projectTitle,
-                                             graphUI: state.graphUI)
+        state.reduxFieldFocused(focusedField: .projectTitle)
     }
 }
 
-struct CatalystProjectTitleModalClosed: GraphUIEvent {
-    func handle(state: GraphUIState) {
+struct CatalystProjectTitleModalClosed: StitchDocumentEvent {
+    func handle(state: StitchDocumentViewModel) {
         // log("CatalystProjectTitleModalClosed")
         withAnimation {
             state.showCatalystProjectTitleModal = false
@@ -159,7 +158,6 @@ struct CatalystTopBarGraphButtons: View {
 
     let document: StitchDocumentViewModel
     let graph: GraphState
-    let graphUI: GraphUIState
     let hasActiveGroupFocused: Bool
     let isFullscreen: Bool // = false
     let isPreviewWindowShown: Bool // = true
@@ -192,7 +190,7 @@ struct CatalystTopBarGraphButtons: View {
             
             // TODO: should be a toast only shows up when no nodes are on-screen?
             CatalystNavBarButton(.FIND_NODE_ON_GRAPH) {
-                graph.findSomeCanvasItemOnGraph(graphUI: graphUI)
+                graph.findSomeCanvasItemOnGraph(document: document)
             }
 
             // TODO: implement
@@ -236,40 +234,42 @@ struct CatalystTopBarGraphButtons: View {
     }
 }
 
-struct LayerInspectorToggled: GraphUIEvent {
-    func handle(state: GraphUIState) {
+struct LayerInspectorToggled: StitchDocumentEvent {
+    func handle(state: StitchDocumentViewModel) {
         
         withAnimation {
             state.showsLayerInspector.toggle()
         }
         
-        // reset selected inspector-row when inspector panel toggled
-        state.propertySidebar.selectedProperty = nil
+        let graph = state.visibleGraph
         
-        state.closeFlyout()
+        // reset selected inspector-row when inspector panel toggled
+        graph.propertySidebar.selectedProperty = nil
+        
+        graph.closeFlyout()
     }
 }
 
-struct GoUpOneTraversalLevel: GraphEvent {
+struct GoUpOneTraversalLevel: StitchDocumentEvent {
 
-    func handle(state: GraphState) {
+    func handle(state: StitchDocumentViewModel) {
 
         log("GoUpOneTraversalLevel called")
         
-        guard state.graphUI.groupNodeFocused.isDefined else {
+        guard state.groupNodeFocused.isDefined else {
             // If there's no current group node, do nothing
             log("GoUpOneTraversalLevel: already at top level")
             return
         }
         
         // Set new active parent
-        state.graphUI.groupNodeBreadcrumbs = state.graphUI.groupNodeBreadcrumbs.dropLast()
+        state.groupNodeBreadcrumbs = state.groupNodeBreadcrumbs.dropLast()
 
         // Reset any active selections
-        state.resetAlertAndSelectionState(graphUI: state.graphUI)
+        state.visibleGraph.resetAlertAndSelectionState(document: state)
 
         // Zoom-out animate to parent
-        state.graphUI.groupTraversedToChild = false
+        state.groupTraversedToChild = false
     }
 }
 

--- a/Stitch/Graph/Toolbar/View/TopBarButtonView.swift
+++ b/Stitch/Graph/Toolbar/View/TopBarButtonView.swift
@@ -86,7 +86,6 @@ struct iPadGraphTopBarButtons: View {
 
     @Bindable var document: StitchDocumentViewModel
     @Bindable var graph: GraphState
-    @Bindable var graphUI: GraphUIState
     let hasActiveGroupFocused: Bool
     let isFullscreen: Bool // = false
     let isPreviewWindowShown: Bool // = true
@@ -112,7 +111,9 @@ struct iPadGraphTopBarButtons: View {
             iPadNavBarButton(action: INSERT_NODE_ACTION,
                              iconName: .sfSymbol(.ADD_NODE_SF_SYMBOL_NAME))
             
-            iPadNavBarButton(action: { graph.findSomeCanvasItemOnGraph(graphUI: graphUI) },
+            iPadNavBarButton(action: {
+                graph.findSomeCanvasItemOnGraph(document: document)
+            },
                              iconName: .sfSymbol(.FIND_NODE_ON_GRAPH))
 
             // TODO: implement

--- a/Stitch/Graph/Util/GraphStateCardinalPoints.swift
+++ b/Stitch/Graph/Util/GraphStateCardinalPoints.swift
@@ -34,24 +34,28 @@ extension GraphState {
     
     // Do we want the node's "position" or its cached-bounds origin ?
     @MainActor
-    func westernMostNodeForBorderCheck(_ canvasItems: CanvasItemViewModels) -> CanvasItemViewModel? {
-        GraphState.westernMostNode(self.groupNodeFocused, canvasItems: canvasItems)
+    func westernMostNodeForBorderCheck(_ canvasItems: CanvasItemViewModels,
+                                       groupNodeFocused: NodeId?) -> CanvasItemViewModel? {
+        GraphState.westernMostNode(groupNodeFocused, canvasItems: canvasItems)
     }
     
     @MainActor
-    func easternMostNodeForBorderCheck(_ canvasItems: CanvasItemViewModels) -> CanvasItemViewModel? {
-        GraphState.easternMostNode(self.groupNodeFocused, canvasItems: canvasItems)
+    func easternMostNodeForBorderCheck(_ canvasItems: CanvasItemViewModels,
+                                       groupNodeFocused: NodeId?) -> CanvasItemViewModel? {
+        GraphState.easternMostNode(groupNodeFocused, canvasItems: canvasItems)
     }
     
     // Do we want the node's "position" or its cached-bounds origin ?
     @MainActor
-    func northernMostNodeForBorderCheck(_ canvasItems: CanvasItemViewModels) -> CanvasItemViewModel? {
-        GraphState.northernMostNode(self.groupNodeFocused, canvasItems: canvasItems)
+    func northernMostNodeForBorderCheck(_ canvasItems: CanvasItemViewModels,
+                                        groupNodeFocused: NodeId?) -> CanvasItemViewModel? {
+        GraphState.northernMostNode(groupNodeFocused, canvasItems: canvasItems)
     }
     
     @MainActor
-    func southernMostNodeForBorderCheck(_ canvasItems: CanvasItemViewModels) -> CanvasItemViewModel? {
-        GraphState.southernMostNode(self.groupNodeFocused, canvasItems: canvasItems)
+    func southernMostNodeForBorderCheck(_ canvasItems: CanvasItemViewModels,
+                                        groupNodeFocused: NodeId?) -> CanvasItemViewModel? {
+        GraphState.southernMostNode(groupNodeFocused, canvasItems: canvasItems)
     }
     
     // western-most node is node with least x-position

--- a/Stitch/Graph/Util/KeyBindingActions.swift
+++ b/Stitch/Graph/Util/KeyBindingActions.swift
@@ -15,10 +15,10 @@ extension NodeRowViewModelId {
     }
 }
 
-struct ArrowPressedWhileInputTextFieldFocused: GraphEvent {
+struct ArrowPressedWhileInputTextFieldFocused: StitchDocumentEvent {
     let wasUpArrow: Bool // currently only up vs down arrows supported
     
-    func handle(state: GraphState) {
+    func handle(state: StitchDocumentViewModel) {
         
         guard state.graphUI.reduxFocusedField?.getTextInputEdit.isDefined ?? false else {
             fatalErrorIfDebug("ArrowKeyPressedWhileInputTextFieldFocused: no text field focused")
@@ -32,10 +32,10 @@ struct ArrowPressedWhileInputTextFieldFocused: GraphEvent {
 }
 
 /// Process arrow key events.
-struct ArrowKeyPressed: GraphEvent {
+struct ArrowKeyPressed: StitchDocumentEvent {
     let arrowKey: ArrowKey
 
-    func handle(state: GraphState) {
+    func handle(state: StitchDocumentViewModel) {
         log("ArrowKeyPressed: \(arrowKey) called.")
 
         // Update selected option for insert node menu
@@ -101,7 +101,7 @@ extension StitchStore {
     func escKeyPressed() {
         // Reset GraphUI state
         if let document = self.currentDocument {
-            document.visibleGraph.resetAlertAndSelectionState(graphUI: document.graphUI)
+            document.visibleGraph.resetAlertAndSelectionState(document: document)
         }
         
         // Reset alert state

--- a/Stitch/Graph/View/ContentView.swift
+++ b/Stitch/Graph/View/ContentView.swift
@@ -29,7 +29,6 @@ struct ContentView: View, KeyboardReadable {
 
     @Bindable var store: StitchStore
     @Bindable var document: StitchDocumentViewModel
-    @Bindable var graphUI: GraphUIState
 
     let alertState: ProjectAlertState
     let routerNamespace: Namespace.ID
@@ -40,7 +39,7 @@ struct ContentView: View, KeyboardReadable {
 
     /// Shows menu wrapper view while node animation takes place
     var showMenu: Bool {
-        graphUI.insertNodeMenuState.show
+        document.insertNodeMenuState.show
     }
 
     var nodeAndMenu: some View {
@@ -48,17 +47,10 @@ struct ContentView: View, KeyboardReadable {
             
             // Best place to listen for TAB key for flyout
             UIKitWrapper(ignoresKeyCommands: true,
-                         inputTextFieldFocused: graphUI.reduxFocusedField?.inputTextFieldWithNumberIsFocused(document.graph) ?? false,
+                         inputTextFieldFocused: document.reduxFocusedField?.inputTextFieldWithNumberIsFocused(document.graph) ?? false,
                          name: .mainGraph) {
                 contentView // the graph
             }
-            
-//            if showMenu {
-//                InsertNodeMenuWrapper(document: document,
-//                                      graphUI: graphUI,
-//                                      menuHeight: $menuHeight,
-//                                      screenSize: $screenSize) // node menu + other animating views
-//            }
         }
     }
 
@@ -71,7 +63,7 @@ struct ContentView: View, KeyboardReadable {
             // Must respect keyboard safe-area
             ProjectWindowSizeReader(previewWindowSizing: previewWindowSizing,
                                     previewWindowSize: document.previewWindowSize,
-                                    isFullScreen: graphUI.isFullScreenMode,
+                                    isFullScreen: document.isFullScreenMode,
                                     showFullScreenAnimateCompleted: $showFullScreenAnimateCompleted,
                                     showFullScreenObserver: showFullScreen,
 //                                    menuHeight: $menuHeight,
@@ -84,8 +76,8 @@ struct ContentView: View, KeyboardReadable {
                 .ignoresSafeArea([.keyboard])
 #endif
         }
-       .environment(\.viewframe, graphUI.frame)
-       .environment(\.isSelectionBoxInUse, graphUI.selection.isSelecting)
+       .environment(\.viewframe, document.frame)
+       .environment(\.isSelectionBoxInUse, document.visibleGraph.selection.isSelecting)
     }
 
     @ViewBuilder
@@ -94,7 +86,7 @@ struct ContentView: View, KeyboardReadable {
             
             // ALWAYS show full-screen preview on iPhone.
             // Also, if in full-screen preview mode on Catalyst or iPad, place the fullscreen preview on top.
-            if showFullScreen.isTrue || GraphUIState.isPhoneDevice {
+            if showFullScreen.isTrue || StitchDocumentViewModel.isPhoneDevice {
                 fullScreenPreviewView
 #if !targetEnvironment(macCatalyst)
                 // Fullscreen ALWAYS ignores ALL safe areas
@@ -144,7 +136,7 @@ struct ContentView: View, KeyboardReadable {
                                 previewSizeDevice: document.previewSizeDevice,
                                 previewWindowBackgroundColor: document.previewWindowBackgroundColor,
                                 graph: document.graph,
-                                graphUI: graphUI) }
+                                graphUI: document) }
         .modifier(FileImportView(fileImportState: alertState.fileImportModalState))
         .modifier(AnimateCompletionHandler(percentage: showFullScreen.value) {
             // only set this state to true when we're animating into full screen mode
@@ -172,8 +164,8 @@ struct ContentView: View, KeyboardReadable {
         
     @ViewBuilder
     var flyout: some View {
-        OpenFlyoutView(graph: document.visibleGraph,
-                       graphUI: graphUI)
+        OpenFlyoutView(document: document,
+                       graph: document.visibleGraph)
     }
 }
 

--- a/Stitch/Graph/View/GraphBaseView.swift
+++ b/Stitch/Graph/View/GraphBaseView.swift
@@ -20,7 +20,6 @@ struct GraphBaseView: View {
     @State private var spaceHeld = false
 
     @Bindable var document: StitchDocumentViewModel
-    @Bindable var graphUI: GraphUIState
     
     @MainActor
     var graph: GraphState {
@@ -58,7 +57,7 @@ struct GraphBaseView: View {
 
     @MainActor
     var selectionState: GraphUISelectionState {
-        graphUI.selection
+        graph.selection
     }
 
     @ViewBuilder
@@ -66,8 +65,7 @@ struct GraphBaseView: View {
     var nodesView: some View {
         NodesView(document: document,
                   graph: graph,
-                  graphUI: graphUI,
-                  groupTraversedToChild: graphUI.groupTraversedToChild)
+                  groupTraversedToChild: document.groupTraversedToChild)
         .overlay {
             // Show debug mode tip view
             if document.isDebugMode {
@@ -125,10 +123,10 @@ struct GraphBaseView: View {
             // IMPORTANT: applying .inspector outside of this ZStack causes displacement of graph contents when graph zoom != 1
             Circle().fill(Stitch.APP_BACKGROUND_COLOR.opacity(0.001))
                 .frame(width: 1, height: 1)
-                .inspector(isPresented: $graphUI.showsLayerInspector) {
+                .inspector(isPresented: $document.showsLayerInspector) {
                     
                     LayerInspectorView(graph: graph,
-                                       graphUI: graphUI)
+                                       graphUI: document)
                     
                     // TODO: setting an inspector width DOES move over the graph view content
                         .inspectorColumnWidth(LayerInspectorView.LAYER_INSPECTOR_WIDTH)

--- a/Stitch/Graph/View/ProjectNavigationView.swift
+++ b/Stitch/Graph/View/ProjectNavigationView.swift
@@ -21,8 +21,7 @@ struct ProjectNavigationView: View {
     var body: some View {
         @Bindable var visibleGraph = document.visibleGraph
         
-        GraphBaseView(document: document,
-                      graphUI: document.graphUI)
+        GraphBaseView(document: document)
         .alert(item: $visibleGraph.migrationWarning) { warningMessage in
             Alert(title: Text("Document Migration Warning"),
                   message: Text(warningMessage.rawValue),
@@ -35,7 +34,7 @@ struct ProjectNavigationView: View {
             log("NodesOnlyView: .onChange(of: document.visibleGraph.graphUpdaterId)")
             document.visibleGraph.updateGraphData()
         }
-        .onChange(of: document.graphUI.groupNodeFocused) {
+        .onChange(of: document.groupNodeFocused?.groupNodeId) {
             document.visibleGraph.refreshGraphUpdaterId()
         }
         .onChange(of: document.isCameraEnabled) { _, isCameraEnabled in

--- a/Stitch/Graph/View/ProjectToolbar.swift
+++ b/Stitch/Graph/View/ProjectToolbar.swift
@@ -86,7 +86,7 @@ struct ProjectToolbarViewModifier: ViewModifier {
                     iPadGraphTopBarButtons(
                         document: document,
                         graph: graph,
-                        hasActiveGroupFocused: graphUI.groupNodeFocused.isDefined,
+                        hasActiveGroupFocused: document.groupNodeFocused.isDefined,
                         isFullscreen: document.isFullScreenMode,
                         isPreviewWindowShown: document.showPreviewWindow,
                         restartPrototypeWindowIconRotationZ: document.restartPrototypeWindowIconRotationZ,

--- a/Stitch/Graph/View/ProjectToolbar.swift
+++ b/Stitch/Graph/View/ProjectToolbar.swift
@@ -19,7 +19,6 @@ struct ProjectToolbarViewModifier: ViewModifier {
     @Environment(StitchStore.self) private var store
     @Bindable var document: StitchDocumentViewModel
     @Bindable var graph: GraphState
-    @Bindable var graphUI: GraphUIState
     let projectName: String
     let projectId: ProjectId
     @Binding var isFullScreen: Bool
@@ -29,12 +28,12 @@ struct ProjectToolbarViewModifier: ViewModifier {
     // Note: Do NOT hide toolbar in Catalyst full screen mode
     @MainActor
     var hideToolbar: Bool {
-        GraphUIState.isPhoneDevice || (!isCatalyst && graphUI.isFullScreenMode)
+        GraphUIState.isPhoneDevice || (!isCatalyst && document.isFullScreenMode)
     }
 
     func body(content: Content) -> some View {
         content
-            .onChange(of: graphUI.isFullScreenMode) { _, newValue in
+            .onChange(of: document.isFullScreenMode) { _, newValue in
                 isFullScreen = newValue
             }
             .toolbarRole(.editor) // no "Back" text on back button
@@ -86,10 +85,11 @@ struct ProjectToolbarViewModifier: ViewModifier {
                 ToolbarItemGroup(placement: .primaryAction) {
                     iPadGraphTopBarButtons(
                         document: document,
+                        graph: graph,
                         hasActiveGroupFocused: graphUI.groupNodeFocused.isDefined,
-                        isFullscreen: graphUI.isFullScreenMode,
-                        isPreviewWindowShown: graphUI.showPreviewWindow,
-                        restartPrototypeWindowIconRotationZ: graphUI.restartPrototypeWindowIconRotationZ,
+                        isFullscreen: document.isFullScreenMode,
+                        isPreviewWindowShown: document.showPreviewWindow,
+                        restartPrototypeWindowIconRotationZ: document.restartPrototypeWindowIconRotationZ,
                         llmRecordingModeEnabled: self.llmRecordingMode,
                         llmRecordingModeActive: document.llmRecording.isRecording)
                 }
@@ -123,17 +123,16 @@ struct ProjectToolbarViewModifier: ViewModifier {
                     CatalystTopBarGraphButtons(
                         document: document,
                         graph: graph,
-                        graphUI: graphUI,
-                        hasActiveGroupFocused: graphUI.groupNodeFocused.isDefined,
-                        isFullscreen: graphUI.isFullScreenMode,
-                        isPreviewWindowShown: graphUI.showPreviewWindow,
+                        hasActiveGroupFocused: document.groupNodeFocused.isDefined,
+                        isFullscreen: document.isFullScreenMode,
+                        isPreviewWindowShown: document.showPreviewWindow,
                         llmRecordingModeEnabled: self.llmRecordingMode,
                         llmRecordingModeActive: document.llmRecording.isRecording)
                 }
                 #endif
 
             }
-            .animation(.spring, value: graphUI.restartPrototypeWindowIconRotationZ) // .animation modifier must be placed here
+            .animation(.spring, value: document.restartPrototypeWindowIconRotationZ) // .animation modifier must be placed here
             .toolbarBackground(.visible, for: .automatic)
             .toolbar(hideToolbar ? .hidden : .automatic)
     }

--- a/Stitch/Graph/View/SelectionBox/ExpansionBoxView.swift
+++ b/Stitch/Graph/View/SelectionBox/ExpansionBoxView.swift
@@ -11,6 +11,7 @@ import StitchSchemaKit
 struct ExpansionBoxView: View {
     
     let graph: GraphState
+    let document: StitchDocumentViewModel
     let box: ExpansionBox
     
     @Environment(\.appTheme) var theme
@@ -33,7 +34,8 @@ struct ExpansionBoxView: View {
         .frame(box.size)
         .position(box.anchorCorner)
         .onChange(of: box) { _, newSelectionBounds in
-            graph.processCanvasSelectionBoxChange(selectionBox: newSelectionBounds.asCGRect)
+            graph.processCanvasSelectionBoxChange(selectionBox: newSelectionBounds.asCGRect,
+                                                  document: document)
         }
     }
 }

--- a/Stitch/Graph/View/StitchProjectView.swift
+++ b/Stitch/Graph/View/StitchProjectView.swift
@@ -13,7 +13,6 @@ struct StitchProjectView: View {
     
     @Bindable var store: StitchStore
     @Bindable var document: StitchDocumentViewModel
-    @Bindable var graphUI: GraphUIState
 
     let alertState: ProjectAlertState
 
@@ -25,7 +24,7 @@ struct StitchProjectView: View {
     }
 
     var activeIndex: ActiveIndex {
-        graphUI.activeIndex
+        document.activeIndex
     }
 
     var body: some View {
@@ -45,7 +44,6 @@ struct StitchProjectView: View {
 
             .modifier(ProjectToolbarViewModifier(document: document,
                                                  graph: graphState,
-                                                 graphUI: document.graphUI,
                                                  // In reality this won't be nil
                                                  projectName: graphState.name,
                                                  projectId: graphState.projectId,
@@ -63,7 +61,6 @@ struct StitchProjectView: View {
     func projectView() -> some View {
         ContentView(store: store,
                     document: document,
-                    graphUI: document.graphUI,
                     alertState: alertState,
                     routerNamespace: routerNamespace)
     }

--- a/Stitch/Graph/View/Util/ProjectWindowSizeReader.swift
+++ b/Stitch/Graph/View/Util/ProjectWindowSizeReader.swift
@@ -10,10 +10,10 @@ import SwiftUI
 import StitchSchemaKit
 
 
-struct NodeMenuHeightSet: GraphUIEvent {
+struct NodeMenuHeightSet: StitchDocumentEvent {
     let newHeight: CGFloat
     
-    func handle(state: GraphUIState) {
+    func handle(state: StitchDocumentViewModel) {
         state.nodeMenuHeight = newHeight
     }
 }

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -81,6 +81,43 @@ final class GraphState: Sendable {
     /// Subscribed by view to trigger graph view update based on data changes.
     @MainActor var graphUpdaterId: Int = .zero
     
+    // Set true / non-nil in methods or action handlers
+    // Set false / nil in StitchUIScrollView
+    // TODO: combine canvasZoomedIn and canvasZoomedOut? can never have both at same time? or we can, and they cancel each other?
+    @MainActor var canvasZoomedIn: GraphManualZoom = .noZoom
+    @MainActor var canvasZoomedOut: GraphManualZoom = .noZoom
+    @MainActor var canvasJumpLocation: CGPoint? = nil
+    @MainActor var canvasPageOffsetChanged: CGPoint? = nil
+    @MainActor var canvasPageZoomScaleChanged: CGFloat? = nil
+    
+    // Hackiness for handling option+drag "duplicate node and drag it"
+    @MainActor var dragDuplication: Bool = false
+    
+    // Only for node cursor selection box done when shift held
+    @MainActor var nodesAlreadySelectedAtStartOfShiftNodeCursorBoxDrag: CanvasItemIdSet? = nil
+    
+    let propertySidebar = PropertySidebarObserver()
+    
+    // e.g. user is hovering over or has selected a layer in the sidebar, which we then highlight in the preview window itself
+    @MainActor var highlightedSidebarLayers: LayerIdSet = .init()
+    
+    @MainActor
+    var edgeEditingState: EdgeEditingState?
+    
+    @MainActor var edgeAnimationEnabled: Bool = false
+    
+    @MainActor var activelyEditedCommentBoxTitle: CommentBoxId?
+
+    @MainActor var commentBoxBoundsDict = CommentBoxBoundsDict()
+
+    // Note: our device-screen reading logic uses `.local` coordinate space and so does not detect that items in the graph actually sit a little lower on the screen.
+    // TODO: better?: just always look at `.global`
+    @MainActor var graphYPosition: CGFloat = .zero
+    
+    @MainActor var selection = GraphUISelectionState()
+
+    @MainActor var activeDragInteraction = ActiveDragInteractionNodeVelocityData()
+    
     @MainActor var lastEncodedDocument: GraphEntity
     @MainActor weak var documentDelegate: StitchDocumentViewModel?
     @MainActor weak var documentEncoderDelegate: (any DocumentEncodable)?
@@ -113,6 +150,10 @@ final class GraphState: Sendable {
 }
 
 extension GraphState {
+    var graphUI: Self {
+        self
+    }
+    
     @MainActor
     var orderedSidebarLayers: [SidebarItemGestureViewModel] {
         self.layersSidebarViewModel.items
@@ -168,9 +209,10 @@ extension GraphState {
         
         self.visibleNodesViewModel
             .updateNodesPagingDict(components: self.components,
-                                   graphFrame: self.graphUI.frame,
+                                   graphFrame: document.frame,
                                    parentGraphPath: self.saveLocation,
-                                   graph: self)
+                                   graph: self,
+                                   document: document)
         
         // Update connected port data
         self.visibleNodesViewModel.updateAllNodeViewData()
@@ -184,15 +226,6 @@ extension GraphState {
             // Update all fields since calculation is skipped
             self.updatePortViews()
         }
-    }
-
-    @MainActor
-    var graphUI: GraphUIState {
-        guard let graphUI = self.documentDelegate?.graphUI else {
-            return GraphUIState(isPhoneDevice: false)
-        }
-        
-        return graphUI
     }
     
     @MainActor
@@ -210,25 +243,25 @@ extension GraphState {
         }
     }
     
-    @MainActor
-    var groupNodeFocused: NodeId? {
-        self.graphUI.groupNodeFocused?.groupNodeId
-    }
+//    @MainActor
+//    var groupNodeFocused: NodeId? {
+//        self.graphUI.groupNodeFocused?.groupNodeId
+//    }
     
     @MainActor
     var nodesDict: NodesViewModelDict {
         self.nodes
     }
 
-    @MainActor
-    var safeAreaInsets: SafeAreaInsets {
-        self.graphUI.safeAreaInsets
-    }
+//    @MainActor
+//    var safeAreaInsets: SafeAreaInsets {
+//        self.graphUI.safeAreaInsets
+//    }
     
-    @MainActor
-    var isFullScreenMode: Bool {
-        self.graphUI.isFullScreenMode
-    }
+//    @MainActor
+//    var isFullScreenMode: Bool {
+//        self.graphUI.isFullScreenMode
+//    }
     
     @MainActor
     func getMediaUrl(forKey key: MediaKey) -> URL? {
@@ -236,7 +269,7 @@ extension GraphState {
     }
     
     @MainActor var multiselectInputs: LayerInputPortSet? {
-        self.graphUI.propertySidebar.inputsCommonToSelectedLayers
+        self.propertySidebar.inputsCommonToSelectedLayers
     }
     
     func undoDeletedMedia(mediaKey: MediaKey) async -> URLResult {
@@ -298,15 +331,15 @@ extension GraphState {
         self.visibleNodesViewModel.resetCache()
     }
     
-    @MainActor
-    var isSidebarFocused: Bool {
-        get {
-            self.graphUI.isSidebarFocused
-        }
-        set(newValue) {
-            self.graphUI.isSidebarFocused = newValue
-        }
-    }
+//    @MainActor
+//    var isSidebarFocused: Bool {
+//        get {
+//            self.graphUI.isSidebarFocused
+//        }
+//        set(newValue) {
+//            self.graphUI.isSidebarFocused = newValue
+//        }
+//    }
 }
 
 extension GraphState {
@@ -427,11 +460,6 @@ extension GraphState {
     }
     
     @MainActor
-    var activeIndex: ActiveIndex {
-        self.graphUI.activeIndex
-    }
-    
-    @MainActor
     var llmRecording: LLMRecordingState {
         self.documentDelegate?.llmRecording ?? .init()
     }
@@ -448,8 +476,8 @@ extension GraphState {
     }
     
     @MainActor
-    func getBroadcasterNodesAtThisTraversalLevel() -> [NodeDelegate] {
-        self.visibleNodesViewModel.getNodesAtThisTraversalLevel(at: self.graphUI.groupNodeFocused?.groupNodeId)
+    func getBroadcasterNodesAtThisTraversalLevel(document: StitchDocumentViewModel) -> [NodeDelegate] {
+        self.visibleNodesViewModel.getNodesAtThisTraversalLevel(at: document.groupNodeFocused?.groupNodeId)
             .compactMap { node in
                 guard node.kind == .patch(.wirelessBroadcaster) else {
                     return nil
@@ -472,9 +500,9 @@ extension GraphState {
     /// Creases a unique hash based on view data which if changes, requires graph data update.
     @MainActor
     func calculateGraphUpdaterId() -> Int {
-        //        let randomInt = Int.random(in: -999999999999999...999999999999)
-        //        log("calculateGraphUpdaterId: randomInt: \(randomInt)")
-        //        return randomInt
+        guard let document = self.documentDelegate else {
+            return .zero
+        }
         
         var hasher = Hasher()
         
@@ -487,7 +515,7 @@ extension GraphState {
         let nodeCount = nodes.keys.count
         
         // Track graph canvas items count
-        let canvasItems = self.getCanvasItemsAtTraversalLevel().count
+        let canvasItems = self.getCanvasItemsAtTraversalLevel(groupNodeFocused: document.groupNodeFocused?.groupNodeId).count
 
         // Tracks edge changes to reset cached data
         let upstreamConnections = allInputsObservers
@@ -501,11 +529,11 @@ extension GraphState {
                     return nil
                 }
                 
-                return $0.activeValue
+                return $0.getActiveValue(activeIndex: document.activeIndex)
             }
         
         // Track group node ID, which fixes edges when traversing
-        let groupNodeIdFocused = self.graphUI.groupNodeFocused
+        let groupNodeIdFocused = document.groupNodeFocused
         
         // Stitch AI changes in case order changes
         let aiActions = self.llmRecording.actions
@@ -734,15 +762,15 @@ extension GraphState {
     }
     
     @MainActor
-    func getNodesAtThisTraversalLevel() -> [NodeDelegate] {
+    func getNodesAtThisTraversalLevel(groupNodeFocused: NodeId?) -> [NodeDelegate] {
         self.visibleNodesViewModel
-            .getNodesAtThisTraversalLevel(at: self.graphUI.groupNodeFocused?.groupNodeId)
+            .getNodesAtThisTraversalLevel(at: groupNodeFocused)
     }
     
     @MainActor
-    func getCanvasItemsAtTraversalLevel() -> CanvasItemViewModels {
+    func getCanvasItemsAtTraversalLevel(groupNodeFocused: NodeId?) -> CanvasItemViewModels {
         self.visibleNodesViewModel
-            .getCanvasItemsAtTraversalLevel(at: self.graphUI.groupNodeFocused?.groupNodeId)
+            .getCanvasItemsAtTraversalLevel(at: groupNodeFocused)
     }
     
     @MainActor

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -243,26 +243,11 @@ extension GraphState {
         }
     }
     
-//    @MainActor
-//    var groupNodeFocused: NodeId? {
-//        self.graphUI.groupNodeFocused?.groupNodeId
-//    }
-    
     @MainActor
     var nodesDict: NodesViewModelDict {
         self.nodes
     }
 
-//    @MainActor
-//    var safeAreaInsets: SafeAreaInsets {
-//        self.graphUI.safeAreaInsets
-//    }
-    
-//    @MainActor
-//    var isFullScreenMode: Bool {
-//        self.graphUI.isFullScreenMode
-//    }
-    
     @MainActor
     func getMediaUrl(forKey key: MediaKey) -> URL? {
         self.mediaLibrary.get(key)
@@ -330,16 +315,6 @@ extension GraphState {
         // Updates node visibility data
         self.visibleNodesViewModel.resetCache()
     }
-    
-//    @MainActor
-//    var isSidebarFocused: Bool {
-//        get {
-//            self.graphUI.isSidebarFocused
-//        }
-//        set(newValue) {
-//            self.graphUI.isSidebarFocused = newValue
-//        }
-//    }
 }
 
 extension GraphState {

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -34,185 +34,38 @@ enum FocusedFieldChangedByArrowKey: Equatable, Hashable {
          downArrow // decrement
 }
 
-@Observable
-final class GraphUIState: Sendable {
-    
-    @MainActor var openPortPreview: OpenedPortPreview?
-    
-    // Set true / non-nil in methods or action handlers
-    // Set false / nil in StitchUIScrollView
-    // TODO: combine canvasZoomedIn and canvasZoomedOut? can never have both at same time? or we can, and they cancel each other?
-    @MainActor var canvasZoomedIn: GraphManualZoom = .noZoom
-    @MainActor var canvasZoomedOut: GraphManualZoom = .noZoom
-    @MainActor var canvasJumpLocation: CGPoint? = nil
-    @MainActor var canvasPageOffsetChanged: CGPoint? = nil
-    @MainActor var canvasPageZoomScaleChanged: CGFloat? = nil
-    
-    @MainActor var nodeMenuHeight: CGFloat = INSERT_NODE_MENU_MAX_HEIGHT
-    
-    @MainActor var sidebarWidth: CGFloat = .zero // i.e. origin of graph from .global frame
-
-    @MainActor var showCatalystProjectTitleModal: Bool = false
-    
-    // Only for node cursor selection box done when shift held
-    @MainActor var nodesAlreadySelectedAtStartOfShiftNodeCursorBoxDrag: CanvasItemIdSet? = nil
-    
-    let propertySidebar = PropertySidebarObserver()
-    
-    @MainActor var lastMomentumRunTime: TimeInterval = .zero
-    
-    // e.g. user is hovering over or has selected a layer in the sidebar, which we then highlight in the preview window itself
-    @MainActor var highlightedSidebarLayers: LayerIdSet = .init()
-
-    @MainActor
-    var edgeEditingState: EdgeEditingState?
-
-    @MainActor var restartPrototypeWindowIconRotationZ: CGFloat = .zero
-
-    // nil = no field focused
-    @MainActor var reduxFocusedField: FocusedUserEditField?
-    
-    // set non-nil by up- and down-arrow key presses while an input's fields are focused
-    // set nil after key press has been handled by `StitchTextEditingBindingField`
-    @MainActor var reduxFocusedFieldChangedByArrowKey: FocusedFieldChangedByArrowKey?
-
-    // Hack: to differentiate state updates that came from undo/redo (and which close the adjustment bar popover),
-    // vs those that came from user manipulation of adjustment bar (which do not close the adjustment bar popover).
-    @MainActor var adjustmentBarSessionId: UUID = .init()
-
-    @MainActor var activelyEditedCommentBoxTitle: CommentBoxId?
-
-    @MainActor var commentBoxBoundsDict = CommentBoxBoundsDict()
-
-    @MainActor
-    static let isPhoneDevice = Stitch.isPhoneDevice()
-
-    @MainActor var edgeAnimationEnabled: Bool = false
-
-    @MainActor var activeSpacebarClickDrag = false
-
-    @MainActor var safeAreaInsets = SafeAreaInsetsEnvironmentKey.defaultValue
-    @MainActor var colorScheme: ColorScheme = defaultColorScheme
-
-    // Hackiness for handling option+drag "duplicate node and drag it"
-    @MainActor var dragDuplication: Bool = false
-
-    @MainActor var doubleTapLocation: CGPoint? {
-        get {
-            self.insertNodeMenuState.doubleTapLocation
-        } set(newValue) {
-            self.insertNodeMenuState.doubleTapLocation = newValue
-        }
-    }
-
-    // which loop index to show
-    @MainActor var activeIndex: ActiveIndex = ActiveIndex(0)
-
-    // GRAPH: UI GROUPS AND LAYER PANELS
-    // layer nodes (group or non-group) that have been selected
-    // via the layer panel UI
-
-    // Starts out as default value, but on first render of GraphView
-    // we get the exact device screen size via GeometryReader.
-    @MainActor var frame = DEFAULT_LANDSCAPE_GRAPH_FRAME
-
-    // Note: our device-screen reading logic uses `.local` coordinate space and so does not detect that items in the graph actually sit a little lower on the screen.
-    // TODO: better?: just always look at `.global`
-    @MainActor var graphYPosition: CGFloat = .zero
-
-    @MainActor var selection = GraphUISelectionState()
-
-    // Control animation direction when group nodes are traversed
-    @MainActor var groupTraversedToChild = false
-
-    // Only applies to non-iPhones so that exiting full-screen mode goes
-    // back to graph instead of projects list
-    @MainActor var isFullScreenMode: Bool = false
-    
-    #if DEV_DEBUG
-//    var showsLayerInspector = true   during dev
-    @MainActor var showsLayerInspector = false // during dev
-    #else
-    @MainActor var showsLayerInspector = false
-    #endif
-    
-    @MainActor var leftSidebarOpen = false
-
-    // Tracks group breadcrumbs when group nodes are visited
-    @MainActor var groupNodeBreadcrumbs: [GroupNodeType] = []
-
-    @MainActor var showPreviewWindow = PREVIEW_SHOWN_DEFAULT_STATE
-
-    @MainActor var insertNodeMenuState = InsertNodeMenuState()
-
-    /*
-     Similar to `activeDragInteraction`, but just for mouse nodes.
-     - nil when LayerHoverEnded or LayerDragEnded
-     - non-nil when LayerHovered or LayerDragged
-     - when non-nil and it’s been more than `DRAG_NODE_VELOCITY_RESET_STEP` since last movement, reset velocity to `.zero`
-     */
-    @MainActor var lastMouseNodeMovement: TimeInterval?
-
-    @MainActor var activeDragInteraction = ActiveDragInteractionNodeVelocityData()
-    
-    // tracks if sidebar is focused
-    @MainActor var isSidebarFocused: Bool = false
-
-    // Explicit `init` is required to use `didSet` on a property
-    @MainActor
-    init(activeSpacebarClickDrag: Bool = false,
-         safeAreaInsets: SafeAreaInsets = SafeAreaInsetsEnvironmentKey.defaultValue,
-         colorScheme: ColorScheme = defaultColorScheme,
-         dragDuplication: Bool = false,
-         doubleTapLocation: CGPoint? = nil,
-         activeIndex: ActiveIndex = .defaultActiveIndex,
-         frame: CGRect = DEFAULT_LANDSCAPE_GRAPH_FRAME,
-         selection: GraphUISelectionState = .init(),
-         groupTraversedToChild: Bool = false,
-         isPhoneDevice: Bool,
-         groupNodeBreadcrumbs: [GroupNodeType] = .init(),
-         showPreviewWindow: Bool = PREVIEW_SHOWN_DEFAULT_STATE,
-         insertNodeMenuState: InsertNodeMenuState = .init(),
-         activeDragInteraction: ActiveDragInteractionNodeVelocityData = .init()) {
-
-        self.activeSpacebarClickDrag = activeSpacebarClickDrag
-        self.safeAreaInsets = safeAreaInsets
-        self.colorScheme = colorScheme
-        self.dragDuplication = dragDuplication
-        self.doubleTapLocation = doubleTapLocation
-        self.activeIndex = activeIndex
-        self.frame = frame
-        self.selection = selection
-        self.groupTraversedToChild = groupTraversedToChild
-        self.isFullScreenMode = isPhoneDevice
-        self.groupNodeBreadcrumbs = groupNodeBreadcrumbs
-        self.showPreviewWindow = showPreviewWindow
-        self.insertNodeMenuState = insertNodeMenuState
-        self.activeDragInteraction = activeDragInteraction
-    }
-}
+typealias GraphUIState = StitchDocumentViewModel
 
 extension StitchDocumentViewModel {
     @MainActor
     func adjustedDoubleTapLocation(_ localPosition: CGPoint) -> CGPoint? {
-        if let doubleTapLocation = self.graphUI.doubleTapLocation {
+        if let doubleTapLocation = self.insertNodeMenuState.doubleTapLocation {
             return adjustPositionToMultipleOf(
                 factorOutGraphOffsetAndScale(
                     location: doubleTapLocation,
                     graphOffset: localPosition,
                     graphScale: self.graphMovement.zoomData,
-                    deviceScreen: self.graphUI.frame))
+                    deviceScreen: self.frame))
         }
         
         return nil
     }
 }
 
-extension GraphUIState {
+extension StitchDocumentViewModel {
+    var graphUI: Self {
+        self
+    }
+    
     // If there's a group in focus
     @MainActor
     var groupNodeFocused: GroupNodeType? {
         self.groupNodeBreadcrumbs.last
+    }
+    
+    @MainActor
+    var doubleTapLocation: CGPoint? {
+        self.insertNodeMenuState.doubleTapLocation
     }
     
     @MainActor
@@ -313,7 +166,7 @@ extension GraphState {
     
     /// Resets various state including any alert state or graph selection state. Called after graph tap gesture or ESC key.
     @MainActor
-    func resetAlertAndSelectionState(graphUI: GraphUIState) {
+    func resetAlertAndSelectionState(document: StitchDocumentViewModel) {
 
         #if !targetEnvironment(macCatalyst)
         // Fixes bug where keyboard may not disappear
@@ -332,32 +185,32 @@ extension GraphState {
             self.graphMovement.graphIsDragged = false            
         }
 
-        graphUI.selection = GraphUISelectionState()
-        self.resetSelectedCanvasItems(graphUI: graphUI)
-        graphUI.insertNodeMenuState.searchResults = InsertNodeMenuState.allSearchOptions
+        self.selection = GraphUISelectionState()
+        self.resetSelectedCanvasItems()
+        document.insertNodeMenuState.searchResults = InsertNodeMenuState.allSearchOptions
         
         // TODO: should we just reset the entire insertNodeMenuState?
         withAnimation(.INSERT_NODE_MENU_TOGGLE_ANIMATION) {
-            graphUI.insertNodeMenuState.show = false
-            graphUI.insertNodeMenuState.doubleTapLocation = nil
+            document.insertNodeMenuState.show = false
+            document.insertNodeMenuState.doubleTapLocation = nil
         }
         
-        graphUI.isFullScreenMode = false
+        document.isFullScreenMode = false
 
-        graphUI.activelyEditedCommentBoxTitle = nil
+        self.activelyEditedCommentBoxTitle = nil
 
         // Wipe any redux-controlled focus field
         // (For now, just used with TextField layers)
-        if graphUI.reduxFocusedField != nil {
-            graphUI.reduxFocusedField = nil
+        if document.reduxFocusedField != nil {
+            document.reduxFocusedField = nil
         }
         
         withAnimation {
-            graphUI.showCatalystProjectTitleModal = false
+            document.showCatalystProjectTitleModal = false
         }
         
-        graphUI.isSidebarFocused = false
-        graphUI.openPortPreview = nil
+        document.isSidebarFocused = false
+        document.openPortPreview = nil
     }
 }
 
@@ -423,10 +276,9 @@ enum GraphDragState: Codable {
 extension GraphState {
         
     @MainActor
-    func resetSelectedCanvasItems(graphUI: GraphUIState) {
+    func resetSelectedCanvasItems() {
         self.getCanvasItems().forEach {
-            $0.deselect(self,
-                        graphUI: graphUI)
+            $0.deselect(self)
         }
     }
 }
@@ -446,58 +298,62 @@ extension GraphState {
     // Keep this helper around
     @MainActor
     func selectSingleNode(_ node: CanvasItemViewModel,
-                          graphUI: GraphUIState) {
+                          document: StitchDocumentViewModel) {
         // ie expansionBox, isSelecting, selected-comments etc.
         // get reset when we select a single node.
-        self.graphUI.selection = GraphUISelectionState()
-        self.resetSelectedCanvasItems(graphUI: graphUI)
-        node.select(self)
+        self.selection = GraphUISelectionState()
+        self.resetSelectedCanvasItems()
+        node.select(self,
+                    document: document)
     }
     
     @MainActor
-    func deselectAllCanvasItems(graphUI: GraphUIState) {
-        self.graphUI.selection = GraphUISelectionState()
-        self.resetSelectedCanvasItems(graphUI: graphUI)
+    func deselectAllCanvasItems() {
+        self.selection = GraphUISelectionState()
+        self.resetSelectedCanvasItems()
     }
     
     @MainActor
     func selectSingleCanvasItem(_ canvasItem: CanvasItemViewModel,
-                                graphUI: GraphUIState) {
+                                document: StitchDocumentViewModel) {
         // ie expansionBox, isSelecting, selected-comments etc.
         // get reset when we select a single canvasItem.
-        self.deselectAllCanvasItems(graphUI: graphUI)
-        canvasItem.select(self)
+        self.deselectAllCanvasItems()
+        canvasItem.select(self,
+                          document: document)
     }
     
     // TEST HELPER
     @MainActor
-    func addNodeToSelections(_ nodeId: CanvasItemId) {
+    func addNodeToSelections(_ nodeId: CanvasItemId,
+                             document: StitchDocumentViewModel) {
         guard let node = self.getCanvasItem(nodeId) else {
             fatalErrorIfDebug()
             return
         }
-        node.select(self)
+        node.select(self,
+                    document: document)
     }
 }
 
 extension CanvasItemViewModel {
     @MainActor
-    func select(_ graph: GraphState) {
+    func select(_ graph: GraphState,
+                document: StitchDocumentViewModel) {
         // Prevent render cycles if already selected
         guard !self.isSelected(graph)  else { return }
         
-        graph.graphUI.selection.selectedNodeIds.insert(self.id)
+        graph.selection.selectedNodeIds.insert(self.id)
         
         // Unfocus sidebar
-        graph.isSidebarFocused = false
+        document.isSidebarFocused = false
     }
     
     @MainActor
-    func deselect(_ graph: GraphState,
-                  graphUI: GraphUIState) {
+    func deselect(_ graph: GraphState) {
         // Prevent render cycles if already unselected
         guard self.isSelected(graph) else { return }
-        graphUI.selection.selectedNodeIds.remove(self.id)
+        graph.selection.selectedNodeIds.remove(self.id)
     }
 }
 
@@ -547,13 +403,14 @@ extension GraphState {
 
 extension GraphState {
     @MainActor
-    var selectedCanvasItems: CanvasItemViewModels {
-        self.getCanvasItemsAtTraversalLevel().filter { $0.isSelected(self) }
+    func getSelectedCanvasItems(groupNodeFocused: NodeId?) -> CanvasItemViewModels {
+        self.getCanvasItemsAtTraversalLevel(groupNodeFocused: groupNodeFocused)
+            .filter { $0.isSelected(self) }
     }
     
     @MainActor
-    var selectedCanvasLayerItemIds: [LayerNodeId] {
-        self.selectedCanvasItems
+    func getSelectedCanvasLayerItemIds(groupNodeFocused: NodeId?) -> [LayerNodeId] {
+        self.getSelectedCanvasItems(groupNodeFocused: groupNodeFocused)
             .filter(\.id.isForLayer)
             .map(\.id.associatedNodeId.asLayerNodeId)
     }

--- a/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
+++ b/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
@@ -103,7 +103,8 @@ extension VisibleNodesViewModel {
     func updateNodesPagingDict(components: [UUID: StitchMasterComponent],
                                graphFrame: CGRect,
                                parentGraphPath: [UUID],
-                               graph: GraphState) {
+                               graph: GraphState,
+                               document: StitchDocumentViewModel) {
 
         // Remove any groups in the node paging dict that no longer exist in GraphSchema:
         let existingGroupPages = self.nodesByPage.compactMap(\.key.getGroupNodePage).toSet
@@ -126,7 +127,8 @@ extension VisibleNodesViewModel {
             // So we currently never hit this condition for new pages.
             // TODO: how to enter a group-node for the first time with a guaranteed node on screen? ... start with a nil localPosition in the pageData?
             if let westernMostNode = westernMostNode,
-               let jumpLocation = graph.getNodeGraphPanLocation(id: westernMostNode.id) {
+               let jumpLocation = graph.getNodeGraphPanLocation(id: westernMostNode.id,
+                                                                document: document) {
                 startOffset = jumpLocation
             }
             
@@ -190,8 +192,9 @@ extension VisibleNodesViewModel {
                 // Special case: we must re-initialize the group orientation input, since its first initialization happens before we have constructed the layer view models that can tell us all the parent's children
                 if layerNode.layer == .group {
                     layerNode.blockOrUnblockFields(
-                        newValue: layerNode.orientationPort.activeValue,
-                        layerInput: .orientation)
+                        newValue: layerNode.orientationPort.getActiveValue(activeIndex: document.activeIndex),
+                        layerInput: .orientation,
+                        activeIndex: document.activeIndex)
                 }
             }
         }

--- a/Stitch/Home/View/ProjectItem/ShareView.swift
+++ b/Stitch/Home/View/ProjectItem/ShareView.swift
@@ -162,7 +162,7 @@ struct ProjectContextMenuModifer: ViewModifier {
                         Image(systemName: "doc.on.doc")
                     })
                     
-                    if !GraphUIState.isPhoneDevice {
+                    if !StitchDocumentViewModel.isPhoneDevice {
                         StitchButton(action: {
                             // Opens project in debug mode
                             projectOpenCallback(document, true)

--- a/StitchTests/nodeUIGroupingTests.swift
+++ b/StitchTests/nodeUIGroupingTests.swift
@@ -47,8 +47,10 @@ class GroupNodeTests: XCTestCase {
         XCTAssert(canvasNode2.parentGroupNodeId == nil)
                 
         // Select the nodes
-        graphState.addNodeToSelections(canvasNode1.id)
-        graphState.addNodeToSelections(canvasNode2.id)
+        graphState.addNodeToSelections(canvasNode1.id,
+                                       document: document)
+        graphState.addNodeToSelections(canvasNode2.id,
+                                       document: document)
             
         // Create the group
         let _ = await document.createGroup(isComponent: false)
@@ -89,14 +91,15 @@ class GroupNodeTests: XCTestCase {
             fatalError()
         }
         
-        graphState.addNodeToSelections(canvasItem.id)
+        graphState.addNodeToSelections(canvasItem.id,
+                                       document: document)
         
         // Make sure only one node is selected
         // TODO: fix after changing "selecting group node = selecting its splitters as well"
         XCTAssertEqual(graphState.selectedNodeIds.count, 1)
         XCTAssertEqual(graphState.selectedNodeIds.first!, canvasItem.id)
         
-        await document.duplicateShortcutKeyPressed()
+        document.duplicateShortcutKeyPressed()
         
         XCTAssertEqual(graphState.groupNodes.keys.count, 2)
         


### PR DESCRIPTION
This PR removes GraphUI in favor of moving its properties to GraphState and StitchDocumentViewModel. This change was motived by the following reasons:
1. The idea of a "Graph UI" is redundant in that existing view models are already in place which mostly track UI state
2. There were many invocations of a weakly referenced GraphUI, causing unnecessary render cycles