### PR TITLE
If GroupNode is visible-on-canvas, then so are its underlying input- and output-splitters

### DIFF
--- a/Stitch/Graph/Gesture/View/GraphMovementViewModifier.swift
+++ b/Stitch/Graph/Gesture/View/GraphMovementViewModifier.swift
@@ -76,6 +76,20 @@ extension GraphState {
             
             if isVisibleInFrame {
                 newVisibleNodes.insert(id)
+                
+                /*
+                 If a GroupNode is "visible on screen" (i.e. within the user's viewport),
+                 then we should consider its underlying input- and output-splitters visible as well,
+                 for the purposes of UI field updates.
+                
+                 Note: CanvasItemId.layerInput and CanvasItemId.layerOutput can never be a GroupNode,
+                 but CanvasItemId.node could be a GroupNode.
+                 */
+                if let potentialGroupNodeId = id.nodeCase {
+                    newVisibleNodes.formUnion(self.visibleNodesViewModel.getSplitterInputRowObserverIds(for: potentialGroupNodeId))
+                    newVisibleNodes.formUnion(self.visibleNodesViewModel.getSplitterOutputRowObserverIds(for: potentialGroupNodeId))
+                }
+                
                 // log("updateVisibleNodes: visible: \(id)")
             } else {
                 // log("updateVisibleNodes: NOT visible: \(id), cachedBounds: \(cachedBounds)")

--- a/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
@@ -74,7 +74,6 @@ final class CanvasItemViewModel: Identifiable, StitchLayoutCachable, Sendable {
     @MainActor var parentGroupNodeId: NodeId?
     
     @MainActor
-//    func isVisibleInFrame(_ graph: GraphState) -> Bool {
     func isVisibleInFrame(_ visibleCanvasIds: CanvasItemIdSet) -> Bool {
         return visibleCanvasIds.contains(self.id)
     }

--- a/Stitch/Graph/View/SelectionBox/ExpansionBoxView.swift
+++ b/Stitch/Graph/View/SelectionBox/ExpansionBoxView.swift
@@ -34,8 +34,7 @@ struct ExpansionBoxView: View {
         .frame(box.size)
         .position(box.anchorCorner)
         .onChange(of: box) { _, newSelectionBounds in
-            graph.processCanvasSelectionBoxChange(selectionBox: newSelectionBounds.asCGRect,
-                                                  document: document)
+            document.processCanvasSelectionBoxChange(selectionBox: newSelectionBounds.asCGRect)
         }
     }
 }

--- a/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
+++ b/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
@@ -252,6 +252,11 @@ extension VisibleNodesViewModel {
             .filter { $0.parentGroupNodeId == focusedGroup }
     }
 
+    @MainActor
+    func getSplitterInputRowObserverIds(for groupNodeId: NodeId?) -> CanvasItemIdSet {
+        self.getSplitterInputRowObservers(for: groupNodeId).reduce(into: CanvasItemIdSet()) { $0.insert(.node($1.id.nodeId)) }
+    }
+    
     /// Obtains input row observers directly from splitter patch nodes given its parent group node.
     @MainActor
     func getSplitterInputRowObservers(for groupNodeId: NodeId?) -> [InputNodeRowObserver] {
@@ -289,6 +294,11 @@ extension VisibleNodesViewModel {
             }
 
         return splitterRowObservers
+    }
+    
+    @MainActor
+    func getSplitterOutputRowObserverIds(for groupNodeId: NodeId?) -> CanvasItemIdSet {
+        self.getSplitterOutputRowObservers(for: groupNodeId).reduce(into: CanvasItemIdSet()) { $0.insert(.node($1.id.nodeId)) }
     }
     
     /// Obtains output row observers directly from splitter patch nodes given its parent group node.


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/6965

https://github.com/user-attachments/assets/d6d5e714-78b5-4ce9-a0cb-e99da559c72e

