### PR TITLE
Disable hit-testing on the hidden preview window's UIKitWrapper

### DIFF
--- a/Stitch/Graph/PrototypePreview/Frame/View/PreviewContent.swift
+++ b/Stitch/Graph/PrototypePreview/Frame/View/PreviewContent.swift
@@ -91,6 +91,7 @@ struct PreviewContent: View {
                              name: .previewWindow) {
                     EmptyView()
                 }
+                             .allowsHitTesting(false)
             }
         } // Group
         .onChange(of: showPreviewWindow) { oldValue, newValue in


### PR DESCRIPTION
We added UIKitWrapper to even the EmptyView / hidden preview window because we wanted better / consistent key listening. However, we were still ending up with a hit area being covered. So we disabled hit tested.

Resolves https://github.com/StitchDesign/Stitch--Old/issues/6989