### PR TITLE
Use identity eval for non-pulse and non-media splitters; start TextField layer output with empty string

### DIFF
--- a/Stitch/Graph/Node/Layer/Type/Text/TextFieldLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Text/TextFieldLayerNode.swift
@@ -117,7 +117,7 @@ func textFieldLayerEval(node: NodeViewModel) -> EvalResult {
     let evalOp: OpWithIndex<PortValue> = { _, loopIndex in
 
         // Note: on the initial evaluation of this layer node, we will not have yet have any `textFieldLayerViewModels`. That's fine; the node eval works fine afterward.
-        let textFieldValueAtIndex = textFieldLayerViewModels[safe: loopIndex]?.text.getString?.string ?? ""
+        let textFieldValueAtIndex = textFieldLayerViewModels[safe: loopIndex]?.textFieldInput ?? ""
 
         // log("textFieldLayerEval: values: \(values)")
         // log("textFieldLayerEval: loopIndex: \(loopIndex)")

--- a/Stitch/Graph/Node/Patch/Type/Value/SplitterPatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Value/SplitterPatchNode.swift
@@ -46,31 +46,41 @@ struct SplitterPatchNode: PatchNodeDefinition {
 func splitterEval(node: PatchNode,
                   graphStep: GraphStepState) -> EvalResult {
 
-    node.loopedEval { (values, loopIndex) -> MediaEvalOpResult in
-        // splitter must have node-type
-        guard let nodeType = node.userVisibleType else {
-            fatalErrorIfDebug()
-            return MediaEvalOpResult(values: [.number(.zero)])
-        }
+    // a Splitter patch must have a node-type
+    assertInDebug(node.userVisibleType.isDefined)
+
+    if node.userVisibleType == .pulse || node.userVisibleType == .media {
         
-        let value: PortValue = values[0]
-        let pulsed = (value.getPulse ?? .zero).shouldPulse(graphStep.graphTime)
-        if nodeType == .pulse {
-            if pulsed {
-                return MediaEvalOpResult(values: [.pulse(graphStep.graphTime)])
+        // TODO: debug why this broke the Monthly Stays demo for non pulse
+        return node.loopedEval { (values, loopIndex) -> MediaEvalOpResult in
+            // splitter must have node-type
+            guard let nodeType = node.userVisibleType else {
+                fatalErrorIfDebug()
+                return MediaEvalOpResult(values: [.number(.zero)])
             }
             
+            let value: PortValue = values[0]
+            
+            let pulsed = (value.getPulse ?? .zero).shouldPulse(graphStep.graphTime)
+            if nodeType == .pulse {
+                if pulsed {
+                    return MediaEvalOpResult(values: [.pulse(graphStep.graphTime)])
+                }
+            }
+            
+            if nodeType == .media,
+               let media = node.getInputMedia(portIndex: 0,
+                                              loopIndex: loopIndex,
+                                              mediaId: nil) {
+                return MediaEvalOpResult(values: [value],
+                                         media: .init(computedMedia: media))
+            }
+            
+            return MediaEvalOpResult(values: [value])
         }
+        .createPureEvalResult(node: node)
         
-        if nodeType == .media,
-            let media = node.getInputMedia(portIndex: 0,
-                                           loopIndex: loopIndex,
-                                           mediaId: nil) {
-            return MediaEvalOpResult(values: [value],
-                                     media: .init(computedMedia: media))
-        }
-        
-        return MediaEvalOpResult(values: [value])
+    } else {
+        return .init(outputsValues: node.inputs)
     }
-    .createPureEvalResult(node: node)
 }

--- a/Stitch/Graph/Node/Patch/Type/Value/SplitterPatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Value/SplitterPatchNode.swift
@@ -51,7 +51,7 @@ func splitterEval(node: PatchNode,
 
     if node.userVisibleType == .pulse || node.userVisibleType == .media {
         
-        // TODO: debug why this broke the Monthly Stays demo for non pulse
+        // TODO: debug why this broke the Monthly Stays demo: https://github.com/StitchDesign/Stitch--Old/issues/7049
         return node.loopedEval { (values, loopIndex) -> MediaEvalOpResult in
             // splitter must have node-type
             guard let nodeType = node.userVisibleType else {


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7049
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7050

