### PR TITLE
Fixed option + drag node regression

### DIFF
--- a/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
+++ b/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
@@ -82,11 +82,9 @@ extension CanvasItemViewModel {
 // What if we have multiple nodes on the graph selected and we hold `Option` + drag?
 struct NodeDuplicateDraggedAction: StitchDocumentEvent {
     let id: NodeId
-    let translation: CGSize
     
     func handle(state: StitchDocumentViewModel) {
         state.visibleGraph.nodeDuplicateDragged(id: id,
-                                                translation: translation,
                                                 document: state)
     }
 }
@@ -94,7 +92,6 @@ struct NodeDuplicateDraggedAction: StitchDocumentEvent {
 extension GraphState {
     @MainActor
     func nodeDuplicateDragged(id: NodeId,
-                              translation: CGSize,
                               document: StitchDocumentViewModel) {
         let state = self
         
@@ -143,36 +140,33 @@ extension GraphState {
             
             return
         }
+        
+        // TODO: necessary????
+        // Changed the dragged node to be the newly created node
+//        self.graphMovement.draggedCanvasItem =
             
         
         // log("NodeDuplicateDraggedAction: state.selectedNodeIds at end: \(state.selectedNodeIds)")
         
         // Drag all selected nodes if dragging already started
-        state.selectedCanvasItems
-            .compactMap { state.getCanvasItem($0) }
-            .forEach { draggedNode in
-                // log("NodeDuplicateDraggedAction: already had dragged node id, so will do normal node drag for id \(draggedNode.id)")
-                state.canvasItemMoved(for: draggedNode,
-                                      translation: translation,
-                                      wasDrag: true,
-                                      document: document)
-            }
+//        state.selectedCanvasItems
+//            .compactMap { state.getCanvasItem($0) }
+//            .forEach { draggedNode in
+//                // log("NodeDuplicateDraggedAction: already had dragged node id, so will do normal node drag for id \(draggedNode.id)")
+//                state.canvasItemMoved(for: draggedNode,
+//                                      translation: translation,
+//                                      wasDrag: true,
+//                                      document: document)
+//            }
     }
 }
 
 struct CanvasItemMoved: StitchDocumentEvent {
-    let canvasItemId: CanvasItemId
     let translation: CGSize
     let wasDrag: Bool
     
     func handle(state: StitchDocumentViewModel) {
-        guard let canvasItem = state.visibleGraph.getCanvasItem(canvasItemId) else {
-            log("CanvasItemMoved: could not find canas item")
-            return
-        }
-        
-        state.visibleGraph.canvasItemMoved(for: canvasItem,
-                                           translation: translation,
+        state.visibleGraph.canvasItemMoved(translation: translation,
                                            wasDrag: wasDrag,
                                            document: state)
     }
@@ -182,8 +176,7 @@ struct CanvasItemMoved: StitchDocumentEvent {
 extension GraphState {
     @MainActor
     // fka `nodeMoved`
-    func canvasItemMoved(for canvasItem: CanvasItemViewModel,
-                         translation: CGSize,
+    func canvasItemMoved(translation: CGSize,
                          // drag vs long-press
                          wasDrag: Bool,
                          document: StitchDocumentViewModel) {
@@ -215,28 +208,29 @@ extension GraphState {
 
         // Exit if another (non-duplicated) node is being dragged
         // Note: do this check AFTER we've set our 'currently dragged id' to be the option-duplicated node's id.
-        // TODO: duplicate-node-drag should also update the `draggedNode` in GraphState ?
+        
+        
         // Overall, node duplication logic needs to be thought through with multigestures in mind.
-        if let draggedCanvasItem = self.graphMovement.draggedCanvasItem,
-           draggedCanvasItem != canvasItem.id {
-            log("canvasItemMoved: some other node is already dragged: \(draggedCanvasItem)")
-            return
-        }
+//        if let draggedCanvasItem = self.graphMovement.draggedCanvasItem,
+//           draggedCanvasItem != canvasItem.id {
+//            log("canvasItemMoved: some other node is already dragged: \(draggedCanvasItem)")
+//            return
+//        }
 
         // Updating for dual-drag; must set before
 
-        self.graphMovement.draggedCanvasItem = canvasItem.id
+//        self.graphMovement.draggedCanvasItem = canvasItem.id
         self.graphMovement.lastCanvasItemTranslation = translation
 
-        // If we don't have an active first gesture,
-        // and graph isn't already dragging,
-        // then set node-drag as active first gesture
-        if self.graphMovement.firstActive == .none {
-            if !self.graphMovement.graphIsDragged {
-                // log("canvasItemMoved: will set .node as active first gesture")
-                self.graphMovement.firstActive = .node
-            }
-        }
+//        // If we don't have an active first gesture,
+//        // and graph isn't already dragging,
+//        // then set node-drag as active first gesture
+//        if self.graphMovement.firstActive == .none {
+//            if !self.graphMovement.graphIsDragged {
+//                // log("canvasItemMoved: will set .node as active first gesture")
+//                self.graphMovement.firstActive = .node
+//            }
+//        }
         if self.graphMovement.firstActive == .graph {
 
             if !self.graphMovement.runningGraphTranslationBeforeNodeDragged.isDefined {
@@ -252,26 +246,26 @@ extension GraphState {
 
         // Dragging an unselected node selects that node
         // and de-selects all other nodes.
-        let alreadySelected = self.isCanvasItemSelected(canvasItem.id)
-        if !alreadySelected {
-            // update node's position
-            self.updateCanvasItemOnDragged(canvasItem, translation: translation)
-
-            // select the canvas item and de-select all the others
-            self.selectSingleCanvasItem(canvasItem.id)
-
-            // add node's edges to highlighted edges; wipe old highlighted edges
-            self.selectedEdges = .init()
-        }
+//        let alreadySelected = self.isCanvasItemSelected(canvasItem.id)
+//        if !alreadySelected {
+//            // update node's position
+//            self.updateCanvasItemOnDragged(canvasItem, translation: translation)
+//
+//            // select the canvas item and de-select all the others
+//            self.selectSingleCanvasItem(canvasItem.id)
+//
+//            // add node's edges to highlighted edges; wipe old highlighted edges
+//            self.selectedEdges = .init()
+//        }
 
         // If we're dragging a node that's already selected,
         // then just update positions of all selected nodes.
-        else {
+//        else {
             self.getSelectedCanvasItems(groupNodeFocused: document.groupNodeFocused?.groupNodeId)
             // need to sort by z index to retain order
                 .sorted { $0.zIndex < $1.zIndex }
                 .forEach { self.updateCanvasItemOnDragged($0, translation: translation) }
-        }
+//        }
 
         // end any edge-drawing
         self.edgeDrawingObserver.reset()

--- a/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
+++ b/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
@@ -90,6 +90,7 @@ struct NodeDuplicateDraggedAction: StitchDocumentEvent {
 }
 
 extension GraphState {
+    /// Duplicates a node before dragging affected canvas items.
     @MainActor
     func nodeDuplicateDragged(id: NodeId,
                               document: StitchDocumentViewModel) {
@@ -140,35 +141,6 @@ extension GraphState {
             
             return
         }
-        
-        // TODO: necessary????
-        // Changed the dragged node to be the newly created node
-//        self.graphMovement.draggedCanvasItem =
-            
-        
-        // log("NodeDuplicateDraggedAction: state.selectedNodeIds at end: \(state.selectedNodeIds)")
-        
-        // Drag all selected nodes if dragging already started
-//        state.selectedCanvasItems
-//            .compactMap { state.getCanvasItem($0) }
-//            .forEach { draggedNode in
-//                // log("NodeDuplicateDraggedAction: already had dragged node id, so will do normal node drag for id \(draggedNode.id)")
-//                state.canvasItemMoved(for: draggedNode,
-//                                      translation: translation,
-//                                      wasDrag: true,
-//                                      document: document)
-//            }
-    }
-}
-
-struct CanvasItemMoved: StitchDocumentEvent {
-    let translation: CGSize
-    let wasDrag: Bool
-    
-    func handle(state: StitchDocumentViewModel) {
-        state.visibleGraph.canvasItemMoved(translation: translation,
-                                           wasDrag: wasDrag,
-                                           document: state)
     }
 }
 
@@ -206,31 +178,8 @@ extension GraphState {
             return
         }
 
-        // Exit if another (non-duplicated) node is being dragged
-        // Note: do this check AFTER we've set our 'currently dragged id' to be the option-duplicated node's id.
-        
-        
-        // Overall, node duplication logic needs to be thought through with multigestures in mind.
-//        if let draggedCanvasItem = self.graphMovement.draggedCanvasItem,
-//           draggedCanvasItem != canvasItem.id {
-//            log("canvasItemMoved: some other node is already dragged: \(draggedCanvasItem)")
-//            return
-//        }
-
-        // Updating for dual-drag; must set before
-
-//        self.graphMovement.draggedCanvasItem = canvasItem.id
         self.graphMovement.lastCanvasItemTranslation = translation
 
-//        // If we don't have an active first gesture,
-//        // and graph isn't already dragging,
-//        // then set node-drag as active first gesture
-//        if self.graphMovement.firstActive == .none {
-//            if !self.graphMovement.graphIsDragged {
-//                // log("canvasItemMoved: will set .node as active first gesture")
-//                self.graphMovement.firstActive = .node
-//            }
-//        }
         if self.graphMovement.firstActive == .graph {
 
             if !self.graphMovement.runningGraphTranslationBeforeNodeDragged.isDefined {
@@ -241,31 +190,11 @@ extension GraphState {
             }
         }
 
-        // first, determine which nodes are selected;
-        // then update positions and selected nodes
-
-        // Dragging an unselected node selects that node
-        // and de-selects all other nodes.
-//        let alreadySelected = self.isCanvasItemSelected(canvasItem.id)
-//        if !alreadySelected {
-//            // update node's position
-//            self.updateCanvasItemOnDragged(canvasItem, translation: translation)
-//
-//            // select the canvas item and de-select all the others
-//            self.selectSingleCanvasItem(canvasItem.id)
-//
-//            // add node's edges to highlighted edges; wipe old highlighted edges
-//            self.selectedEdges = .init()
-//        }
-
-        // If we're dragging a node that's already selected,
-        // then just update positions of all selected nodes.
-//        else {
-            self.getSelectedCanvasItems(groupNodeFocused: document.groupNodeFocused?.groupNodeId)
-            // need to sort by z index to retain order
-                .sorted { $0.zIndex < $1.zIndex }
-                .forEach { self.updateCanvasItemOnDragged($0, translation: translation) }
-//        }
+        // update positions of all selected nodes.
+        self.getSelectedCanvasItems(groupNodeFocused: document.groupNodeFocused?.groupNodeId)
+        // need to sort by z index to retain order
+            .sorted { $0.zIndex < $1.zIndex }
+            .forEach { self.updateCanvasItemOnDragged($0, translation: translation) }
 
         // end any edge-drawing
         self.edgeDrawingObserver.reset()

--- a/Stitch/Graph/Node/View/CanvasItemPositionHandler.swift
+++ b/Stitch/Graph/Node/View/CanvasItemPositionHandler.swift
@@ -74,10 +74,15 @@ struct CanvasItemDragHandler: UIGestureRecognizerRepresentable {
                 }
             }
             
+            // Handles option + drag scenario
             if self.optionHeld,
                let nodeId = canvasItemId.nodeCase {
-                dispatch(NodeDuplicateDraggedAction(id: nodeId))
-            } else {
+                graph.nodeDuplicateDragged(id: nodeId,
+                                           document: document)
+            }
+            
+            // Default dragging scenario
+            else {
                 guard let canvasItem = graph.getCanvasItem(canvasItemId) else {
                     log("CanvasItemMoved: could not find canas item")
                     return

--- a/Stitch/Graph/Node/View/CanvasItemPositionHandler.swift
+++ b/Stitch/Graph/Node/View/CanvasItemPositionHandler.swift
@@ -82,14 +82,19 @@ struct CanvasItemDragHandler: UIGestureRecognizerRepresentable {
                 
                 graph.graphMovement.draggedCanvasItem = canvasItemId
                 
-                // update node's position
-                graph.updateCanvasItemOnDragged(canvasItem, translation: translation)
-
-                // select the canvas item and de-select all the others
-                graph.selectSingleCanvasItem(canvasItem.id)
-
-                // add node's edges to highlighted edges; wipe old highlighted edges
-                graph.selectedEdges = .init()
+                // Dragging an unselected node selects that node
+                // and de-selects all other nodes.
+                let alreadySelected = graph.isCanvasItemSelected(canvasItem.id)
+                if !alreadySelected {
+                    // update node's position
+                    graph.updateCanvasItemOnDragged(canvasItem, translation: translation)
+                    
+                    // select the canvas item and de-select all the others
+                    graph.selectSingleCanvasItem(canvasItem.id)
+                    
+                    // add node's edges to highlighted edges; wipe old highlighted edges
+                    graph.selectedEdges = .init()
+                }
             }
             
         case .changed:

--- a/Stitch/Graph/Node/View/CanvasItemPositionHandler.swift
+++ b/Stitch/Graph/Node/View/CanvasItemPositionHandler.swift
@@ -83,7 +83,6 @@ struct CanvasItemDragHandler: UIGestureRecognizerRepresentable {
                     return
                 }
                 
-                
                 graph.graphMovement.draggedCanvasItem = canvasItemId
                 
                 // Dragging an unselected node selects that node

--- a/Stitch/Graph/Node/View/CanvasItemPositionHandler.swift
+++ b/Stitch/Graph/Node/View/CanvasItemPositionHandler.swift
@@ -20,17 +20,20 @@ struct CanvasItemPositionHandler: ViewModifier {
             .zIndex(zIndex)
             .canvasPosition(id: node.id,
                             position: node.position)
-            .gesture(CanvasItemDragHandler(graph: graph,
+            .gesture(CanvasItemDragHandler(document: document,
+                                           graph: graph,
                                            canvasItemId: node.id))
     }
 }
 
 extension View {
     /// Handles node position, drag gestures, and option+select for duplicating node.
-    func canvasItemPositionHandler(graph: GraphState,
+    func canvasItemPositionHandler(document: StitchDocumentViewModel,
+                                   graph: GraphState,
                                    node: CanvasItemViewModel,
                                    zIndex: ZIndex) -> some View {
-        self.modifier(CanvasItemPositionHandler(graph: graph,
+        self.modifier(CanvasItemPositionHandler(document: document,
+                                                graph: graph,
                                                 node: node,
                                                 zIndex: zIndex))
     }
@@ -43,6 +46,7 @@ extension View {
  (Similar to what we do in sidebar click + shift.)
  */
 struct CanvasItemDragHandler: UIGestureRecognizerRepresentable {
+    let document: StitchDocumentViewModel
     let graph: GraphState
     let canvasItemId: CanvasItemId
     
@@ -97,9 +101,13 @@ struct CanvasItemDragHandler: UIGestureRecognizerRepresentable {
                 }
             }
             
+            graph.canvasItemMoved(translation: translation,
+                                  wasDrag: true,
+                                  document: document)
         case .changed:
-            dispatch(CanvasItemMoved(translation: translation,
-                                     wasDrag: true))
+            graph.canvasItemMoved(translation: translation,
+                                  wasDrag: true,
+                                  document: document)
             
         case .ended, .cancelled, .failed:
             // log("CanvasItemDragHandler: handleUIGestureRecognizerAction: ended, cancelled or failed")

--- a/Stitch/Graph/Node/View/NodeView.swift
+++ b/Stitch/Graph/Node/View/NodeView.swift
@@ -99,9 +99,10 @@ struct NodeView: View {
                     }
                 }
         }
-        .canvasItemPositionHandler(graph: graph,
-                                   node: node,
-                                   zIndex: zIndex)
+                   .canvasItemPositionHandler(document: document,
+                                              graph: graph,
+                                              node: node,
+                                              zIndex: zIndex)
     }
 
     @MainActor

--- a/Stitch/Graph/Node/View/NodeView.swift
+++ b/Stitch/Graph/Node/View/NodeView.swift
@@ -99,7 +99,7 @@ struct NodeView: View {
                     }
                 }
         }
-        .canvasItemPositionHandler(document: document,
+        .canvasItemPositionHandler(graph: graph,
                                    node: node,
                                    zIndex: zIndex)
     }

--- a/Stitch/Graph/Node/View/StitchUIScrollHelpers.swift
+++ b/Stitch/Graph/Node/View/StitchUIScrollHelpers.swift
@@ -45,11 +45,6 @@ struct GraphScrollDataUpdated: StitchDocumentEvent {
             nodePage.zoomData = newZoom
         }
         
-        // Scrolling, zooming ends any node duplication drag
-        // TODO: revisit when we support multi-gestures on iPad again
-        // Usually okay, but we can get stuck in dupe-drag mode if something goes wrong and a handleNodeMoveEnded action isn't fired
-        graph.dragDuplication = false
-        
         // Update which nodes are visible in frame
         graph.updateVisibleNodes()
     }

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -93,9 +93,6 @@ final class GraphState: Sendable {
     @MainActor var canvasPageOffsetChanged: CGPoint? = nil
     @MainActor var canvasPageZoomScaleChanged: CGFloat? = nil
     
-    // Hackiness for handling option+drag "duplicate node and drag it"
-    @MainActor var dragDuplication: Bool = false
-    
     // Only for node cursor selection box done when shift held
     @MainActor var nodesAlreadySelectedAtStartOfShiftNodeCursorBoxDrag: CanvasItemIdSet? = nil
     

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -211,10 +211,6 @@ extension GraphState {
             self.layersSidebarViewModel.isSidebarFocused = false
         }
         
-        // Reset node option dupe-drag
-        // Usually okay, but we can get stuck in dupe-drag mode if something goes wrong and a handleNodeMoveEnded action isn't fired
-        self.dragDuplication = false
-        
         if document.openPortPreview != nil {
             document.openPortPreview = nil
         }


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7099.

Offending commit causing regression is unknown, however some opportunities here to use more gesture events like `began` that allow us to clean up logic and fix the option + drag issues.