### PR TITLE
Fix group node duplication test; better name for createProject fn that was actually doing a side-effect

### DIFF
--- a/Stitch/App/Serialization/DocumentLoading/DocumentEncodable.swift
+++ b/Stitch/App/Serialization/DocumentLoading/DocumentEncodable.swift
@@ -25,10 +25,8 @@ protocol DocumentEncodableDelegate: Observable, AnyObject, Sendable {
     @MainActor var lastEncodedDocument: CodableDocument { get set }
     
     @MainActor func createSchema(from graph: GraphState?) -> CodableDocument
-    
-//    func updateAsync(from schema: CodableDocument) async
-    
-    @MainActor func update(from schema: CodableDocument, rootUrl: URL)
+        
+    @MainActor func update(from schema: CodableDocument, rootUrl: URL?)
     
     @MainActor func willEncodeProject(schema: CodableDocument)
     

--- a/Stitch/App/Serialization/FileDropHandling.swift
+++ b/Stitch/App/Serialization/FileDropHandling.swift
@@ -61,7 +61,7 @@ func handleOnDrop(providers: [NSItemProvider],
                         switch await store?.documentLoader.loadDocument(from: tempURL,
                                                                         isImport: true) {
                         case .loaded(let data, _):
-                            await store?.createNewProject(from: data, isProjectImport: true)
+                            await store?.createNewProjectSideEffect(from: data, isProjectImport: true)
                        default:
                             DispatchQueue.main.async {
                                 dispatch(DisplayError(error: .unsupportedProject))

--- a/Stitch/App/Serialization/Util/File/StitchCustomURL.swift
+++ b/Stitch/App/Serialization/Util/File/StitchCustomURL.swift
@@ -89,7 +89,7 @@ func onCampsiteURLOpen(_ url: URL, store: StitchStore) async throws {
         }
             
         log("onCampsiteURLOpen: will open project from document")
-        await store.createNewProject(from: document, isProjectImport: true)
+        await store.createNewProjectSideEffect(from: document, isProjectImport: true)
     }
     
     return

--- a/Stitch/App/Shortcut/ProjectsHomeCommands.swift
+++ b/Stitch/App/Shortcut/ProjectsHomeCommands.swift
@@ -305,7 +305,7 @@ struct ProjectsHomeCommands: Commands {
                 if activeProject {
                     INSERT_NODE_ACTION()
                 } else {
-                    store.createNewProject(isProjectImport: false)
+                    store.createNewProjectSideEffect(isProjectImport: false)
                 }
             }
 

--- a/Stitch/App/System/StitchSystemViewModel.swift
+++ b/Stitch/App/System/StitchSystemViewModel.swift
@@ -56,7 +56,7 @@ final class StitchSystemViewModel: Sendable, Identifiable {
 
 extension StitchSystemViewModel: DocumentEncodableDelegate {
     func update(from schema: StitchSystem,
-                rootUrl: URL) {
+                rootUrl: URL?) {
         // TODO: come back here
         fatalError()
     }

--- a/Stitch/App/View/StitchRootModifier.swift
+++ b/Stitch/App/View/StitchRootModifier.swift
@@ -42,7 +42,7 @@ struct StitchRootModifier: ViewModifier {
                                           isImport: true) else {
                             return
                         }
-                        store?.createNewProject(from: importedDoc, isProjectImport: true)
+                        store?.createNewProjectSideEffect(from: importedDoc, isProjectImport: true)
                     }
                 }
             } // .onOpenURL
@@ -50,7 +50,7 @@ struct StitchRootModifier: ViewModifier {
                 // Only open document if one is imported
                 if docs.count == 1,
                    let firstDoc = docs.first {
-                    store.createNewProject(from: firstDoc, isProjectImport: true)
+                    store.createNewProjectSideEffect(from: firstDoc, isProjectImport: true)
                 }
 
                 return true

--- a/Stitch/App/ViewModel/StitchStore.swift
+++ b/Stitch/App/ViewModel/StitchStore.swift
@@ -95,7 +95,7 @@ final class ClipboardEncoderDelegate: DocumentEncodableDelegate {
     
     func willEncodeProject(schema: StitchClipboardContent) {}
     
-    func update(from schema: StitchClipboardContent, rootUrl: URL) { }
+    func update(from schema: StitchClipboardContent, rootUrl: URL?) { }
     
     func updateAsync(from schema: StitchClipboardContent) async { }
     

--- a/Stitch/Graph/Node/Component/StitchMasterComponent.swift
+++ b/Stitch/Graph/Node/Component/StitchMasterComponent.swift
@@ -101,7 +101,7 @@ extension StitchMasterComponent: DocumentEncodableDelegate, Identifiable {
         }
     }
     
-    func update(from schema: StitchComponent, rootUrl: URL) {
+    func update(from schema: StitchComponent, rootUrl: URL?) {
         self.lastEncodedDocument = schema
         
         guard let document = self.parentGraph?.documentDelegate else {

--- a/Stitch/Graph/Node/Patch/Type/Value/SplitterPatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Value/SplitterPatchNode.swift
@@ -40,10 +40,7 @@ struct SplitterPatchNode: PatchNodeDefinition {
 
 @MainActor
 func mediaAwareIdentityEvaluation(node: PatchNode) -> EvalResult {
-
-    // a Splitter patch must have a node-type
-    assertInDebug(node.userVisibleType.isDefined)
-
+    
     if node.userVisibleType == .media {
         // TODO: debug why this broke the Monthly Stays demo: https://github.com/StitchDesign/Stitch--Old/issues/7049
         return node.loopedEval { (values, loopIndex) -> MediaEvalOpResult in

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -327,7 +327,7 @@ extension GraphState {
     @MainActor
     func selectCanvasItem(_ canvasItemId: CanvasItemId) {
         // Prevent render cycles if already selected
-        guard !self.isCanvasItemSelected(canvasItemId)  else { return }
+        guard !self.isCanvasItemSelected(canvasItemId) else { return }
         self.selection.selectedCanvasItems.insert(canvasItemId)
         
         // Unfocus sidebar

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -208,7 +208,7 @@ final class StitchDocumentViewModel: Sendable {
 
 extension StitchDocumentViewModel: DocumentEncodableDelegate {
     @MainActor
-    func update(from schema: StitchDocument, rootUrl: URL) {
+    func update(from schema: StitchDocument, rootUrl: URL?) {
         // Sync preview window attributes
         self.previewWindowSize = schema.previewWindowSize
         self.previewSizeDevice = schema.previewSizeDevice
@@ -527,12 +527,29 @@ extension StitchDocumentViewModel {
         self.restartPrototypeWindowIconRotationZ += 360
     }
     
+    // TODO: this still doesn't quite have the correct projectLoader/encoderDelegate needed for all uses in the app
+    @MainActor
+    static func createTestFriendlyDocument() async -> StitchDocumentViewModel {
+        let store = StitchStore()
+        await store.createNewProject(isProjectImport: false,
+                                     isPhoneDevice: false)
+        guard let projectLoader = store.navPath.first,
+              let documentViewModel = projectLoader.documentViewModel else {
+            fatalError()
+        }
+        return documentViewModel
+    }
+    
     @MainActor static func createEmpty() -> StitchDocumentViewModel {
-        .init(from: .init(),
-              graph: .init(),
-              isPhoneDevice: false,
-              projectLoader: .init(url: URL(fileURLWithPath: "")),
-              store: nil,
-              isDebugMode: false)
+        let store = StitchStore()
+        let doc = StitchDocument()
+        let loader = ProjectLoader(url: URL(fileURLWithPath: ""))
+        
+        return .init(from: doc,
+                     graph: .init(),
+                     isPhoneDevice: false,
+                     projectLoader: loader,
+                     store: store,
+                     isDebugMode: false)
     }
 }

--- a/Stitch/Home/Util/ProjectCreatedActions.swift
+++ b/Stitch/Home/Util/ProjectCreatedActions.swift
@@ -10,9 +10,10 @@ import StitchSchemaKit
 
 // Creating a brand new project: empty state, no imported files
 extension StitchStore {
+    // fka `createNewProject`; but we need to indicate in some way, if not by type signature, that this is a side-effect
     @MainActor
-    func createNewProject(from document: StitchDocument = .init(),
-                          isProjectImport: Bool) {
+    func createNewProjectSideEffect(from document: StitchDocument = .init(),
+                                    isProjectImport: Bool) {
         let isPhoneDevice = GraphUIState.isPhoneDevice
         
         Task(priority: .high) { [weak self] in

--- a/Stitch/Home/View/ProjectsHomeViewWrapper.swift
+++ b/Stitch/Home/View/ProjectsHomeViewWrapper.swift
@@ -46,7 +46,7 @@ struct ProjectsHomeViewWrapper: View {
                         
                         // Supports proper color and hover effect on Catalyst homescreen button
                         CatalystNavBarButton(.NEW_PROJECT_SF_SYMBOL_NAME) { [weak store] in
-                            store?.createNewProject(isProjectImport: false)
+                            store?.createNewProjectSideEffect(isProjectImport: false)
                         }
                         // Resolves issue where hover was still active after entering newly created project and then exiting
                         .id(UUID())
@@ -57,7 +57,7 @@ struct ProjectsHomeViewWrapper: View {
                         .id(UUID())
 #else
                         iPadNavBarButton(action: { [weak store] in
-                            store?.createNewProject(isProjectImport: false)
+                            store?.createNewProjectSideEffect(isProjectImport: false)
                         },
                                          iconName: NEW_PROJECT_ICON_NAME)
                         


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/6581

This was very hard to debug: in the test we were silently failing (returning nil) on some code that worked on actual device.

The test-created stitch document view model did not, and still does not, have the proper encoder delegate. 

For now, in test contexts, we allow the encoder delegate's rootURL to be nil. 

