### PR TITLE
In Catalyst nav bar buttons, use `.simultaneousGesture` instead of `UIKitOnTapModifier`'s `UIHostingController`

### DIFF
--- a/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
+++ b/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
@@ -303,10 +303,13 @@ struct CatalystNavBarButton: View, Identifiable {
 
         // Hides the little arrow on Catalyst
         .menuIndicator(.hidden)
+        .simultaneousGesture(TapGesture().onEnded({ _ in
+            action()
+        }))
 
         // SwiftUI Menu's `primaryAction` enables label taps but also changes the button's appearance, losing the hover-highlight effect etc.;
         // so we use UIKitOnTapModifier for proper callback.
-        .modifier(UIKitOnTapModifier(onTapCallback: action))
+//        .modifier(UIKitOnTapModifier(onTapCallback: action))
 
         // TODO: find ideal button size?
         // Note: *must* provide explicit frame


### PR DESCRIPTION
An additional, conservative follow up to https://github.com/StitchDesign/Stitch/pull/967#issue-2944708064

As far as I know, we have not seen disappearing Catalyst nav bar buttons on the homescreen since the above PR, but this PR also reduces a potential variable.

If we see the Catalyst nav bar buttons disappear even after this, we may need to be more aggressive, e.g. remove Menu (at the cost of hover effects?) or introduce SceneDelegate ?