### PR TITLE
Use `didSet` instead of `.onChange` to avoid race condition where the nodes in a just-entered group occasionally did not show

### DIFF
--- a/Stitch/Graph/Gesture/Util/GraphUIScrollActions.swift
+++ b/Stitch/Graph/Gesture/Util/GraphUIScrollActions.swift
@@ -209,46 +209,49 @@ extension GraphState {
 extension StitchDocumentViewModel {
     @MainActor
     var localPositionToPersist: CGPoint {
-        /*
-         TODO: serialize graph-offset by traversal level; introduce centroid/find-node button
-         
-         Ideally, we remember (serialize) each traversal level's graph-offset.
-         Currently, we only remember the root level's graph-offset.
-         So if we were inside a group, we save not the group's graph-offset (graphState.localPosition), but the root graph-offset
-         */
         
-        // log("GraphState.localPositionToPersists: self.localPosition: \(self.localPosition)")
+        return ABSOLUTE_GRAPH_CENTER
         
-        let _rootLevelGraphOffset = self.visibleGraph
-            .visibleNodesViewModel
-            .nodePageDataAtCurrentTraversalLevel(nil)?
-            .localPosition
-        
-        if !_rootLevelGraphOffset.isDefined {
-            log("GraphState.localPositionToPersists: no root level graph offset")
-        }
-        
-        let rootLevelGraphOffset = _rootLevelGraphOffset ?? ABSOLUTE_GRAPH_CENTER
-        
-        let graphOffset = self.graphUI.groupNodeFocused.isDefined ? rootLevelGraphOffset : self.localPosition
-        
-        // log("GraphState.localPositionToPersists: rootLevelGraphOffset: \(rootLevelGraphOffset)")
-        // log("GraphState.localPositionToPersists: graphOffset: \(graphOffset)")
-        
-        // TODO: factor out zoom level
-        
-        let scale = self.graphMovement.zoomData
-        
-        // UIScrollView's contentOffset is based on contentSize, which is a function zoomScale;
-        // but we do not persist zoom;
-        // so, we factor out the effect of zoom on contentOffset.
-        let scaledGraphOffset = CGPoint(x: graphOffset.x * 1/scale,
-                                        y: graphOffset.y * 1/scale)
-        
-        // log("GraphState.localPositionToPersists: scale: \(scale)")
-        // log("GraphState.localPositionToPersists: scaledGraphOffset: \(scaledGraphOffset)")
-        
-        return scaledGraphOffset
+//        /*
+//         TODO: serialize graph-offset by traversal level; introduce centroid/find-node button
+//         
+//         Ideally, we remember (serialize) each traversal level's graph-offset.
+//         Currently, we only remember the root level's graph-offset.
+//         So if we were inside a group, we save not the group's graph-offset (graphState.localPosition), but the root graph-offset
+//         */
+//        
+//        // log("GraphState.localPositionToPersists: self.localPosition: \(self.localPosition)")
+//        
+//        let _rootLevelGraphOffset = self.visibleGraph
+//            .visibleNodesViewModel
+//            .nodePageDataAtCurrentTraversalLevel(nil)?
+//            .localPosition
+//        
+//        if !_rootLevelGraphOffset.isDefined {
+//            log("GraphState.localPositionToPersists: no root level graph offset")
+//        }
+//        
+//        let rootLevelGraphOffset = _rootLevelGraphOffset ?? ABSOLUTE_GRAPH_CENTER
+//        
+//        let graphOffset = self.graphUI.groupNodeFocused.isDefined ? rootLevelGraphOffset : self.localPosition
+//        
+//        // log("GraphState.localPositionToPersists: rootLevelGraphOffset: \(rootLevelGraphOffset)")
+//        // log("GraphState.localPositionToPersists: graphOffset: \(graphOffset)")
+//        
+//        // TODO: factor out zoom level
+//        
+//        let scale = self.graphMovement.zoomData
+//        
+//        // UIScrollView's contentOffset is based on contentSize, which is a function zoomScale;
+//        // but we do not persist zoom;
+//        // so, we factor out the effect of zoom on contentOffset.
+//        let scaledGraphOffset = CGPoint(x: graphOffset.x * 1/scale,
+//                                        y: graphOffset.y * 1/scale)
+//        
+//        // log("GraphState.localPositionToPersists: scale: \(scale)")
+//        // log("GraphState.localPositionToPersists: scaledGraphOffset: \(scaledGraphOffset)")
+//        
+//        return scaledGraphOffset
     }
     
     @MainActor

--- a/Stitch/Graph/Gesture/View/GraphMovementViewModifier.swift
+++ b/Stitch/Graph/Gesture/View/GraphMovementViewModifier.swift
@@ -8,35 +8,6 @@
 import Foundation
 import SwiftUI
 import StitchSchemaKit
-
-struct GraphMovementViewModifier: ViewModifier {
-    @Bindable var graphMovement: GraphMovementObserver
-    @Bindable var currentNodePage: NodePageData
-    @Bindable var graph: GraphState
-    let groupNodeFocused: GroupNodeType?
-    
-    func body(content: Content) -> some View {
-        content
-
-            // Note: `initial: true` seemed to fire only upon first opening of a given project after app re-opened, and not upon every opening of the project?
-            .onChange(of: groupNodeFocused) { _, _ in
-                dispatch(SetGraphScrollDataUponPageChange(
-                    newPageLocalPosition: currentNodePage.localPosition,
-                    newPageZoom: currentNodePage.zoomData
-                ))
-            }
-
-            // TODO: either update these `graphMovement: GraphMovementObserver` in `GraphScrollDataUpdated` OR get rid of GraphMovementObserver completely and merely rely on node-page's offset and zoom
-            .onChange(of: graphMovement.localPosition) { _, newValue in
-                currentNodePage.localPosition = newValue
-                self.graph.updateVisibleNodes()
-            }
-            .onChange(of: graphMovement.zoomData) { _, newValue in
-                currentNodePage.zoomData = newValue
-                self.graph.updateVisibleNodes()
-            }
-    }
-}
     
 extension GraphState {
     /// Accomplishes the following tasks:

--- a/Stitch/Graph/Model/GroupNodeType.swift
+++ b/Stitch/Graph/Model/GroupNodeType.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import StitchSchemaKit
 
 /// Used to represent group data with visual graph hierarchical data.
-enum GroupNodeType: Hashable {
+enum GroupNodeType: Hashable, Equatable {
     case groupNode(NodeId)
     case component(UUID) // NodeID of component node
 }

--- a/Stitch/Graph/Node/View/NodesOnlyView.swift
+++ b/Stitch/Graph/Node/View/NodesOnlyView.swift
@@ -13,7 +13,6 @@ struct NodesOnlyView: View {
     
     @Bindable var document: StitchDocumentViewModel
     @Bindable var graph: GraphState
-    @Bindable var nodePageData: NodePageData
     
     var selection: GraphUISelectionState {
         graph.selection

--- a/Stitch/Graph/Node/View/StitchUIScrollHelpers.swift
+++ b/Stitch/Graph/Node/View/StitchUIScrollHelpers.swift
@@ -8,39 +8,6 @@
 import SwiftUI
 import UIKit
 
-struct SetGraphScrollDataUponPageChange: GraphEvent {
-    let newPageLocalPosition: CGPoint
-    let newPageZoom: CGFloat
-    
-    func handle(state: GraphState) {
-        // log("SetGraphScrollDataUponPageChange: newPageLocalPosition: \(newPageLocalPosition)")
-        // log("SetGraphScrollDataUponPageChange: newPageZoom: \(newPageZoom)")
-        state.canvasPageOffsetChanged = newPageLocalPosition
-        state.canvasPageZoomScaleChanged = newPageZoom
-        
-        /*
-         Set all nodes visible for the field updates, since when we enter the new traversal level
-         our infiniteCanvasCache may not yet have entries for canvas items at this level.
-         
-         Then, do the actual determination of onscreen nodes.
-         
-         (Similar to how, when first loading a project, we set all nodes visible before we call updateVisibleNodes to actually determine on- vs offscreen nodes.)
-         
-         Resolves:
-         - https://github.com/StitchDesign/Stitch--Old/issues/6787
-         - https://github.com/StitchDesign/Stitch--Old/issues/6779
-         
-         */
-        // TODO: doesn't actually fix the issue? The above-level nodes are still *sometimes* what we see when we first enter the lower-level
-        state.visibleNodesViewModel.setAllNodesVisible()
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak state] in
-            state?.updateVisibleNodes()
-        }
-    }
-}
-
-
 // UIScrollView's zooming also updates contentOffset,
 // so we prefer to update both localPosition and zoomData at same time.
 struct GraphScrollDataUpdated: StitchDocumentEvent {
@@ -51,12 +18,12 @@ struct GraphScrollDataUpdated: StitchDocumentEvent {
     func handle(state: StitchDocumentViewModel) {
         
         // // // VERY HELPFUL FOR DEBUGGING
-        // log("GraphScrollDataUpdated: newOffset: \(newOffset)")
-        // log("GraphScrollDataUpdated: newZoom: \(newZoom)")
-        // let xDiff = state.graphMovement.localPosition.x - newOffset.x
-        // let yDiff = state.graphMovement.localPosition.y - newOffset.y
-        // log("GraphScrollDataUpdated: xDiff: \(xDiff)")
-        // log("GraphScrollDataUpdated: yDiff: \(yDiff)")
+        //        log("GraphScrollDataUpdated: newOffset: \(newOffset)")
+        //        log("GraphScrollDataUpdated: newZoom: \(newZoom)")
+        //        let xDiff = state.graphMovement.localPosition.x - newOffset.x
+        //        let yDiff = state.graphMovement.localPosition.y - newOffset.y
+        //        log("GraphScrollDataUpdated: xDiff: \(xDiff)")
+        //        log("GraphScrollDataUpdated: yDiff: \(yDiff)")
         
         state.graphMovement.localPosition = newOffset
         state.graphMovement.zoomData = newZoom

--- a/Stitch/Graph/Node/ViewModel/NodePageData.swift
+++ b/Stitch/Graph/Node/ViewModel/NodePageData.swift
@@ -14,11 +14,30 @@ typealias NodesPagingDict = [NodePageType: NodePageData]
 final class NodePageData {
     // The graph's movement (offset, momentum, etc.) for this traversal level
     // TODO: for root page data, should always be same as the persisted localPosition of GraphEntity; currently we only persist a single localPosition on the document entity
-    var localPosition: CGPoint
+    var localPosition: CGPoint {
+        didSet {
+            // log("NodePageData: didSet: localPosition: oldValue: \(oldValue)")
+            // log("NodePageData: didSet: localPosition: localPosition: \(localPosition)")
+            if localPosition.x.magnitude > WHOLE_GRAPH_LENGTH {
+                fatalErrorIfDebug()
+            }
+            if localPosition.y.magnitude > WHOLE_GRAPH_LENGTH {
+                fatalErrorIfDebug()
+            }
+        }
+    }
 
     var zoomData: CGFloat
 
     init(localPosition: CGPoint, zoomFinal: Double = 1) {
+        // log("NodePageData: init: localPosition: \(localPosition)")
+        // log("NodePageData: init: zoomFinal: \(zoomFinal)")
+        var localPosition = localPosition
+        if (localPosition.x.magnitude > WHOLE_GRAPH_LENGTH) || (localPosition.y.magnitude > WHOLE_GRAPH_LENGTH) {
+            fatalErrorIfDebug()
+            log("NodePageData: localPosition was too large: \(localPosition)", .logToServer)
+            localPosition = ABSOLUTE_GRAPH_CENTER
+        }
         self.localPosition = localPosition
         self.zoomData = zoomFinal
     }

--- a/Stitch/Graph/View/ProjectNavigationView.swift
+++ b/Stitch/Graph/View/ProjectNavigationView.swift
@@ -31,11 +31,8 @@ struct ProjectNavigationView: View {
             })
         }
         .onChange(of: document.visibleGraph.graphUpdaterId) {
-            log("NodesOnlyView: .onChange(of: document.visibleGraph.graphUpdaterId)")
+            // log("ProjectNavigationView: .onChange(of: document.visibleGraph.graphUpdaterId)")
             document.visibleGraph.updateGraphData()
-        }
-        .onChange(of: document.groupNodeFocused?.groupNodeId) {
-            document.visibleGraph.refreshGraphUpdaterId()
         }
         .onChange(of: document.isCameraEnabled) { _, isCameraEnabled in
             if !isCameraEnabled {

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -92,7 +92,19 @@ final class StitchDocumentViewModel: Sendable {
     @MainActor var leftSidebarOpen = false
     
     // Tracks group breadcrumbs when group nodes are visited
-    @MainActor var groupNodeBreadcrumbs: [GroupNodeType] = []
+    @MainActor var groupNodeBreadcrumbs: [GroupNodeType] = [] {
+        didSet {
+            if let nodePageData = self.graph.visibleNodesViewModel.nodePageDataAtCurrentTraversalLevel(self.groupNodeFocused?.groupNodeId) {
+
+                self.graph.canvasPageOffsetChanged = nodePageData.localPosition
+                self.graph.canvasPageZoomScaleChanged = nodePageData.zoomData
+                
+                // Note: refreshing graph-updater-id here in `didSet` seems preferable to `myView.onChange(groupNodeId)`;
+                // seems to remove race condition where groupNodeId change would not trigger the proper re-render.
+                self.graph.refreshGraphUpdaterId()
+            }
+        }
+    }
 
     @MainActor var showPreviewWindow = PREVIEW_SHOWN_DEFAULT_STATE
     
@@ -193,7 +205,7 @@ final class StitchDocumentViewModel: Sendable {
         let documentEncoder = DocumentEncoder(document: schema)
 
         let graph = await GraphState(from: schema.graph,
-                                     localPosition: schema.localPosition,
+                                     localPosition: ABSOLUTE_GRAPH_CENTER, // schema.localPosition,
                                      saveLocation: [],
                                      encoder: documentEncoder)
                 
@@ -427,7 +439,8 @@ extension StitchDocumentViewModel {
                        previewSizeDevice: self.previewSizeDevice,
                        previewWindowBackgroundColor: self.previewWindowBackgroundColor,
                        // Important: `StitchDocument.localPosition` currently represents only the root level's graph-offset
-                       localPosition: self.localPositionToPersist,
+                       // TODO: we currently are not actually using persisted graph-offset; we always open graph afresh to the absolute-center
+                       localPosition: ABSOLUTE_GRAPH_CENTER, // self.localPositionToPersist,
                        zoomData: self.graphMovement.zoomData,
                        cameraSettings: self.cameraSettings)
     }


### PR DESCRIPTION
A `didSet` seems to avoid the race condition that apparently arose from `.onChange(groupNodeId)`.

We also no longer persist any root level graph-offset and will log-to-Sentry any very strange graph offset (seen once when exiting a group).
