### PR TITLE
Improved perf with StitchEngine media handling

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -63,6 +63,7 @@
 		B51C67512C6441A5002F83D1 /* UnpackedValueCoercer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51C67502C6441A5002F83D1 /* UnpackedValueCoercer.swift */; };
 		B51D8809298CA7A000CEBA98 /* AsyncMediaValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51D8808298CA7A000CEBA98 /* AsyncMediaValue.swift */; };
 		B51D8A022CD13D420016CCDA /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = B51D8A012CD13D420016CCDA /* StitchEngine */; };
+		B51EA02B2D78BC6100111945 /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = B51EA02A2D78BC6100111945 /* StitchEngine */; };
 		B521489A2C837CA6009AD42C /* DelayOneNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52148992C837CA6009AD42C /* DelayOneNode.swift */; };
 		B5221F662D397457009FF89A /* SphereLayerNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5221F652D397455009FF89A /* SphereLayerNode.swift */; };
 		B5221F682D397735009FF89A /* StitchEntityType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5221F672D397731009FF89A /* StitchEntityType.swift */; };
@@ -1922,6 +1923,7 @@
 			files = (
 				B5FBE3C42C4195B3006DA0A7 /* DirectoryWatcher in Frameworks */,
 				B5EB3F072C165FE900879947 /* (null) in Frameworks */,
+				B51EA02B2D78BC6100111945 /* StitchEngine in Frameworks */,
 				B501920C2C6D144D00A048ED /* StitchEngine in Frameworks */,
 				20D1601925A802FF005AEB72 /* NonEmpty in Frameworks */,
 				B58AB69D2C152E4C002C63E2 /* (null) in Frameworks */,
@@ -4686,6 +4688,7 @@
 				E42AAE4B2D4844EE002D187D /* Sentry */,
 				B50BC9E32D77881900311551 /* StitchEngine */,
 				B5B8105B2D77E1C90095DA9D /* StitchEngine */,
+				B51EA02A2D78BC6100111945 /* StitchEngine */,
 			);
 			productName = prototype;
 			productReference = 200BD857254F66EB00692903 /* Stitch.app */;
@@ -4773,7 +4776,7 @@
 				E463E7ED2C6FC7090008E318 /* XCRemoteSwiftPackageReference "StitchSchemaKit" */,
 				E4A848A92D32FCFA0029AFDE /* XCRemoteSwiftPackageReference "supabase-swift" */,
 				E42AAE4A2D4844EE002D187D /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
-				B5B8105A2D77E1C90095DA9D /* XCLocalSwiftPackageReference "../StitchEngineClosedSource" */,
+				B51EA0292D78BC6100111945 /* XCRemoteSwiftPackageReference "StitchEngine" */,
 			);
 			productRefGroup = 200BD858254F66EB00692903 /* Products */;
 			projectDirPath = "";
@@ -6584,13 +6587,6 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCLocalSwiftPackageReference section */
-		B5B8105A2D77E1C90095DA9D /* XCLocalSwiftPackageReference "../StitchEngineClosedSource" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../StitchEngineClosedSource;
-		};
-/* End XCLocalSwiftPackageReference section */
-
 /* Begin XCRemoteSwiftPackageReference section */
 		201953D825B25D3300D5296C /* XCRemoteSwiftPackageReference "swift-tagged" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -6622,6 +6618,14 @@
 			requirement = {
 				kind = revision;
 				revision = f771d9ae644935d1e1acfb861be00f403de083b5;
+			};
+		};
+		B51EA0292D78BC6100111945 /* XCRemoteSwiftPackageReference "StitchEngine" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/StitchDesign/StitchEngine";
+			requirement = {
+				kind = revision;
+				revision = ae01d52c4b2fd696d3e26b723d64bf9f93ee1acf;
 			};
 		};
 		B5FBE3C22C4195B3006DA0A7 /* XCRemoteSwiftPackageReference "DirectoryWatcher" */ = {
@@ -6749,6 +6753,11 @@
 		};
 		B51D8A012CD13D420016CCDA /* StitchEngine */ = {
 			isa = XCSwiftPackageProductDependency;
+			productName = StitchEngine;
+		};
+		B51EA02A2D78BC6100111945 /* StitchEngine */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B51EA0292D78BC6100111945 /* XCRemoteSwiftPackageReference "StitchEngine" */;
 			productName = StitchEngine;
 		};
 		B5380E302CF8E51600E6D801 /* StitchEngine */ = {

--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -73,7 +73,6 @@
 		B525BB482C18AFC300A98EB4 /* FileDropHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = B525BB472C18AFC300A98EB4 /* FileDropHandling.swift */; };
 		B526AFFE2C764E8D00B5971F /* SchemaVersions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B526AFFD2C764E8D00B5971F /* SchemaVersions.swift */; };
 		B52A3E632B7F337400B4F1DA /* GraphCopyable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52A3E622B7F337400B4F1DA /* GraphCopyable.swift */; };
-		B52F77882D77D342007710C5 /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = B52F77872D77D342007710C5 /* StitchEngine */; };
 		B530494727A0CBF500D970BB /* ViewUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B530494627A0CBF500D970BB /* ViewUtils.swift */; };
 		B5305CE7285150E2008F11F4 /* beach.png in Resources */ = {isa = PBXBuildFile; fileRef = B5305CE6285150E2008F11F4 /* beach.png */; };
 		B530D5032C18AB390005C6A9 /* AppThemeActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B530D5022C18AB390005C6A9 /* AppThemeActions.swift */; };
@@ -219,6 +218,7 @@
 		B5B20BB2279A171E008A2B5A /* GestureHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B20BB1279A171E008A2B5A /* GestureHostingController.swift */; };
 		B5B300ED2D49627F0064D071 /* NodeMediaUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B300EC2D49627A0064D071 /* NodeMediaUtils.swift */; };
 		B5B43FCC2B4F565300C6A847 /* NodeDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B43FCB2B4F565300C6A847 /* NodeDefinition.swift */; };
+		B5B8105C2D77E1C90095DA9D /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = B5B8105B2D77E1C90095DA9D /* StitchEngine */; };
 		B5B8166B2BBD105C003EA2AD /* NodeIOCoordiante.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B8166A2BBD105C003EA2AD /* NodeIOCoordiante.swift */; };
 		B5B95B982CB6D67A00DA64B3 /* StitchSystemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B95B972CB6D67200DA64B3 /* StitchSystemViewModel.swift */; };
 		B5B95B9A2CB6D6B400DA64B3 /* StitchSystemEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B95B992CB6D6B300DA64B3 /* StitchSystemEncoder.swift */; };
@@ -1937,7 +1937,7 @@
 				B50BC9E42D77881900311551 /* StitchEngine in Frameworks */,
 				EC91034A29109DF3007C548E /* SoulverCore in Frameworks */,
 				B5380E312CF8E51600E6D801 /* StitchEngine in Frameworks */,
-				B52F77882D77D342007710C5 /* StitchEngine in Frameworks */,
+				B5B8105C2D77E1C90095DA9D /* StitchEngine in Frameworks */,
 				B560CE812CF1C93100F31905 /* StitchEngine in Frameworks */,
 				EC17DF0928F626660042BF4F /* MathParser in Frameworks */,
 				E4A848AB2D32FCFA0029AFDE /* PostgREST in Frameworks */,
@@ -4685,7 +4685,7 @@
 				B56F36242D3C1A2E0051C80E /* StitchEngine */,
 				E42AAE4B2D4844EE002D187D /* Sentry */,
 				B50BC9E32D77881900311551 /* StitchEngine */,
-				B52F77872D77D342007710C5 /* StitchEngine */,
+				B5B8105B2D77E1C90095DA9D /* StitchEngine */,
 			);
 			productName = prototype;
 			productReference = 200BD857254F66EB00692903 /* Stitch.app */;
@@ -4773,7 +4773,7 @@
 				E463E7ED2C6FC7090008E318 /* XCRemoteSwiftPackageReference "StitchSchemaKit" */,
 				E4A848A92D32FCFA0029AFDE /* XCRemoteSwiftPackageReference "supabase-swift" */,
 				E42AAE4A2D4844EE002D187D /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
-				B52F77862D77D342007710C5 /* XCRemoteSwiftPackageReference "StitchEngine" */,
+				B5B8105A2D77E1C90095DA9D /* XCLocalSwiftPackageReference "../StitchEngineClosedSource" */,
 			);
 			productRefGroup = 200BD858254F66EB00692903 /* Products */;
 			projectDirPath = "";
@@ -6584,6 +6584,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		B5B8105A2D77E1C90095DA9D /* XCLocalSwiftPackageReference "../StitchEngineClosedSource" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../StitchEngineClosedSource;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		201953D825B25D3300D5296C /* XCRemoteSwiftPackageReference "swift-tagged" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -6615,14 +6622,6 @@
 			requirement = {
 				kind = revision;
 				revision = f771d9ae644935d1e1acfb861be00f403de083b5;
-			};
-		};
-		B52F77862D77D342007710C5 /* XCRemoteSwiftPackageReference "StitchEngine" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/StitchDesign/StitchEngine";
-			requirement = {
-				kind = revision;
-				revision = 4006f42a502eae5946048d2c202d516d63c66cdd;
 			};
 		};
 		B5FBE3C22C4195B3006DA0A7 /* XCRemoteSwiftPackageReference "DirectoryWatcher" */ = {
@@ -6752,11 +6751,6 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = StitchEngine;
 		};
-		B52F77872D77D342007710C5 /* StitchEngine */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = B52F77862D77D342007710C5 /* XCRemoteSwiftPackageReference "StitchEngine" */;
-			productName = StitchEngine;
-		};
 		B5380E302CF8E51600E6D801 /* StitchEngine */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = StitchEngine;
@@ -6778,6 +6772,10 @@
 			productName = StitchEngine;
 		};
 		B58612AE2C68681600C64313 /* StitchEngine */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = StitchEngine;
+		};
+		B5B8105B2D77E1C90095DA9D /* StitchEngine */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = StitchEngine;
 		};

--- a/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9b5391b46b01491c5273c7ba64b3ae6c9a7b8513a1cd95075006db3ef5f12482",
+  "originHash" : "2f217b3ebd4ed4fdf06f7fad2cbf55899cf913fe0a1916b4eb705be2ef0cd05d",
   "pins" : [
     {
       "identity" : "audiokit",
@@ -52,6 +52,14 @@
       "state" : {
         "revision" : "ef309cda2d2f426476181ae294f3b899eac83af4",
         "version" : "2.6.3"
+      }
+    },
+    {
+      "identity" : "stitchengine",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/StitchDesign/StitchEngine",
+      "state" : {
+        "revision" : "ae01d52c4b2fd696d3e26b723d64bf9f93ee1acf"
       }
     },
     {

--- a/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "906ea53775f320cbbf1349503a463e5e89cc8a926639156d5273d631e3d7c8ee",
+  "originHash" : "9b5391b46b01491c5273c7ba64b3ae6c9a7b8513a1cd95075006db3ef5f12482",
   "pins" : [
     {
       "identity" : "audiokit",

--- a/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "55fa3dd0f79ebe2737fb9f4be04340daeffdbaafaa67e3167f25666cdef10627",
+  "originHash" : "906ea53775f320cbbf1349503a463e5e89cc8a926639156d5273d631e3d7c8ee",
   "pins" : [
     {
       "identity" : "audiokit",
@@ -52,14 +52,6 @@
       "state" : {
         "revision" : "ef309cda2d2f426476181ae294f3b899eac83af4",
         "version" : "2.6.3"
-      }
-    },
-    {
-      "identity" : "stitchengine",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StitchDesign/StitchEngine",
-      "state" : {
-        "revision" : "4006f42a502eae5946048d2c202d516d63c66cdd"
       }
     },
     {

--- a/Stitch/Graph/Edge/Util/PortActions.swift
+++ b/Stitch/Graph/Edge/Util/PortActions.swift
@@ -33,7 +33,7 @@ extension InputNodeRowObserver {
            self.id.isMediaSelectorLocation {
             if willUpstreamBeDisconnected,
                let upstreamOutputObserver = self.upstreamOutputObserver {
-                upstreamOutputObserver.getMediaObjects().forEach {
+                upstreamOutputObserver.getComputedMediaObjects().forEach {
                     if let video = $0.video {
                         video.muteSound()
                     }
@@ -55,7 +55,7 @@ extension InputNodeRowObserver {
                                    mediaId: nil)  // setting nil will get object without equality checking
             }.forEach { media in
                 // Run effect to mute sound player
-                self.upstreamOutputObserver?.getMediaObjects().forEach { media in
+                self.upstreamOutputObserver?.getComputedMediaObjects().forEach { media in
                     media.updateVolume(to: .zero)
                 }
             }

--- a/Stitch/Graph/Edge/Util/PortActions.swift
+++ b/Stitch/Graph/Edge/Util/PortActions.swift
@@ -48,17 +48,13 @@ extension InputNodeRowObserver {
         else if self.nodeKind.isSpeakerNode,
                 // Only look at this input if it is the media input
                 self.id.isMediaSelectorLocation,
-                let node = self.nodeDelegate {
-            self.allLoopedValues.enumerated().compactMap { loopIndex, _ in
-                node.getInputMedia(portIndex: 0,
-                                   loopIndex: loopIndex,
-                                   mediaId: nil)  // setting nil will get object without equality checking
-            }.forEach { media in
-                // Run effect to mute sound player
-                self.upstreamOutputObserver?.getComputedMediaObjects().forEach { media in
-                    media.updateVolume(to: .zero)
+                let node = self.upstreamOutputObserver?.nodeDelegate {
+            node.getMediaObservers()?
+                .map(\.computedMedia)
+                .forEach { media in
+                    // Run effect to mute sound player
+                    media?.mediaObject.updateVolume(to: .zero)
                 }
-            }
             self.updateValues([.asyncMedia(nil)])
         } else {
             // Flatten values by default
@@ -121,6 +117,11 @@ extension GraphState {
             return
         }
 
+        // Runs logic to disconnect existing media conntected by edge
+        if downstreamInputObserver.upstreamOutputCoordinate != nil {
+            downstreamInputObserver.removeUpstreamConnection()
+        }
+        
         // Sets edge
         downstreamInputObserver.upstreamOutputCoordinate = edge.from
 

--- a/Stitch/Graph/Node/Eval/EphemeralObserver/NodeEphemeralObservable.swift
+++ b/Stitch/Graph/Node/Eval/EphemeralObserver/NodeEphemeralObservable.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import StitchSchemaKit
+import StitchEngine
 import RealityKit
 import SwiftUI
 

--- a/Stitch/Graph/Node/Eval/MediaEvalOpObservable.swift
+++ b/Stitch/Graph/Node/Eval/MediaEvalOpObservable.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import StitchEngine
 import StitchSchemaKit
 import SwiftUI
 
@@ -86,6 +87,15 @@ extension MediaEvalOpObserver {
 //        default:
 //            return
 //        }
+    }
+}
+
+extension MediaViewModel: StitchEngine.MediaEphemeralObservable {
+    typealias Node = NodeViewModel
+    
+    @MainActor
+    func updateMedia(_ media: GraphMediaValue?) {
+        self.currentMedia = media
     }
 }
 
@@ -364,9 +374,11 @@ actor MediaEvalOpCoordinator {
                           node: NodeDelegate,
                           callback: @Sendable @escaping () async -> PortValues) async {
         let newOutputs = await callback()
-        await node.graphDelegate?.recalculateGraphForMedia(outputValues: .byIndex(newOutputs),
-                                                   nodeId: node.id,
-                                                   loopIndex: loopIndex)
+        await node.graphDelegate?
+            .recalculateGraphForMedia(outputValues: .byIndex(newOutputs),
+                                      media: nil,
+                                      nodeId: node.id,
+                                      loopIndex: loopIndex)
     }
     
     /// Async callback to prevent data races for media object changes.
@@ -383,8 +395,10 @@ actor MediaEvalOpCoordinator {
     func asyncMediaEvalOpList(node: NodeDelegate,
                               callback: @Sendable @escaping () async -> PortValuesList) async {
         let newOutputs = await callback()
-        await node.graphDelegate?.recalculateGraphForMedia(outputValues: .all(newOutputs),
-                                                   nodeId: node.id,
-                                                   loopIndex: 0)
+        await node.graphDelegate?
+            .recalculateGraphForMedia(outputValues: .all(newOutputs),
+                                      media: nil,
+                                      nodeId: node.id,
+                                      loopIndex: 0)
     }
 }

--- a/Stitch/Graph/Node/Eval/MediaEvalOpObservable.swift
+++ b/Stitch/Graph/Node/Eval/MediaEvalOpObservable.swift
@@ -127,11 +127,21 @@ extension MediaEvalOpObservable {
     @MainActor func getUniqueMedia(inputMediaValue: AsyncMediaValue?,
                                    inputPortIndex: Int,
                                    loopIndex: Int) async -> GraphMediaValue? {
+        // Get already existing media if matching ID
+        if self.inputMedia?.id == inputMediaValue?.id {
+            return self.inputMedia
+        }
+        
         if let node = self.nodeDelegate {
-            return await Self.getUniqueMedia(node: node,
-                                             inputMediaValue: inputMediaValue,
-                                             inputPortIndex: inputPortIndex,
-                                             loopIndex: loopIndex)
+            let media = await Self.getUniqueMedia(node: node,
+                                                  inputMediaValue: inputMediaValue,
+                                                  inputPortIndex: inputPortIndex,
+                                                  loopIndex: loopIndex)
+            
+            // Save media to observer
+            self.inputMedia = media
+            
+            return media
         }
         
         return nil

--- a/Stitch/Graph/Node/Eval/MediaEvalOpObservable.swift
+++ b/Stitch/Graph/Node/Eval/MediaEvalOpObservable.swift
@@ -262,7 +262,7 @@ extension MediaEvalOpObservable {
         }
 
         let outputs = MediaEvalResult(from: values).prevOutputs(node: nodeDelegate)
-        let currentMedia = self.inputMedia
+        let currentMedia = self.computedMedia
         
         Task(priority: .high) { [weak self, weak nodeDelegate] in
             guard let nodeDelegate = nodeDelegate else {
@@ -398,8 +398,8 @@ actor MediaEvalOpCoordinator {
                                            callback: @Sendable @escaping () async -> MediaEvalResult) async where MediaEvalResult: MediaEvalResultable {
         let result = await callback()
         await node.graphDelegate?.recalculateGraphForMedia(result: result,
-                                                   nodeId: node.id,
-                                                   loopIndex: loopIndex)
+                                                           nodeId: node.id,
+                                                           loopIndex: loopIndex)
     }
     
     /// Async callback to prevent data races for media object changes.

--- a/Stitch/Graph/Node/Eval/MediaEvalOpObservable.swift
+++ b/Stitch/Graph/Node/Eval/MediaEvalOpObservable.swift
@@ -74,7 +74,7 @@ final class ImageClassifierOpObserver: MediaEvalOpObservable {
 
 extension MediaEvalOpObserver {
     @MainActor func onPrototypeRestart() {
-        self.currentMedia = nil
+        self.resetMedia()
         
         // MARK: below functionality keeps objects in place, which would make restarts less jarring should be an issue again
 //        switch currentMedia?.mediaObject {
@@ -94,19 +94,29 @@ extension MediaViewModel: StitchEngine.MediaEphemeralObservable {
     typealias Node = NodeViewModel
     
     @MainActor
-    func updateMedia(_ media: GraphMediaValue?) {
-        self.currentMedia = media
+    func updateInputMedia(_ media: GraphMediaValue?) {
+        self.inputMedia = media
     }
 }
 
 extension MediaEvalOpViewable {
     @MainActor
-    var currentMedia: GraphMediaValue? {
+    var inputMedia: GraphMediaValue? {
         get {
-            self.mediaViewModel.currentMedia
+            self.mediaViewModel.inputMedia
         }
         set(newValue) {
-            self.mediaViewModel.currentMedia = newValue
+            self.mediaViewModel.inputMedia = newValue
+        }
+    }
+    
+    @MainActor
+    var computedMedia: GraphMediaValue? {
+        get {
+            self.mediaViewModel.computedMedia
+        }
+        set(newValue) {
+            self.mediaViewModel.computedMedia = newValue
         }
     }
 }
@@ -128,7 +138,8 @@ extension MediaEvalOpObservable {
     }
     
     @MainActor func resetMedia() {
-        self.currentMedia = nil
+        self.inputMedia = nil
+        self.computedMedia = nil
     }
     
     /// A specific media eval handler that only creates new media when a particular input's media value has changed.
@@ -157,7 +168,7 @@ extension MediaEvalOpObservable {
             
             guard let inputMediaValue = inputMediaValue else {
                 // Set to nil case
-                mediaObserver.currentMedia = nil
+                mediaObserver.resetMedia()
                 return .init(from: defaultOutputs)
             }
             
@@ -251,7 +262,7 @@ extension MediaEvalOpObservable {
         }
 
         let outputs = MediaEvalResult(from: values).prevOutputs(node: nodeDelegate)
-        let currentMedia = self.currentMedia
+        let currentMedia = self.inputMedia
         
         Task(priority: .high) { [weak self, weak nodeDelegate] in
             guard let nodeDelegate = nodeDelegate else {

--- a/Stitch/Graph/Node/Eval/PatchEvaluation.swift
+++ b/Stitch/Graph/Node/Eval/PatchEvaluation.swift
@@ -12,6 +12,9 @@ import StitchEngine
 
 struct EvalResult: NodeEvalResult, Sendable {
     var outputsValues: PortValuesList
+    
+    var mediaList: [GraphMediaValue?]?
+    
     var runAgain = false
 
     // Determines if media objects changed in a manner which should trigger downstream nodes

--- a/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/Model3DLayerUtil.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/Model3DLayerUtil.swift
@@ -60,7 +60,7 @@ struct Model3DViewModifier: ViewModifier {
                 
                 // Set state for media object
                 let entity = self.createEntity()
-                viewModel.mediaViewModel.currentMedia = .init(computedMedia: .model3D(entity))
+                viewModel.mediaViewModel.inputMedia = .init(computedMedia: .model3D(entity))
             }
             .onChange(of: viewModel.size3D) {
                 self.updateEntity()

--- a/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/Nodes/Model3DLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/Nodes/Model3DLayerNode.swift
@@ -85,7 +85,7 @@ struct Model3DLayerNode: LayerNodeDefinition {
             parentSize: parentSize,
             parentDisablesPosition: parentDisablesPosition,
             parentIsScrollableGrid: parentIsScrollableGrid)
-        .onChange(of: viewModel.mediaViewModel.currentMedia, initial: true) { oldValue, newValue in
+        .onChange(of: viewModel.mediaViewModel.inputMedia, initial: true) { oldValue, newValue in
             // Update transform for 3D model once loaded
             if oldValue != newValue,
                let model3DEntity = newValue?.mediaObject.model3DEntity {

--- a/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/PreviewModel3DLayer.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/PreviewModel3DLayer.swift
@@ -281,7 +281,7 @@ struct ModelEntityLayerViewModifier: ViewModifier {
                      
                         await MainActor.run { [weak entityCopy] in
                             guard let entityCopy = entityCopy else { return }
-                            previewLayer.mediaViewModel.currentMedia = .init(computedMedia: .model3D(entityCopy))
+                            previewLayer.mediaViewModel.inputMedia = .init(computedMedia: .model3D(entityCopy))
                             self.anchorEntity.addChild(entityCopy.containerEntity)
                             
                             self.assignGestures(entity: entityCopy)

--- a/Stitch/Graph/Node/Model/RowData/NodeIOCoordiante.swift
+++ b/Stitch/Graph/Node/Model/RowData/NodeIOCoordiante.swift
@@ -73,6 +73,22 @@ extension NodeIOPortType {
             return nil
         }
     }
+    
+    var isVisualMeiaPortType: Bool {
+        switch self {
+        case .portIndex(let index):
+            return index == 0
+            
+        case .keyPath(let keyPath):
+            switch keyPath.layerInput {
+            case .image, .video:
+                return true
+                
+            default:
+                return false
+            }
+        }
+    }
 }
 
 extension LayerInputPort {

--- a/Stitch/Graph/Node/Patch/Type/Data/NetworkRequestNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Data/NetworkRequestNode.swift
@@ -101,7 +101,7 @@ func networkRequestEval(node: PatchNode,
             values[safe: 10] ?? defaultFalseJSON
         ]
 
-        let prevMedia = mediaObserver.currentMedia
+        let prevMedia = mediaObserver.computedMedia
 
         // What was this case ?
         // if we didn't have a pulse, "don't do anything"

--- a/Stitch/Graph/Node/Patch/Type/Delay/DelayNodeUtil.swift
+++ b/Stitch/Graph/Node/Patch/Type/Delay/DelayNodeUtil.swift
@@ -53,8 +53,9 @@ extension NodeTimerEphemeralObserver {
         guard value.asyncMedia != nil,
               let mediaObject = media else {
             graph.recalculateGraphForMedia(outputValues: .init(from: [value]),
-                                   nodeId: nodeId,
-                                   loopIndex: loopIndex)
+                                           media: nil,
+                                           nodeId: nodeId,
+                                           loopIndex: loopIndex)
             return
         }
         
@@ -75,9 +76,11 @@ extension NodeTimerEphemeralObserver {
             
             await MainActor.run { [weak node] in
                 self.currentMedia = mediaObject
-                return node?.graphDelegate?.recalculateGraphForMedia(outputValues: .byIndex(newOutputs),
-                                                             nodeId: nodeId,
-                                                             loopIndex: loopIndex)
+                return node?.graphDelegate?
+                    .recalculateGraphForMedia(outputValues: .byIndex(newOutputs),
+                                              media: mediaObject,
+                                              nodeId: nodeId,
+                                              loopIndex: loopIndex)
             }
         }
     }

--- a/Stitch/Graph/Node/Patch/Type/Delay/DelayNodeUtil.swift
+++ b/Stitch/Graph/Node/Patch/Type/Delay/DelayNodeUtil.swift
@@ -75,7 +75,7 @@ extension NodeTimerEphemeralObserver {
             let newOutputs = [mediaObject.portValue]
             
             await MainActor.run { [weak node] in
-                self.currentMedia = mediaObject
+                self.computedMedia = mediaObject
                 return node?.graphDelegate?
                     .recalculateGraphForMedia(outputValues: .byIndex(newOutputs),
                                               media: mediaObject,

--- a/Stitch/Graph/Node/Patch/Type/Interaction/PressInteractionPatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/PressInteractionPatchNode.swift
@@ -95,7 +95,8 @@ actor PressInteractionActor {
             
             graph.updateOutputs(at: loopIndex,
                                 node: pressNode,
-                                portValues: createNewValues(graph.graphStepState.graphTime))
+                                portValues: createNewValues(graph.graphStepState.graphTime),
+                                media: nil)
         }
     }
 }

--- a/Stitch/Graph/Node/Patch/Type/Media/MicrophoneFeedNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Media/MicrophoneFeedNode.swift
@@ -66,7 +66,7 @@ struct MicrophoneNode: PatchNodeDefinition {
                 return
             }
             
-            observer.currentMedia = .init(computedMedia: .mic(newSoundPlayer))
+            observer.computedMedia = .init(computedMedia: .mic(newSoundPlayer))
             observer.currentLoadingMediaId = nil
         }
     }
@@ -89,7 +89,7 @@ func microphoneEval(node: PatchNode) -> EvalResult {
             return MediaEvalOpResult(from: node.defaultOutputs)
         }
            
-        guard let currentMedia = mediaObserver.currentMedia,
+        guard let currentMedia = mediaObserver.computedMedia,
               let mic = currentMedia.mediaObject.mic else {
             createMic(isEnabled: isEnabled,
                       observer: mediaObserver)

--- a/Stitch/Graph/Node/Patch/Type/Media/SpeakerNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Media/SpeakerNode.swift
@@ -36,13 +36,16 @@ func speakerNode(id: NodeId,
 
 @MainActor
 func speakerEval(node: PatchNode) -> EvalResult {
+    // MARK: media object is obtained by looking at upstream connected node's saved media objects. This system isn't perfect as not all nodes which can hold media use the MediaEvalOpObserver.
+    let upstreamNode = node.inputsObservers.first?
+        .upstreamOutputObserver?
+        .nodeDelegate
+    
     let _ = loopedEval(node: node) { values, loopIndex in
-        // MARK: media object is obtained by looking at upstream connected node's saved media objects. This system isn't perfect as not all nodes which can hold media use the MediaEvalOpObserver.
         guard let mediaId = values.first?.asyncMedia?.id,
+              let mediaObject = upstreamNode?
+            .getComputedMedia(loopIndex: loopIndex, mediaId: mediaId),
               let volume = values[safe: 1]?.getNumber,
-              let mediaObject = node.getInputMedia(portIndex: 0,
-                                                   loopIndex: loopIndex,
-                                                   mediaId: mediaId),
               let speakerMedia = mediaObject.soundPlayable else {
             log("speakerEval error: no engine or soundinput found.")
             return

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
@@ -260,7 +260,7 @@ extension GraphState {
             return
         }
         
-        mediaObserver.currentMedia = result.media
+        mediaObserver.computedMedia = result.media
         
         // Disable loading state
         // Important to not dispatch main actor task as this creates race conditions

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
@@ -267,8 +267,9 @@ extension GraphState {
         mediaObserver.currentLoadingMediaId = nil
         
         self.recalculateGraphForMedia(outputValues: result.valueResult,
-                              nodeId: nodeId,
-                              loopIndex: loopIndex)
+                                      media: result.media,
+                                      nodeId: nodeId,
+                                      loopIndex: loopIndex)
     }
     
     @MainActor
@@ -276,6 +277,7 @@ extension GraphState {
     /// This updates at a particular loop index rather than all values.
     /// NOTE: we DO NOT want to run the eval of the media node itself again; we just want to evaluate any downstream nodes
     func recalculateGraphForMedia(outputValues: AsyncMediaOutputs,
+                                  media: GraphMediaValue?,
                                   nodeId: NodeId,
                                   loopIndex: Int) {
         let graph = self
@@ -304,7 +306,8 @@ extension GraphState {
             
             graph.updateOutputs(at: loopIndex,
                                 node: node,
-                                portValues: portValues)
+                                portValues: portValues,
+                                media: media)
             
         case .all(let portValuesList):
             var changedDownstreamNodes = NodeIdSet()
@@ -328,6 +331,7 @@ extension GraphState {
                 let downstreamInputs = graph.updateDownstreamInputs(
                     sourceNode: node,
                     flowValues: values,
+                    mediaList: [media],
                     upstreamOutputChanged: true, // Okay to treat a media change as always some output changing?
                     outputCoordinate: .init(portId: index, nodeId: node.id))
                 let downstreamNodes = Set(downstreamInputs.map(\.nodeId)).toSet

--- a/Stitch/Graph/Node/Port/Util/PulseActions.swift
+++ b/Stitch/Graph/Node/Port/Util/PulseActions.swift
@@ -71,6 +71,7 @@ struct ReversePulseCoercion: GraphEvent {
         let changedDownstreamInputIds = state
             .updateDownstreamInputs(sourceNode: node,
                                     flowValues: currentOutputs,
+                                    mediaList: nil,
                                     upstreamOutputChanged: true, // True, since we reversed the pulse effect?
                                     outputCoordinate: pulsedOutput)
         let changedDownstreamNodeIds = Set(changedDownstreamInputIds.map(\.nodeId)).toSet

--- a/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
@@ -123,7 +123,7 @@ struct MediaFieldLabelView<Field: FieldViewModel>: View {
     
     var isVisualMediaPort: Bool {
         self.coordinate.portId == 0 &&
-        self.node.kind.isVisualMediaLayerNode
+        self.node.kind.isVisualMediaNode
     }
     
     var media: GraphMediaValue? {

--- a/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
@@ -141,7 +141,7 @@ struct MediaFieldLabelView<Field: FieldViewModel>: View {
             ValueStitchVideoView(thumbnail: video.thumbnail)
 
         default:
-            if !isVisualMediaPort {
+            if isVisualMediaPort {
                 NilImageView()
             } else {
                 // Other media types: don't show label.

--- a/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
@@ -127,11 +127,15 @@ struct MediaFieldLabelView<Field: FieldViewModel>: View {
         )
     }
     
+    var media: GraphMediaValue? {
+        self.isInput ? self.mediaObserver?.inputMedia : self.mediaObserver?.computedMedia
+    }
+    
     @ViewBuilder
-    func visualMediaView(mediaObserver: MediaViewModel?) -> some View {
+    var visualMediaView: some View {
         // For image and video media pickers,
         // show both dropdown and thumbnail
-        switch mediaObserver?.inputMedia?.mediaObject {
+        switch self.media?.mediaObject {
         case .image(let image):
             ValueStitchImageView(image: image)
         case .video(let video):
@@ -157,7 +161,7 @@ struct MediaFieldLabelView<Field: FieldViewModel>: View {
             if isMultiselectInspectorInputWithHeterogenousValues {
                 NilImageView()
             } else {
-                visualMediaView(mediaObserver: self.mediaObserver)
+                visualMediaView
             }
         }
         .onChange(of: document.activeIndex, initial: true) {

--- a/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
@@ -112,10 +112,13 @@ struct MediaFieldLabelView<Field: FieldViewModel>: View {
     
     @MainActor
     func updateMediaObserver() {
-        self.mediaObserver = Field.getMediaObserver(node: node,
-                                                    rowViewModel: rowViewModel,
-                                                    graph: graph,
-                                                    activeIndex: document.activeIndex)
+        self.mediaObserver = node.getMediaObserver(portType: rowViewModel.id.portType,
+                                                   
+                                                   // TODO: loop support
+                                                   loopIndex: 0,
+                                                   
+                                                   // TODO: remove media ID check
+                                                   mediaId: nil)
     }
     
     var isVisualMediaPort: Bool {

--- a/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
@@ -131,7 +131,7 @@ struct MediaFieldLabelView<Field: FieldViewModel>: View {
     func visualMediaView(mediaObserver: MediaViewModel?) -> some View {
         // For image and video media pickers,
         // show both dropdown and thumbnail
-        switch mediaObserver?.currentMedia?.mediaObject {
+        switch mediaObserver?.inputMedia?.mediaObject {
         case .image(let image):
             ValueStitchImageView(image: image)
         case .video(let video):

--- a/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
@@ -122,12 +122,8 @@ struct MediaFieldLabelView<Field: FieldViewModel>: View {
     }
     
     var isVisualMediaPort: Bool {
-        self.coordinate.portId == 0 && (
-            self.node.kind.isVisualMediaLayerNode ||
-            
-            // Checks if patch node uses observer object used for storing visual media
-            (self.node.ephemeralObservers?.first as? MediaEvalOpViewable) != nil
-        )
+        self.coordinate.portId == 0 &&
+        self.node.kind.isVisualMediaLayerNode
     }
     
     var media: GraphMediaValue? {

--- a/Stitch/Graph/Node/Port/ViewModel/FieldViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/FieldViewModel.swift
@@ -30,12 +30,6 @@ protocol FieldViewModel: StitchLayoutCachable, Observable, AnyObject, Identifiab
          fieldIndex: Int,
          fieldLabel: String,
          rowViewModelDelegate: NodeRowType?)
-    
-//    @MainActor
-//    static func getMediaObserver(node: NodeViewModel,
-//                                 rowViewModel: Self.NodeRowType,
-//                                 graph: GraphState,
-//                                 activeIndex: ActiveIndex) -> MediaViewModel?
 }
 
 extension FieldViewModel {
@@ -93,27 +87,6 @@ final class InputFieldViewModel: FieldViewModel {
         self.fieldLabel = fieldLabel
         self.rowViewModelDelegate = rowViewModelDelegate
     }
-    
-//    @MainActor
-//    static func getMediaObserver(node: NodeViewModel,
-//                                 rowViewModel: InputNodeRowViewModel,
-//                                 graph: GraphState,
-//                                 activeIndex: ActiveIndex) -> MediaViewModel? {
-//        let inputCoordinate = rowViewModel.id.asNodeIOCoordinate
-//        
-//        // MARK: cheating with 0 since logic causes render cycles
-//        let loopCount = 0 //self.rowViewModelDelegate?.rowDelegate?.allLoopedValues.count ?? .zero
-//        
-//        let loopIndex = activeIndex.adjustedIndex(loopCount)
-//        
-//        let mediaObserver = node
-//            .getInputMediaObserver(inputCoordinate: inputCoordinate,
-//                                   loopIndex: loopIndex,
-//                                   // nil mediaId ensures observer is returned
-//                                   mediaId: nil)
-//
-//        return mediaObserver
-//    }
 }
 
 @Observable
@@ -138,21 +111,6 @@ final class OutputFieldViewModel: FieldViewModel {
         self.fieldLabel = fieldLabel
         self.rowViewModelDelegate = rowViewModelDelegate
     }
-    
-//    @MainActor static func getMediaObserver(node: NodeViewModel,
-//                                            rowViewModel: OutputNodeRowViewModel,
-//                                            graph: GraphState,
-//                                            activeIndex: ActiveIndex) -> MediaViewModel? {
-//        // No keypaths ever used for output
-//        let portIndex = rowViewModel.id.portId
-//        let mediaObserver = node
-//            .getVisibleMediaObserver(outputPortId: portIndex,
-//                                     // nil mediaId ensures observer is returned
-//                                     mediaId: nil,
-//                                     graph: graph,
-//                                     activeIndex: activeIndex)
-//        return mediaObserver
-//    }
 }
 
 extension FieldViewModel {

--- a/Stitch/Graph/Node/Port/ViewModel/FieldViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/FieldViewModel.swift
@@ -31,11 +31,11 @@ protocol FieldViewModel: StitchLayoutCachable, Observable, AnyObject, Identifiab
          fieldLabel: String,
          rowViewModelDelegate: NodeRowType?)
     
-    @MainActor
-    static func getMediaObserver(node: NodeViewModel,
-                                 rowViewModel: Self.NodeRowType,
-                                 graph: GraphState,
-                                 activeIndex: ActiveIndex) -> MediaViewModel?
+//    @MainActor
+//    static func getMediaObserver(node: NodeViewModel,
+//                                 rowViewModel: Self.NodeRowType,
+//                                 graph: GraphState,
+//                                 activeIndex: ActiveIndex) -> MediaViewModel?
 }
 
 extension FieldViewModel {
@@ -94,26 +94,26 @@ final class InputFieldViewModel: FieldViewModel {
         self.rowViewModelDelegate = rowViewModelDelegate
     }
     
-    @MainActor
-    static func getMediaObserver(node: NodeViewModel,
-                                 rowViewModel: InputNodeRowViewModel,
-                                 graph: GraphState,
-                                 activeIndex: ActiveIndex) -> MediaViewModel? {
-        let inputCoordinate = rowViewModel.id.asNodeIOCoordinate
-        
-        // MARK: cheating with 0 since logic causes render cycles
-        let loopCount = 0 //self.rowViewModelDelegate?.rowDelegate?.allLoopedValues.count ?? .zero
-        
-        let loopIndex = activeIndex.adjustedIndex(loopCount)
-        
-        let mediaObserver = node
-            .getInputMediaObserver(inputCoordinate: inputCoordinate,
-                                   loopIndex: loopIndex,
-                                   // nil mediaId ensures observer is returned
-                                   mediaId: nil)
-        
-        return mediaObserver
-    }
+//    @MainActor
+//    static func getMediaObserver(node: NodeViewModel,
+//                                 rowViewModel: InputNodeRowViewModel,
+//                                 graph: GraphState,
+//                                 activeIndex: ActiveIndex) -> MediaViewModel? {
+//        let inputCoordinate = rowViewModel.id.asNodeIOCoordinate
+//        
+//        // MARK: cheating with 0 since logic causes render cycles
+//        let loopCount = 0 //self.rowViewModelDelegate?.rowDelegate?.allLoopedValues.count ?? .zero
+//        
+//        let loopIndex = activeIndex.adjustedIndex(loopCount)
+//        
+//        let mediaObserver = node
+//            .getInputMediaObserver(inputCoordinate: inputCoordinate,
+//                                   loopIndex: loopIndex,
+//                                   // nil mediaId ensures observer is returned
+//                                   mediaId: nil)
+//
+//        return mediaObserver
+//    }
 }
 
 @Observable
@@ -139,20 +139,20 @@ final class OutputFieldViewModel: FieldViewModel {
         self.rowViewModelDelegate = rowViewModelDelegate
     }
     
-    @MainActor static func getMediaObserver(node: NodeViewModel,
-                                            rowViewModel: OutputNodeRowViewModel,
-                                            graph: GraphState,
-                                            activeIndex: ActiveIndex) -> MediaViewModel? {
-        // No keypaths ever used for output
-        let portIndex = rowViewModel.id.portId
-        let mediaObserver = node
-            .getVisibleMediaObserver(outputPortId: portIndex,
-                                     // nil mediaId ensures observer is returned
-                                     mediaId: nil,
-                                     graph: graph,
-                                     activeIndex: activeIndex)
-        return mediaObserver
-    }
+//    @MainActor static func getMediaObserver(node: NodeViewModel,
+//                                            rowViewModel: OutputNodeRowViewModel,
+//                                            graph: GraphState,
+//                                            activeIndex: ActiveIndex) -> MediaViewModel? {
+//        // No keypaths ever used for output
+//        let portIndex = rowViewModel.id.portId
+//        let mediaObserver = node
+//            .getVisibleMediaObserver(outputPortId: portIndex,
+//                                     // nil mediaId ensures observer is returned
+//                                     mediaId: nil,
+//                                     graph: graph,
+//                                     activeIndex: activeIndex)
+//        return mediaObserver
+//    }
 }
 
 extension FieldViewModel {

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
@@ -221,9 +221,9 @@ extension NodeRowObserver {
     }
     
     @MainActor
-    func getMediaObjects() -> [StitchMediaObject] {
+    func getComputedMediaObjects() -> [StitchMediaObject] {
         self.nodeDelegate?.ephemeralObservers?.compactMap {
-            ($0 as? MediaEvalOpObservable)?.currentMedia?.mediaObject
+            ($0 as? MediaEvalOpObservable)?.computedMedia?.mediaObject
         } ?? []
     }
     

--- a/Stitch/Graph/Node/Util/NodeMediaUtils.swift
+++ b/Stitch/Graph/Node/Util/NodeMediaUtils.swift
@@ -251,10 +251,12 @@ extension NodeViewModel {
                 return nil
             }
             
+            return layerNode.previewLayerViewModels[safe: loopIndex]?.mediaViewModel
+            
             // MARK: helpers here will not retrieve local imported layer view model, thorough testing needed if scope increases
-            return layerNode.getConnectedInputMediaObserver(keyPath: keyPath,
-                                                            loopIndex: loopIndex,
-                                                            mediaId: mediaId)
+//            return layerNode.getConnectedInputMediaObserver(keyPath: keyPath,
+//                                                            loopIndex: loopIndex,
+//                                                            mediaId: mediaId)
         }
     }
     
@@ -264,7 +266,7 @@ extension NodeViewModel {
                                loopIndex: Int,
                                mediaId: UUID?) -> MediaViewModel? {
         // Do nothing if no upstream connection for media
-        guard let connectedUpstreamNode = self.getUpstreamNode(inputPortIndex: portIndex) else {
+//        guard let connectedUpstreamNode = self.getUpstreamNode(inputPortIndex: portIndex) else {
             
             // MARK: below functionality allows nodes like media import patch nodes to display media at the input even though computed ephemeral observers only hold media. For some nodes like loop builder this isn't ideal as it'll incorrectly display valid data at an empty input.
             if self.kind == .patch(.loopBuilder) {
@@ -274,31 +276,31 @@ extension NodeViewModel {
             // Check if media eval op exists here if no connection
             return self.getComputedMediaObserver(loopIndex: loopIndex,
                                                  mediaId: mediaId)
-        }
+//        }
         
-        return connectedUpstreamNode.getUpstreamNodeMediaObserver(loopIndex: loopIndex,
-                                                                  mediaId: mediaId)
+//        return connectedUpstreamNode.getUpstreamNodeMediaObserver(loopIndex: loopIndex,
+//                                                                  mediaId: mediaId)
     }
     
-    @MainActor
-    private func getUpstreamNode(inputPortIndex: Int) -> NodeViewModel? {
-        self.inputsObservers[safe: inputPortIndex]?.upstreamOutputObserver?.nodeDelegate
-    }
+//    @MainActor
+//    private func getUpstreamNode(inputPortIndex: Int) -> NodeViewModel? {
+//        self.inputsObservers[safe: inputPortIndex]?.upstreamOutputObserver?.nodeDelegate
+//    }
     
-    @MainActor
-    private func getUpstreamNodeMediaObserver(loopIndex: Int,
-                                              mediaId: UUID?) -> MediaViewModel? {
-        // Media object is obtained by looking at upstream connected node's saved media objects.
-        if let viewModel = self.getComputedMediaObserver(loopIndex: loopIndex,
-                                                                          mediaId: mediaId) {
-            return viewModel
-        }
-        
-        // Fallback logic below: recursively check upstream nodes at the firt port index. Provides support for nodes like splitters which don't directly hold media.
-        return self.getInputMediaObserver(portIndex: 0,
-                                          loopIndex: loopIndex,
-                                          mediaId: mediaId)
-    }
+//    @MainActor
+//    private func getUpstreamNodeMediaObserver(loopIndex: Int,
+//                                              mediaId: UUID?) -> MediaViewModel? {
+//        // Media object is obtained by looking at upstream connected node's saved media objects.
+//        if let viewModel = self.getComputedMediaObserver(loopIndex: loopIndex,
+//                                                                          mediaId: mediaId) {
+//            return viewModel
+//        }
+//        
+//        // Fallback logic below: recursively check upstream nodes at the firt port index. Provides support for nodes like splitters which don't directly hold media.
+//        return self.getInputMediaObserver(portIndex: 0,
+//                                          loopIndex: loopIndex,
+//                                          mediaId: mediaId)
+//    }
     
     @MainActor
     /// Gets the media object for some connected input.
@@ -328,46 +330,46 @@ extension NodeRowObserver {
 }
 
 extension LayerNodeViewModel {
-    @MainActor
-    func getConnectedInputMedia(keyPath: LayerInputType,
-                                loopIndex: Int,
-                                mediaId: UUID) -> StitchMediaObject? {
-        if let mediaValue = self.getConnectedInputMediaObserver(keyPath: keyPath,
-                                                                loopIndex: loopIndex,
-                                                                mediaId: mediaId)?.currentMedia {
-            return mediaValue.mediaObject
-        }
-        
-        return nil
-    }
+//    @MainActor
+//    func getConnectedInputMedia(keyPath: LayerInputType,
+//                                loopIndex: Int,
+//                                mediaId: UUID) -> StitchMediaObject? {
+//        if let mediaValue = self.getConnectedInputMediaObserver(keyPath: keyPath,
+//                                                                loopIndex: loopIndex,
+//                                                                mediaId: mediaId)?.currentMedia {
+//            return mediaValue.mediaObject
+//        }
+//        
+//        return nil
+//    }
     
-    @MainActor
-    /// Gets the media observer for some connected input.
-    func getConnectedInputMediaObserver(keyPath: LayerInputType,
-                                        loopIndex: Int,
-                                        mediaId: UUID?) -> MediaViewModel? {
-        let port = self[keyPath: keyPath.layerNodeKeyPath]
-        
-        if let upstreamObserver = port.rowObserver.upstreamOutputObserver,
-           let upstreamNode = upstreamObserver.nodeDelegate {
-            if let upstreamComputedMedia = upstreamNode
-                .getComputedMediaObserver(loopIndex: loopIndex,
-                                          mediaId: mediaId) {
-                return upstreamComputedMedia
-            }
-            
-            // Fallback logic: check input of upstream node and kick-start recursive strategy
-            return upstreamNode.getInputMediaObserver(portIndex: 0,
-                                                      loopIndex: loopIndex,
-                                                      mediaId: mediaId)
-        }
-        
-        // No upstream connection, find media at layer view model
-        guard let layerViewModel = self.previewLayerViewModels[safe: loopIndex],
-              layerViewModel.mediaViewModel.currentMedia?.id == mediaId else {
-            return nil
-        }
-
-        return layerViewModel.mediaViewModel
-    }
+//    @MainActor
+//    /// Gets the media observer for some connected input.
+//    func getConnectedInputMediaObserver(keyPath: LayerInputType,
+//                                        loopIndex: Int,
+//                                        mediaId: UUID?) -> MediaViewModel? {
+//        let port = self[keyPath: keyPath.layerNodeKeyPath]
+//        
+//        if let upstreamObserver = port.rowObserver.upstreamOutputObserver,
+//           let upstreamNode = upstreamObserver.nodeDelegate {
+//            if let upstreamComputedMedia = upstreamNode
+//                .getComputedMediaObserver(loopIndex: loopIndex,
+//                                          mediaId: mediaId) {
+//                return upstreamComputedMedia
+//            }
+//            
+//            // Fallback logic: check input of upstream node and kick-start recursive strategy
+//            return upstreamNode.getInputMediaObserver(portIndex: 0,
+//                                                      loopIndex: loopIndex,
+//                                                      mediaId: mediaId)
+//        }
+//        
+//        // No upstream connection, find media at layer view model
+//        guard let layerViewModel = self.previewLayerViewModels[safe: loopIndex],
+//              layerViewModel.mediaViewModel.currentMedia?.id == mediaId else {
+//            return nil
+//        }
+//
+//        return layerViewModel.mediaViewModel
+//    }
 }

--- a/Stitch/Graph/Node/Util/NodeMediaUtils.swift
+++ b/Stitch/Graph/Node/Util/NodeMediaUtils.swift
@@ -61,20 +61,26 @@ extension MediaEvalOpResult: NodeEvalOpResult {
         let outputs = valuesList.remapOutputs()
         
         // Update ephemeral observers
-        for (newMedia, ephemeralObserver) in zip(mediaList, node.ephemeralObservers ?? []) {
-            guard let mediaObserver = ephemeralObserver as? MediaEvalOpViewable else {
-                fatalErrorIfDebug()
-                break
-            }
-            
-            if let newMedia = newMedia {
-                mediaObserver.currentMedia = newMedia
-            } else {
-                mediaObserver.currentMedia = nil
-            }
-        }
+//        
+//        
+//        // TODO: remove
+//        for (newMedia, ephemeralObserver) in zip(mediaList, node.ephemeralObservers ?? []) {
+//            guard let mediaObserver = ephemeralObserver as? MediaEvalOpViewable else {
+//                fatalErrorIfDebug()
+//                break
+//            }
+//            
+//            if let newMedia = newMedia {
+//                if newMedia != mediaObserver.currentMedia {
+//                    mediaObserver.currentMedia = newMedia
+//                }
+//            } else {
+//                mediaObserver.currentMedia = nil
+//            }
+//        }
         
-        return .init(outputsValues: outputs)
+        return .init(outputsValues: outputs,
+                     mediaList: mediaList)
     }
     
     init(from values: PortValues) {

--- a/Stitch/Graph/Node/Util/NodeMediaUtils.swift
+++ b/Stitch/Graph/Node/Util/NodeMediaUtils.swift
@@ -11,7 +11,9 @@ import StitchSchemaKit
 
 @Observable
 final class MediaViewModel: Sendable {
-    @MainActor var currentMedia: GraphMediaValue?
+    @MainActor var inputMedia: GraphMediaValue?
+    
+    @MainActor var computedMedia: GraphMediaValue?
     
     @MainActor init() { }
 }
@@ -140,9 +142,9 @@ extension MediaEvalValuesListResult {
         }
         
         if let newMedia = media {
-            mediaObserver.currentMedia = newMedia
+            mediaObserver.computedMedia = newMedia
         } else {
-            mediaObserver.currentMedia = nil
+            mediaObserver.computedMedia = nil
         }
         
         return .init(outputsValues: outputs)
@@ -157,7 +159,7 @@ extension NodeViewModel {
                        mediaId: UUID) -> StitchMediaObject? {
         self.getInputMediaObserver(inputCoordinate: coordinate,
                                    loopIndex: loopIndex,
-                                   mediaId: mediaId)?.currentMedia?.mediaObject
+                                   mediaId: mediaId)?.inputMedia?.mediaObject
     }
     
     @MainActor
@@ -177,7 +179,7 @@ extension NodeViewModel {
                             mediaId: UUID?) -> GraphMediaValue? {
         self.getInputMediaObserver(portIndex: portIndex,
                                    loopIndex: loopIndex,
-                                   mediaId: mediaId)?.currentMedia
+                                   mediaId: mediaId)?.inputMedia
     }
     
     @MainActor
@@ -187,7 +189,7 @@ extension NodeViewModel {
                             mediaId: UUID) -> GraphMediaValue? {
         self.getInputMediaObserver(inputCoordinate: coordinate,
                                    loopIndex: loopIndex,
-                                   mediaId: mediaId)?.currentMedia
+                                   mediaId: mediaId)?.inputMedia
     }
 
     @MainActor
@@ -195,7 +197,7 @@ extension NodeViewModel {
     func getComputedMediaValue(loopIndex: Int,
                                mediaId: UUID?) -> GraphMediaValue? {
         self.getComputedMediaObserver(loopIndex: loopIndex,
-                                      mediaId: mediaId)?.currentMedia
+                                      mediaId: mediaId)?.computedMedia
     }
     
     @MainActor
@@ -316,7 +318,7 @@ extension NodeViewModel {
         if let viewModel = (self.ephemeralObservers?[safe: loopIndex] as? MediaEvalOpViewable)?.mediaViewModel {
             // Only check on media ID if provided, else always return object
             if let mediaId = mediaId,
-               viewModel.currentMedia?.id == mediaId {
+               viewModel.computedMedia?.id == mediaId {
                 return viewModel
             }
             

--- a/Stitch/Graph/Node/Util/NodeUtils.swift
+++ b/Stitch/Graph/Node/Util/NodeUtils.swift
@@ -18,14 +18,14 @@ extension NodeKind {
         switch self {
         case .patch(let patch):
             switch patch {
-            case .imageImport, .grayscale, .videoImport:
+            case .imageImport, .grayscale, .videoImport, .cameraFeed:
                 return true
     
             default:
                 return false
             }
             
-        case .layer(let layer):
+        case .layer:
             return self.isVisualMediaLayerNode
             
         default:

--- a/Stitch/Graph/Node/Util/NodeUtils.swift
+++ b/Stitch/Graph/Node/Util/NodeUtils.swift
@@ -14,7 +14,26 @@ extension NodeKind {
     }
 
     /// Returns true if video or image layer node.
-    var isVisualMediaLayerNode: Bool {
+    var isVisualMediaNode: Bool {
+        switch self {
+        case .patch(let patch):
+            switch patch {
+            case .imageImport, .grayscale, .videoImport:
+                return true
+    
+            default:
+                return false
+            }
+            
+        case .layer(let layer):
+            return self.isVisualMediaLayerNode
+            
+        default:
+            return false
+        }
+    }
+    
+    var isVisualMediaLayerNode: Bool{
         self == .layer(.image) || self == .layer(.video)
     }
 }

--- a/Stitch/Graph/Node/View/StitchUIScrollView.swift
+++ b/Stitch/Graph/Node/View/StitchUIScrollView.swift
@@ -393,7 +393,6 @@ final class StitchScrollCoordinator<Content: View>: NSObject, UIScrollViewDelega
         // Do not check borders for ~1 second after (1) jumping to an item on the canvas or (2) zooming in/out
         
         guard !self.borderCheckingDisabled else {
-            // log("checkBorder: border checking disabled")
             Self.updateGraphScrollData(scrollView)
             return
         }

--- a/Stitch/Graph/Node/ViewModel/NodeDelegate.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeDelegate.swift
@@ -57,7 +57,6 @@ extension NodeDelegate {
             }
         case .group(let canvas):
 //            fatalErrorIfDebug("Attempted to retrieve a row observer for a GroupNode input")
-            //            log("Attempted to retrieve a row observer for a GroupNode input")
             return canvas.inputViewModels.compactMap {
                 $0.rowDelegate
             }

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModelNodeCalculatable.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModelNodeCalculatable.swift
@@ -11,6 +11,8 @@ import StitchEngine
 import StitchSchemaKit
 
 extension NodeViewModel: NodeCalculatable {
+    typealias NodeMediaEphemeralObservable = MediaViewModel
+    
     var inputsObservers: [InputNodeRowObserver] {
         get {
             self.getAllInputsObservers()
@@ -27,6 +29,19 @@ extension NodeViewModel: NodeCalculatable {
         set(newValue) {
             self.patchNode?.outputsObservers = newValue
         }
+    }
+    
+    @MainActor
+    func getMediaObservers() -> [MediaViewModel]? {
+        if let layerNode = self.layerNode {
+            return layerNode.previewLayerViewModels.map { $0.mediaViewModel }
+        }
+        
+        if let mediaEvalOpObservers = self.ephemeralObservers as? [MediaEvalOpObserver] {
+            return mediaEvalOpObservers.map(\.mediaViewModel)
+        }
+        
+        return nil
     }
     
     @MainActor

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModelNodeCalculatable.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModelNodeCalculatable.swift
@@ -37,7 +37,7 @@ extension NodeViewModel: NodeCalculatable {
             return layerNode.previewLayerViewModels.map { $0.mediaViewModel }
         }
         
-        if let mediaEvalOpObservers = self.ephemeralObservers as? [MediaEvalOpObserver] {
+        if let mediaEvalOpObservers = self.ephemeralObservers as? [MediaEvalOpViewable] {
             return mediaEvalOpObservers.map(\.mediaViewModel)
         }
         

--- a/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
@@ -498,7 +498,7 @@ struct NonGroupPreviewLayersView: View {
                 // Check for nil case
                 guard let mediaValue = self.mediaValue else {
                     LayerViewModel.resetMedia(self.layerViewModel.mediaObject)
-                    self.layerViewModel.mediaViewModel.currentMedia = nil
+                    self.layerViewModel.mediaViewModel.inputMedia = nil
                     return
                 }
                 

--- a/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
@@ -506,15 +506,6 @@ struct NonGroupPreviewLayersView: View {
                                                     // Media port is always packed
                                                     portType: .packed)
                 
-                // Checks for connected upstream media
-//                if let existingMedia = self.layerNode
-//                    .getConnectedInputMedia(keyPath: layerInputType,
-//                                            loopIndex: self.layerViewModel.id.loopIndex,
-//                                            mediaId: mediaValue.id) {
-//                    self.layerViewModel.mediaViewModel.currentMedia = .init(computedMedia: existingMedia)
-//                    return
-//                }
-                
                 Task(priority: .high) { [weak layerViewModel] in
                     await layerViewModel?.loadMedia(mediaValue: mediaValue,
                                                     document: document,

--- a/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
@@ -507,13 +507,13 @@ struct NonGroupPreviewLayersView: View {
                                                     portType: .packed)
                 
                 // Checks for connected upstream media
-                if let existingMedia = self.layerNode
-                    .getConnectedInputMedia(keyPath: layerInputType,
-                                            loopIndex: self.layerViewModel.id.loopIndex,
-                                            mediaId: mediaValue.id) {
-                    self.layerViewModel.mediaViewModel.currentMedia = .init(computedMedia: existingMedia)
-                    return
-                }
+//                if let existingMedia = self.layerNode
+//                    .getConnectedInputMedia(keyPath: layerInputType,
+//                                            loopIndex: self.layerViewModel.id.loopIndex,
+//                                            mediaId: mediaValue.id) {
+//                    self.layerViewModel.mediaViewModel.currentMedia = .init(computedMedia: existingMedia)
+//                    return
+//                }
                 
                 Task(priority: .high) { [weak layerViewModel] in
                     await layerViewModel?.loadMedia(mediaValue: mediaValue,

--- a/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
@@ -97,7 +97,7 @@ final class LayerViewModel: Sendable {
     
     // State for media needed if we need to async load an import
     @MainActor var mediaObject: StitchMediaObject? {
-        self.mediaViewModel.currentMedia?.mediaObject
+        self.mediaViewModel.inputMedia?.mediaObject
     }
     
     @MainActor
@@ -492,7 +492,7 @@ extension LayerViewModel {
                 // Only set media to nil if mediaValue is nil as well
                 // Fixes issue where camrea feed would stutter
                 if mediaValue == nil {
-                    self.mediaViewModel.currentMedia = nil
+                    self.mediaViewModel.inputMedia = nil
                 }
             }
             return
@@ -507,9 +507,9 @@ extension LayerViewModel {
         }
         
         await MainActor.run {
-            self.mediaViewModel.currentMedia = .init(id: .init(),
-                                                     dataType: .source(mediaKey),
-                                                     mediaObject: newMediaObject)
+            self.mediaViewModel.inputMedia = .init(id: .init(),
+                                                   dataType: .source(mediaKey),
+                                                   mediaObject: newMediaObject)
         }
     }
     

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -850,7 +850,8 @@ extension GraphState {
     @MainActor
     func updateOutputs(at loopIndex: Int,
                        node: NodeViewModel,
-                       portValues: PortValues) {
+                       portValues: PortValues,
+                       media: GraphMediaValue?) {
         let nodeId = node.id
         var outputsToUpdate = node.outputs
         var nodeIdsToRecalculate = NodeIdSet()
@@ -876,10 +877,13 @@ extension GraphState {
             
             outputsToUpdate[portId] = outputToUpdate
             
+            let mediaList: [GraphMediaValue?]? = media == nil ? nil : [media]
+            
             // Update downstream node's inputs
             let changedInputIds = self.updateDownstreamInputs(
                 sourceNode: node,
                 flowValues: outputToUpdate,
+                mediaList: mediaList,
                 upstreamOutputChanged: outputsChanged,
                 outputCoordinate: outputCoordinate)
             let changedNodeIds = Set(changedInputIds.map(\.nodeId)).toSet


### PR DESCRIPTION
This PR aims to reduce media field rendering, which for some scenarios is the highest perf cost in the app. Changes here include:
* Media ephemeral objects now hold media for both "input" and "computed" copies, which aims to replace helpers that used functions to traverse upstream for media. These helpers created extra render cycles in the view.
* Node eval results now include an option for a media list, in addition to its existing port values. StitchEngine updates media ephemeral objects in hose flow.

Node duplication render duration in humane demo reduced by 1/3 after these changes.