### PR TITLE
Reset node dupe-drag state when alerts reset or graph scrolled or zoomed

### DIFF
--- a/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
+++ b/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
@@ -257,7 +257,6 @@ extension GraphState {
 
 // Drag.onEnded
 struct NodeMoveEndedAction: StitchDocumentEvent {
-//    let id: NodeId // id of node or rectangle
     let id: CanvasItemId // id of node or rectangle
 
     func handle(state: StitchDocumentViewModel) {

--- a/Stitch/Graph/Node/View/StitchUIScrollHelpers.swift
+++ b/Stitch/Graph/Node/View/StitchUIScrollHelpers.swift
@@ -45,6 +45,11 @@ struct GraphScrollDataUpdated: StitchDocumentEvent {
             nodePage.zoomData = newZoom
         }
         
+        // Scrolling, zooming ends any node duplication drag
+        // TODO: revisit when we support multi-gestures on iPad again
+        // Usually okay, but we can get stuck in dupe-drag mode if something goes wrong and a handleNodeMoveEnded action isn't fired
+        graph.dragDuplication = false
+        
         // Update which nodes are visible in frame
         graph.updateVisibleNodes()
     }

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -216,6 +216,10 @@ extension GraphState {
             self.layersSidebarViewModel.isSidebarFocused = false
         }
         
+        // Reset node option dupe-drag
+        // Usually okay, but we can get stuck in dupe-drag mode if something goes wrong and a handleNodeMoveEnded action isn't fired
+        self.dragDuplication = false
+        
         if document.openPortPreview != nil {
             document.openPortPreview = nil
         }


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7019

Node dupe-drag with media still feels a bit buggy?