### PR TITLE
Update layer dropdown choices after sidebar name edit; do not revert to layer's full name when sidebar item string is empty

### DIFF
--- a/Stitch/Graph/Node/Util/NodeKindUtils.swift
+++ b/Stitch/Graph/Node/Util/NodeKindUtils.swift
@@ -212,7 +212,7 @@ extension NodeKind {
     }
     
     func getDisplayTitle(customName: String?) -> String {
-        // always prefer a custom name
+        // Always prefer a custom name
         if let customName = customName,
            customName != "" {
             return customName

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListLabelView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListLabelView.swift
@@ -129,10 +129,8 @@ struct SidebarListLabelEditView<ItemViewModel>: View where ItemViewModel: Sideba
     }
     
     var body: some View {
-        
         Group {
             if isFocused {
-                // logInView("SidebarListLabelEditView: editable field")
                 StitchTextEditingBindingField(currentEdit: self.$edit,
                                               fieldType: .sidebarLayerTitle(self.item.id.description),
                                               font: SIDEBAR_LIST_ITEM_FONT,
@@ -143,15 +141,22 @@ struct SidebarListLabelEditView<ItemViewModel>: View where ItemViewModel: Sideba
                                            graph: graph)
                 })
             } else {
-                // logInView("SidebarListLabelEditView: read only")
                 StitchTextView(string: edit + debugId,
                                font: SIDEBAR_LIST_ITEM_FONT,
                                fontColor: fontColor)
                 .padding(.top, 1)
             }
         }
-        .onChange(of: self.self.item.name, initial: true) {
-            self.edit = self.item.name
+         // Not just initialization but also e.g. whenever canvas item updates the layer node's title
+        .onChange(of: self.item.name, initial: true) { oldValue, newValue in
+            
+            // HACK: for edge case where item.name defaults to full layer name *during an active edit* (empty custom-title defaults to full layer name).
+            // TODO: debug why this doesn't happen with edit-fields on canvas item's title
+            if oldValue.count == 1, newValue == self.item.layerFullName {
+                self.edit = ""
+            } else {
+                self.edit = self.item.name
+            }
         }
         .onTapGesture(count: 2) {
             dispatch(ReduxFieldFocused(focusedField: .sidebarLayerTitle(self.item.id.description)))

--- a/Stitch/Graph/Sidebar/ViewModel/SidebarItemGestureViewModel.swift
+++ b/Stitch/Graph/Sidebar/ViewModel/SidebarItemGestureViewModel.swift
@@ -100,12 +100,11 @@ extension SidebarItemGestureViewModel {
     }
     
     @MainActor var name: String {
-        guard let node = self.graphDelegate?.getNodeViewModel(self.id) else {
-//            fatalErrorIfDebug()
-            return ""
-        }
-        
-        return node.getDisplayTitle()
+        self.graphDelegate?.getNodeViewModel(self.id)?.getDisplayTitle() ?? ""
+    }
+    
+    @MainActor var layerFullName: String {
+        self.graphDelegate?.getNode(self.id)?.kind.getDisplayTitle(customName: "") ?? ""
     }
     
     @MainActor var isVisible: Bool {
@@ -125,12 +124,15 @@ extension SidebarItemGestureViewModel {
             fatalErrorIfDebug()
             return
         }
-        
+            
         // Treat this is as a "layer inspector edit" ?
         node.nodeTitleEdited(titleEditType: .layerInspector(self.id),
                              edit: newString,
                              isCommitting: isCommitting,
                              graph: graph)
+        
+        // Recreate the layer drop down choices
+        graph.updateLayerDropdownChoiceCache()
     }
     
     @MainActor

--- a/Stitch/Graph/Sidebar/ViewModel/SidebarItemSwipable.swift
+++ b/Stitch/Graph/Sidebar/ViewModel/SidebarItemSwipable.swift
@@ -20,6 +20,8 @@ protocol SidebarItemSwipable: StitchNestedListElementObservable, Sendable, Ident
     
     @MainActor var name: String { get }
     
+    @MainActor var layerFullName: String { get }
+    
     @MainActor var swipeSetting: SidebarSwipeSetting { get set }
     
     @MainActor var previousSwipeX: CGFloat { get set }

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -454,7 +454,11 @@ extension GraphState {
     @MainActor
     func syncNodes(nodesDict: NodesViewModelDict) {
         self.visibleNodesViewModel.nodes = nodesDict
-        
+        self.updateLayerDropdownChoiceCache()
+    }
+    
+    @MainActor
+    func updateLayerDropdownChoiceCache() {
         // Cache layer node info for perf
         let newLayerCache = nodesDict.values.reduce(into: [NodeId : LayerDropdownChoice]()) { result, node in
             if node.kind.isLayer {


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7076
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7078