### PR TITLE
Hide rarely-used types in node type change menu

### DIFF
--- a/Stitch/Graph/Node/Patch/Util/PatchNodeTypeExtensions.swift
+++ b/Stitch/Graph/Node/Patch/Util/PatchNodeTypeExtensions.swift
@@ -20,7 +20,8 @@ extension UserVisibleType {
 
     var isSelectableAsNodeType: Bool {
         switch self {
-        case .none, .int, .shapeCommandType, .scrollMode, .scrollJumpStyle, .scrollDecelerationRate, .textVerticalAlignment, .textAlignment, .textTransform, .shapeCoordinates:
+        case .none, .int, .shapeCommandType, .scrollMode, .scrollJumpStyle, .scrollDecelerationRate, .textVerticalAlignment, .textAlignment, .textTransform, .shapeCoordinates,
+                .lightType, .mapType, .materialThickness, .mobileHapticStyle, .anchorEntity, .progressIndicatorStyle, .contentMode, .dateAndTimeFormat, .delayStyle, .plane, .deviceAppearance, .deviceOrientation, .vnImageCropOption, .strokeLineCap, .strokeLineJoin, .blendMode:
             return false
         default:
             return true


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7063

Ideally we would use a submenu for 'rarer types,' but Picker does not support submenus (Menu does but does not support checkboxes).

<img width="668" alt="Screenshot 2025-04-01 at 7 25 17 PM" src="https://github.com/user-attachments/assets/0f929af0-0a1f-4f08-8045-74a8f25eb355" />
