### PR TITLE
ZStack `hug` now properly hugs children

### DIFF
--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Anchoring/Anchoring.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Anchoring/Anchoring.swift
@@ -155,10 +155,24 @@ func adjustPosition(size: CGSize, // child's size
         - (size.height * (anchor.y - 0.5))
     
     var pos = CGPoint(x: x, y: y)
+    
+//    log("adjustPosition: size: \(size)")
+//    log("adjustPosition: position: \(position)")
+//    log("adjustPosition: anchor: \(anchor)")
+//    log("adjustPosition: parentSize: \(parentSize)")
+//    log("adjustPosition: isPinnedRendering: \(isPinnedRendering)")
+//    log("adjustPosition: x: \(x)")
+//    log("adjustPosition: y: \(y)")
+//    
+//    log("adjustPosition: pos was: \(pos)")
+    
     if !isPinnedRendering {
         pos.x -= parentSize.width/2
         pos.y -= parentSize.height/2
     }
+    
+//    log("adjustPosition: pos now: \(pos)")
+        
     return pos
     
 }

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Anchoring/Anchoring.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Anchoring/Anchoring.swift
@@ -133,7 +133,7 @@ func adjustPosition(size: CGSize, // child's size
                     position: CGPoint, // child's position; UNSCALED
                     anchor: Anchoring, // child's anchor
                     parentSize: CGSize,
-                    isPinnedRendering: Bool = false) -> CGPoint {
+                    ignoreOffsetTransform: Bool = false) -> CGPoint {
 
     let x = position.x
         + (parentSize.width * anchor.x)
@@ -156,23 +156,11 @@ func adjustPosition(size: CGSize, // child's size
     
     var pos = CGPoint(x: x, y: y)
     
-//    log("adjustPosition: size: \(size)")
-//    log("adjustPosition: position: \(position)")
-//    log("adjustPosition: anchor: \(anchor)")
-//    log("adjustPosition: parentSize: \(parentSize)")
-//    log("adjustPosition: isPinnedRendering: \(isPinnedRendering)")
-//    log("adjustPosition: x: \(x)")
-//    log("adjustPosition: y: \(y)")
-//    
-//    log("adjustPosition: pos was: \(pos)")
-    
-    if !isPinnedRendering {
+    if !ignoreOffsetTransform {
         pos.x -= parentSize.width/2
         pos.y -= parentSize.height/2
     }
-    
-//    log("adjustPosition: pos now: \(pos)")
-        
+            
     return pos
     
 }

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Anchoring/Anchoring.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Anchoring/Anchoring.swift
@@ -132,7 +132,8 @@ extension Anchoring { // : PortValueEnum {
 func adjustPosition(size: CGSize, // child's size
                     position: CGPoint, // child's position; UNSCALED
                     anchor: Anchoring, // child's anchor
-                    parentSize: CGSize) -> CGPoint {
+                    parentSize: CGSize,
+                    isPinnedRendering: Bool = false) -> CGPoint {
 
     let x = position.x
         + (parentSize.width * anchor.x)
@@ -153,7 +154,12 @@ func adjustPosition(size: CGSize, // child's size
         + (parentSize.height * anchor.y)
         - (size.height * (anchor.y - 0.5))
     
-    return .init(x: x, y: y)
+    var pos = CGPoint(x: x, y: y)
+    if !isPinnedRendering {
+        pos.x -= parentSize.width/2
+        pos.y -= parentSize.height/2
+    }
+    return pos
     
 }
 

--- a/Stitch/Graph/PrototypePreview/Frame/View/PreviewWindowElementUIKitGestures.swift
+++ b/Stitch/Graph/PrototypePreview/Frame/View/PreviewWindowElementUIKitGestures.swift
@@ -36,7 +36,7 @@ struct PreviewWindowElementSwiftUIGestures: ViewModifier {
             position: position,
             anchor: anchoring,
             parentSize: parentSize,
-            isPinnedRendering: true)
+            ignoreOffsetTransform: true)
     }
     
     @MainActor
@@ -57,12 +57,7 @@ struct PreviewWindowElementSwiftUIGestures: ViewModifier {
                 // Factor out anchoring (i.e. position + size/2 + anchoring)
                 let location = CGPoint(x: $0.location.x - posForGesture.x,
                                        y: $0.location.y - posForGesture.y)
-                
-//                log("PreviewWindowElementGestures: DragGesture: onChanged: id: \(interactiveLayer.id)")
-//                log("PreviewWindowElementGestures: DragGesture: onChanged: $0.location: \($0.location)")
-//                log("PreviewWindowElementGestures: DragGesture: onChanged: pos: \(pos)")
-//                log("PreviewWindowElementGestures: DragGesture: onChanged: location: \(location)")
-            
+                            
                 graph.layerDragged(interactiveLayer: interactiveLayer,
                                    location: location, // // PRESS NODE ONLY
                                    translation: $0.translation,

--- a/Stitch/Graph/PrototypePreview/Frame/View/PreviewWindowElementUIKitGestures.swift
+++ b/Stitch/Graph/PrototypePreview/Frame/View/PreviewWindowElementUIKitGestures.swift
@@ -86,14 +86,16 @@ struct PreviewWindowElementSwiftUIGestures: ViewModifier {
         
         // `TapGesture`s need to come AFTER `DragGesture`
             .simultaneousGesture(TapGesture(count: 2).onEnded({
-                if let pressIds = self.getPressInteractionIds() {
+                if let pressIds = self.getPressInteractionIds(),
+                   !pressIds.isEmpty {
                     // Set true here, then set false in press node eval
                     self.interactiveLayer.doubleTapped = true
                     graph.scheduleForNextGraphStep(pressIds)
                 }
             }))
             .simultaneousGesture(TapGesture(count: 1).onEnded {
-                if let pressIds = self.getPressInteractionIds() {
+                if let pressIds = self.getPressInteractionIds(),
+                   !pressIds.isEmpty {
                     // Set true here, then set false in press node eval
                     self.interactiveLayer.singleTapped = true
                     graph.scheduleForNextGraphStep(pressIds)

--- a/Stitch/Graph/PrototypePreview/Frame/View/PreviewWindowElementUIKitGestures.swift
+++ b/Stitch/Graph/PrototypePreview/Frame/View/PreviewWindowElementUIKitGestures.swift
@@ -54,20 +54,30 @@ struct PreviewWindowElementSwiftUIGestures: ViewModifier {
   
     @MainActor
     var dragGesture: some Gesture {
-        DragGesture(minimumDistance: minimumDragDistance)
+        DragGesture(minimumDistance: minimumDragDistance
+//                    , coordinateSpace: .local // no change
+                    
+                    // worse
+//                    , coordinateSpace: .named(PreviewContent.prototypeCoordinateSpace)
+//                    , coordinateSpace: .global
+        )
             .onChanged {
-                 // log("PreviewWindowElementGestures: DragGesture: onChanged: id: \(interactiveLayer.id)")
-                
                 // TODO: come up with a better, more accurate velocity calculation
                 // (average vs momentaneous velocity?)
                 let velocity = CGSize(
                     width: $0.predictedEndLocation.x - $0.location.x,
                     height: $0.predictedEndLocation.y - $0.location.y)
                 
+                
+                
                 // Factor out anchoring (i.e. position + size/2 + anchoring)
                 let location = CGPoint(x: $0.location.x - pos.x,
                                        y: $0.location.y - pos.y)
-                     
+                
+                log("PreviewWindowElementGestures: DragGesture: onChanged: id: \(interactiveLayer.id)")
+                log("PreviewWindowElementGestures: DragGesture: onChanged: $0.location: \($0.location)")
+                log("PreviewWindowElementGestures: DragGesture: onChanged: pos: \(pos)")
+                log("PreviewWindowElementGestures: DragGesture: onChanged: location: \(location)")
             
                 graph.layerDragged(interactiveLayer: interactiveLayer,
                                    location: location, // // PRESS NODE ONLY

--- a/Stitch/Graph/PrototypePreview/Frame/View/PreviewWindowElementUIKitGestures.swift
+++ b/Stitch/Graph/PrototypePreview/Frame/View/PreviewWindowElementUIKitGestures.swift
@@ -8,45 +8,37 @@
 import SwiftUI
 import StitchSchemaKit
 
-// TODO: we likely need to inject the SwiftUI view into the UIKit gesture handler
-// tricky?: handling when layers resize?
-
-//// A view modifier attached to a given preview window element
-//struct PreviewWindowElementUIKitGestures: ViewModifier {
-//    @Bindable var graph: GraphState
-//    let interactiveLayer: InteractiveLayer
-//    let position: CGPoint
-//    let size: CGSize
-//    let parentSize: CGSize
-//
-//    func body(content: Content) -> some View {
-//
-//        return content
-//            // .overlay(UIKitGestureRecognizer) needs to come BEFORE SwiftUI gesture handlers
-//            .overlay {
-//                PreviewElementTrackpadPanView(
-//                    interactiveLayer: interactiveLayer,
-//                    position: position,
-//                    size: size,
-//                    parentSize: parentSize,
-//                    graph: graph)
-//            }
-//    } // body
-//}
-
-
 struct PreviewWindowElementSwiftUIGestures: ViewModifier {
     @Bindable var document: StitchDocumentViewModel
     @Bindable var graph: GraphState
     let interactiveLayer: InteractiveLayer
     let position: CGPoint
-    let pos: StitchPosition // for factoring out .anchoring for press node
-    let size: CGSize
+    let size: LayerSize
+    let readSize: CGSize
+    let anchoring: Anchoring
     let parentSize: CGSize
         
     // e.g. ~5 for Switch; 0 for all other layers
     let minimumDragDistance: Double
-        
+       
+    // TODO: can you just use the layerViewModel.readSize ?
+    var sizeForAnchoringAndGestures: CGSize {
+        size.asCGSize(parentSize)
+    }
+    
+    // Note: `position` for gesture needs to ignore the .offset transformation,
+    // i.e. do NOT subtract parentSize/2 from the position
+    var posForGesture: StitchPosition {
+        adjustPosition(
+            // SEE NOTE IN `asCGSizeForLayer`
+            size: size.asCGSizeForLayer(parentSize: parentSize,
+                                        readSize: readSize),
+            position: position,
+            anchor: anchoring,
+            parentSize: parentSize,
+            isPinnedRendering: true)
+    }
+    
     @MainActor
     func getPressInteractionIds() -> NodeIdSet? {
         graph.getPressInteractionIds(for: interactiveLayer.id.layerNodeId)
@@ -54,13 +46,7 @@ struct PreviewWindowElementSwiftUIGestures: ViewModifier {
   
     @MainActor
     var dragGesture: some Gesture {
-        DragGesture(minimumDistance: minimumDragDistance
-//                    , coordinateSpace: .local // no change
-                    
-                    // worse
-//                    , coordinateSpace: .named(PreviewContent.prototypeCoordinateSpace)
-//                    , coordinateSpace: .global
-        )
+        DragGesture(minimumDistance: minimumDragDistance) // implicitly: .local
             .onChanged {
                 // TODO: come up with a better, more accurate velocity calculation
                 // (average vs momentaneous velocity?)
@@ -68,30 +54,28 @@ struct PreviewWindowElementSwiftUIGestures: ViewModifier {
                     width: $0.predictedEndLocation.x - $0.location.x,
                     height: $0.predictedEndLocation.y - $0.location.y)
                 
-                
-                
                 // Factor out anchoring (i.e. position + size/2 + anchoring)
-                let location = CGPoint(x: $0.location.x - pos.x,
-                                       y: $0.location.y - pos.y)
+                let location = CGPoint(x: $0.location.x - posForGesture.x,
+                                       y: $0.location.y - posForGesture.y)
                 
-                log("PreviewWindowElementGestures: DragGesture: onChanged: id: \(interactiveLayer.id)")
-                log("PreviewWindowElementGestures: DragGesture: onChanged: $0.location: \($0.location)")
-                log("PreviewWindowElementGestures: DragGesture: onChanged: pos: \(pos)")
-                log("PreviewWindowElementGestures: DragGesture: onChanged: location: \(location)")
+//                log("PreviewWindowElementGestures: DragGesture: onChanged: id: \(interactiveLayer.id)")
+//                log("PreviewWindowElementGestures: DragGesture: onChanged: $0.location: \($0.location)")
+//                log("PreviewWindowElementGestures: DragGesture: onChanged: pos: \(pos)")
+//                log("PreviewWindowElementGestures: DragGesture: onChanged: location: \(location)")
             
                 graph.layerDragged(interactiveLayer: interactiveLayer,
                                    location: location, // // PRESS NODE ONLY
                                    translation: $0.translation,
                                    velocity: velocity,
                                    parentSize: parentSize,
-                                   childSize: size,
+                                   childSize: sizeForAnchoringAndGestures,
                                    childPosition: position)
             }
             .onEnded {  _ in
                 // log("PreviewWindowElementGestures: DragGesture: id: \(interactiveLayer.id) onEnded")
                 graph.layerDragEnded(interactiveLayer: interactiveLayer,
                                      parentSize: parentSize,
-                                     childSize: size)
+                                     childSize: sizeForAnchoringAndGestures)
             }
     }
     

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/HoverGestureModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/HoverGestureModifier.swift
@@ -20,13 +20,14 @@ struct HoverGestureModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
+        // Previously we could rely on the .position of a child layer to expand the space on which .onContinuousHover operated; but now (April 2025) we use .offset, which does not expand the hit area; so we attach a .contentShape manually
+            .frame(width: previewWindowSize.width, height: previewWindowSize.height)
+            .contentShape(Rectangle())
             .onContinuousHover { phase in
                 switch phase {
 
                 case .active(let location):
-                    //                    #if DEV_DEBUG
-                    //                    log("Hover: active: location: \(location)")
-                    //                    #endif
+                    // log("Hover: active: location: \(location)")
 
                     let now: TimeInterval = Date.now.timeIntervalSince1970
 
@@ -64,7 +65,6 @@ struct HoverGestureModifier: ViewModifier {
                         let velocity = CGPoint(x: dampenedXVelocity,
                                                y: dampenedYVelocity)
 
-                        //                        #if DEV_DEBUG
                         //                        log("Hover: xDiff: \(xDiff)")
                         //                        log("Hover: yDiff: \(yDiff)")
                         //                        log("Hover: timeDiff: \(timeDiff)")
@@ -73,7 +73,6 @@ struct HoverGestureModifier: ViewModifier {
                         //                        log("Hover: dampenedXVelocity: \(dampenedXVelocity)")
                         //                        log("Hover: dampenedYVelocity: \(dampenedYVelocity)")
                         //                        log("Hover: active: location: \(location)")
-                        //                        #endif
                         document.layerHovered(location: location,
                                               velocity: velocity)
                     }
@@ -82,9 +81,7 @@ struct HoverGestureModifier: ViewModifier {
                     self.timeOfLastDragPosition = now
 
                 case .ended:
-                    //                    #if DEV_DEBUG
-                    //                    log("Hover: ended")
-                    //                    #endif
+                    // log("Hover: ended")
                     self.lastDragPosition = nil
                     self.timeOfLastDragPosition = nil
 

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/LayerSizeReader.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/LayerSizeReader.swift
@@ -30,8 +30,8 @@ struct LayerSizeReader: ViewModifier {
                 let frameData = self.getFrame(geometry: proxy)
                 Color.clear
                     .onChange(of: frameData, initial: !isPinnedViewRendering) { _, newFrameData in
-                        log("LayerSizeReader: \(viewModel.layer), newFrameData.size: \(newFrameData.size)")
-                        log("LayerSizeReader: \(viewModel.layer), newFrameData.origin: \(newFrameData.origin)")
+                        // log("LayerSizeReader: \(viewModel.layer), newFrameData.size: \(newFrameData.size)")
+                        // log("LayerSizeReader: \(viewModel.layer), newFrameData.origin: \(newFrameData.origin)")
                         let newSize = newFrameData.size.handleNaN()
                         if viewModel.readSize != newSize {
                             viewModel.readFrame.size = newSize

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/LayerSizeReader.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/LayerSizeReader.swift
@@ -30,7 +30,8 @@ struct LayerSizeReader: ViewModifier {
                 let frameData = self.getFrame(geometry: proxy)
                 Color.clear
                     .onChange(of: frameData, initial: !isPinnedViewRendering) { _, newFrameData in
-                        // log("LayerSizeReader: \(viewModel.layer), newFrameData: \(newFrameData)")
+                        log("LayerSizeReader: \(viewModel.layer), newFrameData.size: \(newFrameData.size)")
+                        log("LayerSizeReader: \(viewModel.layer), newFrameData.origin: \(newFrameData.origin)")
                         let newSize = newFrameData.size.handleNaN()
                         if viewModel.readSize != newSize {
                             viewModel.readFrame.size = newSize

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PinningUtils.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PinningUtils.swift
@@ -360,7 +360,7 @@ func getPinnedViewPosition(pinnedLayerViewModel: LayerViewModel,
                    position: pinReceiverData.origin,
                    anchor: pinnedLayerViewModel.pinAnchor.getAnchoring ?? .topLeft,
                    parentSize: pinReceiverData.size,
-                   isPinnedRendering: true)
+                   ignoreOffsetTransform: true)
 }
 
 

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PinningUtils.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PinningUtils.swift
@@ -359,7 +359,8 @@ func getPinnedViewPosition(pinnedLayerViewModel: LayerViewModel,
     adjustPosition(size: pinnedLayerViewModel.pinnedSize ?? .zero,
                    position: pinReceiverData.origin,
                    anchor: pinnedLayerViewModel.pinAnchor.getAnchoring ?? .topLeft,
-                   parentSize: pinReceiverData.size)
+                   parentSize: pinReceiverData.size,
+                   isPinnedRendering: true)
 }
 
 

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewAbsoluteShapeLayerModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewAbsoluteShapeLayerModifier.swift
@@ -19,6 +19,7 @@ struct PreviewAbsoluteShapeLayerModifier: ViewModifier {
     let isPinnedViewRendering: Bool
     let interactiveLayer: InteractiveLayer
     let position: CGPoint // offset
+    let anchoring: Anchoring
     let rotationX: CGFloat
     let rotationY: CGFloat
     let rotationZ: CGFloat
@@ -93,8 +94,10 @@ struct PreviewAbsoluteShapeLayerModifier: ViewModifier {
                 position: position,
                 // TODO: For handling Press interaction location with Custom Shape layer that uses absolute-coordinate space, what needs to change?
                 // Normally we subtract the anchoring-adjusted position (i.e. `pos`), but that assumes using a .position, not .offset, modifier
-                pos: position, // TOOD: anchoring and size
-                size: size,
+//                pos: position, // TOOD: anchoring and size
+                size: previewWindowSize.toLayerSize,
+                readSize: viewModel.readSize,
+                anchoring: anchoring,
                 parentSize: parentSize,
                 minimumDragDistance: DEFAULT_MINIMUM_DRAG_DISTANCE))
     }

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonModifierWithoutFrame.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonModifierWithoutFrame.swift
@@ -45,11 +45,6 @@ struct PreviewCommonModifierWithoutFrame: ViewModifier {
     
     var isForShapeLayer: Bool = false
     
-    // TODO: can you just use the layerViewModel.readSize ?
-    var sizeForAnchoringAndGestures: CGSize {
-        size.asCGSize(parentSize)
-    }
-    
     // Assumes parentSize has already been scaled etc.
     let parentSize: CGSize
     let parentDisablesPosition: Bool
@@ -72,7 +67,6 @@ struct PreviewCommonModifierWithoutFrame: ViewModifier {
             anchor: anchoring,
             parentSize: parentSize)
     }
-    
     
     func body(content: Content) -> some View {
 
@@ -139,8 +133,9 @@ struct PreviewCommonModifierWithoutFrame: ViewModifier {
                 graph: graph,
                 interactiveLayer: interactiveLayer,
                 position: position,
-                pos: pos,
-                size: sizeForAnchoringAndGestures,
+                size: size,
+                readSize: layerViewModel.readSize,
+                anchoring: anchoring,
                 parentSize: parentSize,
                 minimumDragDistance: minimumDragDistance))
     }

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonPositionModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonPositionModifier.swift
@@ -92,22 +92,3 @@ struct PreviewCommonPositionModifier: ViewModifier {
         }
     }
 }
-
-//struct PreviewCommonPositionModifier: ViewModifier {
-//    
-//    // Is this view a child of a group that uses HStack, VStack or Grid? If so, we ignore this view's position.
-//    // TODO: use .offset instead of .position when layer is a child
-//    let parentDisablesPosition: Bool
-//
-//    // Position already adjusted by anchoring
-//    var pos: StitchPosition
-//    
-//    func body(content: Content) -> some View {
-//        if parentDisablesPosition {
-//            content
-//        } else {
-//            content
-//                .position(x: pos.width, y: pos.height)
-//        }
-//    }
-//}

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonPositionModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonPositionModifier.swift
@@ -87,7 +87,8 @@ struct PreviewCommonPositionModifier: ViewModifier {
                .offset(x: offset.width, y: offset.height)
         } else {
             content
-                .position(x: pos.x, y: pos.y)
+//                .position(x: pos.x, y: pos.y)
+                .offset(x: pos.x, y: pos.y)
         }
     }
 }

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewWindowCoordinateSpaceReader.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewWindowCoordinateSpaceReader.swift
@@ -9,8 +9,6 @@ import Foundation
 import StitchSchemaKit
 import SwiftUI
 
-let PREVIEW_WINDOW_COORDINATE_SPACE = "previewWindow"
-
 struct PreviewWindowCoordinateSpaceReader: ViewModifier {
     
     @Bindable var viewModel: LayerViewModel
@@ -29,15 +27,10 @@ struct PreviewWindowCoordinateSpaceReader: ViewModifier {
     /// Important to only report pin data from ghost view.
     func getFrame(geometry: GeometryProxy) -> CGRect {
         if isPinnedViewRendering {
-            log("PCSR: viewModel.id: \(viewModel.id): no frame")
             return .zero
         } else {
-//            let f = geometry.frame(in: .named(PREVIEW_WINDOW_COORDINATE_SPACE))
-            let f = geometry.frame(in: .named(PreviewContent.prototypeCoordinateSpace))
-            log("PCSR: viewModel.id: \(viewModel.id): frame \(f)")
-            return f
+            return geometry.frame(in: .named(PreviewContent.prototypeCoordinateSpace))
         }
-//        !isPinnedViewRendering ? geometry.frame(in: .named(PREVIEW_WINDOW_COORDINATE_SPACE)) : .zero
     }
     
     func body(content: Content) -> some View {
@@ -48,19 +41,14 @@ struct PreviewWindowCoordinateSpaceReader: ViewModifier {
                     // compare vs. LayerSizeReader which is the size of the view within the .local coordinate space.
                     Color.clear.onChange(of: self.getFrame(geometry: geometry),
                                          initial: !isPinnedViewRendering) { oldValue, newValue in
-                                                
-                        log("PCSR: viewModel.id: \(viewModel.id)")
-                        
-                        log("PCSR: key: \(key), oldValue.size: \(oldValue.size), oldValue.origin: \(oldValue.origin), oldValue.mid: \(oldValue.mid)")
-                        log("PCSR: key: \(key), newValue.size: \(newValue.size), newValue.origin: \(newValue.origin), newValue.mid: \(newValue.mid)")
-                                                
+   
                         //viewModel.previewWindowRect = newValue
                         
                         // If this layer *receives* a pin, populate its pin-receiver data fields:
                         if pinMap.get(viewModel.id.layerNodeId).isDefined,
                            // TODO: how or why can newValue
                            (!newValue.width.isNaN && !newValue.height.isNaN) {
-                            log("PCSR: had pinMap entry for viewModel.id.layerNodeId \(viewModel.id.layerNodeId), newValue.origin: \(newValue.origin)")
+                            // log("PreviewWindowCoordinateSpaceReader: had pinMap entry for viewModel.id.layerNodeId \(viewModel.id.layerNodeId), newValue.origin: \(newValue.origin)")
                                 viewModel.pinReceiverSize = newValue.size
                                 viewModel.pinReceiverOrigin = newValue.origin
                                 viewModel.pinReceiverCenter = newValue.mid
@@ -71,16 +59,14 @@ struct PreviewWindowCoordinateSpaceReader: ViewModifier {
                             // and is generated at top level,
                             // then we only update the "pinned center" (for rotation)
                             if isPinnedViewRendering {
-                                 log("PreviewWindowCoordinateSpaceReader: pinned and at top level")
+                                // log("PreviewWindowCoordinateSpaceReader: pinned and at top level")
                                 viewModel.pinnedCenter = newValue.mid
                             }
                             
                             // Else, if we're not at the top level,
                             // then we read the "pinned size"
                             else {
-                                 log("PreviewWindowCoordinateSpaceReader: pinned but not at top level: newValue.size: \(newValue.size)")
                                 if newValue.width.isNaN || newValue.height.isNaN {
-                                     log("Had NaN, will not set size")
                                     return
                                 }
                                 

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewWindowCoordinateSpaceReader.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewWindowCoordinateSpaceReader.swift
@@ -28,7 +28,16 @@ struct PreviewWindowCoordinateSpaceReader: ViewModifier {
     
     /// Important to only report pin data from ghost view.
     func getFrame(geometry: GeometryProxy) -> CGRect {
-        !isPinnedViewRendering ? geometry.frame(in: .named(PREVIEW_WINDOW_COORDINATE_SPACE)) : .zero
+        if isPinnedViewRendering {
+            log("PCSR: viewModel.id: \(viewModel.id): no frame")
+            return .zero
+        } else {
+//            let f = geometry.frame(in: .named(PREVIEW_WINDOW_COORDINATE_SPACE))
+            let f = geometry.frame(in: .named(PreviewContent.prototypeCoordinateSpace))
+            log("PCSR: viewModel.id: \(viewModel.id): frame \(f)")
+            return f
+        }
+//        !isPinnedViewRendering ? geometry.frame(in: .named(PREVIEW_WINDOW_COORDINATE_SPACE)) : .zero
     }
     
     func body(content: Content) -> some View {
@@ -39,10 +48,11 @@ struct PreviewWindowCoordinateSpaceReader: ViewModifier {
                     // compare vs. LayerSizeReader which is the size of the view within the .local coordinate space.
                     Color.clear.onChange(of: self.getFrame(geometry: geometry),
                                          initial: !isPinnedViewRendering) { oldValue, newValue in
+                                                
+                        log("PCSR: viewModel.id: \(viewModel.id)")
                         
-                        // log("PreviewWindowCoordinateSpaceReader: viewModel.layer: \(viewModel.layer)")
-                        
-                        // log("PreviewWindowCoordinateSpaceReader: key: \(key), size: \(newValue.size), origin: \(newValue.origin), mid: \(newValue.mid)")
+                        log("PCSR: key: \(key), oldValue.size: \(oldValue.size), oldValue.origin: \(oldValue.origin), oldValue.mid: \(oldValue.mid)")
+                        log("PCSR: key: \(key), newValue.size: \(newValue.size), newValue.origin: \(newValue.origin), newValue.mid: \(newValue.mid)")
                                                 
                         //viewModel.previewWindowRect = newValue
                         
@@ -50,6 +60,7 @@ struct PreviewWindowCoordinateSpaceReader: ViewModifier {
                         if pinMap.get(viewModel.id.layerNodeId).isDefined,
                            // TODO: how or why can newValue
                            (!newValue.width.isNaN && !newValue.height.isNaN) {
+                            log("PCSR: had pinMap entry for viewModel.id.layerNodeId \(viewModel.id.layerNodeId), newValue.origin: \(newValue.origin)")
                                 viewModel.pinReceiverSize = newValue.size
                                 viewModel.pinReceiverOrigin = newValue.origin
                                 viewModel.pinReceiverCenter = newValue.mid
@@ -60,16 +71,16 @@ struct PreviewWindowCoordinateSpaceReader: ViewModifier {
                             // and is generated at top level,
                             // then we only update the "pinned center" (for rotation)
                             if isPinnedViewRendering {
-                                // log("PreviewWindowCoordinateSpaceReader: pinned and at top level")
+                                 log("PreviewWindowCoordinateSpaceReader: pinned and at top level")
                                 viewModel.pinnedCenter = newValue.mid
                             }
                             
                             // Else, if we're not at the top level,
                             // then we read the "pinned size"
                             else {
-                                // log("PreviewWindowCoordinateSpaceReader: pinned but not at top level: newValue.size: \(newValue.size)")
+                                 log("PreviewWindowCoordinateSpaceReader: pinned but not at top level: newValue.size: \(newValue.size)")
                                 if newValue.width.isNaN || newValue.height.isNaN {
-                                    // log("Had NaN, will not set size")
+                                     log("Had NaN, will not set size")
                                     return
                                 }
                                 

--- a/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
@@ -55,10 +55,7 @@ struct GeneratePreview: View {
                               realityContent: nil)
             .hidden()
             .disabled(true)
-        }
-        // Top-level coordinate space of preview window; for pinning
-//        .coordinateSpace(name: PREVIEW_WINDOW_COORDINATE_SPACE)
-        
+        }        
         .modifier(HoverGestureModifier(document: document,
                                        previewWindowSize: document.previewWindowSize))
     }

--- a/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
@@ -192,9 +192,9 @@ struct PreviewLayersView: View {
                 }
             }
         }        
-        .modifier(LayerGroupInteractableViewModifier(
-            hasLayerInteraction: graph.hasInteraction(parentId),
-            cornerRadius: parentCornerRadius))
+//        .modifier(LayerGroupInteractableViewModifier(
+//            hasLayerInteraction: graph.hasInteraction(parentId),
+//            cornerRadius: parentCornerRadius))
     }
     
     @MainActor @ViewBuilder

--- a/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
@@ -192,9 +192,6 @@ struct PreviewLayersView: View {
                 }
             }
         }        
-//        .modifier(LayerGroupInteractableViewModifier(
-//            hasLayerInteraction: graph.hasInteraction(parentId),
-//            cornerRadius: parentCornerRadius))
     }
     
     @MainActor @ViewBuilder

--- a/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
@@ -57,7 +57,7 @@ struct GeneratePreview: View {
             .disabled(true)
         }
         // Top-level coordinate space of preview window; for pinning
-        .coordinateSpace(name: PREVIEW_WINDOW_COORDINATE_SPACE)
+//        .coordinateSpace(name: PREVIEW_WINDOW_COORDINATE_SPACE)
         
         .modifier(HoverGestureModifier(document: document,
                                        previewWindowSize: document.previewWindowSize))

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
@@ -90,7 +90,9 @@ struct PreviewGroupLayer: View {
     }
 
     var _size: CGSize {
-        size.asCGSize(parentSize)
+        // size.asCGSize(parentSize)
+        size.asCGSizeForLayer(parentSize: parentSize,
+                              readSize: layerViewModel.readSize)
     }
 
     // TODO: what if only one dimension uses .hug ?
@@ -139,7 +141,9 @@ struct PreviewGroupLayer: View {
                 maxHeight: layerViewModel.getMaxHeight,
                 parentSize: parentSize,
                 sizingScenario: layerViewModel.getSizingScenario,
-                frameAlignment: anchoring.toAlignment))
+                // non-`.center` alignments on `ZStack.frame` creates problems for children placed by .offset
+                frameAlignment: .center //anchoring.toAlignment
+            ))
 
             .background {
                 // TODO: Better way to handle slight gap between outside stroke and background edge when using corner radius? Outside stroke is actually an .overlay'd shape that is slightly larger than the stroked shape.

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
@@ -90,7 +90,6 @@ struct PreviewGroupLayer: View {
     }
 
     var _size: CGSize {
-        // size.asCGSize(parentSize)
         size.asCGSizeForLayer(parentSize: parentSize,
                               readSize: layerViewModel.readSize)
     }
@@ -145,9 +144,6 @@ struct PreviewGroupLayer: View {
         // When using `.offset` instead of `.position` modifier to play layers in preview window,
         // .contentShape must come *after* `.frame`
             .modifier(LayerGroupInteractableViewModifier(
-//                hasLayerInteraction: graph.hasInteraction(parentId),
-//                cornerRadius: parentCornerRadius))
-//                hasLayerInteraction: graph.hasInteraction(layerViewModel.id),
                 hasLayerInteraction: graph.hasInteraction(interactiveLayer.id.layerNodeId),
                 cornerRadius: cornerRadius))
 

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
@@ -141,6 +141,15 @@ struct PreviewGroupLayer: View {
                 // non-`.center` alignments on `ZStack.frame` creates problems for children placed by .offset
                 frameAlignment: .center //anchoring.toAlignment
             ))
+        
+        // When using `.offset` instead of `.position` modifier to play layers in preview window,
+        // .contentShape must come *after* `.frame`
+            .modifier(LayerGroupInteractableViewModifier(
+//                hasLayerInteraction: graph.hasInteraction(parentId),
+//                cornerRadius: parentCornerRadius))
+//                hasLayerInteraction: graph.hasInteraction(layerViewModel.id),
+                hasLayerInteraction: graph.hasInteraction(interactiveLayer.id.layerNodeId),
+                cornerRadius: cornerRadius))
 
             .background {
                 // TODO: Better way to handle slight gap between outside stroke and background edge when using corner radius? Outside stroke is actually an .overlay'd shape that is slightly larger than the stroked shape.
@@ -238,7 +247,6 @@ struct PreviewGroupLayer: View {
                 graph: graph,
                 interactiveLayer: interactiveLayer,
                 position: position,
-//                pos: pos,
                 size: size,
                 readSize: layerViewModel.readSize,
                 anchoring: anchoring,

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewGroup.swift
@@ -109,13 +109,10 @@ struct PreviewGroupLayer: View {
     }
     
     var pos: StitchPosition {
-        adjustPosition(
-            //size: layerViewModel.readSize, // size.asCGSize(parentSize),
-            size: size.asCGSizeForLayer(parentSize: parentSize,
-                                        readSize: layerViewModel.readSize),
-            position: position,
-            anchor: anchoring,
-            parentSize: parentSize)
+        adjustPosition(size: _size,
+                       position: position,
+                       anchor: anchoring,
+                       parentSize: parentSize)
     }
     
     var strokeAdjustedCornerRadius: CGFloat {
@@ -241,8 +238,10 @@ struct PreviewGroupLayer: View {
                 graph: graph,
                 interactiveLayer: interactiveLayer,
                 position: position,
-                pos: pos,
-                size: _size,
+//                pos: pos,
+                size: size,
+                readSize: layerViewModel.readSize,
+                anchoring: anchoring,
                 parentSize: parentSize,
                 minimumDragDistance: DEFAULT_MINIMUM_DRAG_DISTANCE))
     }

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewHitAreaLayer.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewHitAreaLayer.swift
@@ -46,7 +46,6 @@ struct PreviewHitAreaLayer: View {
                 rotationX: .zero,
                 rotationY: .zero,
                 rotationZ: .zero,
-//                size: size.asCGSize(parentSize),
                 size: size,
                 scale: scale,
                 anchoring: anchoring,

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewShapeLayer.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewShapeLayer.swift
@@ -95,6 +95,7 @@ struct PreviewShapeLayer: View {
                     isPinnedViewRendering: isPinnedViewRendering,
                     interactiveLayer: interactiveLayer,
                     position: position,
+                    anchoring: anchoring,
                     rotationX: rotationX,
                     rotationY: rotationY,
                     rotationZ: rotationZ,


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/6370

Main change: we place layers in preview window via `.offset` instead of `.position`. This had a couple domino effects, e.g. `.contentShape`'s placement.

<img width="1428" alt="Screenshot 2025-04-04 at 4 02 32 PM" src="https://github.com/user-attachments/assets/d7556857-bd94-459d-8923-6f4a1cf304ad" />
