### PR TITLE
Non-generic FieldViewModel

### DIFF
--- a/Stitch/Graph/LayerInspector/ColorFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/ColorFlyoutView.swift
@@ -37,8 +37,7 @@ struct ColorFlyoutView: View {
     }
     
     var body: some View {
-        if let fieldObserver = layerInputObserver.fieldValueTypes.first?.fieldObservers.first,
-           let rowId = fieldObserver.rowDelegate?.id {
+        if let fieldObserver = layerInputObserver.fieldValueTypes.first?.fieldObservers.first {
             
             StitchCustomColorPickerView(
                 rowObserver: rowObserver,

--- a/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
@@ -51,7 +51,7 @@ struct GenericFlyoutView: View {
     var hasIncomingEdge: Bool = false
     let layerInput: LayerInputPort
     
-    var fieldValueTypes: [FieldGroupTypeData<InputNodeRowViewModel.FieldType>] {
+    var fieldValueTypes: [FieldGroupTypeData] {
         layerInputObserver.fieldValueTypes
     }
         

--- a/Stitch/Graph/LayerInspector/LayerInspector3DTransformInputView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspector3DTransformInputView.swift
@@ -39,7 +39,7 @@ struct LayerInspector3DTransformInputView: View {
     }
     
     // Note: 3D Transform inputs can never be "blocked"; revisit this if that changes; would just pass down
-    func observerViews(_ fieldObservers: [InputNodeRowViewModel.FieldType]) -> some View {
+    func observerViews(_ fieldObservers: [FieldViewModel]) -> some View {
         
         ForEach(fieldObservers) { fieldObserver  in
             

--- a/Stitch/Graph/LayerInspector/LayerInspectorGridInputView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorGridInputView.swift
@@ -14,7 +14,7 @@ struct LayerInspectorGridInputView: View {
     let layerInputObserver: LayerInputObserver
     let isPropertyRowSelected: Bool
     
-    var allFieldObservers: [InputNodeRowViewModel.FieldType] {
+    var allFieldObservers: [FieldViewModel] {
         layerInputObserver.fieldValueTypes.flatMap(\.fieldObservers)
     }
     
@@ -58,7 +58,7 @@ struct LayerInspectorGridInputView: View {
     }
     
     // Note: a layer's padding and margin inputs/fields can never be blocked; we can revisit this if that changes in the future
-    func observerView(_ fieldObserver: InputNodeRowViewModel.FieldType) -> some View {
+    func observerView(_ fieldObserver: FieldViewModel) -> some View {
         LayerInspectorReadOnlyView(propertySidebar: graph.propertySidebar,
                                    nodeId: node.id,
                                    layerInputObserver: layerInputObserver,
@@ -73,7 +73,7 @@ struct LayerInspectorReadOnlyView: View {
     @Bindable var propertySidebar: PropertySidebarObserver
     let nodeId: NodeId
     let layerInputObserver: LayerInputObserver
-    let fieldObserver: InputNodeRowViewModel.FieldType
+    let fieldObserver: FieldViewModel
     let isPropertyRowSelected: Bool
     
     // TODO: is `InputFieldValueView` ever used in the layer inspector now? ... vs flyout?

--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -127,7 +127,7 @@ struct InspectorLayerInputView: View {
         return layerInput.showsLabelForInspector
     }
     
-    var fieldValueTypes: [FieldGroupTypeData<InputNodeRowViewModel.FieldType>] {
+    var fieldValueTypes: [FieldGroupTypeData] {
         self.layerInputObserver.fieldValueTypes
     }
     
@@ -176,7 +176,7 @@ struct LayerInputFieldsView: View {
     @Bindable var node: NodeViewModel
     @Bindable var rowObserver: InputNodeRowObserver
     @Bindable var rowViewModel: InputNodeRowViewModel
-    let fieldValueTypes: [FieldGroupTypeData<InputNodeRowViewModel.FieldType>]
+    let fieldValueTypes: [FieldGroupTypeData]
     let layerInputObserver: LayerInputObserver
     let isNodeSelected: Bool
         
@@ -258,7 +258,7 @@ struct LayerInputFieldsView: View {
     }
     
     var body: some View {
-        ForEach(fieldValueTypes) { (fieldGroupViewModel: FieldGroupTypeData<InputFieldViewModel>) in
+        ForEach(fieldValueTypes) { (fieldGroupViewModel: FieldGroupTypeData) in
             
             let multipleFieldsPerGroup = fieldGroupViewModel.fieldObservers.count > 1
             
@@ -291,12 +291,12 @@ struct LayerInputFieldsView: View {
                                    isMultifield: _isMultifield)
                     }
                 }
-            }
-        }
+            } // if ...
+        } // ForEach(fieldValueTypes) { ...
     }
     
     @ViewBuilder
-    func fieldsView(fieldGroupViewModel: FieldGroupTypeData<InputFieldViewModel>,
+    func fieldsView(fieldGroupViewModel: FieldGroupTypeData,
                     isMultifield: Bool) -> some View {
         ForEach(fieldGroupViewModel.fieldObservers) { fieldViewModel in
             let isBlocked = self.blockedFields.map { fieldViewModel.isBlocked($0) } ?? false
@@ -307,7 +307,7 @@ struct LayerInputFieldsView: View {
         }
     }
     
-    func isAllFieldsBlockedOut(fieldGroupViewModel: FieldGroupTypeData<InputFieldViewModel>) -> Bool {
+    func isAllFieldsBlockedOut(fieldGroupViewModel: FieldGroupTypeData) -> Bool {
         if let blockedFields = blockedFields {
             return fieldGroupViewModel.fieldObservers.allSatisfy {
                 $0.isBlocked(blockedFields)
@@ -405,11 +405,11 @@ struct LayerInspectorOutputPortView: View {
 struct LayerOutputFieldsView<ValueEntry>: View where ValueEntry: View {
     typealias ValueEntryViewBuilder = (OutputFieldViewModel, Bool) -> ValueEntry
     
-    let fieldValueTypes: [FieldGroupTypeData<OutputNodeRowViewModel.FieldType>]
+    let fieldValueTypes: [FieldGroupTypeData]
     @ViewBuilder var valueEntryView: ValueEntryViewBuilder
 
     var body: some View {
-        ForEach(fieldValueTypes) { (fieldGroupViewModel: FieldGroupTypeData<OutputFieldViewModel>) in
+        ForEach(fieldValueTypes) { (fieldGroupViewModel: FieldGroupTypeData) in
             let isMultifield = fieldGroupViewModel.fieldObservers.count > 1
             
             if let fieldGroupLabel = fieldGroupViewModel.groupLabel {

--- a/Stitch/Graph/Node/Port/Util/Field/TabKeyPressActions.swift
+++ b/Stitch/Graph/Node/Port/Util/Field/TabKeyPressActions.swift
@@ -327,7 +327,7 @@ func getTabEligibleFields(layerNode: LayerNodeViewModel,
              && !layerInput.usesFlyout
         }
     
-    // Turn each non-blocked field on a layeri input into a LayerInputEligibleField
+    // Turn each non-blocked field on a layer input into a LayerInputEligibleField
         .reduce(into: LayerInputEligibleFields(), { partialResult, layerInput in
             (layerNode.getLayerInspectorInputFields(layerInput)).forEach { field in
                 let blockedFields = layerNode.getLayerInputObserver(layerInput).blockedFields

--- a/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
@@ -430,9 +430,8 @@ struct InputFieldValueView: View {
                 
                 
             case .media(let media):
-                MediaFieldValueView(
+                MediaInputFieldValueView(
                     viewModel: viewModel,
-                    rowViewModel: rowViewModel,
                     rowObserver: rowObserver,
                     node: node,
                     isUpstreamValue: isUpstreamValue,

--- a/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/NodeFieldsView.swift
@@ -15,7 +15,7 @@ extension FieldViewModel {
     // TODO: instrument perf here?
     @MainActor
     func isBlocked(_ blockedFields: Set<LayerInputKeyPathType>) -> Bool {
-        blockedFields.blocks(.unpacked(self.fieldLabelIndex.asUnpackedPortType))
+        blockedFields.blocks(.unpacked(self.fieldLabelIndex(self.id.rowId.portType).asUnpackedPortType))
     }
 }
 

--- a/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
@@ -142,22 +142,16 @@ struct OutputValueView: View {
                 EmptyView() // Can't really happen
                 
             case .media(let media):
-                MediaFieldValueView(viewModel: viewModel,
-                                    rowViewModel: rowViewModel,
-                                    rowObserver: rowObserver,
-                                    node: node,
-                                    isUpstreamValue: false,     // only valid for inputs
-                                    media: media,
-                                    mediaName: media.name,
-                                    nodeKind: nodeKind,
-                                    isInput: false,
-                                    fieldIndex: fieldIndex,
-                                    isNodeSelected: isCanvasItemSelected,
-                                    isFieldInsideLayerInspector: false,
-                                    isSelectedInspectorRow: isSelectedInspectorRow,
-                                    isMultiselectInspectorInputWithHeterogenousValues: false,
-                                    graph: graph,
-                                    document: graphUI)
+            MediaFieldLabelView(viewModel: viewModel,
+                                inputType: viewModel.id.rowId.portType,
+                                node: node,
+                                graph: graph,
+                                document: graphUI,
+                                coordinate: rowObserver.id,
+                                isInput: false,
+                                fieldIndex: fieldIndex,
+                                isNodeSelected: isCanvasItemSelected,
+                                isMultiselectInspectorInputWithHeterogenousValues: false)
                 
             case .color(let color):
                 StitchColorPickerOrb(chosenColor: color,

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
@@ -141,7 +141,7 @@ extension LayerInputObserver {
     
     // Returns all fields, regardless of packed vs unpacked
     @MainActor
-    var fieldValueTypes: [FieldGroupTypeData<InputNodeRowViewModel.FieldType>] {
+    var fieldValueTypes: [FieldGroupTypeData] {
         let allFields = self.allInputData.flatMap { (portData: InputLayerNodeRowData) in
             portData.inspectorRowViewModel.fieldValueTypes
         }

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
@@ -18,7 +18,7 @@ final class InputNodeRowViewModel: NodeRowViewModel {
     let id: NodeRowViewModelId
     @MainActor var viewCache: NodeLayoutCache?
     @MainActor var activeValue: PortValue = .number(.zero)
-    @MainActor var fieldValueTypes = FieldGroupTypeDataList<InputFieldViewModel>()
+    @MainActor var fieldValueTypes = FieldGroupTypeDataList()
     @MainActor var connectedCanvasItems: Set<CanvasItemId> = .init()
     @MainActor var anchorPoint: CGPoint?
     @MainActor var portColor: PortColor = .noEdge

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
@@ -11,7 +11,6 @@ import StitchSchemaKit
 
 
 protocol NodeRowViewModel: StitchLayoutCachable, Observable, Identifiable {
-    associatedtype FieldType: FieldViewModel where FieldType.NodeRowType == Self
     associatedtype RowObserver: NodeRowObserver
     associatedtype PortViewType: PortViewData
     
@@ -22,7 +21,7 @@ protocol NodeRowViewModel: StitchLayoutCachable, Observable, Identifiable {
     @MainActor var activeValue: PortValue { get set }
     
     // Holds view models for fields
-    @MainActor var fieldValueTypes: [FieldGroupTypeData<FieldType>] { get set }
+    @MainActor var fieldValueTypes: [FieldGroupTypeData] { get set }
     
     @MainActor var connectedCanvasItems: Set<CanvasItemId> { get set }
     

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputNodeRowViewModel.swift
@@ -16,7 +16,7 @@ final class OutputNodeRowViewModel: NodeRowViewModel {
     let id: NodeRowViewModelId
     @MainActor var viewCache: NodeLayoutCache?
     @MainActor var activeValue: PortValue = .number(.zero)
-    @MainActor var fieldValueTypes = FieldGroupTypeDataList<OutputFieldViewModel>()
+    @MainActor var fieldValueTypes = FieldGroupTypeDataList()
     @MainActor var connectedCanvasItems: Set<CanvasItemId> = .init()
     @MainActor var anchorPoint: CGPoint?
     @MainActor var portColor: PortColor = .noEdge


### PR DESCRIPTION
Our field view model was generic because of the row view model delegate, which turned out to be redundant: we only needed the port type (for `FieldViewModel.fieldLabelIndex`) which was already available on the field coordinate's rowId.

A safe change, just following the compiler. 

QA'd by opening demo projects and interacting with them. 