### PR TITLE
If layer choice not found in cache, add it to cache

### DIFF
--- a/Stitch/Graph/Node/Port/View/Field/InputView/LayerNamesDropDownChoiceView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/LayerNamesDropDownChoiceView.swift
@@ -96,9 +96,18 @@ extension GraphState {
                     return nil
                 }
                 
-                return self.visibleNodesViewModel.layerDropdownChoiceCache.get(layerId)
+                // Note: When a layer node is added via the node menu, we don't call the `syncNodes(nodesDict: NodesViewModelDict)` function that updates the layer-choices cache. Should we call that function more often?
+                // Note: should be fine to populate the cache here? Worst case we have several different layer-dropdowns that run in parallel when rendering?
+                if let cachedChoice = self.visibleNodesViewModel.layerDropdownChoiceCache.get(layerId) {
+                    return cachedChoice
+                } else if let newChoice = self.getNodeViewModel(layerId)?.asLayerDropdownChoice {
+                    self.visibleNodesViewModel.layerDropdownChoiceCache[layerId] = newChoice
+                    return newChoice
+                } else {
+                    return nil
+                }
             }
-        
+
         return initialChoices + layers
     }
     


### PR DESCRIPTION
We weren't calling `syncNodes(nodesDict: NodesViewModelDict)` when adding a layer via the node menu. 

Perhaps easier, and okay perf-wise?, to just update the cache if entry not found.

(Additional calls of `layerDropdownChoices` were from adding Oval and Rect layers nodes to the project.)

![Screenshot 2025-03-06 at 11 11 26 AM](https://github.com/user-attachments/assets/667cfc9d-d182-4ea3-954d-dd57e7e66837)
