### PR TITLE
Fixed crashes from simultaneous mic + sound player nodes

### DIFF
--- a/Stitch/Graph/Node/Patch/Type/Media/MicrophoneFeedNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Media/MicrophoneFeedNode.swift
@@ -42,21 +42,6 @@ struct MicrophoneNode: PatchNodeDefinition {
     }
 }
 
-/// Creates mic and assigns to observer.
-//@MainActor func createMic(isEnabled: Bool,
-//                          observer: MediaEvalOpObserver) {
-////    guard observer.currentLoadingMediaId == nil else {
-////        return
-////    }
-//    
-////    observer.currentLoadingMediaId = .init()
-//
-//    let newMic = StitchMic(isEnabled: isEnabled)
-//    let newSoundPlayer = StitchSoundPlayer(delegate: newMic, willPlay: true)
-//    
-//    observer.computedMedia = .init(computedMedia: .mic(newSoundPlayer))
-//}
-
 // needs to be impure, in order to be able to update state as well;
 // we can create the AVAudioRecorder when we first add the node to the graph;
 // but if eg the microphone is turned off, then we'll need to dispatch a side effect to change the state as well

--- a/Stitch/Graph/Node/Patch/Type/Media/MicrophoneFeedNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Media/MicrophoneFeedNode.swift
@@ -45,31 +45,16 @@ struct MicrophoneNode: PatchNodeDefinition {
 /// Creates mic and assigns to observer.
 @MainActor func createMic(isEnabled: Bool,
                           observer: MediaEvalOpObserver) {
-    guard observer.currentLoadingMediaId == nil else {
-        return
-    }
+//    guard observer.currentLoadingMediaId == nil else {
+//        return
+//    }
     
-    observer.currentLoadingMediaId = .init()
-    
-    Task(priority: .high) { [weak observer] in
-        guard let observer = observer else {
-            return
-        }
+//    observer.currentLoadingMediaId = .init()
 
-        let newMic = await StitchMic(isEnabled: isEnabled)
-        let newSoundPlayer = StitchSoundPlayer(delegate: newMic, willPlay: true)
-        
-        observer.currentLoadingMediaId = .init()
-        await MainActor.run { [weak observer, weak newSoundPlayer] in
-            guard let observer = observer,
-                  let newSoundPlayer = newSoundPlayer else {
-                return
-            }
-            
-            observer.computedMedia = .init(computedMedia: .mic(newSoundPlayer))
-            observer.currentLoadingMediaId = nil
-        }
-    }
+    let newMic = StitchMic(isEnabled: isEnabled)
+    let newSoundPlayer = StitchSoundPlayer(delegate: newMic, willPlay: true)
+    
+    observer.computedMedia = .init(computedMedia: .mic(newSoundPlayer))
 }
 
 // needs to be impure, in order to be able to update state as well;

--- a/Stitch/Graph/Node/Patch/Type/Media/MicrophoneFeedNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Media/MicrophoneFeedNode.swift
@@ -43,19 +43,19 @@ struct MicrophoneNode: PatchNodeDefinition {
 }
 
 /// Creates mic and assigns to observer.
-@MainActor func createMic(isEnabled: Bool,
-                          observer: MediaEvalOpObserver) {
-//    guard observer.currentLoadingMediaId == nil else {
-//        return
-//    }
-    
-//    observer.currentLoadingMediaId = .init()
-
-    let newMic = StitchMic(isEnabled: isEnabled)
-    let newSoundPlayer = StitchSoundPlayer(delegate: newMic, willPlay: true)
-    
-    observer.computedMedia = .init(computedMedia: .mic(newSoundPlayer))
-}
+//@MainActor func createMic(isEnabled: Bool,
+//                          observer: MediaEvalOpObserver) {
+////    guard observer.currentLoadingMediaId == nil else {
+////        return
+////    }
+//    
+////    observer.currentLoadingMediaId = .init()
+//
+//    let newMic = StitchMic(isEnabled: isEnabled)
+//    let newSoundPlayer = StitchSoundPlayer(delegate: newMic, willPlay: true)
+//    
+//    observer.computedMedia = .init(computedMedia: .mic(newSoundPlayer))
+//}
 
 // needs to be impure, in order to be able to update state as well;
 // we can create the AVAudioRecorder when we first add the node to the graph;
@@ -76,10 +76,13 @@ func microphoneEval(node: PatchNode) -> EvalResult {
            
         guard let currentMedia = mediaObserver.computedMedia,
               let mic = currentMedia.mediaObject.mic else {
-            createMic(isEnabled: isEnabled,
-                      observer: mediaObserver)
+            let newMic = StitchMic(isEnabled: isEnabled)
+            let newSoundPlayer = StitchSoundPlayer(delegate: newMic, willPlay: true)
             
-            return MediaEvalOpResult(from: node.defaultOutputs)
+            mediaObserver.computedMedia = .init(computedMedia: .mic(newSoundPlayer))
+            
+            return MediaEvalOpResult(values: node.defaultOutputs,
+                                     media: mediaObserver.computedMedia)
         }
         
         guard var previousVolume: Double = values[safe: 2]?.getNumber,

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Models/StitchMediaObject.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Models/StitchMediaObject.swift
@@ -159,7 +159,7 @@ extension StitchMediaObject {
 
         case .mic(let mic):
             let isEnabled = mic.delegate.isRunning
-            let newMic = await StitchMic(isEnabled: isEnabled)
+            let newMic = StitchMic(isEnabled: isEnabled)
             let newSoundPlayer = StitchSoundPlayer(delegate: newMic, willPlay: isEnabled)
             copiedMediaObject = .mic(newSoundPlayer)
 

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/Sound/SoundHelpers.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/Sound/SoundHelpers.swift
@@ -32,9 +32,13 @@ extension AVAudioRecorder {
 }
 
 extension AVAudioSession {
-    static func enableSpeaker() throws {
+    /// Used by both sound and mic players.
+    /// **NOTE: very important to keep the permissions request consistent by always requesting for mic. Fixes crash where requesting "play and record" after "play" was already establisehd.**
+    static func enableSpeakerAndMic() throws {
         let session = AVAudioSession.sharedInstance()
-        try session.setCategory(.playback, mode: .default)
+        try session.setCategory(.playAndRecord, mode: .default,
+                                // MARK: necessary on iOS!
+                                options: [.allowBluetooth])
         try session.setActive(true)
     }
 }

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/Sound/StitchAudio.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/Sound/StitchAudio.swift
@@ -141,6 +141,4 @@ protocol StitchSoundPlayerDelegate: AnyObject, Sendable {
     @MainActor var engine: AudioEngine { get }
     
     @MainActor var isRunning: Bool { get }
-    
-    static var permissionsCategory: AVAudioSession.Category { get }
 }

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/Sound/StitchMicrophone.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/Sound/StitchMicrophone.swift
@@ -11,11 +11,9 @@ import Foundation
 import StitchSchemaKit
 
 final class StitchMic: NSObject, Sendable, StitchSoundPlayerDelegate {
-    internal static let permissionsCategory = AVAudioSession.Category.playAndRecord
-    private let session: AVAudioSession
     let id = UUID()
     
-    var engine = AudioEngine()
+    @MainActor var engine = AudioEngine()
 
     // Use AudioKit's AmplitudeTap for volume monitoring
     @MainActor private var ampTap: AmplitudeTap?
@@ -29,8 +27,6 @@ final class StitchMic: NSObject, Sendable, StitchSoundPlayerDelegate {
 
     @MainActor
     init(isEnabled: Bool) {
-        self.session = AVAudioSession.sharedInstance()
-    
         super.init()
         
         // Initializer shouldn't call if not enabled
@@ -41,11 +37,7 @@ final class StitchMic: NSObject, Sendable, StitchSoundPlayerDelegate {
         
         do {
             // Important for these session calls to happen before async caller
-            try session.setCategory(Self.permissionsCategory,
-                                    mode: .default,
-                                    // MARK: necessary on iOS!
-                                    options: [.allowBluetooth])
-            try session.setActive(true)
+            try AVAudioSession.enableSpeakerAndMic()
             
             log("initializeAVAudioSession called")
             

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/Sound/StitchMicrophone.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/Sound/StitchMicrophone.swift
@@ -43,10 +43,7 @@ final class StitchMic: NSObject, Sendable, StitchSoundPlayerDelegate {
             
             Task(priority: .high) { [weak self] in
                 if await AVAudioApplication.requestRecordPermission() {
-                    await MainActor.run { [weak self] in
-                        // Disable loading state
-//                        evalObserver?.currentLoadingMediaId = nil
-                        
+                    await MainActor.run { [weak self] in                        
                         // Engine callers, play etc must be called after permissions logic runs
                         self?.engine.output = self?.engine.input
                         
@@ -60,10 +57,7 @@ final class StitchMic: NSObject, Sendable, StitchSoundPlayerDelegate {
                             self?.play()
                         }
                     }
-                } else {
-                    // Disable loading state
-//                    evalObserver?.currentLoadingMediaId = nil
-                    
+                } else {                    
                     // Prompt user to consider enabling mic permissions
                     DispatchQueue.main.async {
                         dispatch(ReceivedStitchFileError(error: .recordingPermissionsDisabled))

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/Sound/StitchSoundFile.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/ObjectTypes/Sound/StitchSoundFile.swift
@@ -11,7 +11,6 @@ import StitchSchemaKit
 import AVFoundation
 
 final class StitchSoundFilePlayer: NSObject, StitchSoundPlayerDelegate {
-    static let permissionsCategory = AVAudioSession.Category.playback
     let id = UUID()
 
     @MainActor var engine = AudioEngine()
@@ -31,8 +30,10 @@ final class StitchSoundFilePlayer: NSObject, StitchSoundPlayerDelegate {
          willLoop: Bool = true,
          rate: AUValue? = nil,
          jumpTime: Double? = nil) {
+        
         // MARK: we had this in a Task object before but calling this async appeared to cause crashes
-        try? AVAudioSession.enableSpeaker()
+        // MARK: must enable the same permissions as mic, changing later causes crash
+        try? AVAudioSession.enableSpeakerAndMic()
 
         do {
             try player.load(url: url)


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/6983

Issue here being requesting "play and record" after "play" was already established. Solution is to make all requests "play and record" since it's unclear if changing the permissions type is even possible.