### PR TITLE
Media now properly flows across wireless nodes

### DIFF
--- a/Stitch/Graph/Node/Eval/NodeEvaluationHelpers.swift
+++ b/Stitch/Graph/Node/Eval/NodeEvaluationHelpers.swift
@@ -9,17 +9,6 @@ import Foundation
 import StitchSchemaKit
 import SwiftUI
 
-/* ----------------------------------------------------------------
- Evaluate: (Inputs, Outputs) -> Outputs
- - only for patches (layers do not have outputs)
- - usually one evaluate fn per (patch, nodeType) combo
- ---------------------------------------------------------------- */
-
-func identityEvaluation(inputs: PortValuesList,
-                        outputs: PortValuesList) -> PortValuesList {
-    inputs
-}
-
 // an evalution that only produces new outputs
 typealias OutputsOnlyPureEval = (PortValuesList, PortValuesList) -> PortValuesList
 
@@ -89,13 +78,4 @@ func outputsOnlyEval(_ eval: @escaping OutputsOnlyArithmeticPureEval,
 func singeOutputEvalResult(_ op: Operation,
                            _ inputs: PortValuesList) -> PortValuesList {
     resultsMaker(inputs)(op)
-}
-
-@MainActor
-func singeOutputEvalResult(_ op: Operation,
-                           input: PortValues,
-                           extensibleInputs: PortValuesList) -> PortValuesList {
-    [outputEvalHelper(input: input,
-                      extensibleInputs: extensibleInputs,
-                      operation: op)]
 }

--- a/Stitch/Graph/Node/Eval/PatchEvaluateExtensions.swift
+++ b/Stitch/Graph/Node/Eval/PatchEvaluateExtensions.swift
@@ -15,11 +15,8 @@ extension Patch {
         switch self {
         case
             // wireless nodes are just splitter nodes with covered up edges and invisible edges
-            .wirelessReceiver, .wirelessBroadcaster:
-            return .node(outputsOnlyEval(identityEvaluation))
-        case .splitter:
-            // .impure(.impure because of pulse nodeType)
-            return .graphStep(splitterEval)
+                .wirelessReceiver, .wirelessBroadcaster, .splitter:
+            return .node(mediaAwareIdentityEvaluation)
         case .imageImport:
             return .node(imageImportEval)
         case .add:
@@ -318,7 +315,7 @@ extension Patch {
         case .transformUnpack:
             return .node(outputsOnlyEval(transformUnpackEval))
         case .closePath:
-            return .node(outputsOnlyEval(identityEvaluation))
+            return .node(mediaAwareIdentityEvaluation)
         case .moveToPack:
             return .node(outputsOnlyEval(moveToPackEval))
         case .lineToPack:

--- a/Stitch/Graph/Node/Model/Definition/PatchNodeDefinitionKinds.swift
+++ b/Stitch/Graph/Node/Model/Definition/PatchNodeDefinitionKinds.swift
@@ -182,9 +182,9 @@ extension Patch {
         case .reverseProgress:
             return nil
         case .wirelessBroadcaster:
-            return nil
+            return WirelessBroadcasterPatchNode.self
         case .wirelessReceiver:
-            return nil
+            return WirelessReceiverPatchNode.self
         case .rgba:
             return nil
         case .arcTan2:

--- a/Stitch/Graph/Node/Patch/Type/Value/SplitterPatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Value/SplitterPatchNode.swift
@@ -10,10 +10,6 @@ import StitchSchemaKit
 import SwiftUI
 import SwiftyJSON
 
-//        let min = 188.0 // not enough
-//        let min = 192.0 // too much ?
-let SPLITTER_NODE_MINIMUM_WIDTH: CGFloat = 190
-
 // Starts out as a number?
 struct SplitterPatchNode: PatchNodeDefinition {
     static let patch = Patch.splitter
@@ -43,14 +39,12 @@ struct SplitterPatchNode: PatchNodeDefinition {
 }
 
 @MainActor
-func splitterEval(node: PatchNode,
-                  graphStep: GraphStepState) -> EvalResult {
+func mediaAwareIdentityEvaluation(node: PatchNode) -> EvalResult {
 
     // a Splitter patch must have a node-type
     assertInDebug(node.userVisibleType.isDefined)
 
-    if node.userVisibleType == .pulse || node.userVisibleType == .media {
-        
+    if node.userVisibleType == .media {
         // TODO: debug why this broke the Monthly Stays demo: https://github.com/StitchDesign/Stitch--Old/issues/7049
         return node.loopedEval { (values, loopIndex) -> MediaEvalOpResult in
             // splitter must have node-type
@@ -60,14 +54,6 @@ func splitterEval(node: PatchNode,
             }
             
             let value: PortValue = values[0]
-            
-            let pulsed = (value.getPulse ?? .zero).shouldPulse(graphStep.graphTime)
-            if nodeType == .pulse {
-                if pulsed {
-                    return MediaEvalOpResult(values: [.pulse(graphStep.graphTime)])
-                }
-            }
-            
             if nodeType == .media,
                let media = node.getInputMedia(portIndex: 0,
                                               loopIndex: loopIndex,

--- a/Stitch/Graph/Node/Patch/Type/WirelessBroadcasterNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/WirelessBroadcasterNode.swift
@@ -9,30 +9,33 @@ import Foundation
 import SwiftUI
 import StitchSchemaKit
 
-@MainActor
-func wirelessBroadcasterNode(id: NodeId,
-                             n: Double = 0,
-                             position: CGSize = .zero,
-                             zIndex: Double = 0.0) -> PatchNode {
+struct WirelessBroadcasterPatchNode: PatchNodeDefinition {
+    static let patch = Patch.wirelessBroadcaster
 
-    let inputs = toInputs(
-        id: id,
-        values: (nil, [.number(n)]))
+    static let defaultUserVisibleType: UserVisibleType? = .number
 
-    let outputs = toOutputs(
-        id: id,
-        offset: inputs.count,
-        values: (nil, [.number(n)]))
+    static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
+        .init(
+            inputs: [
+                .init(
+                    defaultValues: [.number(0)],
+                    label: ""
+                )
+            ],
+            outputs: [
+                .init(
+                    label: "",
+                    type: type ?? .number
+                )
+            ]
+        )
+    }
 
-    return PatchNode(
-        position: position,
-        zIndex: zIndex,
-        id: id,
-        patchName: .wirelessBroadcaster,
-        userVisibleType: .number,
-        inputs: inputs,
-        outputs: outputs)
+    static func createEphemeralObserver() -> NodeEphemeralObservable? {
+        MediaEvalOpObserver()
+    }
 }
+
 
 extension GraphState {
     /// Returns id set of changed nodes.

--- a/Stitch/Graph/Node/Patch/Type/WirelessReceiverNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/WirelessReceiverNode.swift
@@ -9,26 +9,29 @@ import Foundation
 import SwiftUI
 import StitchSchemaKit
 
-@MainActor
-func wirelessReceiverNode(id: NodeId,
-                          n: Double = 0,
-                          position: CGSize = .zero,
-                          zIndex: Double = 0.0) -> PatchNode {
+struct WirelessReceiverPatchNode: PatchNodeDefinition {
+    static let patch = Patch.wirelessReceiver
 
-    let inputs = toInputs(
-        id: id,
-        values: (nil, [.number(n)]))
+    static let defaultUserVisibleType: UserVisibleType? = .number
 
-    let outputs = toOutputs(
-        id: id,
-        offset: inputs.count,
-        values: (nil, [.number(n)]))
+    static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
+        .init(
+            inputs: [
+                .init(
+                    defaultValues: [.number(0)],
+                    label: ""
+                )
+            ],
+            outputs: [
+                .init(
+                    label: "",
+                    type: type ?? .number
+                )
+            ]
+        )
+    }
 
-    return PatchNode(
-        position: position,
-        zIndex: zIndex,
-        id: id,
-        patchName: .wirelessReceiver,
-        inputs: inputs,
-        outputs: outputs)
+    static func createEphemeralObserver() -> NodeEphemeralObservable? {
+        MediaEvalOpObserver()
+    }
 }

--- a/Stitch/Graph/Node/Patch/Util/PatchDefaultNodeExtensions.swift
+++ b/Stitch/Graph/Node/Patch/Util/PatchDefaultNodeExtensions.swift
@@ -127,10 +127,6 @@ extension Patch {
             node = progressNode(id: id, position: position, zIndex: zIndex)
         case .reverseProgress:
             node = reverseProgressNode(id: id, position: position, zIndex: zIndex)
-        case .wirelessReceiver:
-            node = wirelessReceiverNode(id: id, position: position, zIndex: zIndex)
-        case .wirelessBroadcaster:
-            node = wirelessBroadcasterNode(id: id, position: position, zIndex: zIndex)
         case .rgba:
             node = rgbaNode(id: id, position: position, zIndex: zIndex)
         case .lessThanOrEqual:


### PR DESCRIPTION
Use node ephemeral state and media-aware identity eval with wireless nodes.

Resolves https://github.com/StitchDesign/Stitch--Old/issues/7065

sample project: [Wireless pulse, media.stitch.zip](https://github.com/user-attachments/files/19540819/Wireless.pulse.media.stitch.zip)


<img width="1428" alt="Screenshot 2025-03-31 at 1 50 42 PM" src="https://github.com/user-attachments/assets/c6ea7c6f-94d6-49a2-841e-029b0340b7c8" />
