### PR TITLE
Reduced render cycles from sidebar multiselect logic

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -50,6 +50,7 @@
 		B50AD534292C9E3F003CC61E /* InsertNodeMenuSearchResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50AD533292C9E3F003CC61E /* InsertNodeMenuSearchResults.swift */; };
 		B50AD536292C9F69003CC61E /* InsertNodeMenuSearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50AD535292C9F69003CC61E /* InsertNodeMenuSearchBar.swift */; };
 		B50AD538292CB170003CC61E /* KeyBindingActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50AD537292CB170003CC61E /* KeyBindingActions.swift */; };
+		B50BC9E42D77881900311551 /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = B50BC9E32D77881900311551 /* StitchEngine */; };
 		B50C897B2864E2750032E95D /* DelayedEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C897A2864E2750032E95D /* DelayedEffect.swift */; };
 		B50CE3082908D0C40065378E /* StitchTextEditingField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50CE3072908D0C40065378E /* StitchTextEditingField.swift */; };
 		B50F41682C1EB4320082262F /* StitchViewKit in Frameworks */ = {isa = PBXBuildFile; productRef = B50F41672C1EB4320082262F /* StitchViewKit */; };
@@ -1920,6 +1921,7 @@
 				EC1137382719F9B400ADCA72 /* OrderedCollections in Frameworks */,
 				B51D8A022CD13D420016CCDA /* StitchEngine in Frameworks */,
 				E42AAE4C2D4844EE002D187D /* Sentry in Frameworks */,
+				B50BC9E42D77881900311551 /* StitchEngine in Frameworks */,
 				EC91034A29109DF3007C548E /* SoulverCore in Frameworks */,
 				B5380E312CF8E51600E6D801 /* StitchEngine in Frameworks */,
 				B560CE812CF1C93100F31905 /* StitchEngine in Frameworks */,
@@ -4646,6 +4648,7 @@
 				E4A848AC2D32FCFA0029AFDE /* Storage */,
 				B56F36242D3C1A2E0051C80E /* StitchEngine */,
 				E42AAE4B2D4844EE002D187D /* Sentry */,
+				B50BC9E32D77881900311551 /* StitchEngine */,
 			);
 			productName = prototype;
 			productReference = 200BD857254F66EB00692903 /* Stitch.app */;
@@ -4733,7 +4736,7 @@
 				E463E7ED2C6FC7090008E318 /* XCRemoteSwiftPackageReference "StitchSchemaKit" */,
 				E4A848A92D32FCFA0029AFDE /* XCRemoteSwiftPackageReference "supabase-swift" */,
 				E42AAE4A2D4844EE002D187D /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
-				EC9A48DA2D6E694F006A1FC9 /* XCRemoteSwiftPackageReference "StitchEngine" */,
+				B50BC9E22D77881900311551 /* XCLocalSwiftPackageReference "../StitchEngineClosedSource" */,
 			);
 			productRefGroup = 200BD858254F66EB00692903 /* Products */;
 			projectDirPath = "";
@@ -6538,6 +6541,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		B50BC9E22D77881900311551 /* XCLocalSwiftPackageReference "../StitchEngineClosedSource" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../StitchEngineClosedSource;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		201953D825B25D3300D5296C /* XCRemoteSwiftPackageReference "swift-tagged" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -6659,14 +6669,6 @@
 				version = 2.6.3;
 			};
 		};
-		EC9A48DA2D6E694F006A1FC9 /* XCRemoteSwiftPackageReference "StitchEngine" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/StitchDesign/StitchEngine.git";
-			requirement = {
-				kind = revision;
-				revision = ad4468add9702f55d96bbbfd09943f8fec819b6a;
-			};
-		};
 		ECD5438C29A003F8009D0A30 /* XCRemoteSwiftPackageReference "DisplayLink" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/timdonnelly/DisplayLink.git";
@@ -6691,6 +6693,10 @@
 		B501920B2C6D144D00A048ED /* StitchEngine */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = B501920A2C6D144D00A048ED /* XCRemoteSwiftPackageReference "StitchEngine" */;
+			productName = StitchEngine;
+		};
+		B50BC9E32D77881900311551 /* StitchEngine */ = {
+			isa = XCSwiftPackageProductDependency;
 			productName = StitchEngine;
 		};
 		B50F41672C1EB4320082262F /* StitchViewKit */ = {

--- a/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7bc6d60cb599493d0ae6a2e8dd9fdc8ec70d26d605f0be0daab33a1734d85dab",
+  "originHash" : "906ea53775f320cbbf1349503a463e5e89cc8a926639156d5273d631e3d7c8ee",
   "pins" : [
     {
       "identity" : "audiokit",
@@ -52,14 +52,6 @@
       "state" : {
         "revision" : "ef309cda2d2f426476181ae294f3b899eac83af4",
         "version" : "2.6.3"
-      }
-    },
-    {
-      "identity" : "stitchengine",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StitchDesign/StitchEngine.git",
-      "state" : {
-        "revision" : "ad4468add9702f55d96bbbfd09943f8fec819b6a"
       }
     },
     {

--- a/Stitch/Graph/GraphStep/GraphStepIncrementer.swift
+++ b/Stitch/Graph/GraphStep/GraphStepIncrementer.swift
@@ -55,8 +55,6 @@ extension GraphState {
         if let lastMouseMovement = self.documentDelegate?.lastMouseNodeMovement,
            (graphTime - lastMouseMovement) > DRAG_NODE_VELOCITY_RESET_STEP {
             
-            let mouseNodeIds = self.mouseNodes
-            
             for mouseNodeId in self.mouseNodes {
                 if let mouseNodeState = self.getPatchNode(id: mouseNodeId)?.ephemeralObservers?.first as? MouseNodeState {
                     

--- a/Stitch/Graph/LayerInspector/LayerInspectorState.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorState.swift
@@ -27,7 +27,8 @@ typealias LayerInspectorRowIdSet = Set<LayerInspectorRowId>
 final class PropertySidebarObserver: Sendable {
         
     // Non-nil just if we have multiple layers selected
-    @MainActor var inputsCommonToSelectedLayers: LayerInputPortSet?
+    // Values refer to field indices containing heterogenous fields
+    @MainActor var heterogenousFieldsMap: [LayerInputPort : Set<Int>]?
     
     @MainActor var selectedProperty: LayerInspectorRowId?
     
@@ -48,6 +49,17 @@ final class PropertySidebarObserver: Sendable {
     // var safeAreaBottomPadding: CGFloat = 0
     
     init() { }
+}
+
+extension PropertySidebarObserver {
+    @MainActor
+    var inputsCommonToSelectedLayers: Set<LayerInputPort>? {
+        guard let multiselectionHeterogenousMap = self.heterogenousFieldsMap else {
+            return nil
+        }
+        
+        return Set(multiselectionHeterogenousMap.keys)
+    }
 }
 
 struct PropertySidebarFlyoutState: Equatable {

--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -379,7 +379,7 @@ extension GraphState {
         if inspectorFocusedLayers.count > 1 {
             guard let firstLayerId = inspectorFocusedLayers.first,
                   let firstLayer = self.getNodeViewModel(firstLayerId),
-                  let multiselectState = self.graphUI.propertySidebar.inputsCommonToSelectedLayers else {
+                  let multiselectState = self.propertySidebar.inputsCommonToSelectedLayers else {
                 log("getLayerInspectorData: Had multiple selected layers but no multiselect state")
                 return nil
             }

--- a/Stitch/Graph/LayerInspector/LayerMultiselect.swift
+++ b/Stitch/Graph/LayerInspector/LayerMultiselect.swift
@@ -54,6 +54,14 @@ extension LayerInputPortSet {
     // Note: this loses information about the heterogenous values etc.
     @MainActor
     func asLayerInputObserverDict(_ graph: GraphState) -> LayerInputObserverDict {
+        self.toSet.asLayerInputObserverDict(graph)
+    }
+}
+
+extension Set where Element == LayerInputPort {
+    // Note: this loses information about the heterogenous values etc.
+    @MainActor
+    func asLayerInputObserverDict(_ graph: GraphState) -> LayerInputObserverDict {
         self.reduce(into: LayerInputObserverDict()) { partialResult, layerInput in
             if let firstObserver = layerInput.multiselectObservers(graph).first {
                 partialResult.updateValue(firstObserver,

--- a/Stitch/Graph/Menu/ProjectSettingsView.swift
+++ b/Stitch/Graph/Menu/ProjectSettingsView.swift
@@ -234,8 +234,8 @@ struct ProjectSettingsView: View {
         }
 
         return StitchColorPickerView(
-            rowObserver: nil, 
-            layerInputObserver: nil,
+            rowViewModelId: .init(graphItemType: .empty, nodeId: .init(), portId: -1),
+            rowObserver: nil,
             fieldCoordinate: .fakeFieldCoordinate,
             isFieldInsideLayerInspector: false,
             isForFlyout: false,

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Layer/LayerDimensionUtils.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Layer/LayerDimensionUtils.swift
@@ -80,7 +80,7 @@ enum NonNumberLayerDimension: String, Equatable, Codable, CaseIterable {
 extension GraphState {
     @MainActor
     func getFilteredLayerDimensionChoices(node: NodeViewModel,
-                                          layerInputObserver: LayerInputObserver?,
+                                          layerInputPort: LayerInputPort?,
                                           activeIndex: ActiveIndex) -> [NonNumberLayerDimension] {
         
         let allChoices = LayerDimension.choicesAsNonNumberLayerDimension
@@ -92,8 +92,8 @@ extension GraphState {
         }
         
         // TODO: `layerInputObserver` is not passed down to layer inputs on the canvas?
-        if let layerInputObserver = layerInputObserver,
-            layerInputObserver.port == .minSize || layerInputObserver.port == .maxSize {
+        if let layerInputPort = layerInputPort,
+            layerInputPort == .minSize || layerInputPort == .maxSize {
             // Min and max size can only use `auto` (i.e. none), `static number` or `parent percentage`
             return [.auto]
         }

--- a/Stitch/Graph/Node/Port/Util/InputEdit/InputEditedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/InputEdit/InputEditedActions.swift
@@ -133,7 +133,7 @@ extension GraphState {
 
     @MainActor
     func getLayerMultiselectInput(for layerInput: LayerInputPort) -> LayerInputPort? {
-        self.graphUI.propertySidebar
+        self.propertySidebar
             .inputsCommonToSelectedLayers?
             .first(where: { $0 == layerInput })
     }

--- a/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
@@ -88,6 +88,7 @@ struct InputValueEntry: View {
         InputValueView(graph: graph,
                        graphUI: graphUI,
                        viewModel: viewModel,
+                       propertySidebar: graph.propertySidebar,
                        node: node,
                        rowViewModel: rowViewModel,
                        canvasItem: canvasItem,
@@ -165,6 +166,7 @@ struct InputValueView: View {
     @Bindable var graph: GraphState
     @Bindable var graphUI: GraphUIState
     @Bindable var viewModel: InputFieldViewModel
+    @Bindable var propertySidebar: PropertySidebarObserver
     let node: NodeViewModel
     let rowViewModel: InputNodeRowViewModel
     let canvasItem: CanvasItemViewModel?
@@ -210,29 +212,27 @@ struct InputValueView: View {
 
     @MainActor
     var hasHeterogenousValues: Bool {
-        if let layerInputObserver = layerInputObserver {
-            @Bindable var layerInputObserver = layerInputObserver
-            return layerInputObserver.fieldHasHeterogenousValues(
-                fieldIndex,
-                isFieldInsideLayerInspector: isFieldInsideLayerInspector,
-                graph: graph)
-        } else {
+        guard let layerInputPort = layerInputObserver?.port else {
             return false
         }
+        
+        return propertySidebar.heterogenousFieldsMap?
+            .get(layerInputPort)?
+            .contains(self.fieldIndex) ?? false
     }
     
-    @MainActor
-    var isMultiselectInspectorInputWithHeterogenousValues: Bool {
-        if let layerInputObserver = layerInputObserver {
-            @Bindable var layerInputObserver = layerInputObserver
-            return layerInputObserver.fieldHasHeterogenousValues(
-                fieldCoordinate.fieldIndex,
-                isFieldInsideLayerInspector: isFieldInsideLayerInspector,
-                graph: graph)
-        } else {
-            return false
-        }
-    }
+//    @MainActor
+//    var isMultiselectInspectorInputWithHeterogenousValues: Bool {
+//        if let layerInputObserver = layerInputObserver {
+//            @Bindable var layerInputObserver = layerInputObserver
+//            return layerInputObserver.fieldHasHeterogenousValues(
+//                fieldCoordinate.fieldIndex,
+//                isFieldInsideLayerInspector: isFieldInsideLayerInspector,
+//                graph: graph)
+//        } else {
+//            return false
+//        }
+//    }
     
     var body: some View {
         // NodeLayout(observer: viewModel,
@@ -251,6 +251,7 @@ struct InputValueView: View {
                                          choices: nil,
                                          forPropertySidebar: forPropertySidebar,
                                          propertyIsAlreadyOnGraph: propertyIsAlreadyOnGraph,
+                                         hasHeterogenousValues: hasHeterogenousValues,
                                          isFieldInMultifieldInput: isFieldInMultifieldInput,
                                          isForFlyout: isForFlyout,
                                          isSelectedInspectorRow: isSelectedInspectorRow,
@@ -269,6 +270,7 @@ struct InputValueView: View {
                                      isCanvasItemSelected: isCanvasItemSelected,
                                      choices: nil,
                                      forPropertySidebar: forPropertySidebar,
+                                     hasHeterogenousValues: hasHeterogenousValues,
                                      propertyIsAlreadyOnGraph: propertyIsAlreadyOnGraph,
                                      isFieldInMultifieldInput: isFieldInMultifieldInput,
                                      isForFlyout: isForFlyout,
@@ -291,6 +293,7 @@ struct InputValueView: View {
                                                                                      activeIndex: graphUI.activeIndex)
                                         .map(\.rawValue),
                                      forPropertySidebar: forPropertySidebar,
+                                     hasHeterogenousValues: hasHeterogenousValues,
                                      propertyIsAlreadyOnGraph: propertyIsAlreadyOnGraph,
                                      isFieldInMultifieldInput: isFieldInMultifieldInput,
                                      isForFlyout: isForFlyout,
@@ -311,6 +314,7 @@ struct InputValueView: View {
                                      isCanvasItemSelected: isCanvasItemSelected,
                                      choices: StitchSpacing.choices,
                                      forPropertySidebar: forPropertySidebar,
+                                     hasHeterogenousValues: hasHeterogenousValues,
                                      propertyIsAlreadyOnGraph: propertyIsAlreadyOnGraph,
                                      isFieldInMultifieldInput: isFieldInMultifieldInput,
                                      isForFlyout: isForFlyout,
@@ -326,7 +330,7 @@ struct InputValueView: View {
                                  value: bool,
                                  isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                                  isSelectedInspectorRow: isSelectedInspectorRow,
-                                 isMultiselectInspectorInputWithHeterogenousValues: isMultiselectInspectorInputWithHeterogenousValues)
+                                 isMultiselectInspectorInputWithHeterogenousValues: hasHeterogenousValues)
                 
             case .dropdown(let choiceDisplay, let choices):
                 DropDownChoiceView(rowObserver: rowObserver,
@@ -514,7 +518,7 @@ struct InputValueView: View {
                     isNodeSelected: isCanvasItemSelected,
                     isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                     isSelectedInspectorRow: isSelectedInspectorRow,
-                    isMultiselectInspectorInputWithHeterogenousValues: isMultiselectInspectorInputWithHeterogenousValues,
+                    isMultiselectInspectorInputWithHeterogenousValues: hasHeterogenousValues,
                     graph: graph,
                     document: graphUI)
                 
@@ -527,7 +531,7 @@ struct InputValueView: View {
                                         currentColor: color,
                                         hasIncomingEdge: hasIncomingEdge,
                                         graph: graph,
-                                        isMultiselectInspectorInputWithHeterogenousValues: isMultiselectInspectorInputWithHeterogenousValues,
+                                        isMultiselectInspectorInputWithHeterogenousValues: hasHeterogenousValues,
                                         activeIndex: graphUI.activeIndex)
                 
             case .pulse(let pulseTime):

--- a/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
@@ -212,7 +212,7 @@ struct InputValueView: View {
 
     @MainActor
     var hasHeterogenousValues: Bool {
-        guard let layerInputPort = layerInputObserver?.port else {
+        guard let layerInputPort = rowViewModel.id.layerInputPort else {
             return false
         }
         

--- a/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
@@ -92,7 +92,6 @@ struct InputValueEntry: View {
                        node: node,
                        rowViewModel: rowViewModel,
                        canvasItem: canvasItem,
-                       layerInputObserver: layerInputObserver,
                        rowObserver: rowObserver,
                        isCanvasItemSelected: isCanvasItemSelected,
                        forPropertySidebar: forPropertySidebar,
@@ -170,7 +169,6 @@ struct InputValueView: View {
     let node: NodeViewModel
     let rowViewModel: InputNodeRowViewModel
     let canvasItem: CanvasItemViewModel?
-    let layerInputObserver: LayerInputObserver?
     let rowObserver: InputNodeRowObserver
     let isCanvasItemSelected: Bool
     let forPropertySidebar: Bool
@@ -221,6 +219,10 @@ struct InputValueView: View {
             .contains(self.fieldIndex) ?? false
     }
     
+    var layerInputPort: LayerInputPort? {
+        self.rowViewModel.id.layerInputPort
+    }
+    
 //    @MainActor
 //    var isMultiselectInspectorInputWithHeterogenousValues: Bool {
 //        if let layerInputObserver = layerInputObserver {
@@ -244,7 +246,6 @@ struct InputValueView: View {
                                          fieldViewModel: viewModel,
                                          rowObserver: rowObserver,
                                          rowViewModel: rowViewModel,
-                                         layerInputObserver: layerInputObserver,
                                          fieldValue: fieldValue,
                                          fieldCoordinate: fieldCoordinate,
                                          isCanvasItemSelected: isCanvasItemSelected,
@@ -263,7 +264,6 @@ struct InputValueView: View {
                                      rowObserver: rowObserver,
                                      rowViewModel: rowViewModel,
                                      fieldViewModel: viewModel,
-                                     layerInputObserver: layerInputObserver,
                                      fieldValue: fieldValue,
                                      fieldValueNumberType: .number,
                                      fieldCoordinate: fieldCoordinate,
@@ -283,13 +283,12 @@ struct InputValueView: View {
                                      rowObserver: rowObserver,
                                      rowViewModel: rowViewModel,
                                      fieldViewModel: viewModel,
-                                     layerInputObserver: layerInputObserver,
                                      fieldValue: fieldValue,
                                      fieldValueNumberType: layerDimensionField.fieldValueNumberType,
                                      fieldCoordinate: fieldCoordinate,
                                      isCanvasItemSelected: isCanvasItemSelected,
                                      choices: graph.getFilteredLayerDimensionChoices(node: node,
-                                                                                     layerInputObserver: layerInputObserver,
+                                                                                     layerInputPort: layerInputPort,
                                                                                      activeIndex: graphUI.activeIndex)
                                         .map(\.rawValue),
                                      forPropertySidebar: forPropertySidebar,
@@ -307,7 +306,6 @@ struct InputValueView: View {
                                      rowObserver: rowObserver,
                                      rowViewModel: rowViewModel,
                                      fieldViewModel: viewModel,
-                                     layerInputObserver: layerInputObserver,
                                      fieldValue: fieldValue,
                                      fieldValueNumberType: .number,
                                      fieldCoordinate: fieldCoordinate,
@@ -326,7 +324,6 @@ struct InputValueView: View {
                 BoolCheckboxView(rowObserver: rowObserver,
                                  graph: graph,
                                  document: graphUI,
-                                 layerInputObserver: layerInputObserver,
                                  value: bool,
                                  isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                                  isSelectedInspectorRow: isSelectedInspectorRow,
@@ -334,7 +331,6 @@ struct InputValueView: View {
                 
             case .dropdown(let choiceDisplay, let choices):
                 DropDownChoiceView(rowObserver: rowObserver,
-                                   layerInputObserver: layerInputObserver,
                                    graph: graph,
                                    choiceDisplay: choiceDisplay,
                                    choices: choices,
@@ -347,7 +343,6 @@ struct InputValueView: View {
                 StitchFontDropdown(rowObserver: rowObserver,
                                    graph: graph,
                                    stitchFont: stitchFont,
-                                   layerInputObserver: layerInputObserver,
                                    isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                                    propertyIsSelected: isSelectedInspectorRow,
                                    hasHeterogenousValues: hasHeterogenousValues,
@@ -362,7 +357,6 @@ struct InputValueView: View {
                     visibleNodes: graph.visibleNodesViewModel,
                     rowObserver: rowObserver,
                     value: .assignedLayer(layerId),
-                    layerInputObserver: layerInputObserver,
                     isFieldInsideLayerInspector: rowViewModel.isFieldInsideLayerInspector,
                     isForPinTo: false,
                     isSelectedInspectorRow: isSelectedInspectorRow,
@@ -386,7 +380,6 @@ struct InputValueView: View {
                     rowObserver: rowObserver,
                     graph: graph,
                     value: x,
-                    layerInputObserver: layerInputObserver,
                     isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                     hasHeterogenousValues: hasHeterogenousValues,
                     activeIndex: graphUI.activeIndex)
@@ -408,7 +401,6 @@ struct InputValueView: View {
                             rowObserver: rowObserver,
                             graph: graph,
                             value: x,
-                            layerInputObserver: layerInputObserver,
                             isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                             hasHeterogenousValues: hasHeterogenousValues,
                             activeIndex: graphUI.activeIndex)
@@ -419,7 +411,6 @@ struct InputValueView: View {
                             graph: graph,
                             activeIndex: graphUI.activeIndex,
                             value: x,
-                            layerInputObserver: layerInputObserver,
                             isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                             hasHeterogenousValues: hasHeterogenousValues)
                         
@@ -439,7 +430,6 @@ struct InputValueView: View {
                     graph: graph,
                     value: .textAlignment(x),
                     choices: LayerTextAlignment.choices,
-                    layerInputObserver: layerInputObserver,
                     isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                     hasHeterogenousValues: hasHeterogenousValues,
                     activeIndex: graphUI.activeIndex)
@@ -451,7 +441,6 @@ struct InputValueView: View {
                     graph: graph,
                     value: .textVerticalAlignment(x),
                     choices: LayerTextVerticalAlignment.choices,
-                    layerInputObserver: layerInputObserver,
                     isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                     hasHeterogenousValues: hasHeterogenousValues,
                     activeIndex: graphUI.activeIndex)
@@ -463,7 +452,6 @@ struct InputValueView: View {
                     graph: graph,
                     value: .textDecoration(x),
                     choices: LayerTextDecoration.choices,
-                    layerInputObserver: layerInputObserver,
                     isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                     hasHeterogenousValues: hasHeterogenousValues,
                     activeIndex: graphUI.activeIndex)
@@ -474,7 +462,6 @@ struct InputValueView: View {
                     visibleNodes: graph.visibleNodesViewModel,
                     rowObserver: rowObserver,
                     value: .pinTo(pinToId),
-                    layerInputObserver: layerInputObserver,
                     isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                     isForPinTo: true,
                     isSelectedInspectorRow: isSelectedInspectorRow,
@@ -491,7 +478,6 @@ struct InputValueView: View {
                                   graph: graph,
                                   document: graphUI,
                                   selection: anchor,
-                                  layerInputObserver: layerInputObserver,
                                   isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                                   isSelectedInspectorRow: isSelectedInspectorRow,
                                   hasHeterogenousValues: hasHeterogenousValues)
@@ -508,7 +494,6 @@ struct InputValueView: View {
                     rowViewModel: rowViewModel,
                     rowObserver: rowObserver,
                     node: node,
-                    layerInputObserver: layerInputObserver,
                     isUpstreamValue: isUpstreamValue,
                     media: media,
                     mediaName: media.name,
@@ -526,7 +511,6 @@ struct InputValueView: View {
                 ColorOrbValueButtonView(fieldViewModel: viewModel,
                                         rowViewModel: rowViewModel,
                                         rowObserver: rowObserver,
-                                        layerInputObserver: layerInputObserver,
                                         isForFlyout: isForFlyout,
                                         currentColor: color,
                                         hasIncomingEdge: hasIncomingEdge,

--- a/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
@@ -223,19 +223,6 @@ struct InputValueView: View {
         self.rowViewModel.id.layerInputPort
     }
     
-//    @MainActor
-//    var isMultiselectInspectorInputWithHeterogenousValues: Bool {
-//        if let layerInputObserver = layerInputObserver {
-//            @Bindable var layerInputObserver = layerInputObserver
-//            return layerInputObserver.fieldHasHeterogenousValues(
-//                fieldCoordinate.fieldIndex,
-//                isFieldInsideLayerInspector: isFieldInsideLayerInspector,
-//                graph: graph)
-//        } else {
-//            return false
-//        }
-//    }
-    
     var body: some View {
         // NodeLayout(observer: viewModel,
         //            existingCache: viewModel.viewCache) {

--- a/Stitch/Graph/Node/Port/View/Field/InputView/AnchorPopoverView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/AnchorPopoverView.swift
@@ -28,7 +28,6 @@ struct AnchorPopoverView: View {
     let graph: GraphState
     let document: StitchDocumentViewModel
     let selection: Anchoring
-    let layerInputObserver: LayerInputObserver?
     let isFieldInsideLayerInspector: Bool
     let isSelectedInspectorRow: Bool
     let hasHeterogenousValues: Bool

--- a/Stitch/Graph/Node/Port/View/Field/InputView/BoolCheckboxView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/BoolCheckboxView.swift
@@ -16,7 +16,6 @@ struct BoolCheckboxView: View {
     let rowObserver: InputNodeRowObserver? // nil = used in output
     let graph: GraphState
     let document: StitchDocumentViewModel
-    let layerInputObserver: LayerInputObserver?
     let value: Bool
     let isFieldInsideLayerInspector: Bool
     let isSelectedInspectorRow: Bool

--- a/Stitch/Graph/Node/Port/View/Field/InputView/CommonEditingView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/CommonEditingView.swift
@@ -88,6 +88,7 @@ struct CommonEditingView: View {
     let isForFlyout: Bool
     let isForSpacingField: Bool
     let isSelectedInspectorRow: Bool
+    let hasHeterogenousValues: Bool
     
     let isFieldInMultifieldInspectorInputAndNotFlyout: Bool
     let fieldWidth: CGFloat
@@ -142,24 +143,6 @@ struct CommonEditingView: View {
         rowViewModel.layerInput
     }
     
-    @MainActor
-    var multiselectInputs: LayerInputPortSet? {
-        graph.propertySidebar.inputsCommonToSelectedLayers
-    }
-            
-    @MainActor
-    var fieldHasHeterogenousValues: Bool {
-        if let layerInputObserver = layerInputObserver {
-            @Bindable var layerInputObserver = layerInputObserver
-            return layerInputObserver.fieldHasHeterogenousValues(
-                fieldIndex,
-                isFieldInsideLayerInspector: isFieldInsideLayerInspector,
-                graph: graph)
-        } else {
-            return false
-        }
-    }
-    
     var hasPicker: Bool {
         choices.isDefined && !isFieldInMultifieldInspectorInputAndNotFlyout
     }
@@ -212,7 +195,7 @@ struct CommonEditingView: View {
                 self.isHovering = isHovering
             }
         }
-        .onChange(of: self.fieldHasHeterogenousValues, initial: true) { oldValue, newValue in
+        .onChange(of: self.hasHeterogenousValues, initial: true) { oldValue, newValue in
             // log("CommonEditingView: on change of: self.hasHeterogenousValues: id: \(id)")
             // log("CommonEditingView: on change of: self.hasHeterogenousValues: oldValue: \(oldValue)")
             // log("CommonEditingView: on change of: self.hasHeterogenousValues: newValue: \(newValue)")
@@ -349,7 +332,7 @@ struct CommonEditingView: View {
             isHovering: isHovering,
             choices: choices,
             fieldWidth: fieldWidth,
-            fieldHasHeterogenousValues: fieldHasHeterogenousValues,
+            fieldHasHeterogenousValues: hasHeterogenousValues,
             isSelectedInspectorRow: isSelectedInspectorRow,
             isFieldInMultfieldInspectorInput: isFieldInMultifieldInspectorInputAndNotFlyout,
             onTap: {
@@ -372,7 +355,7 @@ struct CommonEditingView: View {
     @MainActor
     func updateCurrentEdit(message: String? = nil) {
         
-        if self.fieldHasHeterogenousValues {
+        if self.hasHeterogenousValues {
             self.currentEdit = .HETEROGENOUS_VALUES
         } else {
             self.currentEdit = isLargeString ? "" : self.inputString

--- a/Stitch/Graph/Node/Port/View/Field/InputView/CommonEditingView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/CommonEditingView.swift
@@ -63,7 +63,6 @@ struct CommonEditingView: View {
     @State var isHovering: Bool = false
     
     @Bindable var inputField: InputFieldViewModel
-    let layerInputObserver: LayerInputObserver?
     
     let inputString: String
     

--- a/Stitch/Graph/Node/Port/View/Field/InputView/CommonEditingViewWrapper.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/CommonEditingViewWrapper.swift
@@ -15,7 +15,6 @@ struct CommonEditingViewWrapper: View {
     @Bindable var fieldViewModel: InputFieldViewModel
     @Bindable var rowObserver: InputNodeRowObserver
     let rowViewModel: InputNodeRowViewModel
-    let layerInputObserver: LayerInputObserver?
     let fieldValue: FieldValue
     let fieldCoordinate: FieldCoordinate
     let isCanvasItemSelected: Bool
@@ -46,9 +45,7 @@ struct CommonEditingViewWrapper: View {
     @MainActor
     var isPaddingFieldInsideInspector: Bool {
         isFieldInMultifieldInspectorInputAndNotFlyout
-        && (layerInputObserver?
-            .getActiveValue(activeIndex: graphUI.activeIndex)
-            .getPadding.isDefined ?? false)
+        && rowViewModel.activeValue.getPadding.isDefined
     }
     
     @MainActor
@@ -74,7 +71,6 @@ struct CommonEditingViewWrapper: View {
     var body: some View {
         let stringValue = fieldValue.stringValue
         CommonEditingView(inputField: fieldViewModel,
-                          layerInputObserver: layerInputObserver,
                           inputString: stringValue,
                           graph: graph,
                           graphUI: graphUI,

--- a/Stitch/Graph/Node/Port/View/Field/InputView/CommonEditingViewWrapper.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/CommonEditingViewWrapper.swift
@@ -22,6 +22,7 @@ struct CommonEditingViewWrapper: View {
     let choices: [String]?
     let forPropertySidebar: Bool
     let propertyIsAlreadyOnGraph: Bool
+    let hasHeterogenousValues: Bool
     let isFieldInMultifieldInput: Bool
     let isForFlyout: Bool
     let isSelectedInspectorRow: Bool
@@ -89,6 +90,7 @@ struct CommonEditingViewWrapper: View {
                           isForFlyout: isForFlyout,
                           isForSpacingField: isForSpacingField,
                           isSelectedInspectorRow: isSelectedInspectorRow,
+                          hasHeterogenousValues: hasHeterogenousValues,
                           isFieldInMultifieldInspectorInputAndNotFlyout: isFieldInMultifieldInspectorInputAndNotFlyout,
                           fieldWidth: fieldWidth)
     }

--- a/Stitch/Graph/Node/Port/View/Field/InputView/DropDownChoiceView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/DropDownChoiceView.swift
@@ -15,8 +15,6 @@ struct DropDownChoiceView: View {
     
     let rowObserver: InputNodeRowObserver
     
-    let layerInputObserver: LayerInputObserver?
-    
     @Bindable var graph: GraphState
     
     let choiceDisplay: String

--- a/Stitch/Graph/Node/Port/View/Field/InputView/FieldValueNumberView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/FieldValueNumberView.swift
@@ -23,6 +23,7 @@ struct FieldValueNumberView: View {
     let isCanvasItemSelected: Bool
     let choices: [String]?
     let forPropertySidebar: Bool
+    let hasHeterogenousValues: Bool
     let propertyIsAlreadyOnGraph: Bool
     let isFieldInMultifieldInput: Bool
     let isForFlyout: Bool
@@ -73,6 +74,7 @@ struct FieldValueNumberView: View {
                                      choices: choices,
                                      forPropertySidebar: forPropertySidebar,
                                      propertyIsAlreadyOnGraph: propertyIsAlreadyOnGraph,
+                                     hasHeterogenousValues: hasHeterogenousValues,
                                      isFieldInMultifieldInput: isFieldInMultifieldInput,
                                      isForFlyout: isForFlyout, 
                                      isSelectedInspectorRow: isSelectedInspectorRow,

--- a/Stitch/Graph/Node/Port/View/Field/InputView/FieldValueNumberView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/FieldValueNumberView.swift
@@ -16,7 +16,6 @@ struct FieldValueNumberView: View {
     @Bindable var rowObserver: InputNodeRowObserver
     @Bindable var rowViewModel: InputNodeRowViewModel
     @Bindable var fieldViewModel: InputFieldViewModel
-    let layerInputObserver: LayerInputObserver?
     let fieldValue: FieldValue
     let fieldValueNumberType: FieldValueNumberType
     let fieldCoordinate: FieldCoordinate
@@ -67,7 +66,6 @@ struct FieldValueNumberView: View {
                                      fieldViewModel: fieldViewModel,
                                      rowObserver: rowObserver,
                                      rowViewModel: rowViewModel,
-                                     layerInputObserver: layerInputObserver,
                                      fieldValue: fieldValue,
                                      fieldCoordinate: fieldCoordinate,
                                      isCanvasItemSelected: isCanvasItemSelected,

--- a/Stitch/Graph/Node/Port/View/Field/InputView/LayerGroupAlignmentChoicesView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/LayerGroupAlignmentChoicesView.swift
@@ -132,7 +132,6 @@ struct LayerGroupHorizontalAlignmentPickerFieldValueView: View {
     let rowObserver: InputNodeRowObserver
     let graph: GraphState
     let value: Anchoring
-    let layerInputObserver: LayerInputObserver?
     let isFieldInsideLayerInspector: Bool
     let hasHeterogenousValues: Bool
     let activeIndex: ActiveIndex
@@ -166,7 +165,6 @@ struct LayerGroupVerticalAlignmentPickerFieldValueView: View {
     let graph: GraphState
     let activeIndex: ActiveIndex
     let value: Anchoring
-    let layerInputObserver: LayerInputObserver?
     let isFieldInsideLayerInspector: Bool
     let hasHeterogenousValues: Bool
     

--- a/Stitch/Graph/Node/Port/View/Field/InputView/LayerGroupOrientationDropDownChoiceView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/LayerGroupOrientationDropDownChoiceView.swift
@@ -40,7 +40,6 @@ struct LayerGroupOrientationDropDownChoiceView: View {
     let rowObserver: InputNodeRowObserver
     let graph: GraphState
     let value: StitchOrientation
-    let layerInputObserver: LayerInputObserver?
     let isFieldInsideLayerInspector: Bool
     let hasHeterogenousValues: Bool
     let activeIndex: ActiveIndex

--- a/Stitch/Graph/Node/Port/View/Field/InputView/LayerNamesDropDownChoiceView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/LayerNamesDropDownChoiceView.swift
@@ -120,7 +120,6 @@ struct LayerNamesDropDownChoiceView: View {
     
     let rowObserver: InputNodeRowObserver
     let value: PortValue
-    let layerInputObserver: LayerInputObserver?
     let isFieldInsideLayerInspector: Bool
     let isForPinTo: Bool
     let isSelectedInspectorRow: Bool

--- a/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
@@ -34,7 +34,6 @@ struct MediaFieldValueView<Field: FieldViewModel>: View {
     let rowViewModel: Field.NodeRowType
     let rowObserver: Field.NodeRowType.RowObserver
     let node: NodeViewModel
-    let layerInputObserver: LayerInputObserver?
     let isUpstreamValue: Bool
     let media: FieldValueMedia
     let mediaName: String

--- a/Stitch/Graph/Node/Port/View/Field/InputView/SpecialPickerFieldValueView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/SpecialPickerFieldValueView.swift
@@ -72,7 +72,6 @@ struct SpecialPickerFieldValueView: View {
     let graph: GraphState
     let value: PortValue
     let choices: PortValues
-    let layerInputObserver: LayerInputObserver?
     let isFieldInsideLayerInspector: Bool
     let hasHeterogenousValues: Bool
     let activeIndex: ActiveIndex

--- a/Stitch/Graph/Node/Port/View/Field/InputView/StitchFontDropdown.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/StitchFontDropdown.swift
@@ -13,7 +13,6 @@ struct StitchFontDropdown: View {
     let rowObserver: InputNodeRowObserver
     let graph: GraphState
     let stitchFont: StitchFont
-    let layerInputObserver: LayerInputObserver?
     let isFieldInsideLayerInspector: Bool
     let propertyIsSelected: Bool
     let hasHeterogenousValues: Bool

--- a/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
@@ -120,15 +120,7 @@ struct OutputValueView: View {
     }
 
     var body: some View {
-//        NodeLayoutView(observer: viewModel) {
             switch fieldValue {
-            case .string(let string):
-                // Leading alignment when multifield
-                readOnlyView(string.string)
-                
-            case .number, .layerDimension, .spacing:
-                readOnlyView(fieldValue.stringValue)
-                
             case .bool(let bool):
                 BoolCheckboxView(rowObserver: nil,
                                  graph: graph,
@@ -142,102 +134,12 @@ struct OutputValueView: View {
                 // Values that use dropdowns for their inputs use instead a display-only view for their outputs
                 readOnlyView(choiceDisplay)
                 
-//            case .textFontDropdown(let stitchFont):
-//                StitchFontDropdown(input: rowObserver,
-//                                   stitchFont: stitchFont,
-//                                   layerInputObserver: nil,
-//                                   isFieldInsideLayerInspector: false,
-//                                   propertyIsSelected: isSelectedInspectorRow)
-//                // need enough width for font design + font weight name
-//                .frame(minWidth: 200,
-//                       alignment: .leading)
-//                .disabled(true)
-                
-//            case .layerDropdown(let layerId):
-//                // TODO: use read-only view if this is an output ?
-//                LayerNamesDropDownChoiceView(graph: graph,
-//                                             id: coordinate,
-//                                             value: .assignedLayer(layerId),
-//                                             layerInputObserver: nil,
-//                                             isFieldInsideLayerInspector: false,
-//                                             isForPinTo: false,
-//                                             isSelectedInspectorRow: isSelectedInspectorRow,
-//                                             choices: [])
-//                .disabled(true)
-                
             case .anchorEntity(let anchorEntityId):
                 let displayName = graph.getNodeViewModel(anchorEntityId ?? .init())?.getDisplayTitle() ?? AnchorDropdownChoice.noneDisplayName
                 readOnlyView(displayName)
                 
-//            case .layerGroupOrientationDropdown(let x):
-//                LayerGroupOrientationDropDownChoiceView(
-//                    id: coordinate,
-//                    value: x,
-//                    layerInputObserver: nil,
-//                    isFieldInsideLayerInspector: false)
-//                .disabled(true)
-                
             case .layerGroupAlignment(_):
                 EmptyView() // Can't really happen
-            
-//            case .textAlignmentPicker(let x):
-//                SpecialPickerFieldValueView(
-//                    currentChoice: .textAlignment(x),
-//                    id: coordinate,
-//                    value: .textAlignment(x),
-//                    choices: LayerTextAlignment.choices,
-//                    layerInputObserver: nil,
-//                    isFieldInsideLayerInspector: false)
-//                .disabled(false)
-                
-//            case .textVerticalAlignmentPicker(let x):
-//                SpecialPickerFieldValueView(
-//                    currentChoice: .textVerticalAlignment(x),
-//                    id: coordinate,
-//                    value: .textVerticalAlignment(x),
-//                    choices: LayerTextVerticalAlignment.choices,
-//                    layerInputObserver: nil,
-//                    isFieldInsideLayerInspector: false)
-//                .disabled(false)
-//            
-//            case .textDecoration(let x):
-//                SpecialPickerFieldValueView(
-//                    currentChoice: .textDecoration(x),
-//                    id: coordinate,
-//                    value: .textDecoration(x),
-//                    choices: LayerTextDecoration.choices,
-//                    layerInputObserver: nil,
-//                    isFieldInsideLayerInspector: false)
-//                .disabled(false)
-//                
-//            case .pinTo(let pinToId):
-//                LayerNamesDropDownChoiceView(graph: graph,
-//                                             id: coordinate,
-//                                             value: .pinTo(pinToId),
-//                                             layerInputObserver: nil,
-//                                             isFieldInsideLayerInspector: false,
-//                                             isForPinTo: true,
-//                                             isSelectedInspectorRow: isSelectedInspectorRow,
-//                                             choices: [] //[pinToId.asLayerDropdownChoice] //
-//                                             //                                            graph.layerDropdownChoices(
-//                                             //                                            isForNode: coordinate.nodeId,
-//                                             //                                            isForLayerGroup: false,
-//                                             ////                                            isFieldInsideLayerInspector: false,
-//                                             //                                            isForPinTo: false)
-//                )
-//                
-//                .disabled(true)
-                
-//            case .anchorPopover(let anchor):
-//                AnchorPopoverView(input: coordinate,
-//                                  selection: anchor,
-//                                  layerInputObserver: nil,
-//                                  isFieldInsideLayerInspector: false,
-//                                  isSelectedInspectorRow: isSelectedInspectorRow)
-//                .frame(width: NODE_INPUT_OR_OUTPUT_WIDTH,
-//                       height: NODE_ROW_HEIGHT,
-//                       // Note: why are these reversed? Because we scaled the view down?
-//                       alignment: .leading)
                 
             case .media(let media):
                 MediaFieldValueView(viewModel: viewModel,
@@ -278,7 +180,6 @@ struct OutputValueView: View {
             default:
                 readOnlyView(self.fieldValue.stringValue)
             }
-//        }
     }
 
     @ViewBuilder func readOnlyView(_ displayName: String) -> some View {

--- a/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
@@ -133,7 +133,6 @@ struct OutputValueView: View {
                 BoolCheckboxView(rowObserver: nil,
                                  graph: graph,
                                  document: graphUI,
-                                 layerInputObserver: nil,
                                  value: bool,
                                  isFieldInsideLayerInspector: false,
                                  isSelectedInspectorRow: isSelectedInspectorRow,
@@ -245,7 +244,6 @@ struct OutputValueView: View {
                                     rowViewModel: rowViewModel,
                                     rowObserver: rowObserver,
                                     node: node,
-                                    layerInputObserver: nil,
                                     isUpstreamValue: false,     // only valid for inputs
                                     media: media,
                                     mediaName: media.name,

--- a/Stitch/Graph/Node/Port/View/Field/ValueButton/ColorOrbValueButtonView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/ValueButton/ColorOrbValueButtonView.swift
@@ -15,7 +15,6 @@ struct ColorOrbValueButtonView: View {
     let fieldViewModel: InputFieldViewModel
     let rowViewModel: InputNodeRowViewModel
     let rowObserver: InputNodeRowObserver
-    let layerInputObserver: LayerInputObserver?
     let isForFlyout: Bool
     let currentColor: Color // the current color, from input
     let hasIncomingEdge: Bool
@@ -48,8 +47,8 @@ struct ColorOrbValueButtonView: View {
             }
         }
 
-        StitchColorPickerView(rowObserver: rowObserver,
-                              layerInputObserver: layerInputObserver,
+        StitchColorPickerView(rowViewModelId: rowViewModel.id,
+                              rowObserver: rowObserver,
                               fieldCoordinate: fieldViewModel.id,
                               isFieldInsideLayerInspector: rowViewModel.isFieldInsideLayerInspector,
                               isForFlyout: isForFlyout,

--- a/Stitch/Graph/Node/Port/View/Field/ValueButton/StitchColorPicker/StitchColorPickerView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/ValueButton/StitchColorPicker/StitchColorPickerView.swift
@@ -54,8 +54,8 @@ struct StitchColorPickerView: View {
     // TODO: opening or closing the color-gradient-picker view should disable nodes copy-paste shortcut
     @State private var show: Bool = false
 
+    let rowViewModelId: NodeRowViewModelId
     let rowObserver: InputNodeRowObserver?
-    let layerInputObserver: LayerInputObserver?
     let fieldCoordinate: FieldCoordinate
     let isFieldInsideLayerInspector: Bool
     let isForFlyout: Bool
@@ -104,10 +104,10 @@ struct StitchColorPickerView: View {
                        isFieldInsideLayerInspector,
                        !isForPreviewWindowBackgroundPicker,
                        !isForIPhone,
-                       let layerInputObserver = layerInputObserver,
+                       let layerPort = rowViewModelId.layerInputPort,
                        let nodeId = rowObserver?.id.nodeId {
                         // iPad
-                        dispatch(FlyoutToggled(flyoutInput: layerInputObserver.port,
+                        dispatch(FlyoutToggled(flyoutInput: layerPort,
                                                flyoutNodeId: nodeId,
                                                fieldToFocus: nil))
                     } else {

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
@@ -359,7 +359,6 @@ extension LayerInputObserver {
     /// Helper only intended for use with ports that don't support unpacked mode.
     @MainActor
     var rowObserver: InputNodeRowObserver {
-        assertInDebug(self.mode == .packed)
         return self._packedData.rowObserver
     }
 }

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
@@ -188,8 +188,7 @@ extension GraphState {
             return nil
         }
         
-        guard let firstSelectedLayer = self.sidebarSelectionState.primary.first,
-              let firstSelectedNode: NodeViewModel = self.getNode(firstSelectedLayer) else {
+        guard let firstSelectedLayer = self.sidebarSelectionState.primary.first else {
             log("multipleSidebarLayersSelected: did not have any selected sidebar layers?")
             return nil
         }
@@ -248,14 +247,7 @@ extension ProjectSidebarObservable {
     
     @MainActor
     func sidebarItemSelectedViaEditMode(_ id: Self.ItemID) {
-        
-        // we selected a group -- so 100% select the group
-        // and 80% all the children further down in the street
-        guard let item = self.retrieveItem(id) else {
-            return
-        }
-           
-        self.addExclusivelyToPrimary(id)  
+        self.addExclusivelyToPrimary(id)
         self.graphDelegate?.updateInspectorFocusedLayers()
     }
 }

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -255,7 +255,7 @@ extension GraphState {
         self.mediaLibrary.get(key)
     }
     
-    @MainActor var multiselectInputs: LayerInputPortSet? {
+    @MainActor var multiselectInputs: Set<LayerInputPort>? {
         self.propertySidebar.inputsCommonToSelectedLayers
     }
     

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -354,6 +354,18 @@ extension StitchDocumentViewModel {
 }
 
 extension GraphState: GraphCalculatable {
+    func didPortsUpdate(ports: Set<StitchEngine.NodePortType<NodeViewModel>>) {
+        // Update multi-selected layers in sidebar with possible heterogenous values
+        if let currentMultiselectionMap = self.propertySidebar.heterogenousFieldsMap {
+            let newMultiselectionMap = Set(currentMultiselectionMap.keys)
+                .getHeterogenousFieldsMap(graph: self)
+            
+            if currentMultiselectionMap != newMultiselectionMap {
+                self.propertySidebar.heterogenousFieldsMap = newMultiselectionMap
+            }
+        }
+    }
+    
     
     @MainActor
     func updateOrderedPreviewLayers() {


### PR DESCRIPTION
This PR adds caching logic for reporting which fields display heterogenous values in a sidebar multiselect scenario. Previous logic introduced extra render cycles thanks to methods get `getNodeViewModel` which required view refresh whenever the nodes dictionary changed.

Perf improves in node duplication on humane demo by roughly 10%.