### PR TITLE
Fixed document retain cycles when closing projects

### DIFF
--- a/Stitch/App/ViewModel/StitchStore.swift
+++ b/Stitch/App/ViewModel/StitchStore.swift
@@ -42,6 +42,9 @@ final class StitchStore: Sendable {
     @MainActor var edgeStyle: EdgeStyle = .defaultEdgeStyle
     @MainActor var appTheme: StitchTheme = .defaultTheme
     
+    // MARK: must be stored here to prevent inspector retain cycle
+    @MainActor var showsLayerInspector = false
+    
     // Tracks ID of project which has a title that's currently getting modified
     @MainActor var projectIdForTitleEdit: ProjectId?
     

--- a/Stitch/Graph/PrototypePreview/Frame/View/FloatingWindowView.swift
+++ b/Stitch/Graph/PrototypePreview/Frame/View/FloatingWindowView.swift
@@ -28,6 +28,7 @@ extension CGSize {
 }
 
 struct FloatingWindowView: View {
+    @Bindable var store: StitchStore
     @Bindable var document: StitchDocumentViewModel
 
     // the screen size of the device that Stitch is running on (e.g. iPad screen or Catalyst window)
@@ -204,7 +205,7 @@ struct FloatingWindowView: View {
     
     var finalXOffset: CGFloat {
         
-        return document.showsLayerInspector ? Self.xOffset - LayerInspectorView.LAYER_INSPECTOR_WIDTH : Self.xOffset
+        return store.showsLayerInspector ? Self.xOffset - LayerInspectorView.LAYER_INSPECTOR_WIDTH : Self.xOffset
         
         //        if showPreviewWindow {
         //            // Original
@@ -224,7 +225,8 @@ struct FloatingWindowView_Previews: PreviewProvider {
     @Namespace static var namespace
 
     static var previews: some View {
-        FloatingWindowView(document: StitchDocumentViewModel.createEmpty(),
+        FloatingWindowView(store: .init(),
+                           document: StitchDocumentViewModel.createEmpty(),
                            deviceScreenSize: DEFAULT_LANDSCAPE_SIZE,
                            showPreviewWindow: true,
                            namespace: namespace)

--- a/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
+++ b/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
@@ -236,19 +236,23 @@ struct CatalystTopBarGraphButtons: View {
     }
 }
 
-struct LayerInspectorToggled: StitchDocumentEvent {
-    func handle(state: StitchDocumentViewModel) {
+struct LayerInspectorToggled: StitchStoreEvent {
+    func handle(store: StitchStore) -> ReframeResponse<NoState> {
         
         withAnimation {
-            state.showsLayerInspector.toggle()
+            store.showsLayerInspector.toggle()
         }
         
-        let graph = state.visibleGraph
+        guard let graph = store.currentDocument?.visibleGraph else {
+            return .noChange
+        }
         
         // reset selected inspector-row when inspector panel toggled
         graph.propertySidebar.selectedProperty = nil
         
         graph.closeFlyout()
+        
+        return .noChange
     }
 }
 

--- a/Stitch/Graph/Util/GraphUIActions.swift
+++ b/Stitch/Graph/Util/GraphUIActions.swift
@@ -131,22 +131,26 @@ struct TogglePreviewWindow: StitchDocumentEvent {
     }
 }
 
-struct ToggleSidebars: StitchDocumentEvent {
-    func handle(state: StitchDocumentViewModel) {
+struct ToggleSidebars: StitchStoreEvent {
+    func handle(store: StitchStore) -> ReframeResponse<NoState> {
+        guard let state = store.currentDocument else { return .noChange }
+        
         // Opens both if both are already closed;
         // else closes both.
-        let inspectorOpen = state.showsLayerInspector
+        let inspectorOpen = store.showsLayerInspector
         let layerSidebarOpen = state.leftSidebarOpen
         
         withAnimation {
             if !inspectorOpen && !layerSidebarOpen {
-                state.showsLayerInspector = true
+                store.showsLayerInspector = true
                 state.leftSidebarOpen = true
             } else {
-                state.showsLayerInspector = false
+                store.showsLayerInspector = false
                 state.leftSidebarOpen = false
             }
         }
+        
+        return .noChange
     }
 }
 

--- a/Stitch/Graph/View/ContentView.swift
+++ b/Stitch/Graph/View/ContentView.swift
@@ -105,7 +105,8 @@ struct ContentView: View, KeyboardReadable {
             if !GraphUIState.isPhoneDevice {
                 // Check if we're on iPhone, otherwise the project view will start to render on
                 // phone before showFullScreen is set
-                ProjectNavigationView(document: document,
+                ProjectNavigationView(store: store,
+                                      document: document,
                                       routerNamespace: routerNamespace)
                 .zIndex(showFullScreen.isTrue ? -99 : 0)
                 .overlay {

--- a/Stitch/Graph/View/GraphBaseView.swift
+++ b/Stitch/Graph/View/GraphBaseView.swift
@@ -19,6 +19,7 @@ struct GraphBaseView: View {
     
     @State private var spaceHeld = false
 
+    @Bindable var store: StitchStore
     @Bindable var document: StitchDocumentViewModel
     
     @MainActor
@@ -123,7 +124,7 @@ struct GraphBaseView: View {
             // IMPORTANT: applying .inspector outside of this ZStack causes displacement of graph contents when graph zoom != 1
             Circle().fill(Stitch.APP_BACKGROUND_COLOR.opacity(0.001))
                 .frame(width: 1, height: 1)
-                .inspector(isPresented: $document.showsLayerInspector) {
+                .inspector(isPresented: $store.showsLayerInspector) {
                     
                     LayerInspectorView(graph: graph,
                                        graphUI: document)

--- a/Stitch/Graph/View/ProjectNavigationView.swift
+++ b/Stitch/Graph/View/ProjectNavigationView.swift
@@ -10,6 +10,7 @@ import StitchSchemaKit
 
 /// UI for interacting with a single project; iPad-only.
 struct ProjectNavigationView: View {
+    @Bindable var store: StitchStore
     @Bindable var document: StitchDocumentViewModel
     let routerNamespace: Namespace.ID
     @Namespace private var topButtonsNamespace
@@ -21,7 +22,8 @@ struct ProjectNavigationView: View {
     var body: some View {
         @Bindable var visibleGraph = document.visibleGraph
         
-        GraphBaseView(document: document)
+        GraphBaseView(store: store,
+                      document: document)
         .alert(item: $visibleGraph.migrationWarning) { warningMessage in
             Alert(title: Text("Document Migration Warning"),
                   message: Text(warningMessage.rawValue),

--- a/Stitch/Graph/View/StitchProjectOverlayView.swift
+++ b/Stitch/Graph/View/StitchProjectOverlayView.swift
@@ -30,6 +30,7 @@ struct StitchProjectOverlayView: View {
                 // Floating preview kept outside NavigationSplitView for animation purposes
                 if !showFullScreen {
                     FloatingWindowView(
+                        store: store,
                         document: document,
                         deviceScreenSize: document.frame.size,
                         showPreviewWindow: showPreviewWindow,

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -88,8 +88,6 @@ final class StitchDocumentViewModel: Sendable {
     // back to graph instead of projects list
     @MainActor var isFullScreenMode: Bool = false
     
-    @MainActor var showsLayerInspector = false
-    
     @MainActor var leftSidebarOpen = false
 
     // Note: important to use `OrderedSet` rather than just list, so that we never have duplicate traversal-levels, see: https://github.com/StitchDesign/Stitch--Old/issues/7038


### PR DESCRIPTION
Closes https://github.com/StitchDesign/Stitch--Old/issues/6997
Closes https://github.com/StitchDesign/Stitch--Old/issues/6954

The issue was caused by the inspector subscribing to state existing in StitchDocumentViewModel. Clearly under the hood the inspector doesn't tear down completely when a project closes, even if that inspector is defined at a child view.

The fix was moving that boolean state to StitchStore.