### PR TITLE
Remove `usesPositionHandler` since no longer used

### DIFF
--- a/Stitch/Graph/Node/View/CanvasItemPositionHandler.swift
+++ b/Stitch/Graph/Node/View/CanvasItemPositionHandler.swift
@@ -25,9 +25,7 @@ struct CanvasItemPositionHandler: ViewModifier {
     
     // ZIndex:
     let zIndex: ZIndex
-    
-    let usePositionHandler: Bool
-    
+        
     // When this node is the last selected node on graph,
     // we raise it and its buttons
     var _zIndex: ZIndex {
@@ -36,42 +34,38 @@ struct CanvasItemPositionHandler: ViewModifier {
     }
     
     func body(content: Content) -> some View {
-        if !usePositionHandler {
-            content
-        }  else {
-            content
-                .zIndex(_zIndex)
-                .canvasPosition(id: node.id,
-                                position: node.position)
-            
-            // MARK: we used to support node touch-down gesture with a hack using long press but this had averse effects on pinch
-                .gesture(
-                    DragGesture(
-                        // minimumDistance: 0, // messes up trackpad pinch
-                        // .global means we must consider zoom in `NodeMoved`
-                        coordinateSpace: .global)
-                    
-                    .onChanged { gesture in
-                        // log("NodePositionHandler: onChanged")
-                        if isOptionPressed,
-                           let nodeId = node.id.nodeCase {
-                            dispatch(NodeDuplicateDraggedAction(
-                                id: nodeId,
-                                translation: gesture.translation))
-                        } else {
-                            document.visibleGraph.canvasItemMoved(for: node,
-                                                                  translation: gesture.translation,
-                                                                  wasDrag: true,
-                                                                  document: document)
-                        }
+        
+        content
+            .zIndex(_zIndex)
+            .canvasPosition(id: node.id,
+                            position: node.position)
+        
+        // MARK: we used to support node touch-down gesture with a hack using long press but this had averse effects on pinch
+            .gesture(
+                DragGesture(
+                    // minimumDistance: 0, // messes up trackpad pinch
+                    // .global means we must consider zoom in `NodeMoved`
+                    coordinateSpace: .global)
+                
+                .onChanged { gesture in
+                    // log("NodePositionHandler: onChanged")
+                    if isOptionPressed,
+                       let nodeId = node.id.nodeCase {
+                        dispatch(NodeDuplicateDraggedAction(
+                            id: nodeId,
+                            translation: gesture.translation))
+                    } else {
+                        document.visibleGraph.canvasItemMoved(for: node,
+                                                              translation: gesture.translation,
+                                                              wasDrag: true,
+                                                              document: document)
                     }
-                        .onEnded { _ in
-                            // log("NodePositionHandler: onEnded")
-                            dispatch(NodeMoveEndedAction(id: node.id))
-                        }
-                ) // .gesture
-        }
-        //            .disabled(!usePositionHandler)
+                }
+                    .onEnded { _ in
+                        // log("NodePositionHandler: onEnded")
+                        dispatch(NodeMoveEndedAction(id: node.id))
+                    }
+            ) // .gesture
     }
 }
 
@@ -79,11 +73,9 @@ extension View {
     /// Handles node position, drag gestures, and option+select for duplicating node.
     func canvasItemPositionHandler(document: StitchDocumentViewModel,
                                    node: CanvasItemViewModel,
-                                   zIndex: ZIndex,
-                                   usePositionHandler: Bool) -> some View {
+                                   zIndex: ZIndex) -> some View {
         self.modifier(CanvasItemPositionHandler(document: document,
                                                 node: node,
-                                                zIndex: zIndex,
-                                                usePositionHandler: usePositionHandler))
+                                                zIndex: zIndex))
     }
 }

--- a/Stitch/Graph/Node/View/NodeView.swift
+++ b/Stitch/Graph/Node/View/NodeView.swift
@@ -22,7 +22,6 @@ struct NodeView: View {
     let canRemoveInput: Bool
 
     let boundsReaderDisabled: Bool
-    let usePositionHandler: Bool
     let updateMenuActiveSelectionBounds: Bool
 
     var zIndex: CGFloat {
@@ -101,8 +100,7 @@ struct NodeView: View {
         }
         .canvasItemPositionHandler(document: document,
                                    node: node,
-                                   zIndex: zIndex,
-                                   usePositionHandler: usePositionHandler)
+                                   zIndex: zIndex)
     }
 
     @MainActor

--- a/Stitch/Graph/Node/View/NodesOnlyView.swift
+++ b/Stitch/Graph/Node/View/NodesOnlyView.swift
@@ -71,7 +71,6 @@ struct NodesOnlyView: View {
                              canAddInput: node.canAddInputs,
                              canRemoveInput: node.canRemoveInputs,
                              boundsReaderDisabled: false,
-                             usePositionHandler: true,
                              updateMenuActiveSelectionBounds: false)
                 }
             }


### PR DESCRIPTION
`usesPositionHandler` is no longer needed since changes to node insertion animation