### PR TITLE
Deselect other canvas items when canvas item's field focused

### DIFF
--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -329,7 +329,7 @@ struct LayerInspectorOutputPortView: View {
     let forFlyout: Bool
 
     var isCanvasItemSelected: Bool {
-        self.canvasItem?.isSelected(graph) ?? false
+        self.canvasItem.map { graph.isCanvasItemSelected($0.id) } ?? false
     }
     
     var propertyIsAlreadyOnGraph: Bool {

--- a/Stitch/Graph/Node/Group/GroupNodeCreationActions.swift
+++ b/Stitch/Graph/Node/Group/GroupNodeCreationActions.swift
@@ -241,7 +241,9 @@ extension StitchDocumentViewModel {
         graph.resetSelectedCanvasItems()
         
         // ... then select the GroupNode and its edges
-        newGroupNode.patchCanvasItem?.select(graph)
+        if let newGroupNodeId = newGroupNode.patchCanvasItem?.id {
+            graph.selectCanvasItem(newGroupNodeId)
+        }
 
         // Stop any active node dragging etc.
         self.graphMovement.stopNodeMovement()

--- a/Stitch/Graph/Node/Port/Util/PulseActions.swift
+++ b/Stitch/Graph/Node/Port/Util/PulseActions.swift
@@ -23,11 +23,11 @@ typealias FlashSet = Set<Coordinate>
 extension GraphState {    
     @MainActor
     func pulseValueButtonClicked(_ inputObserver: InputNodeRowObserver,
-                                 canvasItem: CanvasItemViewModel?) {
+                                 canvasItemId: CanvasItemId?) {
         
         // Select canvas if associated here
-        if let canvasItem = canvasItem { // inputPort.canvasItemDelegate {
-            self.selectSingleNode(canvasItem)
+        if let canvasItemId = canvasItemId {
+            self.selectSingleCanvasItem(canvasItemId)
         }
         
         inputObserver.updateValues([.pulse(self.graphStepState.graphTime)])

--- a/Stitch/Graph/Node/Port/View/Field/ValueButton/PulseValueButtonView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/ValueButton/PulseValueButtonView.swift
@@ -35,11 +35,10 @@ struct PulseValueButtonView: View {
      which is not behavior that we want.
      */
     var body: some View {
-        // TODO: you made this a button, double check it works
         StitchButton {
             if let rowObserver = rowObserver {
                 graph.pulseValueButtonClicked(rowObserver,
-                                              canvasItem: canvasItem)
+                                              canvasItemId: canvasItem?.id)
             } else {
                 log("PulseValueButtonView error: output unexpectedly encountered for \(rowObserver?.id)")
             }

--- a/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
+++ b/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
@@ -99,10 +99,10 @@ extension GraphState {
             }
             
             // If we drag a canvas item that is not yet selected, we'll select it and deselect all the others.
-            if !canvasItem.isSelected(state) {
+            if !state.isCanvasItemSelected(canvasItem.id) {
                 // log("NodeDuplicateDraggedAction: \(canvasItem.id) was NOT already selected")
                 // select the canvas item and de-select all the others
-                state.selectSingleCanvasItem(canvasItem)
+                state.selectSingleCanvasItem(canvasItem.id)
                 // add node's edges to highlighted edges; wipe old highlighted edges
                 state.selectedEdges = .init()
             }
@@ -226,14 +226,13 @@ extension GraphState {
 
         // Dragging an unselected node selects that node
         // and de-selects all other nodes.
-        let alreadySelected = canvasItem.isSelected(self)
-
+        let alreadySelected = self.isCanvasItemSelected(canvasItem.id)
         if !alreadySelected {
             // update node's position
             self.updateCanvasItemOnDragged(canvasItem, translation: translation)
 
             // select the canvas item and de-select all the others
-            self.selectSingleCanvasItem(canvasItem)
+            self.selectSingleCanvasItem(canvasItem.id)
 
             // add node's edges to highlighted edges; wipe old highlighted edges
             self.selectedEdges = .init()

--- a/Stitch/Graph/Node/Util/Movement/NodePositionUtils.swift
+++ b/Stitch/Graph/Node/Util/Movement/NodePositionUtils.swift
@@ -33,32 +33,39 @@ extension CanvasItemViewModel {
         return .init(width: nodeSize.width / denominator,
                      height: nodeSize.height / denominator)
     }
+}
+
+extension StitchDocumentViewModel {
     
+    // fka `CanvasItemViewModel.isTapped`
     @MainActor
-    func isTapped(document: StitchDocumentViewModel) {
+    func canvasItemTapped(_ canvasItem: CanvasItemViewModel) {
+        
+        let canvasItemId: CanvasItemId = canvasItem.id
+        
         log("canvasItemTapped: id: \(self.id)")
-        let graph = document.visibleGraph
+        let graph = self.visibleGraph
         
         // when holding CMD ...
         // TODO: pass this down from the gesture handler or fix key listening
-        if document.keypressState.isCommandPressed {
+        if self.keypressState.isCommandPressed {
             // toggle selection
-            let isSelected = graph.selection.selectedCanvasItems.contains(self.id)
+            let isSelected = graph.selection.selectedCanvasItems.contains(canvasItemId)
             if isSelected {
-                self.deselect(graph)
+                graph.deselectCanvasItem(canvasItemId)
             } else {
-                self.select(graph)
+                graph.selectCanvasItem(canvasItemId)
             }
         }
         
         // when not holding CMD ...
         else {
-            graph.selectSingleCanvasItem(self)
+            graph.selectSingleCanvasItem(canvasItemId)
         }
         
         // if we tapped a node, we're no longer moving it
-        document.graphMovement.draggedCanvasItem = nil
+        self.graphMovement.draggedCanvasItem = nil
         
-        self.zIndex = graph.highestZIndex + 1
+        canvasItem.zIndex = graph.highestZIndex + 1
     }
 }

--- a/Stitch/Graph/Node/Util/NodeCreatedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeCreatedAction.swift
@@ -185,7 +185,7 @@ extension StitchDocumentViewModel {
             self.visibleGraph.layersSidebarViewModel.resetEditModeSelections()
             self.visibleGraph.layersSidebarViewModel.sidebarItemSelectedViaEditMode(sidebarLayerData.id)
             self.visibleGraph.layersSidebarViewModel.selectionState.lastFocused = sidebarLayerData.id
-            self.visibleGraph.deselectAllCanvasItems()
+            self.visibleGraph.resetSelectedCanvasItems()
             
             return layerNode
 

--- a/Stitch/Graph/Node/Util/NodeDeletedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeDeletedAction.swift
@@ -45,9 +45,8 @@ struct SelectedGraphNodesDeleted: StitchDocumentEvent {
         let graph = state.visibleGraph
         
         if graph.getSelectedCanvasItems(groupNodeFocused: state.groupNodeFocused?.groupNodeId).isEmpty,
-           let canvasItemId = canvasItemId,
-           let canvasItem = graph.getCanvasItem(canvasItemId) {
-            canvasItem.select(graph)
+           let canvasItemId = canvasItemId {
+            graph.selectCanvasItem(canvasItemId)
         }
 
         graph.selectedGraphNodesDeleted(

--- a/Stitch/Graph/Node/View/NodeView.swift
+++ b/Stitch/Graph/Node/View/NodeView.swift
@@ -396,7 +396,7 @@ struct NodeViewTapGestureModifier: ViewModifier {
         }
         
         // and select just the node
-        node.isTapped(document: document)
+        document.canvasItemTapped(node)
     }
     
     func onDoubleTap() {

--- a/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
@@ -85,13 +85,7 @@ final class CanvasItemViewModel: Identifiable, StitchLayoutCachable, Sendable {
     
     // Cached subview sizes for performance gains in commit phase
     @MainActor var viewCache: NodeLayoutCache?
-    
-    // Moved state here for render cycle perf on port view for colors
-    @MainActor
-    func isSelected(_ graph: GraphState) -> Bool {
-        return graph.graphUI.selection.selectedCanvasItems.contains(self.id)
-    }
-    
+        
     // Reference back to the parent node entity
     @MainActor
     weak var nodeDelegate: NodeDelegate?

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/TextField/PreviewTextFieldLayerUtils.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/TextField/PreviewTextFieldLayerUtils.swift
@@ -67,8 +67,7 @@ extension StitchDocumentViewModel {
         
         // if we selected a canvas item, we also thereby selected it:
         if let canvasItemId = focusedField.canvasFieldId {
-            graph.getCanvasItem(canvasItemId)?
-                .select(graph)
+            graph.selectSingleCanvasItem(canvasItemId)
         }
     }
     

--- a/Stitch/Graph/Sidebar/Util/JumpToCanvasItem.swift
+++ b/Stitch/Graph/Sidebar/Util/JumpToCanvasItem.swift
@@ -64,7 +64,7 @@ extension GraphState {
         
         self.selection = GraphUISelectionState()
         self.resetSelectedCanvasItems()
-        canvasItem.select(self)
+        self.selectCanvasItem(id)
         
         // Update focused group ONLY IF CHANGED (important to avoid didSet)
         if let canvasItemTraversalLevel = canvasItem.parentGroupNodeId,

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarGroupCreated.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarGroupCreated.swift
@@ -61,7 +61,7 @@ extension LayersSidebarViewModel {
         self.selectionState.resetEditModeSelections()
         self.sidebarItemSelectedViaEditMode(newNode.id)
         self.selectionState.lastFocused = newNode.id
-        graph.deselectAllCanvasItems()
+        graph.resetSelectedCanvasItems()
         
         // NOTE: must do this AFTER children have been assigned to the new layer node; else we return preview window size
         

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
@@ -100,7 +100,7 @@ extension ProjectSidebarObservable {
                 
                 self.editModeSelectTappedItems(tappedItems: self.selectionState.primary)
                 
-                graph.deselectAllCanvasItems()
+                graph.resetSelectedCanvasItems()
                 
             } else {
                 // log("sidebarItemTapped: did not have itemsBetween")
@@ -116,7 +116,7 @@ extension ProjectSidebarObservable {
                     
                     self.editModeSelectTappedItems(tappedItems: self.selectionState.primary)
                     
-                    graph.deselectAllCanvasItems()
+                    graph.resetSelectedCanvasItems()
                 }
             }
         }
@@ -141,7 +141,7 @@ extension ProjectSidebarObservable {
                 self.selectionState.primary.insert(id)
                 self.sidebarItemSelectedViaEditMode(id)
                 self.selectionState.lastFocused = id
-                graph.deselectAllCanvasItems()
+                graph.resetSelectedCanvasItems()
             }
             
         } else {
@@ -153,7 +153,7 @@ extension ProjectSidebarObservable {
             self.selectionState.primary = .init([id])
             self.sidebarItemSelectedViaEditMode(id)
             self.selectionState.lastFocused = id
-            graph.deselectAllCanvasItems()
+            graph.resetSelectedCanvasItems()
         }
         
         graph.updateInspectorFocusedLayers()

--- a/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
+++ b/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
@@ -459,18 +459,19 @@ extension GraphState {
                             let portType: LayerInputKeyPathType = isPacked ? .packed : .unpacked(unpackedId ?? .port0)
                             let layerId = LayerInputType(layerInput: inputType,
                                                          portType: portType)
+                            // TODO: can we use `inputData.canvasItem` or not?
                             if let _ = inputData.canvasItem,
                                let canvasItem = self.getCanvasItem(.layerInput(.init(node: nodeEntity.id,
                                                                                      keyPath: layerId))) {
-                                canvasItem.select(self)
+                                self.selectCanvasItem(canvasItem.id)
                             }
                         }
                     }
                     
                 case .patch, .group, .component:
-                    let stitch = self.getNodeViewModel(nodeEntity.id)
-                    if let canvasItem = stitch?.patchCanvasItem {
-                        canvasItem.select(self)
+                    
+                    if let canvasItem = self.getNodeViewModel(nodeEntity.id)?.patchCanvasItem {
+                        self.selectCanvasItem(canvasItem.id)
                     }
                 }
         }

--- a/Stitch/Graph/Util/NodeSelection/NodeSelectionUtil.swift
+++ b/Stitch/Graph/Util/NodeSelection/NodeSelectionUtil.swift
@@ -123,7 +123,7 @@ extension GraphState {
         self.resetSelectedCanvasItems()
         
         visibleNodes.forEach {
-            $0.select(self)
+            self.selectCanvasItem($0.id)
         }
     }
 }

--- a/StitchTests/nodeUIGroupingTests.swift
+++ b/StitchTests/nodeUIGroupingTests.swift
@@ -47,8 +47,8 @@ class GroupNodeTests: XCTestCase {
         XCTAssert(canvasNode2.parentGroupNodeId == nil)
                 
         // Select the nodes
-        graphState.addNodeToSelections(canvasNode1.id)
-        graphState.addNodeToSelections(canvasNode2.id)
+        graphState.selectCanvasItem(canvasNode1.id)
+        graphState.selectCanvasItem(canvasNode2.id)
             
         // Create the group
         let _ = await document.createGroup(isComponent: false)
@@ -89,7 +89,7 @@ class GroupNodeTests: XCTestCase {
             fatalError()
         }
         
-        graphState.addNodeToSelections(canvasItem.id)
+        graphState.selectCanvasItem(canvasItem.id)
         
         // Make sure only one node is selected
         // TODO: fix after changing "selecting group node = selecting its splitters as well"


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/6781

Also cleans up a couple redundant methods. 

Note: also introduces clearer signature on logic for selecting and deselecting a canvas item. 

Previously this logic was a method on `CanvasItemViewModel` that took a full `GraphState`. However, such a signature misleadingly implied that selection-status was stored on the canvas item itself, like canvas item's z-index. We were also forced to retrieve the full canvas item view model in contexts where we only had, and only needed, the canvas item's id. 

The new signature `(GraphState, CanvasItemId) -> Void` makes clear that we're modifying (part of) GraphState and only need the canvas item id.

