### PR TITLE
In UI, retrieve GroupNode's underlying input- or output-splitters

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -648,6 +648,7 @@
 		EC8BA54726A6383F002E345C /* SmoothValueNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8BA54626A6383F002E345C /* SmoothValueNode.swift */; };
 		EC8BA54926A6388B002E345C /* VelocityNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8BA54826A6388B002E345C /* VelocityNode.swift */; };
 		EC8BD76E2B6C1350009BA60C /* EdgeEditModeOutputHoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8BD76D2B6C1350009BA60C /* EdgeEditModeOutputHoverView.swift */; };
+		EC8C1AA32D7795100058D969 /* NodeViewModelNodeCalculatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8C1AA22D7795100058D969 /* NodeViewModelNodeCalculatable.swift */; };
 		EC8C5C112616334B0099C374 /* OptionSwitchNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8C5C102616334B0099C374 /* OptionSwitchNode.swift */; };
 		EC8C5C152616415F0099C374 /* SoundKitNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8C5C142616415F0099C374 /* SoundKitNode.swift */; };
 		EC8C5C2326165C870099C374 /* PulseOnChangeNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8C5C2226165C870099C374 /* PulseOnChangeNode.swift */; };
@@ -1604,6 +1605,7 @@
 		EC8BA54626A6383F002E345C /* SmoothValueNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmoothValueNode.swift; sourceTree = "<group>"; };
 		EC8BA54826A6388B002E345C /* VelocityNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VelocityNode.swift; sourceTree = "<group>"; };
 		EC8BD76D2B6C1350009BA60C /* EdgeEditModeOutputHoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeEditModeOutputHoverView.swift; sourceTree = "<group>"; };
+		EC8C1AA22D7795100058D969 /* NodeViewModelNodeCalculatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeViewModelNodeCalculatable.swift; sourceTree = "<group>"; };
 		EC8C5C102616334B0099C374 /* OptionSwitchNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionSwitchNode.swift; sourceTree = "<group>"; };
 		EC8C5C142616415F0099C374 /* SoundKitNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundKitNode.swift; sourceTree = "<group>"; };
 		EC8C5C2226165C870099C374 /* PulseOnChangeNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PulseOnChangeNode.swift; sourceTree = "<group>"; };
@@ -3222,7 +3224,7 @@
 			isa = PBXGroup;
 			children = (
 				EC0F33492BED93D9008093BC /* NodeDelegate.swift */,
-				B5EC61FA2A5F5713002A639F /* NodeViewModel.swift */,
+				EC8C1AA42D7795E40058D969 /* NodeViewModel */,
 				ECC30E112C234E8800F0F54C /* CanvasItemViewModel.swift */,
 				ECB7B5D22A72DD9400E2D30B /* NodePageData.swift */,
 				ECB7B5D02A72DD7600E2D30B /* NodeViewModelType.swift */,
@@ -4378,6 +4380,15 @@
 			path = Font;
 			sourceTree = "<group>";
 		};
+		EC8C1AA42D7795E40058D969 /* NodeViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				B5EC61FA2A5F5713002A639F /* NodeViewModel.swift */,
+				EC8C1AA22D7795100058D969 /* NodeViewModelNodeCalculatable.swift */,
+			);
+			path = NodeViewModel;
+			sourceTree = "<group>";
+		};
 		EC96B0432B8D087F00B58227 /* Pack */ = {
 			isa = PBXGroup;
 			children = (
@@ -5240,6 +5251,7 @@
 				EC731CB92A37F05100241CB2 /* PatchDescription.swift in Sources */,
 				B59F03B72CB75B8D00A9422C /* GraphComponentHashable.swift in Sources */,
 				B5B00FFA2BBFC7E000E83CE7 /* LayerInputType.swift in Sources */,
+				EC8C1AA32D7795100058D969 /* NodeViewModelNodeCalculatable.swift in Sources */,
 				ECD0E1A028D3697D00133045 /* Base64StringToImagePatchNode.swift in Sources */,
 				B5F8D6A82C224A6600B99E5C /* LayerNodeData.swift in Sources */,
 				EC3A6C472C20C27300CCBACC /* NodeRowObserverSchemaObserverIdentifiable.swift in Sources */,

--- a/Stitch/Graph/Node/Group/GroupNodeCreationActions.swift
+++ b/Stitch/Graph/Node/Group/GroupNodeCreationActions.swift
@@ -427,8 +427,13 @@ extension GraphState {
 
     @MainActor
     func outputExists(_ output: OutputCoordinate) -> Bool {
-        self.getPatchNode(id: output.nodeId)?
-            .getOutputRowObserver(for: output.portType)
+        guard let portId = output.portId else {
+            fatalErrorIfDebug("Attempted to check if a layer input exists?")
+            return false
+        }
+        
+        return self.getPatchNode(id: output.nodeId)?
+            .getOutputRowObserver(for: portId)
             .isDefined ?? false
     }
 

--- a/Stitch/Graph/Node/Group/GroupNodeDestructionActions.swift
+++ b/Stitch/Graph/Node/Group/GroupNodeDestructionActions.swift
@@ -110,16 +110,14 @@ extension GraphState {
     @MainActor
     func insertEdgesAfterGroupUncreated(for splitterNode: NodeViewModel) {
         guard splitterNode.splitterType?.isGroupSplitter ?? false else {
-            #if DEBUG
-            fatalError()
-            #endif
+            fatalErrorIfDebug()
             return
         }
 
         let splitterOutputCoordinate = NodeIOCoordinate(portId: .zero,
                                                         nodeId: splitterNode.id)
 
-        guard let upstreamOutput = splitterNode.getInputRowObserver(0)?.upstreamOutputCoordinate,
+        guard let upstreamOutput = splitterNode.getInputRowObserver(for: .portIndex(0))?.upstreamOutputCoordinate,
               let downstreamInputsFromSplitter = self.connections.get(splitterOutputCoordinate) else {
             // Nothing to do if no upstream output or downstream inputs
             return

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -224,7 +224,7 @@ extension InputNodeRowObserver {
 
         // Set current upstream observer
         return self.nodeDelegate?.graphDelegate?.getNodeViewModel(upstreamCoordinate.nodeId)?
-            .getOutputRowObserver(upstreamPortId)
+            .getOutputRowObserver(for: upstreamPortId)
     }
     
     @MainActor
@@ -314,7 +314,11 @@ extension InputNodeRowObserver {
 
         // Check for connected row observer rather than just setting ID--makes for
         // a more robust check in ensuring the connection actually exists
-        assertInDebug(self.nodeDelegate?.graphDelegate?.visibleNodesViewModel.getOutputRowObserver(for: connectedOutputObserver.id) != nil)
+        assertInDebug(connectedOutputObserver
+            .id
+            .portId
+            .flatMap { self.nodeDelegate?.getOutputRowObserver(for: $0) }
+            .isDefined)
         
         // Report to output observer that there's an edge (for port colors)
         // We set this to false on default above

--- a/Stitch/Graph/Node/Util/NodeMediaUtils.swift
+++ b/Stitch/Graph/Node/Util/NodeMediaUtils.swift
@@ -224,7 +224,7 @@ extension NodeViewModel {
                                  mediaId: UUID?,
                                  graph: GraphState,
                                  activeIndex: ActiveIndex) -> MediaViewModel? {
-        guard let rowObserver = self.getOutputRowObserver(outputPortId) else {
+        guard let rowObserver = self.getOutputRowObserver(for: outputPortId) else {
             fatalErrorIfDebug()
             return nil
         }

--- a/Stitch/Graph/Node/View/NodeViewType.swift
+++ b/Stitch/Graph/Node/View/NodeViewType.swift
@@ -122,7 +122,7 @@ struct DefaultNodeInputView: View {
                            canvas: canvas,
                            rowViewModels: canvas.inputViewModels,
                            nodeIO: .input) { rowViewModel in
-            if let rowObserver = node.getInputRowObserver(for: rowViewModel.id.portType) {
+            if let rowObserver = node.getInputRowObserverForUI(for: rowViewModel.id.portType, graph) {
                 let layerInputObserver: LayerInputObserver? = rowObserver.id.layerInput
                     .flatMap { node.layerNode?.getLayerInputObserver($0.layerInput) }
                 
@@ -172,7 +172,8 @@ struct DefaultNodeOutputView: View {
                            canvas: canvas,
                            rowViewModels: canvas.outputViewModels,
                            nodeIO: .output) { rowViewModel in
-            if let rowObserver = node.getOutputRowObserver(for: rowViewModel.id.portType) {
+            if let portId = rowViewModel.id.portType.portId,
+               let rowObserver = node.getOutputRowObserverForUI(for: portId, graph) {
                 HStack {
                     NodeOutputView(graph: graph,
                                    graphUI: document,

--- a/Stitch/Graph/Node/ViewModel/NodeDelegate.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeDelegate.swift
@@ -26,6 +26,23 @@ extension NodeDelegate {
     var defaultOutputsList: PortValuesList {
         self.defaultOutputs.map { [$0] }
     }
+   
+    /// Retrieves GroupNode's underlying input-splitters
+    @MainActor func getAllInputsObserversForUI(_ graph: GraphState) -> [InputNodeRowObserver] {
+        switch self.nodeType {
+        case .patch(let patch):
+            return patch.inputsObservers
+        case .layer(let layer):
+            return layer.getSortedInputPorts().flatMap { portObserver in
+                // Grabs packed or unpacked data depending on what's used
+                portObserver.allInputData.map { $0.rowObserver }
+            }
+        case .group(let canvas):
+            return graph.visibleNodesViewModel.getSplitterInputRowObservers(for: self.id)
+        case .component(let component):
+            return component.inputsObservers
+        }
+    }
     
     /// Similar to `getAllInputsObservers` but gets unpacked layer observers if used.
     @MainActor func getAllInputsObservers() -> [InputNodeRowObserver] {
@@ -37,16 +54,51 @@ extension NodeDelegate {
                 // Grabs packed or unpacked data depending on what's used
                 portObserver.allInputData.map { $0.rowObserver }
             }
+            
+        // Maybe should debug-crash here instead?
         case .group(let canvas):
+            fatalErrorIfDebug("Attempted to retrieve a row observer for a GroupNode input")
             return canvas.inputViewModels.compactMap {
                 $0.rowDelegate
             }
         case .component(let component):
-            return component.canvas.inputViewModels.compactMap {
-                $0.rowDelegate
-            }
+            return component.inputsObservers
         }
     }
+    
+    /// Retrieves GroupNode's underlying output-splitters
+    @MainActor func getAllOutputsObserversForUI(_ graph: GraphState) -> [OutputNodeRowObserver] {
+        switch self.nodeType {
+        case .patch(let patch):
+            return patch.outputsObservers
+        case .layer(let layer):
+            return layer.outputPorts.map { $0.rowObserver }
+        case .group(let canvas):
+            return graph.visibleNodesViewModel.getSplitterOutputRowObservers(for: self.id)
+        case .component(let component):
+            return component.outputsObservers
+        }
+    }
+    
+    @MainActor func getAllOutputsObservers() -> [OutputNodeRowObserver] {
+        switch self.nodeType {
+        case .patch(let patch):
+            return patch.outputsObservers
+        case .layer(let layer):
+            return layer.outputPorts.map { $0.rowObserver }
+        case .group(let canvas):
+            fatalErrorIfDebug("Attempted to retrieve a row observer for a GroupNode output")
+            return canvas.outputViewModels.compactMap {
+                $0.rowDelegate
+            }
+        case .component(let component):
+            // We look at the component's canvas item's list of OutputNodeRowViewModel,
+            // and then grab each OutputNodeRowViewModel's row delegate ie. OutputNodeRowObserver ?
+            // Why not just do `component.outputsObservers` ?
+            return component.outputsObservers
+        }
+    }
+    
     
     @MainActor
     var allInputRowViewModels: [InputNodeRowViewModel] {

--- a/Stitch/Graph/Node/ViewModel/NodeDelegate.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeDelegate.swift
@@ -45,6 +45,7 @@ extension NodeDelegate {
     }
     
     /// Similar to `getAllInputsObservers` but gets unpacked layer observers if used.
+    /// Retrieve inputs for patch, layers or components. Not intented for group nodes.
     @MainActor func getAllInputsObservers() -> [InputNodeRowObserver] {
         switch self.nodeType {
         case .patch(let patch):
@@ -54,8 +55,6 @@ extension NodeDelegate {
                 // Grabs packed or unpacked data depending on what's used
                 portObserver.allInputData.map { $0.rowObserver }
             }
-            
-        // Maybe should debug-crash here instead?
         case .group(let canvas):
             fatalErrorIfDebug("Attempted to retrieve a row observer for a GroupNode input")
             return canvas.inputViewModels.compactMap {
@@ -73,13 +72,14 @@ extension NodeDelegate {
             return patch.outputsObservers
         case .layer(let layer):
             return layer.outputPorts.map { $0.rowObserver }
-        case .group(let canvas):
+        case .group:
             return graph.visibleNodesViewModel.getSplitterOutputRowObservers(for: self.id)
         case .component(let component):
             return component.outputsObservers
         }
     }
     
+    /// Retrieve outputs for patch, layers or components. Not intented for group nodes.
     @MainActor func getAllOutputsObservers() -> [OutputNodeRowObserver] {
         switch self.nodeType {
         case .patch(let patch):

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel.swift
@@ -145,23 +145,6 @@ extension NodeViewModel: NodeCalculatable {
         }
     }
     
-    @MainActor func getAllOutputsObservers() -> [OutputNodeRowObserver] {        
-        switch self.nodeType {
-        case .patch(let patch):
-            return patch.outputsObservers
-        case .layer(let layer):
-            return layer.outputPorts.map { $0.rowObserver }
-        case .group(let canvas):
-            return canvas.outputViewModels.compactMap {
-                $0.rowDelegate
-            }
-        case .component(let component):
-            return component.canvas.outputViewModels.compactMap {
-                $0.rowDelegate
-            }
-        }
-    }
-    
     // after we eval a node, we sets its current inputs to be its previous inputs,
     // so that we know we've run the node once,
     // and so that we won't run the node again until at least one of the inputs has changed
@@ -394,40 +377,64 @@ extension NodeViewModel {
         }
     }
     
+    // ADDED: looks at
+    @MainActor
+    func getInputRowObserverForUI(for portType: NodeIOPortType,
+                                  _ graph: GraphState) -> InputNodeRowObserver? {
+        switch portType {
+        
+        case .portIndex(let portId):
+            // LayerNode inputs NEVER use portId, only keyPath
+            assertInDebug(!self.nodeType.kind.getLayer.isDefined)
+            return self.getAllInputsObserversForUI(graph)[safe: portId]
+            
+        case .keyPath(let keyPath):
+            return self.getInputRowObserver(for: portType)
+        }
+    }
+    
+    @MainActor
+    func getInputRowObserver(_ portId: Int) -> InputNodeRowObserver? {
+        self.getInputRowObserver(for: .portIndex(portId))
+    }
+    
     @MainActor
     func getInputRowObserver(for portType: NodeIOPortType) -> InputNodeRowObserver? {
+        
         switch portType {
+        
         case .portIndex(let portId):
-            // Assumes patch node or component for port ID
-            return self.patchNode?.inputsObservers[safe: portId] ??
-            self.nodeType.componentNode?.inputsObservers[safe: portId]
-
+            return self.getAllInputsObservers()[safe: portId]
+        
         case .keyPath(let keyPath):
+            // For layer inputs, prefer accessing via Swift keyPath
             guard let layerNode = self.layerNode else {
                 fatalErrorIfDebug()
                 return nil
             }
-            
             return layerNode[keyPath: keyPath.layerNodeKeyPath].rowObserver
         }
     }
-
+    
     @MainActor
-    func getInputRowObserver(_ portId: Int) -> InputNodeRowObserver? {
-        self.inputsObservers[safe: portId]
+    func getOutputRowObserverForUI(for portId: Int,
+                                   _ graph: GraphState) -> OutputNodeRowObserver? {
+        self.getAllOutputsObserversForUI(graph)[safe: portId]
+    }
+    
+    // TODO: reintroduce difference between `OutputCoordinate(portId: Int, NodeId)` and `InputCoordinate(portType: NodeIOPortType, NodeId)`
+    @MainActor
+    func getOutputRowObserver(for portType: NodeIOPortType) -> OutputNodeRowObserver? {
+        guard let portId = portType.portId else {
+            fatalErrorIfDebug("Attempted to retrieve an output observer using a layer input?")
+            return nil
+        }
+        return self.getAllOutputsObservers()[safe: portId]
     }
     
     @MainActor
-    func getOutputRowObserver(for portType: NodeIOPortType) -> OutputNodeRowObserver? {
-        switch portType {
-        case .keyPath:
-            // No support here
-            fatalErrorIfDebug()
-            return nil
-            
-        case .portIndex(let portId):
-            return self.getOutputRowObserver(portId)
-        }
+    func getOutputRowObserver(for portId: Int) -> OutputNodeRowObserver? {
+        self.getAllOutputsObservers()[safe: portId]
     }
     
     @MainActor
@@ -480,21 +487,6 @@ extension NodeViewModel {
         }
     }
 
-    /// Gets output row observer for some node.
-    @MainActor
-    func getOutputRowObserver(_ portId: Int) -> OutputNodeRowObserver? {
-        // Check for output in layer
-        if let layerNode = self.layerNode {
-            guard let outputRow = layerNode.outputPorts[safe: portId]?.rowObserver else {
-                return nil
-            }
-            
-            return outputRow
-        }
-        
-        return self.patchNode?.outputsObservers[safe: portId]
-    }
-    
     @MainActor
     private func updateRowObservers<RowObserver>(rowObservers: [RowObserver],
                                                  newIOValues: PortValuesList) where RowObserver: NodeRowObserver {

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModel.swift
@@ -96,113 +96,6 @@ final class NodeViewModel: Sendable {
     }
 }
 
-extension NodeViewModel: NodeCalculatable {
-    var inputsObservers: [InputNodeRowObserver] {
-        get {
-            self.getAllInputsObservers()
-        }
-        set(newValue) {
-            self.patchNode?.inputsObservers = newValue
-        }
-    }
-    
-    var outputsObservers: [OutputNodeRowObserver] {
-        get {
-            self.getAllOutputsObservers()
-        }
-        set(newValue) {
-            self.patchNode?.outputsObservers = newValue
-        }
-    }
-    
-    @MainActor
-    var isComponentOutputSplitter: Bool {
-        let isNodeInComponent = !(self.graphDelegate?.saveLocation.isEmpty ?? true)
-        return self.splitterType == .output && isNodeInComponent
-    }
-    
-    @MainActor func getAllParentInputsObservers() -> [InputNodeRowObserver] {
-        self.getAllInputsObservers()
-    }
-    
-    @MainActor
-    var inputsValuesList: PortValuesList {
-        switch self.nodeType {
-        case .patch(let patch):
-            return patch.inputsObservers.map { $0.allLoopedValues }
-        case .layer(let layer):
-            return layer.getSortedInputPorts().map { inputPort in
-                inputPort.allLoopedValues
-            }
-        case .group(let canvas):
-            return canvas.inputViewModels.compactMap {
-                $0.rowDelegate?.allLoopedValues
-            }
-        case .component(let componentData):
-            return componentData.canvas.inputViewModels.compactMap {
-                $0.rowDelegate?.allLoopedValues
-            }
-        }
-    }
-    
-    // after we eval a node, we sets its current inputs to be its previous inputs,
-    // so that we know we've run the node once,
-    // and so that we won't run the node again until at least one of the inputs has changed
-    
-    // If unable to run eval for a node (e.g. because it is one of the layer nodes that does not support node eval),
-    // return `nil` rather than an empty list of inputs
-    @MainActor func evaluate() -> EvalResult? {
-        switch self.nodeType {
-        case .patch(let patchNodeViewModel):
-            // NodeKind.evaluate is our legacy eval caller, cheeck for those first
-            if let eval = patchNodeViewModel.patch.evaluate {
-                return eval.runEvaluation(
-                    node: self
-                )
-            }
-
-            // New-style eval which doesn't require filling out a switch statement
-            guard let nodeType = self.kind.graphNode else {
-                fatalErrorIfDebug()
-                return nil
-            }
-            
-            return nodeType.evaluate(node: self)
-        
-        case .layer(let layerNodeViewModel):
-            // Only a handful of layer nodes have node evals
-            if let eval = layerNodeViewModel.layer.evaluate {
-                return eval.runEvaluation(
-                    node: self
-                )
-            } else {
-                return nil
-            }
-            
-        case .component(let component):
-            return component.evaluate()
-            
-        case .group:
-            fatalErrorIfDebug()
-            return nil
-        }
-    }
-    
-    @MainActor
-    func inputsWillUpdate(values: PortValuesList) {
-        // update cache for longest loop length
-        self.longestLoopLength = self.kind.determineMaxLoopCount(from: values)
-        
-        // Updates preview layers if layer specified
-        // Must be before runEval check below since most layers don't have eval!
-        self.layerNode?.didValuesUpdate(newValuesList: values)
-    }
-    
-    @MainActor
-    var isGroupNode: Bool {
-        self.kind == .group
-    }
-}
 
 extension NodeViewModel: PatchNodeViewModelDelegate {
     func userVisibleTypeChanged(oldType: UserVisibleType,
@@ -376,8 +269,8 @@ extension NodeViewModel {
             rowObserver.updateValues(values)
         }
     }
-    
-    // ADDED: looks at
+
+    /// Retrieves a GroupNode's underlying input-splitter.
     @MainActor
     func getInputRowObserverForUI(for portType: NodeIOPortType,
                                   _ graph: GraphState) -> InputNodeRowObserver? {
@@ -388,7 +281,7 @@ extension NodeViewModel {
             assertInDebug(!self.nodeType.kind.getLayer.isDefined)
             return self.getAllInputsObserversForUI(graph)[safe: portId]
             
-        case .keyPath(let keyPath):
+        case .keyPath:
             return self.getInputRowObserver(for: portType)
         }
     }
@@ -422,7 +315,7 @@ extension NodeViewModel {
         self.getAllOutputsObserversForUI(graph)[safe: portId]
     }
     
-    // TODO: reintroduce difference between `OutputCoordinate(portId: Int, NodeId)` and `InputCoordinate(portType: NodeIOPortType, NodeId)`
+    // TODO: reintroduce difference between `OutputCoordinate(portId: Int, NodeId)` and `InputCoordinate(portType: NodeIOPortType, NodeId)`; probably best introduced at the Input- vs OutputNodeRowObserver level.
     @MainActor
     func getOutputRowObserver(for portType: NodeIOPortType) -> OutputNodeRowObserver? {
         guard let portId = portType.portId else {
@@ -551,7 +444,7 @@ extension NodeViewModel {
 extension NodeViewModel {
     @MainActor
     var inputsRowCount: Int {
-        self.getAllParentInputsObservers().count
+        self.getAllInputsObservers().count
     }
     
     @MainActor

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModelNodeCalculatable.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModelNodeCalculatable.swift
@@ -1,0 +1,117 @@
+//
+//  NodeViewModelNodeCalculatable.swift
+//  Stitch
+//
+//  Created by Christian J Clampitt on 3/4/25.
+//
+
+import Foundation
+import SwiftUI
+import StitchEngine
+import StitchSchemaKit
+
+extension NodeViewModel: NodeCalculatable {
+    var inputsObservers: [InputNodeRowObserver] {
+        get {
+            self.getAllInputsObservers()
+        }
+        set(newValue) {
+            self.patchNode?.inputsObservers = newValue
+        }
+    }
+    
+    var outputsObservers: [OutputNodeRowObserver] {
+        get {
+            self.getAllOutputsObservers()
+        }
+        set(newValue) {
+            self.patchNode?.outputsObservers = newValue
+        }
+    }
+    
+    @MainActor
+    var isComponentOutputSplitter: Bool {
+        let isNodeInComponent = !(self.graphDelegate?.saveLocation.isEmpty ?? true)
+        return self.splitterType == .output && isNodeInComponent
+    }
+        
+    @MainActor
+    var inputsValuesList: PortValuesList {
+        switch self.nodeType {
+        case .patch(let patch):
+            return patch.inputsObservers.map { $0.allLoopedValues }
+        case .layer(let layer):
+            return layer.getSortedInputPorts().map { inputPort in
+                inputPort.allLoopedValues
+            }
+        case .group(let canvas):
+            return canvas.inputViewModels.compactMap {
+                $0.rowDelegate?.allLoopedValues
+            }
+        case .component(let componentData):
+            return componentData.canvas.inputViewModels.compactMap {
+                $0.rowDelegate?.allLoopedValues
+            }
+        }
+    }
+    
+    /*
+     After we eval a node, we sets its current inputs to be its previous inputs,
+     so that we know we've run the node once,
+     and so that we won't run the node again until at least one of the inputs has changed
+    
+     If unable to run eval for a node (e.g. because it is one of the layer nodes that does not support node eval),
+     return `nil` rather than an empty list of inputs.
+     */
+    @MainActor func evaluate() -> EvalResult? {
+        switch self.nodeType {
+        case .patch(let patchNodeViewModel):
+            // NodeKind.evaluate is our legacy eval caller, cheeck for those first
+            if let eval = patchNodeViewModel.patch.evaluate {
+                return eval.runEvaluation(
+                    node: self
+                )
+            }
+
+            // New-style eval which doesn't require filling out a switch statement
+            guard let nodeType = self.kind.graphNode else {
+                fatalErrorIfDebug()
+                return nil
+            }
+            
+            return nodeType.evaluate(node: self)
+        
+        case .layer(let layerNodeViewModel):
+            // Only a handful of layer nodes have node evals
+            if let eval = layerNodeViewModel.layer.evaluate {
+                return eval.runEvaluation(
+                    node: self
+                )
+            } else {
+                return nil
+            }
+            
+        case .component(let component):
+            return component.evaluate()
+            
+        case .group:
+            fatalErrorIfDebug()
+            return nil
+        }
+    }
+    
+    @MainActor
+    func inputsWillUpdate(values: PortValuesList) {
+        // update cache for longest loop length
+        self.longestLoopLength = self.kind.determineMaxLoopCount(from: values)
+        
+        // Updates preview layers if layer specified
+        // Must be before runEval check below since most layers don't have eval!
+        self.layerNode?.didValuesUpdate(newValuesList: values)
+    }
+    
+    @MainActor
+    var isGroupNode: Bool {
+        self.kind == .group
+    }
+}

--- a/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
+++ b/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
@@ -319,7 +319,7 @@ extension VisibleNodesViewModel {
             .compactMap { node in
                 switch node.splitterType {
                 case .output:
-                    return node.getOutputRowObserver(0)
+                    return node.getOutputRowObserver(for: 0)
                 default:
                     // Shouldn't be called
                     fatalErrorIfDebug()
@@ -363,12 +363,6 @@ extension VisibleNodesViewModel {
         self.nodes.values.forEach { node in
             node.updateAllConnectedNodes()
         }
-    }
-    
-    @MainActor
-    func getOutputRowObserver(for coordinate: NodeIOCoordinate) -> OutputNodeRowObserver? {
-        self.nodes.get(coordinate.nodeId)?
-            .getOutputRowObserver(for: coordinate.portType)
     }
     
     @MainActor


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/6977

We now properly display inputs and outputs on a GroupNode.

`getInputObserverForUI(port, graph)` is now specifically for UI cases where GroupNode is needed; all other cases still use `getInputObserver(port)`.

Also moved implementation of NodeCalculatable to own file. 

<img width="800" alt="Screenshot 2025-03-04 at 1 16 19 PM" src="https://github.com/user-attachments/assets/a385a707-3fc5-49ea-99d4-af3eecb8f895" />
<img width="735" alt="Screenshot 2025-03-04 at 1 15 54 PM" src="https://github.com/user-attachments/assets/31caa648-c38f-4bd9-9c38-a560392ba4f2" />
