### PR TITLE
Rename OutputNodeRowObserver's `didValuesUpdate` to something more specific: `kickOffPulseReversalSideEffects`

### DIFF
--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/InputNodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/InputNodeRowObserver.swift
@@ -63,8 +63,9 @@ final class InputNodeRowObserver: NodeRowObserver, InputNodeRowCalculatable {
         self.hasLoopedValues = values.hasLoop
     }
     
+    // OUTPUT ONLY
     @MainActor
-    func didValuesUpdate() { }
+    func kickOffPulseReversalSideEffects() { }
     
     func updateOutputValues(_ values: [StitchSchemaKit.CurrentPortValue.PortValue]) {
         fatalErrorIfDebug("Should never be called for InputNodeRowObserver")

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -64,8 +64,9 @@ protocol NodeRowObserver: AnyObject, Observable, Identifiable, Sendable, NodeRow
          id: NodeIOCoordinate,
          upstreamOutputCoordinate: NodeIOCoordinate?)
     
+    // OUTPUT ONLY
     @MainActor
-    func didValuesUpdate()
+    func kickOffPulseReversalSideEffects()
 }
 
 extension NodeRowObserver {

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
@@ -55,8 +55,13 @@ extension NodeRowObserver {
         }
         
         self.postProcessing(oldValues: oldValues, newValues: newValues)
+  
+        // TODO: better to only define `kickOffPulseReversalSideEffects` only on `OutputNodeRowObserver`, but what is the perf cost of type-casting at a high frequency?
+        //        if let output = self as? OutputNodeRowObserver {
+        //            output.didValuesUpdate()
+        //        }
         
-        self.didValuesUpdate()
+        self.kickOffPulseReversalSideEffects()
     }
     
     @MainActor

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/OutputNodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/OutputNodeRowObserver.swift
@@ -51,8 +51,9 @@ final class OutputNodeRowObserver: NodeRowObserver {
         self.hasLoopedValues = values.hasLoop
     }
     
+    // fka `didValuesUpdate`; but only actually used for pulse reversion
     @MainActor
-    func didValuesUpdate() {
+    func kickOffPulseReversalSideEffects() {
         let graphTime = self.nodeDelegate?.graphDelegate?.graphStepState.graphTime ?? .zero
         
         // Must also run pulse reversion effects


### PR DESCRIPTION
Communicates:
1. what's that function is actually doing
2. that the function is only not actually generic (it's only for pulsed outputs)