### PR TITLE
Reduced render cycles from fields

### DIFF
--- a/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
@@ -71,18 +71,15 @@ struct GenericFlyoutView: View {
     @ViewBuilder @MainActor
     var flyoutRows: some View {
         // Assumes: all flyouts (besides shadow-flyout) have a single row which contains multiple fields
-        LayerInputFieldsView(fieldValueTypes: fieldValueTypes,
+        LayerInputFieldsView(layerInputFieldType: .flyout,
+                             document: graphUI,
+                             graph: graph,
+                             node: node,
+                             rowObserver: layerInputObserver.packedRowObserver,
+                             rowViewModel: rowViewModel,
+                             fieldValueTypes: fieldValueTypes,
                              layerInputObserver: layerInputObserver,
-                             forFlyout: true) { inputFieldViewModel, isMultifield in
-            GenericFlyoutRowView(
-                    graph: graph,
-                    graphUI: graphUI,
-                    viewModel: inputFieldViewModel,
-                    rowViewModel: rowViewModel,
-                    node: node,
-                    layerInputObserver: layerInputObserver,
-                    isMultifield: isMultifield)
-            }
+                             isNodeSelected: false)
     }
 }
 

--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -213,32 +213,43 @@ struct LayerInputFieldsView<ValueEntry>: View where ValueEntry: View {
             let _isMultifield = isMultifield || multipleFieldsPerGroup
             
             if !self.isAllFieldsBlockedOut(fieldGroupViewModel: fieldGroupViewModel) {
-                NodeFieldsView(
-                    fieldGroupViewModel: fieldGroupViewModel,
-                    valueEntryView: valueEntryView) {
-                    // TODO: how to handle the multifield "shadow offset" input in the Shadow Flyout? For now, we stack those fields vertically
-                    if forFlyout {
-                            VStack {
-                                ForEach(fieldGroupViewModel.fieldObservers) { fieldViewModel in
-                                    let isBlocked = self.blockedFields.map { fieldViewModel.isBlocked($0) } ?? false
-                                    if !isBlocked {
-                                        self.valueEntryView(fieldViewModel,
-                                                            _isMultifield)
-                                    }
-                                }
-                            }
-                    } else {
-                        HStack {
-                            ForEach(fieldGroupViewModel.fieldObservers) { fieldViewModel in
-                                let isBlocked = self.blockedFields.map { fieldViewModel.isBlocked($0) } ?? false
-                                if !isBlocked {
-                                    self.valueEntryView(fieldViewModel,
-                                                        _isMultifield)
-                                }
-                            }
-                        }
+                // Only non-nil for 3D transform
+                // NOTE: this only shows up for PACKED 3D Transform; unpacked 3D Transform fields are treat as Number fields, which are not created with a `groupLabel`
+                // Alternatively we could create Number fieldGroups with their proper parent label if they are for an unpacked multifeld layer input?
+                if let fieldGroupLabel = fieldGroupViewModel.groupLabel {
+                    HStack {
+                        LabelDisplayView(label: fieldGroupLabel,
+                                         isLeftAligned: false,
+                                         fontColor: STITCH_FONT_GRAY_COLOR,
+                                         isSelectedInspectorRow: false)
+                        Spacer()
                     }
                 }
+                
+                // TODO: how to handle the multifield "shadow offset" input in the Shadow Flyout? For now, we stack those fields vertically
+                if forFlyout {
+                    VStack {
+                        fieldsView(fieldGroupViewModel: fieldGroupViewModel,
+                                   isMultifield: _isMultifield)
+                    }
+                } else {
+                    HStack {
+                        fieldsView(fieldGroupViewModel: fieldGroupViewModel,
+                                   isMultifield: _isMultifield)
+                    }
+                }
+            }
+        }
+    }
+    
+    @ViewBuilder
+    func fieldsView(fieldGroupViewModel: FieldGroupTypeData<InputFieldViewModel>,
+                    isMultifield: Bool) -> some View {
+        ForEach(fieldGroupViewModel.fieldObservers) { fieldViewModel in
+            let isBlocked = self.blockedFields.map { fieldViewModel.isBlocked($0) } ?? false
+            if !isBlocked {
+                self.valueEntryView(fieldViewModel,
+                                    isMultifield)
             }
         }
     }
@@ -347,13 +358,21 @@ struct LayerOutputFieldsView<ValueEntry>: View where ValueEntry: View {
     var body: some View {
         ForEach(fieldValueTypes) { (fieldGroupViewModel: FieldGroupTypeData<OutputFieldViewModel>) in
             let isMultifield = fieldGroupViewModel.fieldObservers.count > 1
-            NodeFieldsView(fieldGroupViewModel: fieldGroupViewModel,
-                           valueEntryView: self.valueEntryView) {
+            
+            if let fieldGroupLabel = fieldGroupViewModel.groupLabel {
                 HStack {
-                    ForEach(fieldGroupViewModel.fieldObservers) { fieldViewModel in
-                        self.valueEntryView(fieldViewModel,
-                                            isMultifield)
-                    }
+                    LabelDisplayView(label: fieldGroupLabel,
+                                     isLeftAligned: false,
+                                     fontColor: STITCH_FONT_GRAY_COLOR,
+                                     isSelectedInspectorRow: false)
+                    Spacer()
+                }
+            }
+            
+            HStack {
+                ForEach(fieldGroupViewModel.fieldObservers) { fieldViewModel in
+                    self.valueEntryView(fieldViewModel,
+                                        isMultifield)
                 }
             }
         }

--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -119,7 +119,7 @@ struct InspectorLayerInputView: View {
     var layerInspectorRowId: LayerInspectorRowId {
         .layerInput(layerInputType)
     }
-    
+
     var layerInput: LayerInputPort {
         self.layerInputObserver.port
     }
@@ -135,36 +135,12 @@ struct InspectorLayerInputView: View {
         return layerInput.showsLabelForInspector
     }
     
-    var layerInputData: InputLayerNodeRowData {
-        layerInputObserver._packedData
-    }
-    
     var fieldValueTypes: [FieldGroupTypeData<InputNodeRowViewModel.FieldType>] {
         self.layerInputObserver.fieldValueTypes
     }
     
     var propertyRowIsSelected: Bool {
         graph.propertySidebar.selectedProperty == layerInspectorRowId
-    }
-        
-    @MainActor
-    func valueEntryView(inputFieldViewModel: InputFieldViewModel,
-                        isMultiField: Bool) -> InputValueEntry {
-        InputValueEntry(graph: graph,
-                        graphUI: document,
-                        viewModel: inputFieldViewModel,
-                        node: node,
-                        rowViewModel: layerInputData.inspectorRowViewModel,
-                        canvasItem: nil,
-                        rowObserver: layerInputData.rowObserver,
-                        isCanvasItemSelected: false,
-                        hasIncomingEdge: false,
-                        isForLayerInspector: true,
-                        isPackedLayerInputAlreadyOnCanvas: layerInputObserver.getCanvasItemForWholeInput().isDefined,
-                        isFieldInMultifieldInput: layerInputObserver.usesMultifields,
-                        isForFlyout: forFlyout,
-                        isSelectedInspectorRow: propertyRowIsSelected,
-                        useIndividualFieldLabel: layerInputObserver.useIndividualFieldLabel(activeIndex: document.activeIndex))
     }
     
     var body: some View {
@@ -178,23 +154,37 @@ struct InspectorLayerInputView: View {
                                  isSelectedInspectorRow: propertyRowIsSelected)
             }
             Spacer()
-            LayerInputFieldsView(fieldValueTypes: fieldValueTypes,
+            LayerInputFieldsView(layerInputFieldType: forFlyout ? .flyout : .inspector,
+                                 document: document,
+                                 graph: graph,
+                                 node: node,
+                                 rowObserver: layerInputObserver.packedRowObserver,
+                                 rowViewModel: layerInputObserver._packedData.inspectorRowViewModel,
+                                 fieldValueTypes: fieldValueTypes,
                                  layerInputObserver: layerInputObserver,
-                                 forFlyout: forFlyout,
-                                 valueEntryView: valueEntryView)
+                                 isNodeSelected: false)
         }
     }
 }
 
+enum LayerInputFieldType {
+    case inspector
+    case canvas(CanvasItemViewModel)
+    case flyout
+}
+
 // fka `LayerInputFieldsView`
 // Used by InspectorLayerInputView, most flyouts and CanvasLayerInputView
-struct LayerInputFieldsView<ValueEntry>: View where ValueEntry: View {
-    typealias ValueEntryViewBuilder = (InputFieldViewModel, Bool) -> ValueEntry
-    
+struct LayerInputFieldsView: View {
+    let layerInputFieldType: LayerInputFieldType
+    @Bindable var document: StitchDocumentViewModel
+    @Bindable var graph: GraphState
+    @Bindable var node: NodeViewModel
+    @Bindable var rowObserver: InputNodeRowObserver
+    @Bindable var rowViewModel: InputNodeRowViewModel
     let fieldValueTypes: [FieldGroupTypeData<InputNodeRowViewModel.FieldType>]
     let layerInputObserver: LayerInputObserver
-    let forFlyout: Bool
-    @ViewBuilder var valueEntryView: ValueEntryViewBuilder
+    let isNodeSelected: Bool
         
     var isMultifield: Bool {
         layerInputObserver.usesMultifields || fieldValueTypes.count > 1
@@ -202,6 +192,75 @@ struct LayerInputFieldsView<ValueEntry>: View where ValueEntry: View {
     
     var blockedFields: LayerPortTypeSet? {
         layerInputObserver.blockedFields
+    }
+    
+    var forFlyout: Bool {
+        switch self.layerInputFieldType {
+        case .flyout:
+            return true
+            
+        default:
+            return false
+        }
+    }
+    
+    @ViewBuilder
+    func valueEntryView(_ portViewModel: InputFieldViewModel,
+                        _ isMultifield: Bool) -> some View {
+        switch layerInputFieldType {
+        case .inspector:
+            let layerInputType = LayerInputType(layerInput: layerInputObserver.port,
+                                                portType: .packed)
+            let layerInspectorRowId: LayerInspectorRowId = .layerInput(layerInputType)
+            let layerInputData: InputLayerNodeRowData = layerInputObserver._packedData
+            let propertyRowIsSelected = graph.propertySidebar.selectedProperty == layerInspectorRowId
+            
+            // InspectorLayerInputView
+            InputValueEntry(graph: graph,
+                            graphUI: document,
+                            viewModel: portViewModel,
+                            node: node,
+                            rowViewModel: layerInputData.inspectorRowViewModel,
+                            canvasItem: nil,
+                            rowObserver: layerInputData.rowObserver,
+                            isCanvasItemSelected: false,
+                            hasIncomingEdge: false,
+                            isForLayerInspector: true,
+                            isPackedLayerInputAlreadyOnCanvas: layerInputObserver.getCanvasItemForWholeInput().isDefined,
+                            isFieldInMultifieldInput: layerInputObserver.usesMultifields,
+                            isForFlyout: false,
+                            isSelectedInspectorRow: propertyRowIsSelected,
+                            useIndividualFieldLabel: layerInputObserver.useIndividualFieldLabel(activeIndex: document.activeIndex))
+            
+        case .canvas(let canvasNode):
+            // CanvasLayerInputView
+            InputValueEntry(graph: graph,
+                            graphUI: document,
+                            viewModel: portViewModel,
+                            node: node,
+                            rowViewModel: rowViewModel,
+                            canvasItem: canvasNode,
+                            rowObserver: rowObserver,
+                            isCanvasItemSelected: isNodeSelected,
+                            hasIncomingEdge: rowObserver.upstreamOutputCoordinate.isDefined,
+                            isForLayerInspector: false,
+                            isPackedLayerInputAlreadyOnCanvas: true, // Always true for canvas layer input
+                            isFieldInMultifieldInput: isMultifield,
+                            isForFlyout: false,
+                            isSelectedInspectorRow: false, // Always false for canvas layer input
+                            useIndividualFieldLabel: true)
+            
+        case .flyout:
+            // GenericFlyoutView
+            GenericFlyoutRowView(
+                graph: graph,
+                graphUI: document,
+                viewModel: portViewModel,
+                rowViewModel: rowViewModel,
+                node: node,
+                layerInputObserver: layerInputObserver,
+                isMultifield: isMultifield)
+        }
     }
     
     var body: some View {

--- a/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
@@ -8,35 +8,7 @@
 import SwiftUI
 import StitchSchemaKit
 
-
 typealias LayerPortTypeSet = Set<LayerInputKeyPathType>
-
-struct NodeFieldsView<FieldType, ValueEntryView, FieldsView>: View where FieldType: FieldViewModel,
-                                                             ValueEntryView: View,
-                                                             FieldsView: View {
-    let fieldGroupViewModel: FieldGroupTypeData<FieldType>
-    
-    @ViewBuilder var valueEntryView: (FieldType, Bool) -> ValueEntryView
-    @ViewBuilder var fieldsView: () -> FieldsView
-        
-    var body: some View {
-        
-        // Only non-nil for 3D transform
-        // NOTE: this only shows up for PACKED 3D Transform; unpacked 3D Transform fields are treat as Number fields, which are not created with a `groupLabel`
-        // Alternatively we could create Number fieldGroups with their proper parent label if they are for an unpacked multifeld layer input?
-        if let fieldGroupLabel = fieldGroupViewModel.groupLabel {
-            HStack {
-                LabelDisplayView(label: fieldGroupLabel,
-                                 isLeftAligned: false,
-                                 fontColor: STITCH_FONT_GRAY_COLOR,
-                                 isSelectedInspectorRow: false)                
-                Spacer()
-            }
-        }
-        
-        fieldsView()
-    }
-}
 
 extension FieldViewModel {
     

--- a/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
@@ -120,7 +120,7 @@ struct OutputValueView: View {
     }
 
     var body: some View {
-            switch fieldValue {
+        switch fieldValue {
             case .bool(let bool):
                 BoolCheckboxView(rowObserver: nil,
                                  graph: graph,
@@ -178,7 +178,7 @@ struct OutputValueView: View {
                 
             default:
                 readOnlyView(self.fieldValue.stringValue)
-            }
+        }
     }
 
     @ViewBuilder func readOnlyView(_ displayName: String) -> some View {

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
@@ -10,7 +10,7 @@ import StitchSchemaKit
 
 // Must be a class for coordinate keypaths, which expect a reference type on the other end.
 @Observable
-final class LayerInputObserver {
+final class LayerInputObserver: Identifiable {
     // Not intended to be used as an API given both data payloads always exist
     // Variables here necessary to ensure keypaths logic works
 

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
@@ -147,11 +147,11 @@ extension NodeRowViewModel {
                                                 unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
                                                 unpackedPortIndex: unpackedPortIndex)
         
-//        let didFieldsChange = !zip(self.fieldValueTypes, fields).allSatisfy { $0 == $1 }
+        let didFieldsChange = !zip(self.fieldValueTypes, fields).allSatisfy { $0.id == $1.id }
         
-        self.fieldValueTypes = fields
-//        if self.fieldValueTypes.isEmpty || didFieldsChange {
-//        }
+        if self.fieldValueTypes.isEmpty || didFieldsChange {
+            self.fieldValueTypes = fields
+        }
     }
     
     @MainActor

--- a/Stitch/Graph/Node/View/CanvasLayerInputView.swift
+++ b/Stitch/Graph/Node/View/CanvasLayerInputView.swift
@@ -17,26 +17,6 @@ struct CanvasLayerInputView: View {
     let inputRowObserver: InputNodeRowObserver
     let inputRowViewModel: InputNodeRowViewModel
     let isNodeSelected: Bool
-                
-    @ViewBuilder @MainActor
-    func valueEntryView(portViewModel: InputFieldViewModel,
-                        isMultiField: Bool) -> InputValueEntry {
-        InputValueEntry(graph: graph,
-                        graphUI: document,
-                        viewModel: portViewModel,
-                        node: node,
-                        rowViewModel: inputRowViewModel,
-                        canvasItem: canvasNode,
-                        rowObserver: inputRowObserver,
-                        isCanvasItemSelected: isNodeSelected,
-                        hasIncomingEdge: inputRowObserver.upstreamOutputCoordinate.isDefined,
-                        isForLayerInspector: false,
-                        isPackedLayerInputAlreadyOnCanvas: true, // Always true for canvas layer input
-                        isFieldInMultifieldInput: isMultiField,
-                        isForFlyout: false,
-                        isSelectedInspectorRow: false, // Always false for canvas layer input
-                        useIndividualFieldLabel: true)
-    }
     
     var body: some View {
         HStack {
@@ -59,10 +39,15 @@ struct CanvasLayerInputView: View {
                                  isSelectedInspectorRow: false)
             }
             
-            LayerInputFieldsView(fieldValueTypes: inputRowViewModel.fieldValueTypes,
+            LayerInputFieldsView(layerInputFieldType: .canvas(canvasNode),
+                                 document: document,
+                                 graph: graph,
+                                 node: node,
+                                 rowObserver: inputRowObserver,
+                                 rowViewModel: inputRowViewModel,
+                                 fieldValueTypes: inputRowViewModel.fieldValueTypes,
                                  layerInputObserver: layerInputObserver,
-                                 forFlyout: false,
-                                 valueEntryView: valueEntryView)
+                                 isNodeSelected: isNodeSelected)
         }
         .modifier(CanvasPortHeightModifier())
     }


### PR DESCRIPTION
Perf hangups from frequent updates to field view model publishers and passing in view builder functions into views.