### PR TITLE
Media looping fixes

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -80,6 +80,7 @@
 		B53265F0298FAAC200FB10B0 /* AsyncSingletonMediaEval.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53265EF298FAAC200FB10B0 /* AsyncSingletonMediaEval.swift */; };
 		B5368D112A886ADA00FE3489 /* LayerActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5368D102A886ADA00FE3489 /* LayerActions.swift */; };
 		B5368D132A886C1900FE3489 /* InteractionLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5368D122A886C1900FE3489 /* InteractionLayer.swift */; };
+		B5379EF42D9E31A300EC772B /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = B5379EF32D9E31A300EC772B /* StitchEngine */; };
 		B5380E312CF8E51600E6D801 /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = B5380E302CF8E51600E6D801 /* StitchEngine */; };
 		B53857B02B50682400428962 /* NodeDefinitionKinds.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53857AF2B50682400428962 /* NodeDefinitionKinds.swift */; };
 		B5386FB02C9A929B00AD8065 /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = B5386FAF2C9A929B00AD8065 /* StitchEngine */; };
@@ -1962,6 +1963,7 @@
 				E4A848AD2D32FCFA0029AFDE /* Storage in Frameworks */,
 				B5BAB0412CD6C28D00693EC5 /* StitchEngine in Frameworks */,
 				EC53F3C3287E27250021095B /* Numerics in Frameworks */,
+				B5379EF42D9E31A300EC772B /* StitchEngine in Frameworks */,
 				EC15E42A2602A08B006F2E08 /* CloudKit.framework in Frameworks */,
 				201953DA25B25D3300D5296C /* Tagged in Frameworks */,
 				EC211A4B2698A8B70068A0F0 /* SwiftyJSON in Frameworks */,
@@ -4699,6 +4701,7 @@
 				B5B8105B2D77E1C90095DA9D /* StitchEngine */,
 				B53AA63F2D9B1683008D5C23 /* StitchEngine */,
 				B5E030682D9C5BEF00FDC5A5 /* StitchEngine */,
+				B5379EF32D9E31A300EC772B /* StitchEngine */,
 			);
 			productName = prototype;
 			productReference = 200BD857254F66EB00692903 /* Stitch.app */;
@@ -4786,7 +4789,7 @@
 				E463E7ED2C6FC7090008E318 /* XCRemoteSwiftPackageReference "StitchSchemaKit" */,
 				E4A848A92D32FCFA0029AFDE /* XCRemoteSwiftPackageReference "supabase-swift" */,
 				E42AAE4A2D4844EE002D187D /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
-				B5E030672D9C5BEF00FDC5A5 /* XCLocalSwiftPackageReference "../StitchEngineClosedSource" */,
+				B5379EF22D9E31A300EC772B /* XCRemoteSwiftPackageReference "StitchEngine" */,
 			);
 			productRefGroup = 200BD858254F66EB00692903 /* Products */;
 			projectDirPath = "";
@@ -6602,13 +6605,6 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCLocalSwiftPackageReference section */
-		B5E030672D9C5BEF00FDC5A5 /* XCLocalSwiftPackageReference "../StitchEngineClosedSource" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../StitchEngineClosedSource;
-		};
-/* End XCLocalSwiftPackageReference section */
-
 /* Begin XCRemoteSwiftPackageReference section */
 		201953D825B25D3300D5296C /* XCRemoteSwiftPackageReference "swift-tagged" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -6632,6 +6628,14 @@
 			requirement = {
 				kind = revision;
 				revision = f771d9ae644935d1e1acfb861be00f403de083b5;
+			};
+		};
+		B5379EF22D9E31A300EC772B /* XCRemoteSwiftPackageReference "StitchEngine" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/StitchDesign/StitchEngine";
+			requirement = {
+				kind = revision;
+				revision = 960b58d152a01543d7924f8f095ae9b6fe526fd5;
 			};
 		};
 		B5FBE3C22C4195B3006DA0A7 /* XCRemoteSwiftPackageReference "DirectoryWatcher" */ = {
@@ -6758,6 +6762,11 @@
 		};
 		B51D8A012CD13D420016CCDA /* StitchEngine */ = {
 			isa = XCSwiftPackageProductDependency;
+			productName = StitchEngine;
+		};
+		B5379EF32D9E31A300EC772B /* StitchEngine */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B5379EF22D9E31A300EC772B /* XCRemoteSwiftPackageReference "StitchEngine" */;
 			productName = StitchEngine;
 		};
 		B5380E302CF8E51600E6D801 /* StitchEngine */ = {

--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -87,7 +87,6 @@
 		B539C2EA2B92BF3D00C6CEC3 /* DocumentEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B539C2E92B92BF3D00C6CEC3 /* DocumentEncodable.swift */; };
 		B53A92292A7D80CC00192E86 /* GraphMovementViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53A92282A7D80CC00192E86 /* GraphMovementViewModifier.swift */; };
 		B53AA6402D9B1683008D5C23 /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = B53AA63F2D9B1683008D5C23 /* StitchEngine */; };
-		B53AA6432D9B1B52008D5C23 /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = B53AA6422D9B1B52008D5C23 /* StitchEngine */; };
 		B53B1D96289E265900489652 /* StitchVideoPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53B1D95289E265900489652 /* StitchVideoPlayer.swift */; };
 		B53E0BEC2D35B5E00072FD43 /* BoxLayerNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53E0BEB2D35B5DD0072FD43 /* BoxLayerNode.swift */; };
 		B53E0BEF2D36E1220072FD43 /* LayerInspectorSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53E0BEE2D36E1120072FD43 /* LayerInspectorSection.swift */; };
@@ -253,6 +252,7 @@
 		B5D7EC79298DDEF300549E80 /* StitchEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D7EC78298DDEF300549E80 /* StitchEnvironment.swift */; };
 		B5DB632E2C61A8C900B78B68 /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = B5DB632D2C61A8C900B78B68 /* StitchEngine */; };
 		B5DDF6FE293AD24C00D72220 /* GraphStepManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DDF6FD293AD24C00D72220 /* GraphStepManager.swift */; };
+		B5E030692D9C5BEF00FDC5A5 /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = B5E030682D9C5BEF00FDC5A5 /* StitchEngine */; };
 		B5E0DDF828DA88090080BE71 /* StitchFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E0DDF728DA88090080BE71 /* StitchFileManager.swift */; };
 		B5E0DDFA28DBF4B90080BE71 /* StitchFileManagerProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E0DDF928DBF4B90080BE71 /* StitchFileManagerProject.swift */; };
 		B5E0DDFC28DBF6770080BE71 /* DocumentEncodableUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E0DDFB28DBF6770080BE71 /* DocumentEncodableUtil.swift */; };
@@ -1949,7 +1949,7 @@
 				E42AAE4C2D4844EE002D187D /* Sentry in Frameworks */,
 				B50BC9E42D77881900311551 /* StitchEngine in Frameworks */,
 				EC91034A29109DF3007C548E /* SoulverCore in Frameworks */,
-				B53AA6432D9B1B52008D5C23 /* StitchEngine in Frameworks */,
+				B5E030692D9C5BEF00FDC5A5 /* StitchEngine in Frameworks */,
 				B5380E312CF8E51600E6D801 /* StitchEngine in Frameworks */,
 				B5B8105C2D77E1C90095DA9D /* StitchEngine in Frameworks */,
 				B560CE812CF1C93100F31905 /* StitchEngine in Frameworks */,
@@ -4698,7 +4698,7 @@
 				B50BC9E32D77881900311551 /* StitchEngine */,
 				B5B8105B2D77E1C90095DA9D /* StitchEngine */,
 				B53AA63F2D9B1683008D5C23 /* StitchEngine */,
-				B53AA6422D9B1B52008D5C23 /* StitchEngine */,
+				B5E030682D9C5BEF00FDC5A5 /* StitchEngine */,
 			);
 			productName = prototype;
 			productReference = 200BD857254F66EB00692903 /* Stitch.app */;
@@ -4786,7 +4786,7 @@
 				E463E7ED2C6FC7090008E318 /* XCRemoteSwiftPackageReference "StitchSchemaKit" */,
 				E4A848A92D32FCFA0029AFDE /* XCRemoteSwiftPackageReference "supabase-swift" */,
 				E42AAE4A2D4844EE002D187D /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
-				B53AA6412D9B1B52008D5C23 /* XCRemoteSwiftPackageReference "StitchEngine" */,
+				B5E030672D9C5BEF00FDC5A5 /* XCLocalSwiftPackageReference "../StitchEngineClosedSource" */,
 			);
 			productRefGroup = 200BD858254F66EB00692903 /* Products */;
 			projectDirPath = "";
@@ -6602,6 +6602,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		B5E030672D9C5BEF00FDC5A5 /* XCLocalSwiftPackageReference "../StitchEngineClosedSource" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../StitchEngineClosedSource;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		201953D825B25D3300D5296C /* XCRemoteSwiftPackageReference "swift-tagged" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -6625,14 +6632,6 @@
 			requirement = {
 				kind = revision;
 				revision = f771d9ae644935d1e1acfb861be00f403de083b5;
-			};
-		};
-		B53AA6412D9B1B52008D5C23 /* XCRemoteSwiftPackageReference "StitchEngine" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/StitchDesign/StitchEngine";
-			requirement = {
-				kind = revision;
-				revision = cafae6d51beada94ec88eab6afa6efde589f0597;
 			};
 		};
 		B5FBE3C22C4195B3006DA0A7 /* XCRemoteSwiftPackageReference "DirectoryWatcher" */ = {
@@ -6773,11 +6772,6 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = StitchEngine;
 		};
-		B53AA6422D9B1B52008D5C23 /* StitchEngine */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = B53AA6412D9B1B52008D5C23 /* XCRemoteSwiftPackageReference "StitchEngine" */;
-			productName = StitchEngine;
-		};
 		B560CE802CF1C93100F31905 /* StitchEngine */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = StitchEngine;
@@ -6807,6 +6801,10 @@
 			productName = StitchEngine;
 		};
 		B5DB632D2C61A8C900B78B68 /* StitchEngine */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = StitchEngine;
+		};
+		B5E030682D9C5BEF00FDC5A5 /* StitchEngine */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = StitchEngine;
 		};

--- a/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "906ea53775f320cbbf1349503a463e5e89cc8a926639156d5273d631e3d7c8ee",
+  "originHash" : "2f217b3ebd4ed4fdf06f7fad2cbf55899cf913fe0a1916b4eb705be2ef0cd05d",
   "pins" : [
     {
       "identity" : "audiokit",
@@ -52,6 +52,14 @@
       "state" : {
         "revision" : "ef309cda2d2f426476181ae294f3b899eac83af4",
         "version" : "2.6.3"
+      }
+    },
+    {
+      "identity" : "stitchengine",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/StitchDesign/StitchEngine",
+      "state" : {
+        "revision" : "960b58d152a01543d7924f8f095ae9b6fe526fd5"
       }
     },
     {

--- a/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2f217b3ebd4ed4fdf06f7fad2cbf55899cf913fe0a1916b4eb705be2ef0cd05d",
+  "originHash" : "906ea53775f320cbbf1349503a463e5e89cc8a926639156d5273d631e3d7c8ee",
   "pins" : [
     {
       "identity" : "audiokit",
@@ -52,14 +52,6 @@
       "state" : {
         "revision" : "ef309cda2d2f426476181ae294f3b899eac83af4",
         "version" : "2.6.3"
-      }
-    },
-    {
-      "identity" : "stitchengine",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StitchDesign/StitchEngine",
-      "state" : {
-        "revision" : "cafae6d51beada94ec88eab6afa6efde589f0597"
       }
     },
     {

--- a/Stitch/Graph/Edge/Util/PortActions.swift
+++ b/Stitch/Graph/Edge/Util/PortActions.swift
@@ -48,7 +48,7 @@ extension InputNodeRowObserver {
                 // Only look at this input if it is the media input
                 self.id.isMediaSelectorLocation,
                 let node = self.upstreamOutputObserver?.nodeDelegate {
-            node.getMediaObservers()?
+            node.getAllMediaObservers()?
                 .map(\.computedMedia)
                 .forEach { media in
                     // Run effect to mute sound player

--- a/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/Nodes/Model3DLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/Nodes/Model3DLayerNode.swift
@@ -88,10 +88,10 @@ struct Model3DLayerNode: LayerNodeDefinition {
             parentSize: parentSize,
             parentDisablesPosition: parentDisablesPosition,
             parentIsScrollableGrid: parentIsScrollableGrid)
-        .onChange(of: viewModel.mediaViewModel.inputMedia, initial: true) { oldValue, newValue in
+        .onChange(of: viewModel.mediaObject, initial: true) { oldValue, newValue in
             // Update transform for 3D model once loaded
             if oldValue != newValue,
-               let model3DEntity = newValue?.mediaObject.model3DEntity {
+               let model3DEntity = newValue?.model3DEntity {
                 Self.updateTransform(entity: model3DEntity,
                                      layerViewModel: viewModel)
             }

--- a/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
+++ b/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
@@ -27,12 +27,7 @@ final class LayerNodeViewModel {
     // View models for layers in prototype window
     @MainActor var previewLayerViewModels: [LayerViewModel] = []
  
-    // Processes media
-    
-    // TODO: this won't work, we need to process a potential loop. Should always be at top level because
-    // 1. manual user edits happen here, and
-    // 2. computed media gets processed by hoseflow
-    
+    // Gets updated when upstream nodes pass down media
     @MainActor var mediaList = [GraphMediaValue?]()
     
     // Some layer nodes contain outputs

--- a/Stitch/Graph/Node/Patch/Type/Loop/LoopBuilder.swift
+++ b/Stitch/Graph/Node/Patch/Type/Loop/LoopBuilder.swift
@@ -77,7 +77,7 @@ func loopBuilderEval(node: PatchNode,
         return valueForIndex
     }
     
-    return node.loopedEval(MediaEvalOpObserver.self,
+    let result = node.loopedEval(MediaEvalOpObserver.self,
                            inputsValuesList: [flattenedInputs]) { (values, mediaObserver, index) -> MediaEvalOpResult in
         assertInDebug(values.first != nil)
         
@@ -90,10 +90,11 @@ func loopBuilderEval(node: PatchNode,
         switch node.userVisibleType {
         case .media:
             guard let inputMediaValue = values.first?.asyncMedia,
-                  // MARK: loop and port index are flipped
-                  let mediaObject = node.getInputMediaValue(portIndex: index,
-                                                            loopIndex: 0,
-                                                            mediaId: inputMediaValue.id) else {
+//                  // MARK: loop and port index are flipped
+//                  let mediaObject = node.getInputMediaValue(portIndex: 0,
+//                                                            loopIndex: index,
+//                                                            mediaId: inputMediaValue.id) else {
+                    let mediaObject = mediaObserver.inputMedia else {
                 return .init(from: [indexPortValue,
                                     .asyncMedia(nil)])
             }
@@ -110,6 +111,8 @@ func loopBuilderEval(node: PatchNode,
         }
     }
                            .createPureEvalResult(node: node)
+    
+    return result
 }
 
 

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModelNodeCalculatable.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModelNodeCalculatable.swift
@@ -32,7 +32,7 @@ extension NodeViewModel: NodeCalculatable {
     }
     
     @MainActor
-    func getMediaObservers() -> [MediaViewModel]? {
+    func getAllMediaObservers() -> [MediaViewModel]? {
         if let layerNode = self.layerNode {
             return layerNode.previewLayerViewModels.map { $0.mediaViewModel }
         }
@@ -42,6 +42,31 @@ extension NodeViewModel: NodeCalculatable {
         }
         
         return nil
+    }
+    
+    @MainActor
+    func getMediaObservers(port: NodeIOCoordinate) -> [MediaViewModel]? {
+        guard let allMediaObservers = self.getAllMediaObservers() else {
+            return nil
+        }
+            
+        switch self.kind {
+        case .patch(let patch) where patch == .loopBuilder:
+            // Edge case for loop builder which has ephemeral objects for each port, rather than a loop for one port
+            guard let portIndex = port.portId else {
+                fatalErrorIfDebug()
+                return nil
+            }
+            
+            guard let mediaByPort = allMediaObservers[safe: portIndex] else {
+                return nil
+            }
+            
+            return [mediaByPort]
+            
+        default:
+            return allMediaObservers
+        }
     }
     
     @MainActor
@@ -66,6 +91,36 @@ extension NodeViewModel: NodeCalculatable {
         case .component(let componentData):
             return componentData.canvas.inputViewModels.compactMap {
                 $0.rowDelegate?.allLoopedValues
+            }
+        }
+    }
+    
+    /// Updates media ephemeral objects after eval completes.
+    @MainActor func updateMediaAfterEval(mediaList: [GraphMediaValue?]) {
+        guard let mediaObservers = self.getAllMediaObservers() else {
+            return
+        }
+
+        switch self.kind {
+        case .patch(let patch) where patch == .loopBuilder:
+            // Edge case: one observable for each port index, so we lengthen media list to match ports
+            let lengthenedMediaList = mediaList.lengthenArray(mediaObservers.count)
+            Self.zipMediaIntoObservers(mediaList: lengthenedMediaList,
+                                       mediaObservers: mediaObservers)
+            
+        default:
+            // Default case: loop of observables for one port index
+            Self.zipMediaIntoObservers(mediaList: mediaList,
+                                       mediaObservers: mediaObservers)
+        }
+    }
+    
+    @MainActor
+    private static func zipMediaIntoObservers(mediaList: [GraphMediaValue?],
+                                              mediaObservers: [MediaViewModel]) {
+        for (media, ephemeralObserver) in zip(mediaList, mediaObservers) {
+            if ephemeralObserver.computedMedia != media {
+                ephemeralObserver.computedMedia = media
             }
         }
     }

--- a/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
@@ -496,6 +496,7 @@ struct NonGroupPreviewLayersView: View {
                 // Check for nil case
                 guard let mediaValue = self.mediaValue else {
                     LayerViewModel.resetMedia(self.layerViewModel.mediaObject)
+                    self.layerNode.mediaList = []
                     self.layerViewModel.mediaViewModel.inputMedia = nil
                     return
                 }

--- a/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
@@ -482,7 +482,7 @@ struct NonGroupPreviewLayersView: View {
                              parentIsScrollableGrid: parentIsScrollableGrid,
                              realityContent: realityContent)
             .onChange(of: mediaValue, initial: true) {
-                guard let mediaPort = self.mediaPort else {
+                guard self.mediaPort != nil else {
                     assertInDebug(self.mediaValue == nil)
                     return
                 }

--- a/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
@@ -510,9 +510,15 @@ extension LayerViewModel {
         }
         
         await MainActor.run { [weak self] in
-            self?.mediaViewModel.inputMedia = .init(id: .init(),
-                                                    dataType: .source(mediaKey),
-                                                    mediaObject: newMediaObject)
+            let mediaValue = GraphMediaValue(id: .init(),
+                                             dataType: .source(mediaKey),
+                                             mediaObject: newMediaObject)
+            
+            // Update parent layer node to override past upstream data
+            self?.nodeDelegate?.layerNode?.mediaList = [mediaValue]
+            
+            // Update media here at this preview layer
+            self?.mediaViewModel.inputMedia = mediaValue
         }
     }
     

--- a/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
@@ -9,6 +9,7 @@ import Foundation
 import SwiftUI
 import RealityKit
 import StitchSchemaKit
+import StitchEngine
 
 extension PinToId {
     static let defaultPinToId = Self.root
@@ -486,13 +487,15 @@ extension LayerViewModel {
         guard let mediaValue = mediaValue,
               let mediaKey = mediaValue.mediaKey else {
             // Covers media scenarios, ensuring we set to nil while task makes copy
-            await MainActor.run {
-                Self.resetMedia(self.mediaObject)
+            await MainActor.run { [weak self] in
+                guard let viewModel = self else { return }
+                
+                Self.resetMedia(viewModel.mediaObject)
                 
                 // Only set media to nil if mediaValue is nil as well
                 // Fixes issue where camrea feed would stutter
                 if mediaValue == nil {
-                    self.mediaViewModel.inputMedia = nil
+                    viewModel.mediaViewModel.inputMedia = nil
                 }
             }
             return
@@ -506,10 +509,10 @@ extension LayerViewModel {
             return
         }
         
-        await MainActor.run {
-            self.mediaViewModel.inputMedia = .init(id: .init(),
-                                                   dataType: .source(mediaKey),
-                                                   mediaObject: newMediaObject)
+        await MainActor.run { [weak self] in
+            self?.mediaViewModel.inputMedia = .init(id: .init(),
+                                                    dataType: .source(mediaKey),
+                                                    mediaObject: newMediaObject)
         }
     }
     


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/6992.
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7068
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7067
Resolves https://github.com/StitchDesign/Stitch--Old/issues/6992

This PR fixes issues caused by recent media handling changes, which used to correctly obtain media by traversing upstream nodes. That implementation changed in favor of a system that holds media locally at each node, which jeopardized media looping for layer nodes.

The new media handling approach has StitchEngine handling media at hoseflow. To fix the layer media looping, logic has moved from StitchEngine to its client for handling some media events. This was needed to enable `LayerNodeViewModel` to hold upstream media, and then later pass down this info to `LayerViewModel` once all upstream nodes have been accounted for in eval.