### PR TITLE
Reduced render cycles from project title text fields

### DIFF
--- a/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
+++ b/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
@@ -246,7 +246,9 @@ extension PatchNodeViewModel {
     func updateMathExpressionNodeInputs(newExpression: String,
                                         node: NodeDelegate) {
         // Always set math-expr on node for its eval and (default) title
-        self.mathExpression = newExpression
+        if self.mathExpression != newExpression {
+            self.mathExpression = newExpression            
+        }
         
         // log("updateMathExpressionNodeInputs: newExpression: \(newExpression)")
 

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -406,7 +406,11 @@ extension GraphState {
     @MainActor
     private func updateSynchronousProperties(from schema: GraphEntity) {
         assertInDebug(self.id == schema.id)
-        self.name = schema.name
+        
+        if self.name != schema.name {
+            self.name = schema.name
+        }
+        
         self.layersSidebarViewModel.update(from: schema.orderedSidebarLayers)
     }
     

--- a/Stitch/Home/View/ProjectItem/ProjectsListItemView.swift
+++ b/Stitch/Home/View/ProjectItem/ProjectsListItemView.swift
@@ -161,8 +161,16 @@ struct ProjectsListItemView: View {
         } labelView: {
             switch projectLoader.loadingDocument {
             case .loaded(let document, _):
-                ProjectThumbnailTextField(document: document,
-                                          namespace: namespace)
+                if self.store.currentDocument == nil {
+                    ProjectThumbnailTextField(document: document,
+                                              namespace: namespace)
+                } else {
+                    // Perf fix hides text field when home screen not visible
+                    Text(document.name)
+                        .font(STITCH_FONT)
+                        .lineLimit(1)
+                }
+                
             default:
                 // Blank text view to copy height of loaded view
                 Color.clear


### PR DESCRIPTION
Text field logic requires the full document data struct, which causes render cycles if _anything_ in the structure changes (which happens on each encoding). Fix here is to use read-only logic when a graph is visible since the home screen text field isn't needed when a graph is open.