### PR TITLE
Reduced render cycles caused by edges

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -158,6 +158,7 @@
 		B5657D392C0B94A300287362 /* GraphMediaValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5657D382C0B94A300287362 /* GraphMediaValue.swift */; };
 		B569E58B2B06A8B100C7435B /* NodeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B569E58A2B06A8B100C7435B /* NodeInfo.swift */; };
 		B56EA8A62C409898003D39E2 /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = B56EA8A52C409898003D39E2 /* StitchEngine */; };
+		B56EC9F22D81524A00C4ACF3 /* ConnectedEdgeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56EC9F12D81524500C4ACF3 /* ConnectedEdgeData.swift */; };
 		B56F36252D3C1A2E0051C80E /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = B56F36242D3C1A2E0051C80E /* StitchEngine */; };
 		B56FFB212C18B4F600623CC7 /* AnimationUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56FFB202C18B4F600623CC7 /* AnimationUtils.swift */; };
 		B56FFB242C18B53C00623CC7 /* StitchHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56FFB232C18B53C00623CC7 /* StitchHostingController.swift */; };
@@ -1139,6 +1140,7 @@
 		B5657D352C0983E300287362 /* MediaEvalOpObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaEvalOpObservable.swift; sourceTree = "<group>"; };
 		B5657D382C0B94A300287362 /* GraphMediaValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphMediaValue.swift; sourceTree = "<group>"; };
 		B569E58A2B06A8B100C7435B /* NodeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeInfo.swift; sourceTree = "<group>"; };
+		B56EC9F12D81524500C4ACF3 /* ConnectedEdgeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedEdgeData.swift; sourceTree = "<group>"; };
 		B56FFB202C18B4F600623CC7 /* AnimationUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationUtils.swift; sourceTree = "<group>"; };
 		B56FFB232C18B53C00623CC7 /* StitchHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StitchHostingController.swift; sourceTree = "<group>"; };
 		B56FFB292C18B72500623CC7 /* MediaImportUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaImportUtils.swift; sourceTree = "<group>"; };
@@ -3321,6 +3323,7 @@
 		B56FFB5C2C19652F00623CC7 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				B56EC9F12D81524500C4ACF3 /* ConnectedEdgeData.swift */,
 				ECA92A5F260A6CDA00281B52 /* EdgeAnchorData.swift */,
 				EC16587C2B6AF03F00FE4AE6 /* EdgeEditingState.swift */,
 				EC1658812B6AFDDA00FE4AE6 /* EdgeEditingModeInputLabel.swift */,
@@ -5692,6 +5695,7 @@
 				EC804494294431C800DCFCF4 /* LayerEvalHelpers.swift in Sources */,
 				B56FFB422C18F7AB00623CC7 /* SafeAreaInsets.swift in Sources */,
 				ECA2E2B927F6210D00D31ECF /* SidebarListItemSelectionStatus.swift in Sources */,
+				B56EC9F22D81524A00C4ACF3 /* ConnectedEdgeData.swift in Sources */,
 				B549AD7229CFC30D002F3252 /* NodePositionUtils.swift in Sources */,
 				EC28D55B26B2142D00E1118E /* LayerGroups.swift in Sources */,
 				20308FAB25AD1721008CE3BE /* MiscUtils.swift in Sources */,

--- a/Stitch/Graph/Edge/Model/ConnectedEdgeData.swift
+++ b/Stitch/Graph/Edge/Model/ConnectedEdgeData.swift
@@ -1,0 +1,53 @@
+//
+//  ConnectedEdgeData.swift
+//  Stitch
+//
+//  Created by Elliot Boschwitz on 3/11/25.
+//
+
+import SwiftUI
+import StitchSchemaKit
+
+struct ConnectedEdgeData: Equatable {
+    static func == (lhs: ConnectedEdgeData, rhs: ConnectedEdgeData) -> Bool {
+        lhs.upstreamRowObserver.id == rhs.upstreamRowObserver.id &&
+        lhs.downstreamRowObserver.id == rhs.downstreamRowObserver.id &&
+        lhs.zIndex == rhs.zIndex
+    }
+    
+    let upstreamRowObserver: OutputNodeRowViewModel
+    let downstreamRowObserver: InputNodeRowViewModel
+    let inputData: EdgeAnchorDownstreamData
+    let outputData: EdgeAnchorUpstreamData
+    let zIndex: Double
+    
+    @MainActor
+    init?(downstreamRowObserver: InputNodeRowViewModel) {
+        guard let downstreamNode = downstreamRowObserver.nodeDelegate,
+              let upstreamRowObserver = downstreamRowObserver.rowDelegate?.upstreamOutputObserver?.nodeRowViewModel,
+              let inputData = EdgeAnchorDownstreamData(
+                from: downstreamRowObserver,
+                upstreamNodeId: upstreamRowObserver.canvasItemDelegate?.id),
+              let outputData = EdgeAnchorUpstreamData(
+                from: upstreamRowObserver,
+                connectedDownstreamNode: downstreamNode) else {
+            return nil
+        }
+        
+        self.upstreamRowObserver = upstreamRowObserver
+        self.downstreamRowObserver = downstreamRowObserver
+        self.inputData = inputData
+        self.outputData = outputData
+        
+        let upstreamRowObserverZIndex = upstreamRowObserver.canvasItemDelegate?.zIndex ?? 0
+        let defaultInputNodeIndex = downstreamRowObserver.canvasItemDelegate?.zIndex ?? 0
+        let zIndexOfInputNode = downstreamRowObserver.canvasItemDelegate?.zIndex ?? defaultInputNodeIndex
+        self.zIndex = max(upstreamRowObserverZIndex, zIndexOfInputNode)
+    }
+}
+
+extension ConnectedEdgeData: Identifiable {
+    var id: NodeRowViewModelId {
+        self.downstreamRowObserver.id
+    }
+}

--- a/Stitch/Graph/Edge/Model/EdgeAnchorData.swift
+++ b/Stitch/Graph/Edge/Model/EdgeAnchorData.swift
@@ -21,12 +21,25 @@ struct EdgeAnchorUpstreamData {
     let lastUpstreamObserver: OutputNodeRowViewModel
     
     // Edge-specific data used for calculating Y distance for edge views
-    // Optional to support edge dragging
-    let firstConnectedUpstreamObserver: OutputNodeRowViewModel?
-    let lastConnectedUpstreamObserver: OutputNodeRowViewModel?
+    let firstConnectedUpstreamObserver: OutputNodeRowViewModel
+    let lastConnectedUpstreamObserver: OutputNodeRowViewModel
     
     let totalOutputs: Int
 }
+
+
+//struct EdgeAnchorUpstreamData {
+//    // Port-specific data
+//    let firstUpstreamObserver: OutputNodeRowViewModel
+//    let lastUpstreamObserver: OutputNodeRowViewModel
+//    
+//    // Edge-specific data used for calculating Y distance for edge views
+//    // Optional to support edge dragging
+//    let firstConnectedUpstreamObserver: OutputNodeRowViewModel?
+//    let lastConnectedUpstreamObserver: OutputNodeRowViewModel?
+//    
+//    let totalOutputs: Int
+//}
 
 struct EdgeAnchorDownstreamData {
     // Port-specific data
@@ -34,10 +47,21 @@ struct EdgeAnchorDownstreamData {
     let lastInputObserver: InputNodeRowViewModel
     
     // Edge-specific data used for calculating Y distance for edge views
-    // Optional to support possible edges for animation
-    let firstConnectedInputObserver: InputNodeRowViewModel?
-    let lastConectedInputObserver: InputNodeRowViewModel?
+    let firstConnectedInputObserver: InputNodeRowViewModel
+    let lastConectedInputObserver: InputNodeRowViewModel
 }
+
+
+//struct EdgeAnchorDownstreamData {
+//    // Port-specific data
+//    let firstInputObserver: InputNodeRowViewModel
+//    let lastInputObserver: InputNodeRowViewModel
+//    
+//    // Edge-specific data used for calculating Y distance for edge views
+//    // Optional to support possible edges for animation
+//    let firstConnectedInputObserver: InputNodeRowViewModel?
+//    let lastConectedInputObserver: InputNodeRowViewModel?
+//}
 
 extension EdgeAnchorUpstreamData {
     @MainActor
@@ -52,13 +76,23 @@ extension EdgeAnchorUpstreamData {
         
         guard let connectedDownstreamNode = connectedDownstreamNode else {
             // Hits on edge drag when no eligible input found yet
-            self.init(firstUpstreamObserver: firstUpstreamObserver,
-                      lastUpstreamObserver: lastUpstreamObserver,
-                      firstConnectedUpstreamObserver: nil,
-                      lastConnectedUpstreamObserver: nil,
-                      totalOutputs: outputsCount)
-            return
+//            self.init(firstUpstreamObserver: firstUpstreamObserver,
+//                      lastUpstreamObserver: lastUpstreamObserver,
+//                      firstConnectedUpstreamObserver: nil,
+//                      lastConnectedUpstreamObserver: nil,
+//                      totalOutputs: outputsCount)
+            return nil
         }
+        
+//        guard let connectedDownstreamNode = connectedDownstreamNode else {
+//            // Hits on edge drag when no eligible input found yet
+//            self.init(firstUpstreamObserver: firstUpstreamObserver,
+//                      lastUpstreamObserver: lastUpstreamObserver,
+//                      firstConnectedUpstreamObserver: nil,
+//                      lastConnectedUpstreamObserver: nil,
+//                      totalOutputs: outputsCount)
+//            return
+//        }
         
         let downstreamInputs = connectedDownstreamNode.getAllInputsObservers()
         
@@ -86,12 +120,12 @@ extension EdgeAnchorUpstreamData {
         // Should have been at least one connection found
         guard let firstConnectedUpstreamObserver = firstConnectedUpstreamObserver else {
             // Can be hit right after edge disconnection
-            self.init(firstUpstreamObserver: firstUpstreamObserver,
-                      lastUpstreamObserver: lastUpstreamObserver,
-                      firstConnectedUpstreamObserver: nil,
-                      lastConnectedUpstreamObserver: nil,
-                      totalOutputs: outputsCount)
-            return
+//            self.init(firstUpstreamObserver: firstUpstreamObserver,
+//                      lastUpstreamObserver: lastUpstreamObserver,
+//                      firstConnectedUpstreamObserver: nil,
+//                      lastConnectedUpstreamObserver: nil,
+//                      totalOutputs: outputsCount)
+            return nil
         }
               
         self.init(firstUpstreamObserver: firstUpstreamObserver,
@@ -129,6 +163,10 @@ extension EdgeAnchorDownstreamData {
                 
                 lastConnectedInputObserver = input
             }
+        }
+        
+        guard let firstConnectedInputObserver = firstConnectedInputObserver else {
+            return nil
         }
         
         self.init(firstInputObserver: firstInputObserver,

--- a/Stitch/Graph/Edge/Model/EdgeAnchorData.swift
+++ b/Stitch/Graph/Edge/Model/EdgeAnchorData.swift
@@ -74,14 +74,15 @@ extension EdgeAnchorUpstreamData {
             return nil
         }
         
-        let downstreamInputs = connectedDownstreamNode.getAllInputsObservers()
+        let downstreamInputs = connectedDownstreamNode.allInputRowViewModels
         
         // Find top and bottom-most edges from upstream node connecting to this node
         var firstConnectedUpstreamObserver: OutputNodeRowViewModel?
         var lastConnectedUpstreamObserver: OutputNodeRowViewModel?
-        downstreamInputs.forEach{ downstreamInput in
+        downstreamInputs.forEach { downstreamInput in
             // Do nothing if no connection from this input
-            guard let upstreamToThisInput = downstreamInput.upstreamOutputObserver?.allRowViewModels.first(where: { $0.id.isNode }) else {
+            guard let upstreamToThisInput = downstreamInput.rowDelegate?.upstreamOutputObserver?.nodeRowViewModel
+                else {
                 return
             }
             

--- a/Stitch/Graph/Edge/Model/EdgeAnchorData.swift
+++ b/Stitch/Graph/Edge/Model/EdgeAnchorData.swift
@@ -21,8 +21,9 @@ struct EdgeAnchorUpstreamData {
     let lastUpstreamObserver: OutputNodeRowViewModel
     
     // Edge-specific data used for calculating Y distance for edge views
-    let firstConnectedUpstreamObserver: OutputNodeRowViewModel
-    let lastConnectedUpstreamObserver: OutputNodeRowViewModel
+    // Optional to support edge dragging
+    let firstConnectedUpstreamObserver: OutputNodeRowViewModel?
+    let lastConnectedUpstreamObserver: OutputNodeRowViewModel?
     
     let totalOutputs: Int
 }
@@ -65,34 +66,13 @@ struct EdgeAnchorDownstreamData {
 
 extension EdgeAnchorUpstreamData {
     @MainActor
-    init?(from upstreamRowObserver: OutputNodeRowViewModel?,
-          connectedDownstreamNode: NodeDelegate?) {
-        guard let upstreamRowObserver = upstreamRowObserver,
-              let outputsCount = upstreamRowObserver.canvasItemDelegate?.outputViewModels.count,
+    init?(from upstreamRowObserver: OutputNodeRowViewModel,
+          connectedDownstreamNode: NodeViewModel) {
+        guard let outputsCount = upstreamRowObserver.canvasItemDelegate?.outputViewModels.count,
               let firstUpstreamObserver = upstreamRowObserver.canvasItemDelegate?.outputViewModels.first,
               let lastUpstreamObserver = upstreamRowObserver.canvasItemDelegate?.outputViewModels[safe: outputsCount - 1] else {
             return nil
         }
-        
-        guard let connectedDownstreamNode = connectedDownstreamNode else {
-            // Hits on edge drag when no eligible input found yet
-//            self.init(firstUpstreamObserver: firstUpstreamObserver,
-//                      lastUpstreamObserver: lastUpstreamObserver,
-//                      firstConnectedUpstreamObserver: nil,
-//                      lastConnectedUpstreamObserver: nil,
-//                      totalOutputs: outputsCount)
-            return nil
-        }
-        
-//        guard let connectedDownstreamNode = connectedDownstreamNode else {
-//            // Hits on edge drag when no eligible input found yet
-//            self.init(firstUpstreamObserver: firstUpstreamObserver,
-//                      lastUpstreamObserver: lastUpstreamObserver,
-//                      firstConnectedUpstreamObserver: nil,
-//                      lastConnectedUpstreamObserver: nil,
-//                      totalOutputs: outputsCount)
-//            return
-//        }
         
         let downstreamInputs = connectedDownstreamNode.getAllInputsObservers()
         
@@ -118,15 +98,9 @@ extension EdgeAnchorUpstreamData {
         }
         
         // Should have been at least one connection found
-        guard let firstConnectedUpstreamObserver = firstConnectedUpstreamObserver else {
-            // Can be hit right after edge disconnection
-//            self.init(firstUpstreamObserver: firstUpstreamObserver,
-//                      lastUpstreamObserver: lastUpstreamObserver,
-//                      firstConnectedUpstreamObserver: nil,
-//                      lastConnectedUpstreamObserver: nil,
-//                      totalOutputs: outputsCount)
-            return nil
-        }
+//        guard let firstConnectedUpstreamObserver = firstConnectedUpstreamObserver else {
+//            return nil
+//        }
               
         self.init(firstUpstreamObserver: firstUpstreamObserver,
                   lastUpstreamObserver: lastUpstreamObserver,

--- a/Stitch/Graph/Edge/Model/EdgeAnchorData.swift
+++ b/Stitch/Graph/Edge/Model/EdgeAnchorData.swift
@@ -115,15 +115,15 @@ extension EdgeAnchorDownstreamData {
     @MainActor
     init?(from inputRowObserver: InputNodeRowViewModel,
           upstreamNodeId: CanvasItemId? = nil) {
-        guard let inputsCount = inputRowObserver.nodeDelegate?.inputsRowCount,
+        guard let inputsCount = inputRowObserver.canvasItemDelegate?.inputViewModels.count,
               let firstInputObserver = inputRowObserver.canvasItemDelegate?.inputViewModels.first,
               let lastInputObserver = inputRowObserver.canvasItemDelegate?.inputViewModels[safe: inputsCount - 1],
-              let node = inputRowObserver.nodeDelegate,
+              let canvas = inputRowObserver.canvasItemDelegate,
               let upstreamConnectedNodeId = upstreamNodeId ?? inputRowObserver.rowDelegate?.upstreamOutputObserver?.nodeRowViewModel?.canvasItemDelegate?.id else {
             return nil
         }
 
-        let allInputs = node.allInputViewModels
+        let allInputs = canvas.inputViewModels
         
         // Iterate through inputs at this node to find other connected edges from same upstream node id
         var firstConnectedInputObserver: InputNodeRowViewModel?

--- a/Stitch/Graph/Edge/Model/EdgeAnchorData.swift
+++ b/Stitch/Graph/Edge/Model/EdgeAnchorData.swift
@@ -28,20 +28,6 @@ struct EdgeAnchorUpstreamData {
     let totalOutputs: Int
 }
 
-
-//struct EdgeAnchorUpstreamData {
-//    // Port-specific data
-//    let firstUpstreamObserver: OutputNodeRowViewModel
-//    let lastUpstreamObserver: OutputNodeRowViewModel
-//    
-//    // Edge-specific data used for calculating Y distance for edge views
-//    // Optional to support edge dragging
-//    let firstConnectedUpstreamObserver: OutputNodeRowViewModel?
-//    let lastConnectedUpstreamObserver: OutputNodeRowViewModel?
-//    
-//    let totalOutputs: Int
-//}
-
 struct EdgeAnchorDownstreamData {
     // Port-specific data
     let firstInputObserver: InputNodeRowViewModel
@@ -51,18 +37,6 @@ struct EdgeAnchorDownstreamData {
     let firstConnectedInputObserver: InputNodeRowViewModel
     let lastConectedInputObserver: InputNodeRowViewModel
 }
-
-
-//struct EdgeAnchorDownstreamData {
-//    // Port-specific data
-//    let firstInputObserver: InputNodeRowViewModel
-//    let lastInputObserver: InputNodeRowViewModel
-//    
-//    // Edge-specific data used for calculating Y distance for edge views
-//    // Optional to support possible edges for animation
-//    let firstConnectedInputObserver: InputNodeRowViewModel?
-//    let lastConectedInputObserver: InputNodeRowViewModel?
-//}
 
 extension EdgeAnchorUpstreamData {
     @MainActor
@@ -97,11 +71,6 @@ extension EdgeAnchorUpstreamData {
                 lastConnectedUpstreamObserver = firstConnectedUpstreamObserver
             }
         }
-        
-        // Should have been at least one connection found
-//        guard let firstConnectedUpstreamObserver = firstConnectedUpstreamObserver else {
-//            return nil
-//        }
               
         self.init(firstUpstreamObserver: firstUpstreamObserver,
                   lastUpstreamObserver: lastUpstreamObserver,

--- a/Stitch/Graph/Edge/Model/EdgeEditingState.swift
+++ b/Stitch/Graph/Edge/Model/EdgeEditingState.swift
@@ -22,7 +22,7 @@ struct PossibleEdge: Hashable {
     var isCommitted: Bool // = false
 }
 
-extension PossibleEdge {
+extension PossibleEdge: Identifiable {
     var id: InputPortViewData {
         edge.id
     }

--- a/Stitch/Graph/Edge/Util/EdgeEditingActions.swift
+++ b/Stitch/Graph/Edge/Util/EdgeEditingActions.swift
@@ -208,6 +208,8 @@ struct PossibleEdgeDecommitmentCompleted: GraphEvent {
         
         state.removeEdgeAt(input: edge.to,
                            activeIndex: activeIndex)
+        
+        state.encodeProjectInBackground()
     }
 }
 

--- a/Stitch/Graph/Edge/Util/EdgeUtils.swift
+++ b/Stitch/Graph/Edge/Util/EdgeUtils.swift
@@ -75,17 +75,20 @@ extension GraphState {
         
         // Which node is this cursor-drawn-edge extended from?
         // Never create an edge from an output to an input on the very same node.
-        cursorNodeId: CanvasItemId,
-        
-        // Since deleted nodes are not removed from prefDict,
-        // if we iterate through prefDict, we will potentially propose a deleted input.
-        // So instead we iterate through VisibleNodes' inputs (i.e. inputs at this traversal level).
-        eligibleInputCandidates: [InputNodeRowViewModel]) {
+        cursorNodeId: CanvasItemId) {
         
         var nearestInputs = [InputNodeRowViewModel]()
+            
+            let canvasItemsAtThisTraversalLevel = self
+                .getCanvasItemsAtTraversalLevel(groupNodeFocused: documentDelegate?.groupNodeFocused?.groupNodeId)
+            
+            let eligibleInputs = canvasItemsAtThisTraversalLevel
+                .flatMap { canvasItem -> [InputNodeRowViewModel] in
+                    canvasItem.inputViewModels
+                }
         
         // Only look at pref-dict inputs' which are on this level
-        for inputViewModel in eligibleInputCandidates {
+        for inputViewModel in eligibleInputs {
             guard let inputCenter = inputViewModel.anchorPoint else {
                 continue
             }

--- a/Stitch/Graph/Edge/View/EdgeDrawingView.swift
+++ b/Stitch/Graph/Edge/View/EdgeDrawingView.swift
@@ -87,10 +87,10 @@ struct EdgeFromDraggedOutputView: View {
                          firstTo: inputAnchorData?.firstInputObserver.anchorPoint ?? .zero,
                          lastFrom: outputAnchorData.lastUpstreamObserver.anchorPoint ?? .zero,
                          lastTo: inputAnchorData?.lastInputObserver.anchorPoint ?? .zero,
-                         firstFromWithEdge: outputAnchorData.firstConnectedUpstreamObserver?.anchorPoint?.y,
-                         lastFromWithEdge: outputAnchorData.lastConnectedUpstreamObserver?.anchorPoint?.y,
-                         firstToWithEdge: inputAnchorData?.firstConnectedInputObserver?.anchorPoint?.y,
-                         lastToWithEdge: inputAnchorData?.lastConectedInputObserver?.anchorPoint?.y,
+                         firstFromWithEdge: outputAnchorData.firstConnectedUpstreamObserver.anchorPoint?.y,
+                         lastFromWithEdge: outputAnchorData.lastConnectedUpstreamObserver.anchorPoint?.y,
+                         firstToWithEdge: inputAnchorData?.firstConnectedInputObserver.anchorPoint?.y,
+                         lastToWithEdge: inputAnchorData?.lastConectedInputObserver.anchorPoint?.y,
                          totalOutputs: outputAnchorData.totalOutputs,
                          // we never animate the actively dragged edge
                          edgeAnimationEnabled: false)

--- a/Stitch/Graph/Edge/View/EdgeDrawingView.swift
+++ b/Stitch/Graph/Edge/View/EdgeDrawingView.swift
@@ -11,15 +11,14 @@ import StitchSchemaKit
 struct EdgeDrawingView: View {
     let graph: GraphState
     @Bindable var edgeDrawingObserver: EdgeDrawingObserver
-    let inputsAtThisTraversalLevel: [InputNodeRowViewModel]
+//    let inputsAtThisTraversalLevel: [InputNodeRowViewModel]
     
     var body: some View {
         if let outputDrag = edgeDrawingObserver.drawingGesture {
             EdgeFromDraggedOutputView(
                 graph: graph,
                 outputDrag: outputDrag,
-                nearestEligibleInput: edgeDrawingObserver.nearestEligibleInput,
-                eligibleInputCandidates: inputsAtThisTraversalLevel)
+                nearestEligibleInput: edgeDrawingObserver.nearestEligibleInput)
         } else {
             EmptyView()
         }
@@ -34,7 +33,7 @@ struct EdgeFromDraggedOutputView: View {
     // ie cursor position
     let outputDrag: OutputDragGesture
     let nearestEligibleInput: InputNodeRowViewModel?
-    let eligibleInputCandidates: [InputNodeRowViewModel]
+//    let eligibleInputCandidates: [InputNodeRowViewModel]
 
     var outputRowViewModel: OutputNodeRowViewModel {
         outputDrag.output
@@ -43,11 +42,6 @@ struct EdgeFromDraggedOutputView: View {
     // Note: the rules for the color of an actively dragged edge are simple: highlighted-loop if a loop, else highlighted.
     @MainActor
     var color: PortColor {
-        guard nearestEligibleInput.isDefined else {
-            // Actively dragged edges are always gray if there is no eligible input yet
-            return .noEdge
-        }
-        
         if outputRowViewModel.rowDelegate?.hasLoopedValues ?? false {
             return .highlightedLoopEdge
         } else {
@@ -69,11 +63,12 @@ struct EdgeFromDraggedOutputView: View {
     
     var body: some View {
         Group {
-            if let outputAnchorData = EdgeAnchorUpstreamData(from: outputRowViewModel,
-                                                             connectedDownstreamNode: nearestEligibleInput?.nodeDelegate),
+            if let downstreamNode = outputDrag.output.nodeDelegate,
+                let outputAnchorData = EdgeAnchorUpstreamData(from: outputRowViewModel,
+                                                              connectedDownstreamNode: downstreamNode),
                let outputPortViewData = outputRowViewModel.portViewData,
-               let pointFrom = outputRowViewModel.anchorPoint,
-               let outputNodeId = outputRowViewModel.canvasItemDelegate?.id {
+               let outputNodeId = outputRowViewModel.canvasItemDelegate?.id,
+               let pointFrom = outputRowViewModel.anchorPoint {
                 let edge = PortEdgeUI(from: outputPortViewData,
                                       to: .init(portId: -1,
                                                 canvasId: outputNodeId))
@@ -87,20 +82,21 @@ struct EdgeFromDraggedOutputView: View {
                          firstTo: inputAnchorData?.firstInputObserver.anchorPoint ?? .zero,
                          lastFrom: outputAnchorData.lastUpstreamObserver.anchorPoint ?? .zero,
                          lastTo: inputAnchorData?.lastInputObserver.anchorPoint ?? .zero,
-                         firstFromWithEdge: outputAnchorData.firstConnectedUpstreamObserver.anchorPoint?.y,
-                         lastFromWithEdge: outputAnchorData.lastConnectedUpstreamObserver.anchorPoint?.y,
+                         firstFromWithEdge: outputAnchorData.firstConnectedUpstreamObserver?.anchorPoint?.y,
+                         lastFromWithEdge: outputAnchorData.lastConnectedUpstreamObserver?.anchorPoint?.y,
                          firstToWithEdge: inputAnchorData?.firstConnectedInputObserver.anchorPoint?.y,
                          lastToWithEdge: inputAnchorData?.lastConectedInputObserver.anchorPoint?.y,
                          totalOutputs: outputAnchorData.totalOutputs,
                          // we never animate the actively dragged edge
                          edgeAnimationEnabled: false)
                 .animation(.default, value: color)
-                .onChange(of: pointTo) {
-                    graph.findEligibleInput(
-                        cursorLocation: pointTo,
-                        cursorNodeId: outputNodeId,
-                        eligibleInputCandidates: eligibleInputCandidates)
-                }
+            }
+        }
+        .onChange(of: pointTo) {
+            if let outputNodeId = outputRowViewModel.canvasItemDelegate?.id {
+                graph.findEligibleInput(
+                    cursorLocation: pointTo,
+                    cursorNodeId: outputNodeId)
             }
         }
     }

--- a/Stitch/Graph/Edge/View/EdgeDrawingView.swift
+++ b/Stitch/Graph/Edge/View/EdgeDrawingView.swift
@@ -33,7 +33,6 @@ struct EdgeFromDraggedOutputView: View {
     // ie cursor position
     let outputDrag: OutputDragGesture
     let nearestEligibleInput: InputNodeRowViewModel?
-//    let eligibleInputCandidates: [InputNodeRowViewModel]
 
     var outputRowViewModel: OutputNodeRowViewModel {
         outputDrag.output

--- a/Stitch/Graph/Edge/View/EditMode/EdgeEditModeLabelsView.swift
+++ b/Stitch/Graph/Edge/View/EditMode/EdgeEditModeLabelsView.swift
@@ -15,23 +15,15 @@ struct EdgeInputLabelsView: View {
     var body: some View {
         let showLabels = graph.edgeEditingState?.labelsShown ?? false
         
-        if let nearbyCanvasItem: CanvasItemId = graph.edgeEditingState?.nearbyCanvasItem {
-            ForEach(graph.connectedEdges) { edgeData in
-                let inputRowViewModel = edgeData.downstreamRowObserver
-                
-                // Doesn't seem to be needed? Checking the canvasItemDelegate seems to work well
-                // visibleNodeId property checks for group splitter inputs
-                // let isInputForNearbyNode = inputRowViewModel.visibleNodeIds.contains(nearbyCanvasItem)
-                
-                let isInputOnNearbyCanvasItem = inputRowViewModel.canvasItemDelegate?.id == nearbyCanvasItem
-                let isVisible = isInputOnNearbyCanvasItem && showLabels
-                
+        if let nearbyCanvasItem: CanvasItemId = graph.edgeEditingState?.nearbyCanvasItem,
+           let nearbyCanvas = graph.getCanvasItem(nearbyCanvasItem) {
+            ForEach(nearbyCanvas.inputViewModels) { inputRowViewModel in                
                 EdgeEditModeLabelsView(document: document,
                                        portId: inputRowViewModel.id.portId)
                 .position(inputRowViewModel.anchorPoint ?? .zero)
-                .opacity(isVisible ? 1 : 0)
+                .opacity(showLabels ? 1 : 0)
                 .animation(.linear(duration: .EDGE_EDIT_MODE_NODE_UI_ELEMENT_ANIMATION_LENGTH),
-                           value: isVisible)
+                           value: showLabels)
             }
         } else {
             EmptyView()

--- a/Stitch/Graph/Edge/View/EditMode/EdgeEditModeLabelsView.swift
+++ b/Stitch/Graph/Edge/View/EditMode/EdgeEditModeLabelsView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 import StitchSchemaKit
 
 struct EdgeInputLabelsView: View {
-    let inputs: [InputNodeRowViewModel]
     @Bindable var document: StitchDocumentViewModel
     @Bindable var graph: GraphState
 
@@ -17,7 +16,8 @@ struct EdgeInputLabelsView: View {
         let showLabels = graph.edgeEditingState?.labelsShown ?? false
         
         if let nearbyCanvasItem: CanvasItemId = graph.edgeEditingState?.nearbyCanvasItem {
-            ForEach(inputs) { inputRowViewModel in
+            ForEach(graph.connectedEdges) { edgeData in
+                let inputRowViewModel = edgeData.downstreamRowObserver
                 
                 // Doesn't seem to be needed? Checking the canvasItemDelegate seems to work well
                 // visibleNodeId property checks for group splitter inputs

--- a/Stitch/Graph/Edge/View/ExistingEdgesView.swift
+++ b/Stitch/Graph/Edge/View/ExistingEdgesView.swift
@@ -61,6 +61,7 @@ extension ConnectedEdgeView {
         self.upstreamObserver = data.upstreamRowObserver
         self.inputData = data.inputData
         self.outputData = data.outputData
+        self.zIndex = data.zIndex
         self.edgeAnimationEnabled = edgeAnimationEnabled
     }
 //    @MainActor
@@ -119,6 +120,7 @@ struct ConnectedEdgeView: View {
     let inputData: EdgeAnchorDownstreamData
     let outputData: EdgeAnchorUpstreamData
     let edgeAnimationEnabled: Bool
+    let zIndex: Double
     
     // Optional in event we only have possible edge
 //    let upstreamObserver: OutputNodeRowViewModel?
@@ -158,15 +160,9 @@ struct ConnectedEdgeView: View {
                                   to: inputPortViewData)
             let portColor: PortColor = inputObserver.portColor
             let isSelectedEdge = (portColor == .highlightedEdge || portColor == .highlightedLoopEdge)
-            
-            // TODO: this is a problem with delegates
-            
-            let upstreamObserverZIndex = upstreamObserver.canvasItemDelegate?.zIndex ?? 0
-            let defaultInputNodeIndex = inputObserver.canvasItemDelegate?.zIndex ?? 0
-            let zIndexOfInputNode = inputObserver.canvasItemDelegate?.zIndex ?? defaultInputNodeIndex
-            let base = max(upstreamObserverZIndex, zIndexOfInputNode)
-            let boost = isSelectedEdge ? SELECTED_EDGE_Z_INDEX_BOOST : 0
-            let zIndex: ZIndex = base + boost
+           
+            let zIndexBoost = isSelectedEdge ? SELECTED_EDGE_Z_INDEX_BOOST : 0
+            let newZIndex: ZIndex = self.zIndex + zIndexBoost
             
             EdgeView(edge: edge,
                      pointFrom: pointFrom,
@@ -183,7 +179,7 @@ struct ConnectedEdgeView: View {
                      lastToWithEdge: lastToWithEdge,
                      totalOutputs: totalOutputs,
                      edgeAnimationEnabled: edgeAnimationEnabled)
-            .zIndex(zIndex)
+            .zIndex(newZIndex)
             
         } else {
             Color.clear

--- a/Stitch/Graph/Edge/View/ExistingEdgesView.swift
+++ b/Stitch/Graph/Edge/View/ExistingEdgesView.swift
@@ -10,46 +10,25 @@ import StitchSchemaKit
 
 struct GraphConnectedEdgesView: View {
     @Bindable var graph: GraphState
-//    let allConnectedInputs: [InputNodeRowViewModel]
-    
-//    var animatingEdges: PossibleEdgeSet {
-//        graph.edgeEditingState?.possibleEdges ?? .init()
-//    }
-//    
+
     var edgeAnimationEnabled: Bool {
         graph.edgeAnimationEnabled
     }
     
-//    var shownPossibleEdgeIds: Set<PossibleEdgeId> {
-//        graph.edgeEditingState?.shownIds ?? .init()
-//    }
+    // Filter out "possible" edges, enabling animation
+    func isEdgeAnimating(_ edgeData: ConnectedEdgeData) -> Bool {
+        graph.edgeEditingState?.possibleEdges.first(where: {
+            $0.edge.to == edgeData.downstreamRowObserver.portViewData
+        }) == nil
+    }
     
-//    @MainActor
-//    func getPossibleEdgeUpstreamObserver(from input: InputNodeRowViewModel,
-//                                         possibleEdge: PossibleEdge?) -> OutputNodeRowViewModel? {
-//        guard let possibleEdge = possibleEdge,
-//              let node = graph.getCanvasItem(possibleEdge.edge.from.canvasId),
-//              let upstreamRowObserver = node.outputViewModels[safe: possibleEdge.edge.from.portId] else {
-//            return nil
-//        }
-//
-//        return upstreamRowObserver
-//    }
-//    
     var body: some View {
         ForEach(graph.connectedEdges) { edgeData in
-            // Bindable fixes issue where edges may not appear initially
-//            @Bindable var inputObserver = inputObserver
-            
-//            let possibleEdge = animatingEdges.first(where: { $0.edge.to == inputObserver.portViewData })
-            
-//            let possibleEdgeOutputObserver = self.getPossibleEdgeUpstreamObserver(
-//                from: inputObserver,
-//                possibleEdge: possibleEdge)
-            
-            ConnectedEdgeView(data: edgeData,
-                              edgeAnimationEnabled: edgeAnimationEnabled)
-            
+            // Filter out animated edges enables keyboard shortcut animation
+            if !self.isEdgeAnimating(edgeData) {
+                ConnectedEdgeView(data: edgeData,
+                                  edgeAnimationEnabled: edgeAnimationEnabled)
+            }
         }
     }
 }
@@ -76,10 +55,6 @@ struct CandidateEdgesView: View {
         graph.edgeEditingState?.shownIds ?? .init()
     }
     
-//    var possibleEdges: [PossibleEdge] {
-//        animatingEdges.first(where: { $0.edge.to == inputObserver.portViewData })
-//    }
-    
     @MainActor
     func getPossibleEdgeUpstreamObserver(possibleEdge: PossibleEdge) -> OutputNodeRowViewModel? {
         guard let node = graph.getCanvasItem(possibleEdge.edge.from.canvasId),
@@ -104,7 +79,6 @@ struct CandidateEdgesView: View {
         // Place possible-edges above existing edges
         Group {
             ForEach(animatingEdges) { possibleEdge in
-                //            let possibleEdge = animatingEdges.first(where: { $0.edge.to == inputObserver.portViewData }) in
                 if let outputObserver = self
                     .getPossibleEdgeUpstreamObserver(possibleEdge: possibleEdge),
                    let inputObserver = self
@@ -123,18 +97,6 @@ struct CandidateEdgesView: View {
                 }
             }
         }
-//        .onChange(of: graph.edgeEditingState?.possibleEdges, initial: true) { _, newPossibleEdges in
-//            let candidateInputs: [InputNodeRowViewModel] = newPossibleEdges?.compactMap {
-//                let inputData = $0.edge.to
-//                
-//                guard let node = self.graph.getCanvasItem(inputData.canvasId),
-//                      let inputRow = node.inputViewModels[safe: inputData.portId] else {
-//                    return nil
-//                }
-//                
-//                return inputRow
-//            } ?? []
-//        }
     }
 }
 

--- a/Stitch/Graph/Edge/View/ExistingEdgesView.swift
+++ b/Stitch/Graph/Edge/View/ExistingEdgesView.swift
@@ -15,11 +15,11 @@ struct GraphConnectedEdgesView: View {
         graph.edgeAnimationEnabled
     }
     
-    // Filter out "possible" edges, enabling animation
+    // Identifies if some edge data contains "possible" edges, used during keyboard shortcut11
     func isEdgeAnimating(_ edgeData: ConnectedEdgeData) -> Bool {
         graph.edgeEditingState?.possibleEdges.first(where: {
             $0.edge.to == edgeData.downstreamRowObserver.portViewData
-        }) == nil
+        }) != nil
     }
     
     var body: some View {

--- a/Stitch/Graph/Edge/View/ExistingEdgesView.swift
+++ b/Stitch/Graph/Edge/View/ExistingEdgesView.swift
@@ -39,50 +39,73 @@ struct GraphConnectedEdgesView: View {
     var body: some View {
         ForEach(allConnectedInputs) { inputObserver in
             // Bindable fixes issue where edges may not appear initially
-            @Bindable var inputObserver = inputObserver
+//            @Bindable var inputObserver = inputObserver
             
-            let possibleEdge = animatingEdges.first(where: { $0.edge.to == inputObserver.portViewData })
+//            let possibleEdge = animatingEdges.first(where: { $0.edge.to == inputObserver.portViewData })
             
-            let possibleEdgeOutputObserver = self.getPossibleEdgeUpstreamObserver(
-                from: inputObserver,
-                possibleEdge: possibleEdge)
+//            let possibleEdgeOutputObserver = self.getPossibleEdgeUpstreamObserver(
+//                from: inputObserver,
+//                possibleEdge: possibleEdge)
             
-            let upstreamObserver = inputObserver.rowDelegate?.upstreamOutputObserver?.nodeRowViewModel
+            if let upstreamObserver = inputObserver.rowDelegate?.upstreamOutputObserver?.nodeRowViewModel {
+                ConnectedEdgeView(
+                    inputObserver: inputObserver,
+                    outputObserver: upstreamObserver,
+                    //                possibleEdgeOutputObserver: possibleEdgeOutputObserver,
+                    //                possibleEdge: possibleEdge,
+                    edgeAnimationEnabled: edgeAnimationEnabled)
+                //                shownPossibleEdgeIds: shownPossibleEdgeIds)
+            }
             
-            ConnectedEdgeView(
-                inputObserver: inputObserver,
-                outputObserver: upstreamObserver,
-                possibleEdgeOutputObserver: possibleEdgeOutputObserver,
-                possibleEdge: possibleEdge,
-                edgeAnimationEnabled: edgeAnimationEnabled,
-                shownPossibleEdgeIds: shownPossibleEdgeIds)
         }
     }
 }
 
 extension ConnectedEdgeView {
     @MainActor
-    init(inputObserver: InputNodeRowViewModel,
-         outputObserver: OutputNodeRowViewModel?,
-         possibleEdgeOutputObserver: OutputNodeRowViewModel?,
-         possibleEdge: PossibleEdge?,
-         edgeAnimationEnabled: Bool,
-         shownPossibleEdgeIds: Set<PossibleEdgeId>) {
+    init?(inputObserver: InputNodeRowViewModel,
+          outputObserver: OutputNodeRowViewModel,
+          edgeAnimationEnabled: Bool) {
         let downstreamNode = inputObserver.nodeDelegate
-        // Needs to have at least a connected output or a "possible" output
-        let outputObserverForData = outputObserver ?? possibleEdgeOutputObserver
-        self.inputData = .init(from: inputObserver,
-                               upstreamNodeId: outputObserverForData?.canvasItemDelegate?.id)
-        self.outputData = .init(from: outputObserverForData,
-                                connectedDownstreamNode: downstreamNode)
         
+        guard let inputData = EdgeAnchorDownstreamData(
+            from: inputObserver,
+            upstreamNodeId: outputObserver.canvasItemDelegate?.id),
+              let outputData = EdgeAnchorUpstreamData(
+                from: outputObserver,
+                connectedDownstreamNode: downstreamNode) else {
+            return nil
+        }
+        
+        self.inputData = inputData
+        self.outputData = outputData
         self.upstreamObserver = outputObserver
         self.inputObserver = inputObserver
         self.edgeAnimationEnabled = edgeAnimationEnabled
-        self.possibleEdge = possibleEdge
-        self.possibleEdgeOutputObserver = possibleEdgeOutputObserver
-        self.shownPossibleEdgeIds = shownPossibleEdgeIds
     }
+    
+//    @MainActor
+//    init(inputObserver: InputNodeRowViewModel,
+//         outputObserver: OutputNodeRowViewModel?,
+//         possibleEdgeOutputObserver: OutputNodeRowViewModel?,
+//         possibleEdge: PossibleEdge?,
+//         edgeAnimationEnabled: Bool,
+//         shownPossibleEdgeIds: Set<PossibleEdgeId>) {
+//        let downstreamNode = inputObserver.nodeDelegate
+//        // Needs to have at least a connected output or a "possible" output
+//        let outputObserverForData = outputObserver ?? possibleEdgeOutputObserver
+//        self.inputData = .init(from: inputObserver,
+//                               upstreamNodeId: outputObserverForData?.canvasItemDelegate?.id)
+//        self.outputData = .init(from: outputObserverForData,
+//                                connectedDownstreamNode: downstreamNode)
+//        
+//        self.upstreamObserver = outputObserver
+//        self.inputObserver = inputObserver
+//        self.edgeAnimationEnabled = edgeAnimationEnabled
+//        self.possibleEdge = possibleEdge
+//        self.possibleEdgeOutputObserver = possibleEdgeOutputObserver
+//        self.shownPossibleEdgeIds = shownPossibleEdgeIds
+//    }
 }
 
 struct ConnectedEdgeView: View {
@@ -90,40 +113,54 @@ struct ConnectedEdgeView: View {
     @Environment(\.appTheme) private var theme
     @Environment(\.edgeStyle) private var edgeStyle
     
-    // Optional in event we only have possible edge
-    let upstreamObserver: OutputNodeRowViewModel?
     @Bindable var inputObserver: InputNodeRowViewModel
-    let inputData: EdgeAnchorDownstreamData?
-    let outputData: EdgeAnchorUpstreamData?
+    @Bindable var upstreamObserver: OutputNodeRowViewModel
+    let inputData: EdgeAnchorDownstreamData
+    let outputData: EdgeAnchorUpstreamData
     let edgeAnimationEnabled: Bool
-    let possibleEdge: PossibleEdge?
-    let possibleEdgeOutputObserver: OutputNodeRowViewModel?
-    let shownPossibleEdgeIds: Set<PossibleEdgeId>
+    
+    // Optional in event we only have possible edge
+//    let upstreamObserver: OutputNodeRowViewModel?
+    
+//    let possibleEdge: PossibleEdge?
+//    let possibleEdgeOutputObserver: OutputNodeRowViewModel?
+//    let shownPossibleEdgeIds: Set<PossibleEdgeId>
         
     var body: some View {
-        let firstUpstreamObserver = inputData?.firstInputObserver
-        let firstInputObserver = inputData?.firstInputObserver
-        let lastInputObserver = inputData?.lastInputObserver
-        let firstConnectedInputObserver = inputData?.firstConnectedInputObserver
-        let lastConnectedInputObserver = inputData?.lastConectedInputObserver
-        let lastUpstreamObserver = outputData?.lastUpstreamObserver
-        let totalOutputs = outputData?.totalOutputs ?? 0
-        let lastConnectedUpstreamObserver = outputData?.lastConnectedUpstreamObserver
-        let pointTo = inputObserver.anchorPoint ?? .zero
+        let firstUpstreamObserver = inputData.firstInputObserver
+        let firstInputObserver = inputData.firstInputObserver
+        let lastInputObserver = inputData.lastInputObserver
+        let firstConnectedInputObserver = inputData.firstConnectedInputObserver
+        let lastConnectedInputObserver = inputData.lastConectedInputObserver
+        let lastUpstreamObserver = outputData.lastUpstreamObserver
+        let totalOutputs = outputData.totalOutputs
+        let lastConnectedUpstreamObserver = outputData.lastConnectedUpstreamObserver
+//        let pointTo = inputObserver.anchorPoint
         let edgeAnimationEnabled = edgeAnimationEnabled
-        let possibleEdge = possibleEdge
-        let possibleEdgeOutputObserver = possibleEdgeOutputObserver
-        let shownPossibleEdgeIds = shownPossibleEdgeIds
+        
+//        let possibleEdge = possibleEdge
+//        let possibleEdgeOutputObserver = possibleEdgeOutputObserver
+//        let shownPossibleEdgeIds = shownPossibleEdgeIds
         
         if let inputPortViewData = inputObserver.portViewData,
-           let upstreamObserver = upstreamObserver,
            let outputPortViewData = upstreamObserver.portViewData,
            let pointTo = inputObserver.anchorPoint,
-           let pointFrom = upstreamObserver.anchorPoint {
+           let pointFrom = upstreamObserver.anchorPoint,
+           let firstFrom = firstUpstreamObserver.anchorPoint,
+           let firstTo = firstInputObserver.anchorPoint,
+           let lastFrom = lastUpstreamObserver.anchorPoint,
+           let lastTo = lastInputObserver.anchorPoint,
+           let firstFromWithEdge = firstConnectedInputObserver.anchorPoint?.y,
+           let lastFromWithEdge = lastConnectedUpstreamObserver.anchorPoint?.y,
+           let firstToWithEdge = firstConnectedInputObserver.anchorPoint?.y,
+           let lastToWithEdge = lastConnectedInputObserver.anchorPoint?.y {
             let edge = PortEdgeUI(from: outputPortViewData,
                                   to: inputPortViewData)
             let portColor: PortColor = inputObserver.portColor
             let isSelectedEdge = (portColor == .highlightedEdge || portColor == .highlightedLoopEdge)
+            
+            // TODO: this is a problem with delegates
+            
             let upstreamObserverZIndex = upstreamObserver.canvasItemDelegate?.zIndex ?? 0
             let defaultInputNodeIndex = inputObserver.canvasItemDelegate?.zIndex ?? 0
             let zIndexOfInputNode = inputObserver.canvasItemDelegate?.zIndex ?? defaultInputNodeIndex
@@ -136,34 +173,34 @@ struct ConnectedEdgeView: View {
                      pointTo: pointTo,
                      color: portColor.color(theme),
                      isActivelyDragged: false,
-                     firstFrom: firstUpstreamObserver?.anchorPoint ?? .zero,
-                     firstTo: firstInputObserver?.anchorPoint ?? .zero,
-                     lastFrom: lastUpstreamObserver?.anchorPoint ?? .zero,
-                     lastTo: lastInputObserver?.anchorPoint ?? .zero,
-                     firstFromWithEdge: firstConnectedInputObserver?.anchorPoint?.y ?? .zero,
-                     lastFromWithEdge: lastConnectedUpstreamObserver?.anchorPoint?.y ?? .zero,
-                     firstToWithEdge: firstConnectedInputObserver?.anchorPoint?.y ?? .zero,
-                     lastToWithEdge: lastConnectedInputObserver?.anchorPoint?.y ?? .zero,
+                     firstFrom: firstFrom,
+                     firstTo: firstTo,
+                     lastFrom: lastFrom,
+                     lastTo: lastTo,
+                     firstFromWithEdge: firstFromWithEdge,
+                     lastFromWithEdge: lastFromWithEdge,
+                     firstToWithEdge: firstToWithEdge,
+                     lastToWithEdge: lastToWithEdge,
                      totalOutputs: totalOutputs,
                      edgeAnimationEnabled: edgeAnimationEnabled)
             .zIndex(zIndex)
             
         } else {
-            EmptyView()
+            Color.clear
         }
             
         // Place possible-edges above existing edges
-        if let possibleEdge = possibleEdge,
-           let possibleEdgeOutputObserver = possibleEdgeOutputObserver {
-            PossibleEdgeView(edgeStyle: edgeStyle,
-                             possibleEdge: possibleEdge,
-                             shownPossibleEdgeIds: shownPossibleEdgeIds,
-                             from: possibleEdgeOutputObserver.anchorPoint ?? .zero,
-                             to: pointTo,
-                             totalOutputs: totalOutputs,
-                             // Note: an animated edit-mode edge use its output's color, rather than input's color, since the input will be gray until animation is completed
-                             color: possibleEdgeOutputObserver.portColor.color(theme))
-        }
+//        if let possibleEdge = possibleEdge,
+//           let possibleEdgeOutputObserver = possibleEdgeOutputObserver {
+//            PossibleEdgeView(edgeStyle: edgeStyle,
+//                             possibleEdge: possibleEdge,
+//                             shownPossibleEdgeIds: shownPossibleEdgeIds,
+//                             from: possibleEdgeOutputObserver.anchorPoint ?? .zero,
+//                             to: pointTo,
+//                             totalOutputs: totalOutputs,
+//                             // Note: an animated edit-mode edge use its output's color, rather than input's color, since the input will be gray until animation is completed
+//                             color: possibleEdgeOutputObserver.portColor.color(theme))
+//        }
     }
 }
 

--- a/Stitch/Graph/Edge/View/ExistingEdgesView.swift
+++ b/Stitch/Graph/Edge/View/ExistingEdgesView.swift
@@ -110,50 +110,6 @@ extension ConnectedEdgeView {
         self.zIndex = data.zIndex
         self.edgeAnimationEnabled = edgeAnimationEnabled
     }
-//    @MainActor
-//    init?(inputObserver: InputNodeRowViewModel,
-//          outputObserver: OutputNodeRowViewModel,
-//          edgeAnimationEnabled: Bool) {
-//        let downstreamNode = inputObserver.nodeDelegate
-//        
-//        guard let inputData = EdgeAnchorDownstreamData(
-//            from: inputObserver,
-//            upstreamNodeId: outputObserver.canvasItemDelegate?.id),
-//              let outputData = EdgeAnchorUpstreamData(
-//                from: outputObserver,
-//                connectedDownstreamNode: downstreamNode) else {
-//            return nil
-//        }
-//        
-//        self.inputData = inputData
-//        self.outputData = outputData
-//        self.upstreamObserver = outputObserver
-//        self.inputObserver = inputObserver
-//        self.edgeAnimationEnabled = edgeAnimationEnabled
-//    }
-    
-//    @MainActor
-//    init(inputObserver: InputNodeRowViewModel,
-//         outputObserver: OutputNodeRowViewModel?,
-//         possibleEdgeOutputObserver: OutputNodeRowViewModel?,
-//         possibleEdge: PossibleEdge?,
-//         edgeAnimationEnabled: Bool,
-//         shownPossibleEdgeIds: Set<PossibleEdgeId>) {
-//        let downstreamNode = inputObserver.nodeDelegate
-//        // Needs to have at least a connected output or a "possible" output
-//        let outputObserverForData = outputObserver ?? possibleEdgeOutputObserver
-//        self.inputData = .init(from: inputObserver,
-//                               upstreamNodeId: outputObserverForData?.canvasItemDelegate?.id)
-//        self.outputData = .init(from: outputObserverForData,
-//                                connectedDownstreamNode: downstreamNode)
-//        
-//        self.upstreamObserver = outputObserver
-//        self.inputObserver = inputObserver
-//        self.edgeAnimationEnabled = edgeAnimationEnabled
-//        self.possibleEdge = possibleEdge
-//        self.possibleEdgeOutputObserver = possibleEdgeOutputObserver
-//        self.shownPossibleEdgeIds = shownPossibleEdgeIds
-//    }
 }
 
 struct ConnectedEdgeView: View {
@@ -166,13 +122,6 @@ struct ConnectedEdgeView: View {
     let outputData: EdgeAnchorUpstreamData
     let edgeAnimationEnabled: Bool
     let zIndex: Double
-    
-    // Optional in event we only have possible edge
-//    let upstreamObserver: OutputNodeRowViewModel?
-    
-//    let possibleEdge: PossibleEdge?
-//    let possibleEdgeOutputObserver: OutputNodeRowViewModel?
-//    let shownPossibleEdgeIds: Set<PossibleEdgeId>
         
     var body: some View {
         let firstUpstreamObserver = inputData.firstInputObserver
@@ -183,11 +132,6 @@ struct ConnectedEdgeView: View {
         let lastUpstreamObserver = outputData.lastUpstreamObserver
         let totalOutputs = outputData.totalOutputs
         let lastConnectedUpstreamObserver = outputData.lastConnectedUpstreamObserver
-//        let pointTo = inputObserver.anchorPoint
-        
-//        let possibleEdge = possibleEdge
-//        let possibleEdgeOutputObserver = possibleEdgeOutputObserver
-//        let shownPossibleEdgeIds = shownPossibleEdgeIds
         
         if let inputPortViewData = inputObserver.portViewData,
            let outputPortViewData = upstreamObserver.portViewData,
@@ -229,19 +173,6 @@ struct ConnectedEdgeView: View {
         } else {
             Color.clear
         }
-            
-        // Place possible-edges above existing edges
-//        if let possibleEdge = possibleEdge,
-//           let possibleEdgeOutputObserver = possibleEdgeOutputObserver {
-//            PossibleEdgeView(edgeStyle: edgeStyle,
-//                             possibleEdge: possibleEdge,
-//                             shownPossibleEdgeIds: shownPossibleEdgeIds,
-//                             from: possibleEdgeOutputObserver.anchorPoint ?? .zero,
-//                             to: pointTo,
-//                             totalOutputs: totalOutputs,
-//                             // Note: an animated edit-mode edge use its output's color, rather than input's color, since the input will be gray until animation is completed
-//                             color: possibleEdgeOutputObserver.portColor.color(theme))
-//        }
     }
 }
 

--- a/Stitch/Graph/Edge/View/ExistingEdgesView.swift
+++ b/Stitch/Graph/Edge/View/ExistingEdgesView.swift
@@ -236,7 +236,7 @@ struct ConnectedEdgeView: View {
            let lastFrom = lastUpstreamObserver.anchorPoint,
            let lastTo = lastInputObserver.anchorPoint,
            let firstFromWithEdge = firstConnectedInputObserver.anchorPoint?.y,
-           let lastFromWithEdge = lastConnectedUpstreamObserver.anchorPoint?.y,
+           let lastFromWithEdge = lastConnectedUpstreamObserver?.anchorPoint?.y,
            let firstToWithEdge = firstConnectedInputObserver.anchorPoint?.y,
            let lastToWithEdge = lastConnectedInputObserver.anchorPoint?.y {
             let edge = PortEdgeUI(from: outputPortViewData,

--- a/Stitch/Graph/Edge/View/ExistingEdgesView.swift
+++ b/Stitch/Graph/Edge/View/ExistingEdgesView.swift
@@ -10,7 +10,7 @@ import StitchSchemaKit
 
 struct GraphConnectedEdgesView: View {
     @Bindable var graph: GraphState
-    let allConnectedInputs: [InputNodeRowViewModel]
+//    let allConnectedInputs: [InputNodeRowViewModel]
     
     var animatingEdges: PossibleEdgeSet {
         graph.edgeEditingState?.possibleEdges ?? .init()
@@ -37,7 +37,7 @@ struct GraphConnectedEdgesView: View {
     }
     
     var body: some View {
-        ForEach(allConnectedInputs) { inputObserver in
+        ForEach(graph.connectedEdges) { edgeData in
             // Bindable fixes issue where edges may not appear initially
 //            @Bindable var inputObserver = inputObserver
             
@@ -47,42 +47,43 @@ struct GraphConnectedEdgesView: View {
 //                from: inputObserver,
 //                possibleEdge: possibleEdge)
             
-            if let upstreamObserver = inputObserver.rowDelegate?.upstreamOutputObserver?.nodeRowViewModel {
-                ConnectedEdgeView(
-                    inputObserver: inputObserver,
-                    outputObserver: upstreamObserver,
-                    //                possibleEdgeOutputObserver: possibleEdgeOutputObserver,
-                    //                possibleEdge: possibleEdge,
-                    edgeAnimationEnabled: edgeAnimationEnabled)
-                //                shownPossibleEdgeIds: shownPossibleEdgeIds)
-            }
+            ConnectedEdgeView(data: edgeData,
+                              edgeAnimationEnabled: edgeAnimationEnabled)
             
         }
     }
 }
 
 extension ConnectedEdgeView {
-    @MainActor
-    init?(inputObserver: InputNodeRowViewModel,
-          outputObserver: OutputNodeRowViewModel,
-          edgeAnimationEnabled: Bool) {
-        let downstreamNode = inputObserver.nodeDelegate
-        
-        guard let inputData = EdgeAnchorDownstreamData(
-            from: inputObserver,
-            upstreamNodeId: outputObserver.canvasItemDelegate?.id),
-              let outputData = EdgeAnchorUpstreamData(
-                from: outputObserver,
-                connectedDownstreamNode: downstreamNode) else {
-            return nil
-        }
-        
-        self.inputData = inputData
-        self.outputData = outputData
-        self.upstreamObserver = outputObserver
-        self.inputObserver = inputObserver
+    @MainActor init(data: ConnectedEdgeData,
+                    edgeAnimationEnabled: Bool) {
+        self.inputObserver = data.downstreamRowObserver
+        self.upstreamObserver = data.upstreamRowObserver
+        self.inputData = data.inputData
+        self.outputData = data.outputData
         self.edgeAnimationEnabled = edgeAnimationEnabled
     }
+//    @MainActor
+//    init?(inputObserver: InputNodeRowViewModel,
+//          outputObserver: OutputNodeRowViewModel,
+//          edgeAnimationEnabled: Bool) {
+//        let downstreamNode = inputObserver.nodeDelegate
+//        
+//        guard let inputData = EdgeAnchorDownstreamData(
+//            from: inputObserver,
+//            upstreamNodeId: outputObserver.canvasItemDelegate?.id),
+//              let outputData = EdgeAnchorUpstreamData(
+//                from: outputObserver,
+//                connectedDownstreamNode: downstreamNode) else {
+//            return nil
+//        }
+//        
+//        self.inputData = inputData
+//        self.outputData = outputData
+//        self.upstreamObserver = outputObserver
+//        self.inputObserver = inputObserver
+//        self.edgeAnimationEnabled = edgeAnimationEnabled
+//    }
     
 //    @MainActor
 //    init(inputObserver: InputNodeRowViewModel,
@@ -136,7 +137,6 @@ struct ConnectedEdgeView: View {
         let totalOutputs = outputData.totalOutputs
         let lastConnectedUpstreamObserver = outputData.lastConnectedUpstreamObserver
 //        let pointTo = inputObserver.anchorPoint
-        let edgeAnimationEnabled = edgeAnimationEnabled
         
 //        let possibleEdge = possibleEdge
 //        let possibleEdgeOutputObserver = possibleEdgeOutputObserver

--- a/Stitch/Graph/Node/Group/GroupNodeCreationActions.swift
+++ b/Stitch/Graph/Node/Group/GroupNodeCreationActions.swift
@@ -377,8 +377,8 @@ extension GraphState {
         splitterNode.splitterType = splitterType
         
         // Slightly modify date for consistent port ordering
-        let lastModifiedDate = splitterNode.splitterNode?.lastModifiedDate ?? Date.now
-        splitterNode.splitterNode?.lastModifiedDate = lastModifiedDate
+        let lastModifiedDate = splitterNode.splitterNode?.entity.lastModifiedDate ?? Date.now
+        splitterNode.splitterNode?.entity.lastModifiedDate = lastModifiedDate
             .addingTimeInterval(Double(portId) * 0.01)
 
         self.visibleNodesViewModel.nodes.updateValue(newSplitterNode, forKey: newSplitterNode.id)

--- a/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
+++ b/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
@@ -22,18 +22,6 @@ protocol PatchNodeViewModelDelegate: NodeDelegate {
                                 newType: UserVisibleType)
 }
 
-// TODO: move
-final class SplitterNodeViewModel {
-    @MainActor var entity: SplitterNodeEntity
-    weak var groupCanvas: CanvasItemViewModel?
-    
-    @MainActor init?(entity: SplitterNodeEntity?) {
-        guard let entity = entity else { return nil }
-        
-        self.entity = entity
-    }
-}
-
 @Observable
 final class PatchNodeViewModel: Sendable {
     let id: NodeId
@@ -407,5 +395,16 @@ extension NodeViewModel {
     @MainActor
     var isWireless: Bool {
         patch == .wirelessBroadcaster || patch == .wirelessReceiver
+    }
+}
+
+final class SplitterNodeViewModel {
+    @MainActor var entity: SplitterNodeEntity
+    weak var groupCanvas: CanvasItemViewModel?
+    
+    @MainActor init?(entity: SplitterNodeEntity?) {
+        guard let entity = entity else { return nil }
+        
+        self.entity = entity
     }
 }

--- a/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
+++ b/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
@@ -22,6 +22,18 @@ protocol PatchNodeViewModelDelegate: NodeDelegate {
                                 newType: UserVisibleType)
 }
 
+// TODO: move
+final class SplitterNodeViewModel {
+    @MainActor var entity: SplitterNodeEntity
+    weak var groupCanvas: CanvasItemViewModel?
+    
+    @MainActor init?(entity: SplitterNodeEntity?) {
+        guard let entity = entity else { return nil }
+        
+        self.entity = entity
+    }
+}
+
 @Observable
 final class PatchNodeViewModel: Sendable {
     let id: NodeId
@@ -49,7 +61,7 @@ final class PatchNodeViewModel: Sendable {
     @MainActor var mathExpression: String?
     
     // Splitter types are for group input, output, or inline nodes
-    @MainActor var splitterNode: SplitterNodeEntity?
+    @MainActor var splitterNode: SplitterNodeViewModel?
     
     @MainActor weak var delegate: PatchNodeViewModelDelegate?
     
@@ -61,7 +73,7 @@ final class PatchNodeViewModel: Sendable {
         self.patch = schema.patch
         self.userVisibleType = schema.userVisibleType
         self.mathExpression = schema.mathExpression
-        self.splitterNode = schema.splitterNode
+        self.splitterNode = .init(entity: schema.splitterNode)
         
         // Create initial inputs and outputs using default data
         let rowDefinitions = NodeKind.patch(schema.patch)
@@ -121,8 +133,10 @@ extension PatchNodeViewModel: SchemaObserver {
                                          activeIndex: graph.documentDelegate?.activeIndex ?? .init(.zero))
             }
         }
-        if self.splitterNode != schema.splitterNode {
-            self.splitterNode = schema.splitterNode
+        if let splitterNodeViewModel = self.splitterNode,
+           let newSplitterNodeEntity = schema.splitterNode,
+           splitterNodeViewModel.entity != newSplitterNodeEntity {
+            splitterNodeViewModel.entity = newSplitterNodeEntity
         }
     }
 
@@ -132,7 +146,7 @@ extension PatchNodeViewModel: SchemaObserver {
                         inputs: self.inputsObservers.map { $0.createSchema() },
                         canvasEntity: self.canvasObserver.createSchema(),
                         userVisibleType: self.userVisibleType,
-                        splitterNode: self.splitterNode, 
+                        splitterNode: self.splitterNode?.entity,
                         mathExpression: self.mathExpression)
     }
     
@@ -150,6 +164,14 @@ extension PatchNodeViewModel {
         
         self.outputsObservers.forEach {
             $0.initializeDelegate(node)
+        }
+        
+        // Assign weak for group canvas if group splitter node
+        if let splitterNode = self.splitterNode,
+           splitterNode.entity.type.isGroupSplitter,
+           let groupNodeId = self.canvasObserver.parentGroupNodeId,
+           let groupCanvasItem = self.delegate?.graphDelegate?.getNodeViewModel(groupNodeId)?.nodeType.groupNode {
+            splitterNode.groupCanvas = groupCanvasItem
         }
         
         self.canvasObserver.initializeDelegate(node,
@@ -176,7 +198,7 @@ extension PatchNodeViewModel {
         self.init(from: entity)
         self.initializeDelegate(delegate)
         self.delegate = delegate
-        self.splitterNode = splitterNode
+        self.splitterNode = .init(entity: splitterNode)
     }
 
     @MainActor convenience init(id: NodeId,
@@ -218,7 +240,7 @@ extension PatchNodeViewModel {
     @MainActor
     var splitterType: SplitterType? {
         get {
-            self.splitterNode?.type
+            self.splitterNode?.entity.type
         }
         set(newValue) {
             guard let newValue = newValue else {
@@ -226,9 +248,9 @@ extension PatchNodeViewModel {
                 return
             }
 
-            self.splitterNode = SplitterNodeEntity(id: self.id,
-                                                   lastModifiedDate: .init(),
-                                                   type: newValue)
+            self.splitterNode?.entity = SplitterNodeEntity(id: self.id,
+                                                           lastModifiedDate: .init(),
+                                                           type: newValue)
         }
     }
     

--- a/Stitch/Graph/Node/Port/View/PortValuesPreview/PortPreviewPopoverView.swift
+++ b/Stitch/Graph/Node/Port/View/PortValuesPreview/PortPreviewPopoverView.swift
@@ -27,9 +27,8 @@ struct PortPreviewOpened: StitchDocumentEvent {
 }
 
 struct PortPreviewPopoverWrapperView: View {
-    let allInputs: [InputNodeRowViewModel]
-    let allOutputs: [OutputNodeRowViewModel]
     let openPortPreview: OpenedPortPreview
+    @Bindable var canvas: CanvasItemViewModel
     
     var body: some View {
         
@@ -37,9 +36,8 @@ struct PortPreviewPopoverWrapperView: View {
         switch openPortPreview.nodeIO {
         
         case .input:
-            if let rowViewModel = allInputs.first(where: {
-                $0.canvasItemDelegate?.id == openPortPreview.canvasItemId
-                && $0.rowDelegate?.id == openPortPreview.port
+            if let rowViewModel = canvas.inputViewModels.first(where: {
+                $0.rowDelegate?.id == openPortPreview.port
             }),
                let inputObserver = rowViewModel.rowDelegate,
                let anchor = rowViewModel.anchorPoint {
@@ -51,9 +49,8 @@ struct PortPreviewPopoverWrapperView: View {
             }
 
         case .output:
-            if let rowViewModel = allOutputs.first(where: {
-                $0.canvasItemDelegate?.id == openPortPreview.canvasItemId
-                && $0.rowDelegate?.id == openPortPreview.port
+            if let rowViewModel = canvas.outputViewModels.first(where: {
+                $0.rowDelegate?.id == openPortPreview.port
             }),
                let outputObserver = rowViewModel.rowDelegate,
                let anchor = rowViewModel.anchorPoint {

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/InputNodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/InputNodeRowObserver.swift
@@ -220,11 +220,3 @@ extension InputNodeRowObserver {
         connectedOutputObserver.containsDownstreamConnection = true
     }
 }
-
-// TODO: move
-extension Array where Element: NodeRowViewModel {
-    @MainActor
-    func first(_ id: NodeIOCoordinate) -> Element? {
-        self.first { $0.rowDelegate?.id == id }
-    }
-}

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/InputNodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/InputNodeRowObserver.swift
@@ -146,7 +146,7 @@ extension InputNodeRowObserver {
             inputs.append(patchInput)
             
             // Find row view models for group if applicable
-            if patchNode.splitterNode?.type == .input {
+            if patchNode.splitterNode?.entity.type == .input {
                 // Group id is the only other row view model's canvas's parent ID
                 if let groupNodeId = inputs.first?.canvasItemDelegate?.parentGroupNodeId,
                    let groupNode = self.nodeDelegate?.graphDelegate?.getNodeViewModel(groupNodeId)?.nodeType.groupNode {
@@ -218,5 +218,13 @@ extension InputNodeRowObserver {
         // Report to output observer that there's an edge (for port colors)
         // We set this to false on default above
         connectedOutputObserver.containsDownstreamConnection = true
+    }
+}
+
+// TODO: move
+extension Array where Element: NodeRowViewModel {
+    @MainActor
+    func first(_ id: NodeIOCoordinate) -> Element? {
+        self.first { $0.rowDelegate?.id == id }
     }
 }

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -213,3 +213,10 @@ extension NodeRowObserver {
         }
     }
 }
+
+extension Array where Element: NodeRowViewModel {
+    @MainActor
+    func first(_ id: NodeIOCoordinate) -> Element? {
+        self.first { $0.rowDelegate?.id == id }
+    }
+}

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/OutputNodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/OutputNodeRowObserver.swift
@@ -92,7 +92,7 @@ extension OutputNodeRowObserver {
             outputs.append(patchOutput)
             
             // Find row view models for group if applicable
-            if patchNode.splitterNode?.type == .output {
+            if patchNode.splitterNode?.entity.type == .output {
                 // Group id is the only other row view model's canvas's parent ID
                 if let groupNodeId = outputs.first?.canvasItemDelegate?.parentGroupNodeId,
                    let groupNode = self.nodeDelegate?.graphDelegate?.getNodeViewModel(groupNodeId)?.nodeType.groupNode {

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
@@ -80,9 +80,15 @@ extension NodeRowViewModel {
         
         switch Self.nodeIO {
         case .input:
-            self.anchorPoint = .init(x: offsetX, y: anchorY)
+            let newAnchorPoint = CGPoint(x: offsetX, y: anchorY)
+            if self.anchorPoint != newAnchorPoint {
+                self.anchorPoint = newAnchorPoint
+            }
         case .output:
-            self.anchorPoint = .init(x: offsetX + size.width, y: anchorY)
+            let newAnchorPoint = CGPoint(x: offsetX + size.width, y: anchorY)
+            if self.anchorPoint != newAnchorPoint {
+                self.anchorPoint = newAnchorPoint
+            }
         }
     }
     
@@ -110,7 +116,10 @@ extension NodeRowViewModel {
                                   initialValue: rowDelegate.getActiveValue(activeIndex: node.graphDelegate?.documentDelegate?.activeIndex ?? .init(.zero)))
         }
         
-        self.portViewData = self.getPortViewData()
+        let newPortViewData = self.getPortViewData()
+        if self.portViewData != newPortViewData {
+            self.portViewData = newPortViewData
+        }
     }
     
     /// Considerable perf cost from `ConnectedEdgeView`, so now a function.

--- a/Stitch/Graph/Node/View/NodesView.swift
+++ b/Stitch/Graph/Node/View/NodesView.swift
@@ -85,17 +85,16 @@ struct NodesView: View {
 }
 
 struct CanvasEdgesViewModifier: ViewModifier {
-    @State private var allInputs: [InputNodeRowViewModel] = []
-    @State private var allOutputs: [OutputNodeRowViewModel] = []
-    @State private var connectedInputs: [InputNodeRowViewModel] = []
+//    @State private var allInputs: [InputNodeRowViewModel] = []
+//    @State private var allOutputs: [OutputNodeRowViewModel] = []
+//    @State private var connectedInputs: [InputNodeRowViewModel] = []
     
     @Bindable var document: StitchDocumentViewModel
     @Bindable var graph: GraphState
     
     @MainActor
-    func connectedEdgesView(allConnectedInputs: [InputNodeRowViewModel]) -> some View {
-        GraphConnectedEdgesView(graph: graph,
-                                allConnectedInputs: allConnectedInputs)
+    func connectedEdgesView() -> some View {
+        GraphConnectedEdgesView(graph: graph)
     }
     
     @MainActor
@@ -121,42 +120,42 @@ struct CanvasEdgesViewModifier: ViewModifier {
         
         return content
         // Moves expensive computation here to reduce render cycles
-            .onChange(of: graph.graphUpdaterId, initial: true) {
-                // log("CanvasEdgesViewModifier: .onChange(of: self.graph.graphUpdaterId)")
-                let canvasItemsAtThisTraversalLevel = self.graph
-                    .getCanvasItemsAtTraversalLevel(groupNodeFocused: document.groupNodeFocused?.groupNodeId)
-                
-                let newInputs = canvasItemsAtThisTraversalLevel
-                    .flatMap { canvasItem -> [InputNodeRowViewModel] in
-                        canvasItem.inputViewModels
-                    }
-                
-                
-                let newConnections = allInputs.filter { input in
-                    guard input.nodeDelegate?.patchNodeViewModel?.patch != .wirelessReceiver else {
-                        return false
-                    }
-                    return input.rowDelegate?.containsUpstreamConnection ?? false
-                }
-                
-                let newOutputs = canvasItemsAtThisTraversalLevel
-                    .flatMap { $0.outputViewModels }
-
-                if self.allInputs.map(\.id).toSet != newInputs.map(\.id).toSet {
-                    self.allInputs = newInputs
-                }
-                
-                if self.connectedInputs.map(\.id).toSet != newConnections.map(\.id).toSet {
-                    self.connectedInputs = newConnections
-                }
-                
-                if self.allOutputs.map(\.id).toSet != newOutputs.map(\.id).toSet {
-                    self.allOutputs = newOutputs
-                }
-            }
+//            .onChange(of: graph.graphUpdaterId, initial: true) {
+//                // log("CanvasEdgesViewModifier: .onChange(of: self.graph.graphUpdaterId)")
+//                let canvasItemsAtThisTraversalLevel = self.graph
+//                    .getCanvasItemsAtTraversalLevel(groupNodeFocused: document.groupNodeFocused?.groupNodeId)
+//                
+//                let newInputs = canvasItemsAtThisTraversalLevel
+//                    .flatMap { canvasItem -> [InputNodeRowViewModel] in
+//                        canvasItem.inputViewModels
+//                    }
+//                
+//                
+//                let newConnections = newInputs.filter { input in
+//                    guard input.nodeDelegate?.patchNodeViewModel?.patch != .wirelessReceiver else {
+//                        return false
+//                    }
+//                    return input.rowDelegate?.containsUpstreamConnection ?? false
+//                }
+//                
+//                let newOutputs = canvasItemsAtThisTraversalLevel
+//                    .flatMap { $0.outputViewModels }
+//
+//                if self.allInputs.map(\.id).toSet != newInputs.map(\.id).toSet {
+//                    self.allInputs = newInputs
+//                }
+//                
+//                if self.connectedInputs.map(\.id).toSet != newConnections.map(\.id).toSet {
+//                    self.connectedInputs = newConnections
+//                }
+//                
+//                if self.allOutputs.map(\.id).toSet != newOutputs.map(\.id).toSet {
+//                    self.allOutputs = newOutputs
+//                }
+//            }
             .background {
                 // Using background ensures edges z-index are always behind ndoes
-                connectedEdgesView(allConnectedInputs: self.connectedInputs) // + candidateInputs)
+                connectedEdgesView() // + candidateInputs)
             }
 //            .overlay {
 //                edgeDrawingView(inputs: allInputs,

--- a/Stitch/Graph/Node/View/NodesView.swift
+++ b/Stitch/Graph/Node/View/NodesView.swift
@@ -92,14 +92,6 @@ struct CanvasEdgesViewModifier: ViewModifier {
     @Bindable var document: StitchDocumentViewModel
     @Bindable var graph: GraphState
     
-    @MainActor
-    func edgeDrawingView(inputs: [InputNodeRowViewModel],
-                         graph: GraphState) -> some View {
-        EdgeDrawingView(graph: graph,
-                        edgeDrawingObserver: graph.edgeDrawingObserver,
-                        inputsAtThisTraversalLevel: inputs)
-    }
-    
     func body(content: Content) -> some View {
         // Including "possible" inputs enables edge animation
         let candidateInputs: [InputNodeRowViewModel] = graph.edgeEditingState?.possibleEdges.compactMap {
@@ -155,14 +147,15 @@ struct CanvasEdgesViewModifier: ViewModifier {
                 
                 CandidateEdgesView(graph: graph)
             }
-//            .overlay {
-//                edgeDrawingView(inputs: allInputs,
-//                                graph: self.graph)
-//                
+            .overlay {
+                EdgeDrawingView(graph: graph,
+                                edgeDrawingObserver: graph.edgeDrawingObserver)
+                
+                // TODO: come back to labels
 //                EdgeInputLabelsView(inputs: allInputs,
 //                                    document: document,
 //                                    graph: graph)
-//                
+                
 //                // TODO: does PortPreviewPopoverView render too many times when open?
 //                // TODO: more elegant way to do this? Generic types giving Swift compiler trouble
 //                if let openPortPreview = document.openPortPreview {
@@ -171,6 +164,6 @@ struct CanvasEdgesViewModifier: ViewModifier {
 //                        allOutputs: allOutputs,
 //                        openPortPreview: openPortPreview)
 //                }
-//            }
+            }
     }
 }

--- a/Stitch/Graph/Node/View/NodesView.swift
+++ b/Stitch/Graph/Node/View/NodesView.swift
@@ -39,11 +39,6 @@ struct NodesView: View {
     }
     
     var body: some View {
-//        let currentNodePage = self.graph.visibleNodesViewModel
-//            .getViewData(groupNodeFocused: document.groupNodeFocused?.groupNodeId) ?? .init(localPosition: graph.localPosition)
-                
-        // CommentBox needs to be affected by graph offset and zoom
-//         but can live somewhere else?
         InfiniteCanvas(graph: graph,
                        existingCache: graph.visibleNodesViewModel.infiniteCanvasCache,
                        needsInfiniteCanvasCacheReset: graph.visibleNodesViewModel.needsInfiniteCanvasCacheReset) {
@@ -85,10 +80,6 @@ struct NodesView: View {
 }
 
 struct CanvasEdgesViewModifier: ViewModifier {
-//    @State private var allInputs: [InputNodeRowViewModel] = []
-//    @State private var allOutputs: [OutputNodeRowViewModel] = []
-//    @State private var connectedInputs: [InputNodeRowViewModel] = []
-    
     @Bindable var document: StitchDocumentViewModel
     @Bindable var graph: GraphState
     

--- a/Stitch/Graph/Node/View/NodesView.swift
+++ b/Stitch/Graph/Node/View/NodesView.swift
@@ -126,41 +126,54 @@ struct CanvasEdgesViewModifier: ViewModifier {
                 let canvasItemsAtThisTraversalLevel = self.graph
                     .getCanvasItemsAtTraversalLevel(groupNodeFocused: document.groupNodeFocused?.groupNodeId)
                 
-                self.allInputs = canvasItemsAtThisTraversalLevel
+                let newInputs = canvasItemsAtThisTraversalLevel
                     .flatMap { canvasItem -> [InputNodeRowViewModel] in
                         canvasItem.inputViewModels
                     }
                 
-                self.connectedInputs = allInputs.filter { input in
+                
+                let newConnections = allInputs.filter { input in
                     guard input.nodeDelegate?.patchNodeViewModel?.patch != .wirelessReceiver else {
                         return false
                     }
                     return input.rowDelegate?.containsUpstreamConnection ?? false
                 }
                 
-                self.allOutputs = canvasItemsAtThisTraversalLevel
+                let newOutputs = canvasItemsAtThisTraversalLevel
                     .flatMap { $0.outputViewModels }
+
+                if self.allInputs.map(\.id).toSet != newInputs.map(\.id).toSet {
+                    self.allInputs = newInputs
+                }
+                
+                if self.connectedInputs.map(\.id).toSet != newConnections.map(\.id).toSet {
+                    self.connectedInputs = newConnections
+                }
+                
+                if self.allOutputs.map(\.id).toSet != newOutputs.map(\.id).toSet {
+                    self.allOutputs = newOutputs
+                }
             }
             .background {
                 // Using background ensures edges z-index are always behind ndoes
-                connectedEdgesView(allConnectedInputs: connectedInputs + candidateInputs)
+                connectedEdgesView(allConnectedInputs: self.connectedInputs) // + candidateInputs)
             }
-            .overlay {
-                edgeDrawingView(inputs: allInputs,
-                                graph: self.graph)
-                
-                EdgeInputLabelsView(inputs: allInputs,
-                                    document: document,
-                                    graph: graph)
-                
-                // TODO: does PortPreviewPopoverView render too many times when open?
-                // TODO: more elegant way to do this? Generic types giving Swift compiler trouble
-                if let openPortPreview = document.openPortPreview {
-                    PortPreviewPopoverWrapperView(
-                        allInputs: allInputs,
-                        allOutputs: allOutputs,
-                        openPortPreview: openPortPreview)
-                }
-            }
+//            .overlay {
+//                edgeDrawingView(inputs: allInputs,
+//                                graph: self.graph)
+//                
+//                EdgeInputLabelsView(inputs: allInputs,
+//                                    document: document,
+//                                    graph: graph)
+//                
+//                // TODO: does PortPreviewPopoverView render too many times when open?
+//                // TODO: more elegant way to do this? Generic types giving Swift compiler trouble
+//                if let openPortPreview = document.openPortPreview {
+//                    PortPreviewPopoverWrapperView(
+//                        allInputs: allInputs,
+//                        allOutputs: allOutputs,
+//                        openPortPreview: openPortPreview)
+//                }
+//            }
     }
 }

--- a/Stitch/Graph/Node/View/NodesView.swift
+++ b/Stitch/Graph/Node/View/NodesView.swift
@@ -93,58 +93,10 @@ struct CanvasEdgesViewModifier: ViewModifier {
     @Bindable var graph: GraphState
     
     func body(content: Content) -> some View {
-        // Including "possible" inputs enables edge animation
-        let candidateInputs: [InputNodeRowViewModel] = graph.edgeEditingState?.possibleEdges.compactMap {
-            let inputData = $0.edge.to
-            
-            guard let node = self.graph.getCanvasItem(inputData.canvasId),
-                  let inputRow = node.inputViewModels[safe: inputData.portId] else {
-                return nil
-            }
-            
-            return inputRow
-        } ?? []
-        
-        return content
-        // Moves expensive computation here to reduce render cycles
-//            .onChange(of: graph.graphUpdaterId, initial: true) {
-//                // log("CanvasEdgesViewModifier: .onChange(of: self.graph.graphUpdaterId)")
-//                let canvasItemsAtThisTraversalLevel = self.graph
-//                    .getCanvasItemsAtTraversalLevel(groupNodeFocused: document.groupNodeFocused?.groupNodeId)
-//                
-//                let newInputs = canvasItemsAtThisTraversalLevel
-//                    .flatMap { canvasItem -> [InputNodeRowViewModel] in
-//                        canvasItem.inputViewModels
-//                    }
-//                
-//                
-//                let newConnections = newInputs.filter { input in
-//                    guard input.nodeDelegate?.patchNodeViewModel?.patch != .wirelessReceiver else {
-//                        return false
-//                    }
-//                    return input.rowDelegate?.containsUpstreamConnection ?? false
-//                }
-//                
-//                let newOutputs = canvasItemsAtThisTraversalLevel
-//                    .flatMap { $0.outputViewModels }
-//
-//                if self.allInputs.map(\.id).toSet != newInputs.map(\.id).toSet {
-//                    self.allInputs = newInputs
-//                }
-//                
-//                if self.connectedInputs.map(\.id).toSet != newConnections.map(\.id).toSet {
-//                    self.connectedInputs = newConnections
-//                }
-//                
-//                if self.allOutputs.map(\.id).toSet != newOutputs.map(\.id).toSet {
-//                    self.allOutputs = newOutputs
-//                }
-//            }
+        content
             .background {
                 // Using background ensures edges z-index are always behind ndoes
-//                connectedEdgesView() // + candidateInputs)
                 GraphConnectedEdgesView(graph: graph)
-                
                 CandidateEdgesView(graph: graph)
             }
             .overlay {
@@ -153,9 +105,7 @@ struct CanvasEdgesViewModifier: ViewModifier {
                 
                 EdgeInputLabelsView(document: document,
                                     graph: graph)
-                
-//                // TODO: does PortPreviewPopoverView render too many times when open?
-//                // TODO: more elegant way to do this? Generic types giving Swift compiler trouble
+
                 if let openPortPreview = document.openPortPreview,
                    let canvas = graph.getCanvasItem(openPortPreview.canvasItemId) {
                     PortPreviewPopoverWrapperView(

--- a/Stitch/Graph/Node/View/NodesView.swift
+++ b/Stitch/Graph/Node/View/NodesView.swift
@@ -39,8 +39,8 @@ struct NodesView: View {
     }
     
     var body: some View {
-        let currentNodePage = self.graph.visibleNodesViewModel
-            .getViewData(groupNodeFocused: document.groupNodeFocused?.groupNodeId) ?? .init(localPosition: graph.localPosition)
+//        let currentNodePage = self.graph.visibleNodesViewModel
+//            .getViewData(groupNodeFocused: document.groupNodeFocused?.groupNodeId) ?? .init(localPosition: graph.localPosition)
                 
         // CommentBox needs to be affected by graph offset and zoom
 //         but can live somewhere else?
@@ -91,11 +91,6 @@ struct CanvasEdgesViewModifier: ViewModifier {
     
     @Bindable var document: StitchDocumentViewModel
     @Bindable var graph: GraphState
-    
-    @MainActor
-    func connectedEdgesView() -> some View {
-        GraphConnectedEdgesView(graph: graph)
-    }
     
     @MainActor
     func edgeDrawingView(inputs: [InputNodeRowViewModel],
@@ -155,7 +150,10 @@ struct CanvasEdgesViewModifier: ViewModifier {
 //            }
             .background {
                 // Using background ensures edges z-index are always behind ndoes
-                connectedEdgesView() // + candidateInputs)
+//                connectedEdgesView() // + candidateInputs)
+                GraphConnectedEdgesView(graph: graph)
+                
+                CandidateEdgesView(graph: graph)
             }
 //            .overlay {
 //                edgeDrawingView(inputs: allInputs,

--- a/Stitch/Graph/Node/View/NodesView.swift
+++ b/Stitch/Graph/Node/View/NodesView.swift
@@ -151,19 +151,17 @@ struct CanvasEdgesViewModifier: ViewModifier {
                 EdgeDrawingView(graph: graph,
                                 edgeDrawingObserver: graph.edgeDrawingObserver)
                 
-                // TODO: come back to labels
-//                EdgeInputLabelsView(inputs: allInputs,
-//                                    document: document,
-//                                    graph: graph)
+                EdgeInputLabelsView(document: document,
+                                    graph: graph)
                 
 //                // TODO: does PortPreviewPopoverView render too many times when open?
 //                // TODO: more elegant way to do this? Generic types giving Swift compiler trouble
-//                if let openPortPreview = document.openPortPreview {
-//                    PortPreviewPopoverWrapperView(
-//                        allInputs: allInputs,
-//                        allOutputs: allOutputs,
-//                        openPortPreview: openPortPreview)
-//                }
+                if let openPortPreview = document.openPortPreview,
+                   let canvas = graph.getCanvasItem(openPortPreview.canvasItemId) {
+                    PortPreviewPopoverWrapperView(
+                        openPortPreview: openPortPreview,
+                        canvas: canvas)
+                }
             }
     }
 }

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -662,11 +662,11 @@ extension GraphState {
             
             let title = node.displayTitle
             
-            if splitterNode.type == .input {
+            if splitterNode.entity.type == .input {
                 result.updateValue(title, forKey: .input(patchNode.inputsObservers.first!.id))
             }
             
-            else if splitterNode.type == .output {
+            else if splitterNode.entity.type == .output {
                 result.updateValue(title, forKey: .output(patchNode.outputsObservers.first!.id))
             }
         }

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -15,50 +15,6 @@ import StitchEngine
 import SwiftUI
 import Vision
 
-struct ConnectedEdgeData: Equatable {
-    static func == (lhs: ConnectedEdgeData, rhs: ConnectedEdgeData) -> Bool {
-        lhs.upstreamRowObserver.id == rhs.upstreamRowObserver.id &&
-        lhs.downstreamRowObserver.id == rhs.downstreamRowObserver.id &&
-        lhs.zIndex == rhs.zIndex
-    }
-    
-    let upstreamRowObserver: OutputNodeRowViewModel
-    let downstreamRowObserver: InputNodeRowViewModel
-    let inputData: EdgeAnchorDownstreamData
-    let outputData: EdgeAnchorUpstreamData
-    let zIndex: Double
-    
-    @MainActor
-    init?(downstreamRowObserver: InputNodeRowViewModel) {
-        guard let downstreamNode = downstreamRowObserver.nodeDelegate,
-              let upstreamRowObserver = downstreamRowObserver.rowDelegate?.upstreamOutputObserver?.nodeRowViewModel,
-              let inputData = EdgeAnchorDownstreamData(
-                from: downstreamRowObserver,
-                upstreamNodeId: upstreamRowObserver.canvasItemDelegate?.id),
-              let outputData = EdgeAnchorUpstreamData(
-                from: upstreamRowObserver,
-                connectedDownstreamNode: downstreamNode) else {
-            return nil
-        }
-        
-        self.upstreamRowObserver = upstreamRowObserver
-        self.downstreamRowObserver = downstreamRowObserver
-        self.inputData = inputData
-        self.outputData = outputData
-        
-        let upstreamRowObserverZIndex = upstreamRowObserver.canvasItemDelegate?.zIndex ?? 0
-        let defaultInputNodeIndex = downstreamRowObserver.canvasItemDelegate?.zIndex ?? 0
-        let zIndexOfInputNode = downstreamRowObserver.canvasItemDelegate?.zIndex ?? defaultInputNodeIndex
-        self.zIndex = max(upstreamRowObserverZIndex, zIndexOfInputNode)
-    }
-}
-
-extension ConnectedEdgeData: Identifiable {
-    var id: NodeRowViewModelId {
-        self.downstreamRowObserver.id
-    }
-}
-
 @Observable
 final class GraphState: Sendable {
     
@@ -376,13 +332,6 @@ extension GraphState {
         
         // Updates node visibility data
         self.visibleNodesViewModel.resetCache()
-        
-//        // Update edges after everything else
-//        let newEdges = self.getVisualEdgeData(groupNodeFocused: self.documentDelegate?.groupNodeFocused?.groupNodeId)
-//        
-//        if self.connectedEdges != newEdges {
-//            self.connectedEdges = newEdges
-//        }
     }
     
     @MainActor
@@ -402,9 +351,6 @@ extension GraphState {
             }
             return input.rowDelegate?.containsUpstreamConnection ?? false
         }
-        
-//        let newOutputs = canvasItemsAtThisTraversalLevel
-//            .flatMap { $0.outputViewModels }
         
         return connectedInputs.compactMap { connection in
             ConnectedEdgeData(downstreamRowObserver: connection)

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -30,9 +30,8 @@ struct ConnectedEdgeData: Equatable {
     
     @MainActor
     init?(downstreamRowObserver: InputNodeRowViewModel) {
-        let downstreamNode = downstreamRowObserver.nodeDelegate
-        
-        guard let upstreamRowObserver = downstreamRowObserver.rowDelegate?.upstreamOutputObserver?.nodeRowViewModel,
+        guard let downstreamNode = downstreamRowObserver.nodeDelegate,
+              let upstreamRowObserver = downstreamRowObserver.rowDelegate?.upstreamOutputObserver?.nodeRowViewModel,
               let inputData = EdgeAnchorDownstreamData(
                 from: downstreamRowObserver,
                 upstreamNodeId: upstreamRowObserver.canvasItemDelegate?.id),

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -118,6 +118,8 @@ final class GraphState: Sendable {
     // Tracks labels for group ports for perf
     @MainActor var groupPortLabels = [Coordinate : String]()
     
+    // 
+    
     @MainActor var lastEncodedDocument: GraphEntity
     @MainActor weak var documentDelegate: StitchDocumentViewModel?
     @MainActor weak var documentEncoderDelegate: (any DocumentEncodable)?

--- a/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
+++ b/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
@@ -270,8 +270,8 @@ extension VisibleNodesViewModel {
             }
             // sort new inputs/inputs by the date the splitter was created
             .sorted {
-                ($0.splitterNode?.lastModifiedDate ?? Date.now) <
-                    ($1.splitterNode?.lastModifiedDate ?? Date.now)
+                ($0.splitterNode?.entity.lastModifiedDate ?? Date.now) <
+                    ($1.splitterNode?.entity.lastModifiedDate ?? Date.now)
             }
 
         // get the first (and only) row observer for this splitter node
@@ -314,8 +314,8 @@ extension VisibleNodesViewModel {
             }
             // sort new inputs/outputs by the date the splitter was created
             .sorted {
-                ($0.splitterNode?.lastModifiedDate ?? Date.now) <
-                    ($1.splitterNode?.lastModifiedDate ?? Date.now)
+                ($0.splitterNode?.entity.lastModifiedDate ?? Date.now) <
+                    ($1.splitterNode?.entity.lastModifiedDate ?? Date.now)
             }
 
         // get the first (and only) row observer for this splitter node


### PR DESCRIPTION
This PR caches needed edge data for populating visual edges, fixing perf issues caused by accessing graph state and weak references from views. 

Perf improvement is around 17% when duplicating nodes on the Humane graph.