### PR TITLE
Fixed perf from recent group node fixes

### DIFF
--- a/Stitch/Graph/Node/View/NodesView.swift
+++ b/Stitch/Graph/Node/View/NodesView.swift
@@ -61,18 +61,6 @@ struct NodesView: View {
         
            .coordinateSpace(name: Self.coordinateNameSpace)
 
-        // TODO: either update these `graphMovement: GraphMovementObserver` in `GraphScrollDataUpdated` OR get rid of GraphMovementObserver completely and merely rely on node-page's offset and zoom
-           .onChange(of: graph.graphMovement.localPosition) { _, newValue in
-               // log("GraphMovementViewModifier: .onChange(of: graph.graphMovement.localPosition): \(newValue)")
-               currentNodePage.localPosition = newValue
-               self.graph.updateVisibleNodes()
-           }
-           .onChange(of: graph.graphMovement.zoomData) { _, newValue in
-               // log("GraphMovementViewModifier: .onChange(of: graph.graphMovement.zoomData): \(newValue)")
-               currentNodePage.zoomData = newValue
-               self.graph.updateVisibleNodes()
-           }
-        
         // should come after edges, so that edges are offset, scaled etc.
            .modifier(StitchUIScrollViewModifier(document: document,
                                                 graph: graph))

--- a/Stitch/Graph/Node/View/StitchUIScrollHelpers.swift
+++ b/Stitch/Graph/Node/View/StitchUIScrollHelpers.swift
@@ -25,15 +25,29 @@ struct GraphScrollDataUpdated: StitchDocumentEvent {
         //        log("GraphScrollDataUpdated: xDiff: \(xDiff)")
         //        log("GraphScrollDataUpdated: yDiff: \(yDiff)")
         
+        // NOTE: we no longer persist after graph scroll ends, since we now always open the graph to the center.
+        let graph = state.visibleGraph
+        
         state.graphMovement.localPosition = newOffset
         state.graphMovement.zoomData = newZoom
+
+        let pageType: NodePageType = state.groupNodeFocused?.groupNodeId.nodePageType ?? .root
         
-        // NOTE: we no longer persist after graph scroll ends, since we now always open the graph to the center.
+        guard let nodePage = graph.visibleNodesViewModel.nodesByPage.get(pageType) else {
+            fatalErrorIfDebug()
+            return
+        }
         
-//        if shouldPersist {
-//            log("GraphScrollDataUpdated: will persist")
-//            state.encodeProjectInBackground()
-//        }
+        if nodePage.localPosition != newOffset {
+            nodePage.localPosition = newOffset
+        }
+        
+        if nodePage.zoomData != newZoom {
+            nodePage.zoomData = newZoom
+        }
+        
+        // Update which nodes are visible in frame
+        graph.updateVisibleNodes()
     }
     
 }


### PR DESCRIPTION
Perf problems caused by costly onChange handlers causing renders on all graph movement. Logic moved to actions which are consistently called on changes.

Perf regression from #915.