### PR TITLE
Copy + Paste support for layers

### DIFF
--- a/Stitch/Graph/CommentBox/Util/CommentBoxActions.swift
+++ b/Stitch/Graph/CommentBox/Util/CommentBoxActions.swift
@@ -20,7 +20,7 @@ extension GraphState {
     @MainActor
     func commentBoxCreated(nodeId: CanvasItemId,
                            groupNodeFocused: NodeId?) {
-        var selectedNodes = self.selectedNodeIds
+        var selectedNodes = self.selectedCanvasItems
 
         // Alternatively?: always add this id to selectedNodes in GraphUIState, so that we start it selected.
         if selectedNodes.isEmpty {

--- a/Stitch/Graph/CommentBox/View/CommentBoxView.swift
+++ b/Stitch/Graph/CommentBox/View/CommentBoxView.swift
@@ -21,7 +21,7 @@ struct CommentBoxView: View {
     
     @MainActor
     var atleastOneNodeSelected: Bool {
-        !graph.selectedNodeIds.isEmpty
+        !graph.selectedCanvasItems.isEmpty
     }
 
     @MainActor

--- a/Stitch/Graph/Node/Group/GroupNodeCreationActions.swift
+++ b/Stitch/Graph/Node/Group/GroupNodeCreationActions.swift
@@ -184,7 +184,7 @@ extension StitchDocumentViewModel {
             .getCanvasItemsAtTraversalLevel(groupNodeFocused: self.groupNodeFocused?.groupNodeId)
             .map(\.id).toSet
         
-        assertInDebug(!self.visibleGraph.selectedNodeIds.contains(where: { selectedNodeId in !nodesAtThisLevel.contains(selectedNodeId) }))
+        assertInDebug(!self.visibleGraph.selectedCanvasItems.contains(where: { selectedNodeId in !nodesAtThisLevel.contains(selectedNodeId) }))
         
         // Update selected canvas items with new parent id
         // Components are set with nil because of new graph state

--- a/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
+++ b/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
@@ -111,7 +111,7 @@ extension GraphState {
             // Copy nodes if no drag started yet
             let copiedComponentResult = self
                 .createCopiedComponent(groupNodeFocused: document.groupNodeFocused,
-                                       selectedNodeIds: state.selectedNodeIds.compactMap(\.nodeCase).toSet)
+                                       selectedNodeIds: state.selectedCanvasItems.compactMap(\.nodeCase).toSet)
             
             let (newComponent, nodeIdMap) = Self.updateCopiedNodes(
                 component: copiedComponentResult.component,
@@ -138,7 +138,7 @@ extension GraphState {
         // log("NodeDuplicateDraggedAction: state.selectedNodeIds at end: \(state.selectedNodeIds)")
         
         // Drag all selected nodes if dragging already started
-        state.selectedNodeIds
+        state.selectedCanvasItems
             .compactMap { state.getCanvasItem($0) }
             .forEach { draggedNode in
                 // log("NodeDuplicateDraggedAction: already had dragged node id, so will do normal node drag for id \(draggedNode.id)")

--- a/Stitch/Graph/Node/Util/NodeDeletedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeDeletedAction.swift
@@ -29,7 +29,7 @@ struct DeleteShortcutKeyPressed: StitchDocumentEvent {
 
             // delete nodes
             graph.selectedGraphNodesDeleted(
-                selectedNodes: graph.selectedNodeIds)
+                selectedNodes: graph.selectedCanvasItems)
         }
                 
         state.encodeProjectInBackground()
@@ -51,7 +51,7 @@ struct SelectedGraphNodesDeleted: StitchDocumentEvent {
         }
 
         graph.selectedGraphNodesDeleted(
-            selectedNodes: graph.selectedNodeIds)
+            selectedNodes: graph.selectedCanvasItems)
 
         state.encodeProjectInBackground()
     }

--- a/Stitch/Graph/Util/NodeSelection/CopyAndPasteNodesActions.swift
+++ b/Stitch/Graph/Util/NodeSelection/CopyAndPasteNodesActions.swift
@@ -28,16 +28,24 @@ struct SelectedGraphItemsCut: StitchDocumentEvent {
         }
 
         // Copy selected graph data to clipboard
-        graph.copyToClipboard(selectedNodeIds: graph.selectedNodeIds.compactMap(\.nodeCase).toSet,
+        graph.copyToClipboard(selectedNodeIds: graph.selectedPatchAndLayerNodes,
                               groupNodeFocused: state.groupNodeFocused)
 
         // Delete selected nodes
-        graph.selectedNodeIds.forEach {
+        graph.selectedCanvasItems.forEach {
             graph.deleteCanvasItem($0)
         }
 
         graph.updateGraphData()
         state.encodeProjectInBackground()
+    }
+}
+
+extension GraphState {
+    @MainActor
+    var selectedPatchAndLayerNodes: NodeIdSet {
+        self.selectedCanvasItems.compactMap(\.nodeCase).toSet
+            .union(self.selectedSidebarLayers)
     }
 }
 
@@ -53,8 +61,8 @@ struct SelectedGraphItemsCopied: StitchDocumentEvent {
         }
         
         let graph = state.visibleGraph
-                
-        graph.copyToClipboard(selectedNodeIds: graph.selectedNodeIds.compactMap(\.nodeCase).toSet,
+        
+        graph.copyToClipboard(selectedNodeIds: graph.selectedPatchAndLayerNodes,
                               groupNodeFocused: state.groupNodeFocused)
     }
 }

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -386,7 +386,7 @@ enum GraphManualZoom: Equatable, Hashable, Codable {
 
 extension GraphState {
     @MainActor
-    var selectedNodeIds: Set<CanvasItemId> {
+    var selectedCanvasItems: Set<CanvasItemId> {
         self.nodes.values
             .flatMap { node in
                 node.getAllCanvasObservers()

--- a/Stitch/Home/View/ProjectItem/ProjectsListItemView.swift
+++ b/Stitch/Home/View/ProjectItem/ProjectsListItemView.swift
@@ -125,9 +125,7 @@ struct ProjectsListItemView: View {
                                          previewWindowBackgroundColor: nil)
                     .modifier(ProjectsListItemErrorOverlayViewModifer())
             case .loaded(let document, let thumbnail):
-#if DEV_DEBUG
-                logInView("LOADED: \(document.name) \(document.id)")
-#endif
+                // logInView("LOADED: \(document.name) \(document.id)")
                 ProjectsListItemIconView(
                     projectThumbnail: thumbnail,
                     previewWindowBackgroundColor: document.previewWindowBackgroundColor,

--- a/StitchTests/nodeUIGroupingTests.swift
+++ b/StitchTests/nodeUIGroupingTests.swift
@@ -93,8 +93,8 @@ class GroupNodeTests: XCTestCase {
         
         // Make sure only one node is selected
         // TODO: fix after changing "selecting group node = selecting its splitters as well"
-        XCTAssertEqual(graphState.selectedNodeIds.count, 1)
-        XCTAssertEqual(graphState.selectedNodeIds.first!, canvasItem.id)
+        XCTAssertEqual(graphState.selectedCanvasItems.count, 1)
+        XCTAssertEqual(graphState.selectedCanvasItems.first!, canvasItem.id)
         
         await document.duplicateShortcutKeyPressed()
         


### PR DESCRIPTION
Including canvas layer inputs and outputs. 

Can copy-paste both layers and patches, including media. 

Resolves https://github.com/StitchDesign/Stitch--Old/issues/6470

Note that copy-pasting media into the same project over and over again can be slow?





https://github.com/user-attachments/assets/d5c63a27-a0d0-47c0-9927-1e5ac950790b


