### PR TITLE
Do not persist when graph scroll ends

### DIFF
--- a/Stitch/Graph/Gesture/View/GraphMovementViewModifier.swift
+++ b/Stitch/Graph/Gesture/View/GraphMovementViewModifier.swift
@@ -19,7 +19,7 @@ struct GraphMovementViewModifier: ViewModifier {
         content
 
             // Note: `initial: true` seemed to fire only upon first opening of a given project after app re-opened, and not upon every opening of the project?
-            .onChange(of: groupNodeFocused) { oldValue, newValue in
+            .onChange(of: groupNodeFocused) { _, _ in
                 dispatch(SetGraphScrollDataUponPageChange(
                     newPageLocalPosition: currentNodePage.localPosition,
                     newPageZoom: currentNodePage.zoomData
@@ -28,11 +28,11 @@ struct GraphMovementViewModifier: ViewModifier {
 
             // TODO: either update these `graphMovement: GraphMovementObserver` in `GraphScrollDataUpdated` OR get rid of GraphMovementObserver completely and merely rely on node-page's offset and zoom
             .onChange(of: graphMovement.localPosition) { _, newValue in
-                currentNodePage.localPosition = graphMovement.localPosition
+                currentNodePage.localPosition = newValue
                 self.graph.updateVisibleNodes()
             }
             .onChange(of: graphMovement.zoomData) { _, newValue in
-                currentNodePage.zoomData = graphMovement.zoomData
+                currentNodePage.zoomData = newValue
                 self.graph.updateVisibleNodes()
             }
     }

--- a/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
@@ -78,7 +78,7 @@ struct MediaFieldValueView<Field: FieldViewModel>: View {
                                       isSelectedInspectorRow: isSelectedInspectorRow,
                                       activeIndex: document.activeIndex)
                 .onChange(of: mediaName, initial: true) {
-                    print("media name in inner value view: \(mediaName)")
+                    // log("media name in inner value view: \(mediaName)")
                 }
             }
             

--- a/Stitch/Graph/Node/View/StitchUIScrollHelpers.swift
+++ b/Stitch/Graph/Node/View/StitchUIScrollHelpers.swift
@@ -54,10 +54,12 @@ struct GraphScrollDataUpdated: StitchDocumentEvent {
         state.graphMovement.localPosition = newOffset
         state.graphMovement.zoomData = newZoom
         
-        if shouldPersist {
-            // log("GraphScrollDataUpdated: will persist")
-            state.encodeProjectInBackground()
-        }
+        // NOTE: we no longer persist after graph scroll ends, since we now always open the graph to the center.
+        
+//        if shouldPersist {
+//            log("GraphScrollDataUpdated: will persist")
+//            state.encodeProjectInBackground()
+//        }
     }
     
 }

--- a/Stitch/Graph/Node/ViewModel/NodeDelegate.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeDelegate.swift
@@ -57,7 +57,7 @@ extension NodeDelegate {
             }
         case .group(let canvas):
 //            fatalErrorIfDebug("Attempted to retrieve a row observer for a GroupNode input")
-            log("Attempted to retrieve a row observer for a GroupNode input")
+            //            log("Attempted to retrieve a row observer for a GroupNode input")
             return canvas.inputViewModels.compactMap {
                 $0.rowDelegate
             }


### PR DESCRIPTION
... since we now always open the graph to the center anyway.