### PR TITLE
Specific update methods for inputs vs outputs

### DIFF
--- a/Stitch/Graph/Edge/Util/PortActions.swift
+++ b/Stitch/Graph/Edge/Util/PortActions.swift
@@ -40,7 +40,7 @@ extension InputNodeRowObserver {
             }
 
             // Mutate video metadata to clear video state--this will update the view
-            self.updateValues([.asyncMedia(nil)])
+            self.updateValuesInInput([.asyncMedia(nil)])
         }
 
         // Remove audio from disconnected speaker nodes.
@@ -54,11 +54,11 @@ extension InputNodeRowObserver {
                     // Run effect to mute sound player
                     media?.mediaObject.updateVolume(to: .zero)
                 }
-            self.updateValues([.asyncMedia(nil)])
+            self.updateValuesInInput([.asyncMedia(nil)])
         } else {
             // Flatten values by default
             let flattenedValues = self.allLoopedValues.flattenValues()
-            self.updateValues(flattenedValues)
+            self.updateValuesInInput(flattenedValues)
         }
         
         // Removes connection--important to do this after media handling above

--- a/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
+++ b/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
@@ -130,7 +130,7 @@ final class StitchComponentViewModel: Sendable {
         let splitterOutputs = Self.getOutputSplitters(graph: graph)
         let outputsObservers = splitterOutputs.enumerated().map { index, splitterOutput in
             if let existingOutput = existingOutputsObservers[safe: index] {
-                existingOutput.updateValues(splitterOutput.values)
+                existingOutput.updateValuesInOutput(splitterOutput.values)
                 return existingOutput
             }
             
@@ -262,7 +262,7 @@ extension StitchComponentViewModel {
         
         // Update graph's inputs before calculating full graph
         zip(splitterInputs, self.inputsObservers).forEach { splitter, input in
-            splitter.updateValues(input.allLoopedValues)
+            splitter.updateValuesInInput(input.allLoopedValues)
         }
         
         self.graph.calculate(from: self.graph.allNodesToCalculate)
@@ -278,7 +278,7 @@ extension StitchComponentViewModel {
         
         // Update outputs here after graph calculation
         zip(splitterOutputs, self.outputsObservers).forEach { splitter, output in
-            output.updateValues(splitter.allLoopedValues)
+            output.updateValuesInOutput(splitter.allLoopedValues)
         }
         
         return .init(outputsValues: self.outputsObservers.map(\.allLoopedValues))

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
@@ -402,6 +402,6 @@ func createPatchNode(from importedMediaURL: URL,
     }
 
     // Import nodes always use first input
-    node.getInputRowObserver(0)?.updateValues([.asyncMedia(asyncMedia)])
+    node.getInputRowObserver(0)?.updateValuesInInput([.asyncMedia(asyncMedia)])
     return .success(node)
 }

--- a/Stitch/Graph/Node/Port/Util/PortValue/CoercerUtils.swift
+++ b/Stitch/Graph/Node/Port/Util/PortValue/CoercerUtils.swift
@@ -191,8 +191,7 @@ extension PortValues {
     }
 }
 
-// TODO: this should be defined on inputs but not outputs
-extension NodeRowObserver {
+extension InputNodeRowObserver {
     /*
      Coerce the passed in PortValues to the type represented by `thisType: PortValue`.
 
@@ -216,15 +215,14 @@ extension NodeRowObserver {
         let newValues = values.coerce(to: thisType,
                                       currentGraphTime: currentGraphTime)
 
-        // Update new values to input observer
-        self.updateValues(newValues,
-                          oldValues: oldValues)
+        self.updateValuesInInput(newValues)
     }
 }
 
 extension InputNodeRowObserver {
     
-    // used during graph eval
+    // Used by StitchEngine when checking whether
+    // a downstream input value has changed.
     @MainActor
     func coerce(theseValues: [PortValue],
                 toThisType: PortValue,

--- a/Stitch/Graph/Node/Port/Util/PulseActions.swift
+++ b/Stitch/Graph/Node/Port/Util/PulseActions.swift
@@ -19,7 +19,7 @@ extension GraphState {
             self.selectSingleCanvasItem(canvasItemId)
         }
         
-        inputObserver.updateValues([.pulse(self.graphStepState.graphTime)])
+        inputObserver.updateValuesInInput([.pulse(self.graphStepState.graphTime)])
         
         self.scheduleForNextGraphStep(inputObserver.id.nodeId)
     }

--- a/Stitch/Graph/Node/Port/Util/TypeChange/NodeTypeChangedHelpers.swift
+++ b/Stitch/Graph/Node/Port/Util/TypeChange/NodeTypeChangedHelpers.swift
@@ -22,7 +22,7 @@ extension NodeKind {
     }
 }
 
-extension NodeRowObserver {
+extension InputNodeRowObserver {
 
     // used only for type coercion
     @MainActor

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
@@ -204,7 +204,7 @@ extension LayerInputObserver {
     @MainActor
     func updatePortValues(_ values: PortValues) {
         // Updating the packed observer will always update unpacked observers if the mode is set as unpacked
-        self._packedData.rowObserver.updateValues(values)
+        self._packedData.rowObserver.updateValuesInInput(values)
     }
     
     /// All-up values for this port
@@ -348,7 +348,7 @@ extension LayerInputObserver {
             self._packedData.resetOnPackModeToggle()
             
             // Update values of new unpacked row observers
-            self._unpackedData.updateValues(from: values,
+            self._unpackedData.updateUnpackedObserverValues(from: values,
                                             layerNode: layerNode)
             
         case .packed:

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputUnpackedPortObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputUnpackedPortObserver.swift
@@ -97,10 +97,11 @@ extension LayerInputUnpackedPortObserver {
         self.allPorts.map { $0.createSchema() }
     }
     
+    // fka `updateValues` but changed becuse XCode was incorrectly picking it up as a use of a `NodeRowObserver.updateValues`
     /// From packed values, unpacks them for unpack layer input scenario.
     @MainActor
-    func updateValues(from packedValues: PortValues,
-                      layerNode: LayerNodeViewModel) {
+    func updateUnpackedObserverValues(from packedValues: PortValues,
+                                      layerNode: LayerNodeViewModel) {
         let unpackedValues = packedValues.map { self.layerPort.unpackValues(from: $0) }
         
         guard let unpackedPortCount = unpackedValues.first??.count else {
@@ -131,7 +132,7 @@ extension LayerInputUnpackedPortObserver {
             let rowObserver = layerNode[keyPath: layerId.layerNodeKeyPath].rowObserver
             
             // Update row observer values per usual
-            rowObserver.updateValues(values)
+            rowObserver.updateValuesInInput(values)
         }
     }
 }

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -190,6 +190,7 @@ extension NodeRowObserver {
     func initializeDelegate(_ node: NodeDelegate) {
         self.nodeDelegate = node
         
+        // TODO: why do we handle post-processing when we've assigned the nodeDelegate? ... is it just because post-processing requires a nodeDelegate?
         switch Self.nodeIOType {
         case .input:
             self.inputPostProcessing(oldValues: [], newValues: self.values)

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverPostProcessing.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverPostProcessing.swift
@@ -173,6 +173,8 @@ extension NodeRowObserver {
         }
         
         self.updatePulsedOutputsForThisGraphStep()
+        
+        // TODO: should we also update `graph.portsToUpdate` ?
     }
     
     // fka `didValuesUpdate`; but only actually used for pulse reversion

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverPostProcessing.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverPostProcessing.swift
@@ -167,6 +167,11 @@ extension GraphState {
 extension NodeRowObserver {
     @MainActor
     func outputPostProcessing() {
+        guard let node = self.nodeDelegate,
+              let graph = node.graphDelegate else {
+            return
+        }
+        
         guard Self.nodeIOType == .output else {
             fatalErrorIfDebug()
             return
@@ -174,7 +179,8 @@ extension NodeRowObserver {
         
         self.updatePulsedOutputsForThisGraphStep()
         
-        // TODO: should we also update `graph.portsToUpdate` ?
+        // TODO: do we need to do this or not?
+        // graph.portsToUpdate.insert(.allOutputs(node.id))
     }
     
     // fka `didValuesUpdate`; but only actually used for pulse reversion

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverSchemaObserverIdentifiable.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverSchemaObserverIdentifiable.swift
@@ -23,7 +23,7 @@ extension InputNodeRowObserver: SchemaObserverIdentifiable {
 
         // Update values if no upstream connection
         if let values = schema.portData.values {
-            self.updateValues(values)
+            self.updateValuesInInput(values)
         }
     }
 
@@ -42,7 +42,7 @@ extension InputNodeRowObserver: SchemaObserverIdentifiable {
             
         case .values(let values):
             let values = values.isEmpty ? [inputType.getDefaultValue(for: layer)] : values
-            self.updateValues(values)
+            self.updateValuesInInput(values)
         }
     }
 

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/OutputNodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/OutputNodeRowObserver.swift
@@ -48,12 +48,32 @@ final class OutputNodeRowObserver: NodeRowObserver {
         self.hasLoopedValues = values.hasLoop
     }
 
+    // Implements StitchEngine protocol
     func updateOutputValues(_ values: [PortValue]) {
-        self.updateValues(values)
+        self.updateValuesInOutput(values)
+    }
+}
+
+@MainActor
+func updateRowObservers(rowObservers: [OutputNodeRowObserver],
+                        newIOValues: PortValuesList) {
+    
+    newIOValues.enumerated().forEach { portId, newValues in
+        guard let observer = rowObservers[safe: portId] else {
+            log("Could not retrieve output observer for portId \(portId)")
+            return
+        }
+        observer.updateOutputValues(newValues)
     }
 }
 
 extension OutputNodeRowObserver {
+    @MainActor
+    func updateValuesInOutput(_ newValues: PortValues) {
+        self.setValuesInRowObserver(newValues)
+        self.outputPostProcessing()
+    }
+    
     @MainActor
     var hasEdge: Bool {
         self.containsDownstreamConnection

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModel.swift
@@ -265,12 +265,12 @@ extension NodeViewModel {
         let outputsObservers = self.getAllOutputsObservers()
         
         if let newValuesList = newValuesList {
-            self.updateRowObservers(rowObservers: outputsObservers,
-                                    newIOValues: newValuesList)
+            updateRowObservers(rowObservers: outputsObservers,
+                               newIOValues: newValuesList)
         }
 
         zip(outputsObservers, newValuesList ?? self.outputs).forEach { rowObserver, values in
-            rowObserver.updateValues(values)
+            rowObserver.updateValuesInOutput(values)
         }
     }
 
@@ -381,24 +381,6 @@ extension NodeViewModel {
                 let outputData = layerNode.outputPorts[safe: portId]
                 return outputData?.inspectorRowViewModel
             }
-        }
-    }
-
-    @MainActor
-    private func updateRowObservers<RowObserver>(rowObservers: [RowObserver],
-                                                 newIOValues: PortValuesList) where RowObserver: NodeRowObserver {
-        
-        newIOValues.enumerated().forEach { portId, newValues in
-            guard let observer = rowObservers[safe: portId] else {
-#if DEV_DEBUG
-                log("NodeViewModel.initializeThrottlers error: no observer found, this shouldn't happen.")
-                log("NodeViewModel.initializeThrottlers: error: node.id: \(self.id)")
-                log("NodeViewModel.initializeThrottlers: error: portId: \(portId)")
-#endif
-                return
-            }
-            
-            observer.updateValues(newValues)
         }
     }
     
@@ -620,7 +602,7 @@ extension NodeViewModel {
             return
         }
 
-        self.getAllOutputsObservers()[safe: portId]?.updateValues(values)
+        self.getAllOutputsObservers()[safe: portId]?.updateValuesInOutput(values)
     }
     
     // don't worry about making the input a loop or not --

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -887,7 +887,7 @@ extension GraphState {
             }
             
             // If we can't find the old value at this loop index, assume the output changed
-            var outputsChanged: Bool = outputValuesToUpdate[safe: loopIndex].map { $0 != newOutputValue } ?? true
+            let outputsChanged: Bool = outputValuesToUpdate[safe: loopIndex].map { $0 != newOutputValue } ?? true
             
             // Insert new output value at correct loop index
             outputValuesToUpdate[loopIndex] = newOutputValue

--- a/StitchTests/evalTests.swift
+++ b/StitchTests/evalTests.swift
@@ -37,7 +37,7 @@ class EvalTests: XCTestCase {
         }
         
         zip(inputs, node.inputsObservers).forEach { values, inputObserver in
-            inputObserver.updateValues(values)
+            inputObserver.updateValuesInInput(values)
         }
         
         let result = LoopSelectNode.evaluate(node: node)


### PR DESCRIPTION
In the last 3-4 weeks we've solved several bugs that arose from lack of clarity around `didInputsUpdate` vs `setValuesInInput` vs `updateValues` etc.
- e.g. we made `setValuesInInput` update the values in the input already, thus breaking our post-processing logic (e.g. de-assigning a layer from an interaction patch node)
- e.g. we failed to have `updateValues` update the "refresh these UI fields" ports, thus breaking unpacked layers inputs

No one new coming to the codebase is going to understand `didInputsUpdate` vs `setValuesInInput` vs `updateValues` etc.

This PR takes a step toward simplifying our logic: we are always either updating an input or an output, and the differences between the two are clear:
- updating an input: coercing values, potentially updating interaction cache and camera settings etc.
- updating an output: never coerce values, only need to worry about pulsed outputs
- update either input or output: a small core of common logic

The change was easy because in every context where we were using the generic `updateValues`, we actually already knew that we were in an `InputNodeRowObserver` or an `OutputNodeRowObserver`.



