### PR TITLE
Attempted fix for disappearing Catalyst nav buttons

### DIFF
--- a/Stitch/App/View/Component/StitchButton.swift
+++ b/Stitch/App/View/Component/StitchButton.swift
@@ -118,7 +118,7 @@ struct UIKitTappableWrapper<T: View>: UIViewControllerRepresentable {
     }
 }
 
-class UIKitTappableWrapperDelegate: NSObject, UIGestureRecognizerDelegate {
+final class UIKitTappableWrapperDelegate: NSObject, UIGestureRecognizerDelegate {
     var tapCallback: () -> Void
 
     init(tapCallback: @escaping () -> Void) {

--- a/Stitch/App/View/ViewUtil/ViewUtils.swift
+++ b/Stitch/App/View/ViewUtil/ViewUtils.swift
@@ -22,18 +22,6 @@ func createBinding<T: Any & Sendable>(_ value: T,
     }
 }
 
-struct UIKitOnTapModifier: ViewModifier {
-    let onTapCallback: () -> Void
-
-    func body(content: Content) -> some View {
-        UIKitTappableWrapper() {
-            onTapCallback()
-        } view: {
-            content
-        }
-    }
-}
-
 extension View {
     /// Used to update some `State` property given a Redux state boolean value.
     func stitchAnimated(willAnimateBinding: Binding<Bool>,

--- a/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
+++ b/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
@@ -189,8 +189,10 @@ struct CatalystTopBarGraphButtons: View {
             }
             
             // TODO: should be a toast only shows up when no nodes are on-screen?
-            CatalystNavBarButton(.FIND_NODE_ON_GRAPH) {
-                graph.findSomeCanvasItemOnGraph(document: document)
+            CatalystNavBarButton(.FIND_NODE_ON_GRAPH) { [weak graph, weak document] in
+                if let document = document {
+                    graph?.findSomeCanvasItemOnGraph(document: document)
+                }
             }
 
             // TODO: implement
@@ -292,7 +294,7 @@ struct CatalystNavBarButton: View, Identifiable {
             // 'Empty menu' so that nothing happens when we tap the Menu's label
             EmptyView()
         } label: {
-            Button(action: {}) {
+            Button(action: action) {
                 // TODO: any .resizable(), .fixedSize() etc. needed?
                 image
             }
@@ -306,7 +308,7 @@ struct CatalystNavBarButton: View, Identifiable {
 
         // SwiftUI Menu's `primaryAction` enables label taps but also changes the button's appearance, losing the hover-highlight effect etc.;
         // so we use UIKitOnTapModifier for proper callback.
-        .modifier(UIKitOnTapModifier(onTapCallback: action))
+//        .modifier(UIKitOnTapModifier(onTapCallback: action))
 
         // TODO: find ideal button size?
         // Note: *must* provide explicit frame

--- a/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
+++ b/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
@@ -283,32 +283,20 @@ struct GoUpOneTraversalLevel: StitchDocumentEvent {
 struct CatalystNavBarButton: View, Identifiable {
 
     // let systemName: String  for `Image(systemName:)`
-    var image: Image
+    let image: Image
     let action: () -> Void
     var rotationZ: CGFloat = 0 // some icons stay the same but just get rotated
 
     var id: String
 
     var body: some View {
-        Menu {
-            // 'Empty menu' so that nothing happens when we tap the Menu's label
-            EmptyView()
-        } label: {
-            Button(action: action) {
-                // TODO: any .resizable(), .fixedSize() etc. needed?
-                image
-            }
+        Button(action: action) {
+            image
         }
+        .buttonStyle(.borderless)
         // rotation3DEffect must be applied here
         .rotation3DEffect(Angle(degrees: rotationZ),
                           axis: (x: 0, y: 0, z: rotationZ))
-
-        // Hides the little arrow on Catalyst
-        .menuIndicator(.hidden)
-
-        // SwiftUI Menu's `primaryAction` enables label taps but also changes the button's appearance, losing the hover-highlight effect etc.;
-        // so we use UIKitOnTapModifier for proper callback.
-//        .modifier(UIKitOnTapModifier(onTapCallback: action))
 
         // TODO: find ideal button size?
         // Note: *must* provide explicit frame

--- a/Stitch/Graph/Toolbar/View/TopBarButtonView.swift
+++ b/Stitch/Graph/Toolbar/View/TopBarButtonView.swift
@@ -161,7 +161,11 @@ struct iPadGraphTopBarMiscMenu: View {
 //                             iconName: .sfSymbol(.ADD_NODE_SF_SYMBOL_NAME),
 //                             label: "Insert Node")
             
-            iPadTopBarButton(action: { graph.findSomeCanvasItemOnGraph(document: document) },
+            iPadTopBarButton(action: { [weak graph, weak document] in
+                if let document = document {
+                    graph?.findSomeCanvasItemOnGraph(document: document)
+                }
+            },
                              iconName: .sfSymbol(.FIND_NODE_ON_GRAPH),
                              label: "Find Node")
             

--- a/Stitch/Home/View/ProjectsHomeViewWrapper.swift
+++ b/Stitch/Home/View/ProjectsHomeViewWrapper.swift
@@ -45,8 +45,8 @@ struct ProjectsHomeViewWrapper: View {
 #if targetEnvironment(macCatalyst)
                         
                         // Supports proper color and hover effect on Catalyst homescreen button
-                        CatalystNavBarButton(.NEW_PROJECT_SF_SYMBOL_NAME) {
-                            store.createNewProject(isProjectImport: false)
+                        CatalystNavBarButton(.NEW_PROJECT_SF_SYMBOL_NAME) { [weak store] in
+                            store?.createNewProject(isProjectImport: false)
                         }
                         // Resolves issue where hover was still active after entering newly created project and then exiting
                         .id(UUID())
@@ -56,8 +56,8 @@ struct ProjectsHomeViewWrapper: View {
                         }
                         .id(UUID())
 #else
-                        iPadNavBarButton(action: {
-                            store.createNewProject(isProjectImport: false)
+                        iPadNavBarButton(action: { [weak store] in
+                            store?.createNewProject(isProjectImport: false)
                         },
                                          iconName: NEW_PROJECT_ICON_NAME)
                         


### PR DESCRIPTION
Changes:
1. Catalyst nav bar buttons used a Menu component to fix an issue where nav bar buttons don't have hover effects. That menu button used EmptyViews for its dropdown as to not show a menu. This hackiness, combined with the EmptyView, could be an issue.
2. Removed retain cycles in action closures for nav bar buttons.