### PR TITLE
Remove several non-sense GraphState methods that accessed Document in a type-unclear way

### DIFF
--- a/Stitch/Graph/CommentBox/Util/CommentBoxGestureActions.swift
+++ b/Stitch/Graph/CommentBox/Util/CommentBoxGestureActions.swift
@@ -12,9 +12,15 @@ import StitchSchemaKit
 extension GraphState {
     @MainActor
     func commentBoxTapped(box: CommentBoxViewModel) {
+        
+        guard let document = self.documentDelegate else {
+            fatalErrorIfDebug()
+            return
+        }
+        
         // If CMD held:
         // TODO: pass this down from the gesture handler
-        if self.keypressState.isCommandPressed {
+        if document.keypressState.isCommandPressed {
             if self.selection
                 .selectedCommentBoxes.contains(id) {
                 self.selection.selectedCommentBoxes.remove(id)

--- a/Stitch/Graph/Node/Patch/Type/ARRaycastingNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/ARRaycastingNode.swift
@@ -69,7 +69,7 @@ struct ARRaycastingNode: PatchNodeDefinition {
 func arRayCastingEval(node: PatchNode) -> EvalResult {
     let graphTime = node.graphDelegate?.graphStepState.graphTime ?? .zero
     let defaultOutputs = node.defaultOutputs
-    let arView = node.graphDelegate?.cameraFeed?.arView
+    let arView = node.graphDelegate?.documentDelegate?.cameraFeed?.arView
         
     // Must be accessed on main thread
     let centerPoint = arView?.arView.center ?? .zero

--- a/Stitch/Graph/Node/Patch/Type/ConvertPositionNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/ConvertPositionNode.swift
@@ -47,6 +47,10 @@ func convertPositionEval(node: PatchNode,
 
     let defaultOpResult = PortValue.position(.zero)
     
+    guard let previewWindowSize = graphState.documentDelegate?.previewWindowSize else {
+        return [[defaultOpResult]]
+    }
+    
     let op: OpWithIndex<PortValue> = { (values: PortValues, loopIndex: Int) -> PortValue in
         // log("convertPositionEval: op: values: \(values)")
         
@@ -69,9 +73,9 @@ func convertPositionEval(node: PatchNode,
          */
         let fromLayerId: LayerNodeId? = values[safe: 0]?.getInteractionId
         let toLayerId: LayerNodeId? = values[safe: 3]?.getInteractionId
-        
+                
         let previewWindowRect = CGRect(origin: .zero,
-                                       size: graphState.previewWindowSize)
+                                       size: previewWindowSize)
         
         let fromLayerViewModel: LayerViewModel? = fromLayerId.flatMap(layerViewModelAtIndex)
         let fromRect: CGRect = fromLayerViewModel?.readFrame ?? previewWindowRect

--- a/Stitch/Graph/Node/Patch/Type/Interaction/Keyboard/KeyboardNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/Keyboard/KeyboardNode.swift
@@ -29,9 +29,12 @@ struct KeyboardNode: PatchNodeDefinition {
 @MainActor
 func keyboardEval(node: PatchNode,
                   graph: GraphState) -> EvalResult {
+
+    // We should always have a document delegate
+    assertInDebug(graph.documentDelegate.isDefined)
     
     let graphTime = graph.graphStepState.graphTime
-    let keypressState = graph.keypressState
+    let keypressState = graph.documentDelegate?.keypressState ?? .init()
 
     return node.loopedEval { values, _ in
         let character = values.first?.getString?.string ?? ""

--- a/Stitch/Graph/PrototypePreview/Layer/Util/LayerDragEndedActions.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Util/LayerDragEndedActions.swift
@@ -25,6 +25,11 @@ extension GraphState {
         // log("layerDragEnded: interactiveLayer.id: \(interactiveLayer.id)")
          // log("layerDragEnded CALLED")
 
+        guard let previewWindowSize = self.documentDelegate?.previewWindowSize else {
+            fatalErrorIfDebug("layerDragEnded: Must have preview window size")
+            return
+        }
+        
         var nodesToRecalculate = NodeIdSet()
         
         let pressInteractionIdSet: IdSet = self.getPressInteractionIds(for: interactiveLayer.id.layerNodeId)
@@ -41,7 +46,7 @@ extension GraphState {
                                       gestureLocation: nil,
                                       velocity: nil,
                                       leftClick: false,
-                                      previewWindowSize: self.previewWindowSize,
+                                      previewWindowSize: previewWindowSize,
                                       graphTime: self.graphStepState.graphTime)
         
         nodesToRecalculate = nodesToRecalculate.union(mouseNodeIds)

--- a/Stitch/Graph/PrototypePreview/Layer/Util/LayerDraggedActions.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Util/LayerDraggedActions.swift
@@ -26,6 +26,11 @@ extension GraphState {
                       childSize: CGSize,
                       childPosition: CGPoint) {
                 
+        guard let previewWindowSize = self.documentDelegate?.previewWindowSize else {
+            fatalErrorIfDebug("layerDragEnded: Must have preview window size")
+            return
+        }
+        
         // log("layerDragged CALLED")
         
         var nodesToRecalculate = NodeIdSet()
@@ -46,7 +51,7 @@ extension GraphState {
                                                         gestureLocation: location,
                                                         velocity: velocity.toCGPoint,
                                                         leftClick: true,
-                                                        previewWindowSize: self.previewWindowSize,
+                                                        previewWindowSize: previewWindowSize,
                                                         graphTime: self.graphStepState.graphTime)
         
         nodesToRecalculate = nodesToRecalculate.union(mouseNodeIds)

--- a/Stitch/Graph/Sidebar/Util/Gesture/LegacySidebarActions.swift
+++ b/Stitch/Graph/Sidebar/Util/Gesture/LegacySidebarActions.swift
@@ -117,7 +117,7 @@ extension ProjectSidebarObservable {
         }
          
         // We're just starting an option dupe-drag and need to duplicate the layers
-        if graph.keypressState.isOptionPressed
+        if document.keypressState.isOptionPressed
             && !state.selectionState.haveDuplicated
             && !state.selectionState.optionDragInProgress {
             // log("SidebarListItemDragged: option held during drag; will duplicate layers")

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
@@ -302,7 +302,7 @@ extension SidebarItemGestureViewModel {
             self.sidebarDelegate?.sidebarItemTapped(
                 id: itemId,
                 shiftHeld: isShiftDown,
-                commandHeld: graph.keypressState.isCommandPressed,
+                commandHeld: document.keypressState.isCommandPressed,
                 graph: graph,
                 document: document)
         }

--- a/Stitch/Graph/ViewModel/GraphDelegate.swift
+++ b/Stitch/Graph/ViewModel/GraphDelegate.swift
@@ -17,41 +17,12 @@ extension GraphState {
         }
     }
     
+    // TODO: use a specific GraphId
     @MainActor
     var projectId: UUID { self.id }
-    
-    @MainActor
-    var cameraFeedManager: LoadingStatus<StitchSingletonMediaObject>? {
-        self.documentDelegate?.cameraFeedManager
-    }
-    
-    @MainActor
-    var locationManager: LoadingStatus<StitchSingletonMediaObject>? {
-        self.documentDelegate?.locationManager
-    }
-    
-    @MainActor var keypressState: KeyPressState {
-        self.documentDelegate?.keypressState ?? .init()
-    }
-    
-    @MainActor var previewWindowSize: CGSize {
-        self.documentDelegate?.previewWindowSize ?? .init()
-    }
-    
+                
+    // TODO: remove
     @MainActor var graphMovement: GraphMovementObserver {
         self.documentDelegate?.graphMovement ?? .init()
-    }
-    
-    @MainActor var isGeneratingProjectThumbnail: Bool {
-        self.documentDelegate?.isGeneratingProjectThumbnail ?? false
-    }
-    
-    @MainActor
-    var cameraFeed: CameraFeedManager? {
-        self.cameraFeedManager?.loadedInstance?.cameraFeedManager
-    }
-    
-    @MainActor var cameraSettings: CameraSettings {
-        self.documentDelegate?.cameraSettings ?? .init()
     }
 }


### PR DESCRIPTION
What does it mean if `documentDelegate` is nil? 

We can't have key press state or preview window size if we don't have a project loaded. 

What does providing `.zero` for a preview window size even mean? 
What scenario does that cover?


<img width="708" alt="Screenshot 2025-04-08 at 1 59 32 PM" src="https://github.com/user-attachments/assets/36ebc6f3-365e-4567-b12e-d700a6b73f6b" />
