### PR TITLE
Use type-safe IDs for Graph, CommentBox

### DIFF
--- a/Stitch/App/Model/AppState.swift
+++ b/Stitch/App/Model/AppState.swift
@@ -23,5 +23,5 @@ struct AppState: Equatable {
     var isShowingDrawer = false
 
     // Tracks ID of project which has a title that's currently getting modified
-    var projectIdForTitleEdit: ProjectId?
+    var projectIdForTitleEdit: GraphId?
 }

--- a/Stitch/App/Model/ProjectAlertState.swift
+++ b/Stitch/App/Model/ProjectAlertState.swift
@@ -34,7 +34,7 @@ final class ProjectAlertState: Sendable {
     @MainActor var showSampleAppsSheet = false
 
     // If a project was recently deleted, store the undo event here
-    @MainActor var deletedProjectId: ProjectId?
+    @MainActor var deletedGraphId: GraphId?
 
     // Alert state to confirm deleting ALL projects
     @MainActor var showDeleteAllProjectsConfirmation = false

--- a/Stitch/App/Serialization/Util/File/StitchDocumentUtil.swift
+++ b/Stitch/App/Serialization/Util/File/StitchDocumentUtil.swift
@@ -49,7 +49,7 @@ extension StitchDocument: StitchDocumentEncodable, StitchDocumentMigratable {
         Self.getRootUrl(from: self.id)
     }
     
-    public var id: ProjectId {
+    public var id: UUID {
         get {
             self.graph.id
         }

--- a/Stitch/App/Util/Action/HandleStitchAction.swift
+++ b/Stitch/App/Util/Action/HandleStitchAction.swift
@@ -76,7 +76,7 @@ struct ProjectDeletedAndWillExitCurrentProject: StitchStoreEvent {
 }
 
 struct UndoDeleteProject: StitchStoreEvent {
-    let projectId: ProjectId
+    let projectId: GraphId
     
     func handle(store: StitchStore) -> ReframeResponse<NoState> {
         store.undoDeleteProject(projectId: projectId)

--- a/Stitch/App/View/StitchNavStack.swift
+++ b/Stitch/App/View/StitchNavStack.swift
@@ -30,7 +30,7 @@ struct StitchNavStack: View {
                     
                 }
                 .onChange(of: store.navPath.first) { _, currentProject in
-                    let currentProjectId = currentProject?.id
+                    let currentGraphId = currentProject?.id
                     
                     // Rest undo if project closed
                     if !store.isCurrentProjectSelected {
@@ -40,7 +40,7 @@ struct StitchNavStack: View {
                     // Remove references to other StitchDocuments to release them from memory
                     // Logic here needed for drag-and-drop import with existing document open
                     store.allProjectUrls.forEach { projectLoader in
-                        if projectLoader.id != currentProjectId &&
+                        if projectLoader.id != currentGraphId &&
                             projectLoader.documentViewModel != nil {
                             // In case references are stored here (but probably not)
                             projectLoader.lastEncodedDocument = nil

--- a/Stitch/App/ViewModel/StitchStore.swift
+++ b/Stitch/App/ViewModel/StitchStore.swift
@@ -46,7 +46,7 @@ final class StitchStore: Sendable {
     @MainActor var showsLayerInspector = false
     
     // Tracks ID of project which has a title that's currently getting modified
-    @MainActor var projectIdForTitleEdit: ProjectId?
+    @MainActor var projectIdForTitleEdit: GraphId?
     
     let environment: StitchEnvironment
     
@@ -121,11 +121,11 @@ extension StitchStore: GlobalDispatchDelegate {
 extension StitchStore {
     @MainActor
     var isCurrentProjectSelected: Bool {
-        self.currentProjectId.isDefined
+        self.currentGraphId.isDefined
     }
 
     @MainActor
-    var currentProjectId: ProjectId? {
+    var currentGraphId: GraphId? {
         currentDocument?.projectId
     }
 

--- a/Stitch/Graph/CommentBox/Util/CommentBoxDataUtils.swift
+++ b/Stitch/Graph/CommentBox/Util/CommentBoxDataUtils.swift
@@ -12,19 +12,15 @@ import StitchSchemaKit
 typealias CommentBoxIdSet = Set<CommentBoxId>
 typealias CommentBoxViewModels = [CommentBoxViewModel]
 
-// struct CommentBoxId: Equatable, Identifiable, Codable, Hashable {
-//    var id: UUID = .init()
-//
-//    static let fakeId: Self = .init()
-// }
-
-typealias CommentBoxId = UUID
-
-// struct CommentBoxId: Equatable, Identifiable, Codable, Hashable {
-//    var id: UUID = .init()
-//
-//    static let fakeId: Self = .init()
-// }
+struct CommentBoxId: Hashable, Codable, Equatable, Identifiable {
+    var id: UUID { self.value }
+    
+    let value: UUID
+    
+    init(_ value: UUID = UUID()) {
+        self.value = value
+    }
+}
 
 extension CommentBoxId {
     static let fakeId: Self = .init()

--- a/Stitch/Graph/CommentBox/Util/CommentBoxGestureActions.swift
+++ b/Stitch/Graph/CommentBox/Util/CommentBoxGestureActions.swift
@@ -22,10 +22,10 @@ extension GraphState {
         // TODO: pass this down from the gesture handler
         if document.keypressState.isCommandPressed {
             if self.selection
-                .selectedCommentBoxes.contains(id) {
-                self.selection.selectedCommentBoxes.remove(id)
+                .selectedCommentBoxes.contains(box.id) {
+                self.selection.selectedCommentBoxes.remove(box.id)
             } else {
-                self.selection.selectedCommentBoxes.insert(id)
+                self.selection.selectedCommentBoxes.insert(box.id)
             }
         }
 
@@ -33,7 +33,7 @@ extension GraphState {
         else {
             // reset selection state; select only this comment box
             self.selection = .init()
-            self.selection.selectedCommentBoxes = Set([id])
+            self.selection.selectedCommentBoxes = Set([box.id])
         }
 
         box.zIndex = self.highestZIndex + 1
@@ -209,14 +209,14 @@ extension GraphState {
         // ALWAYS update this comment box's bounds
         self.commentBoxBoundsDict.updateValue(
             newestBoxBounds,
-            forKey: id)
+            forKey: box.id)
 
         // RE-DETERMINE WHICH NODES FALL WITHIN THIS COMMENT BOX
         // Assumes this comment box's bounds were recently updated
         self.rebuildCommentBoxes(currentTraversalLevel: groupNodeFocused)
 
-        guard let box = self.commentBoxesDict.get(id) else {
-            log("CommentBoxExpansionDragEnded: could not retrieve comment box \(id)")
+        guard let box = self.commentBoxesDict.get(box.id) else {
+            log("CommentBoxExpansionDragEnded: could not retrieve comment box \(box.id)")
             return
         }
 
@@ -241,7 +241,7 @@ extension GraphState {
         // Add this box's bounds to the bounds-dict
         self.commentBoxBoundsDict.updateValue(
             bounds,
-            forKey: id)
+            forKey: box.id)
 
         // Then redetermine which nodes fall into the boxes
         // TODO: only redetermine for this single box, not all boxes?

--- a/Stitch/Graph/CommentBox/ViewModel/CommentBoxViewModel.swift
+++ b/Stitch/Graph/CommentBox/ViewModel/CommentBoxViewModel.swift
@@ -8,11 +8,11 @@
 import StitchSchemaKit
 import SwiftUI
 
-typealias CommentBoxesDict = [UUID: CommentBoxViewModel]
+typealias CommentBoxesDict = [CommentBoxId: CommentBoxViewModel]
 
 @Observable
 final class CommentBoxViewModel {
-    var id: UUID = .init()
+    var id: CommentBoxId = .init()
     var groupId: NodeId?
     var title: String = "Comment"
     var color: Color
@@ -56,7 +56,7 @@ extension CommentBoxViewModel: SchemaObserver {
 
     @MainActor
     func update(from schema: CommentBoxData) {
-        self.id = schema.id
+        self.id = .init(schema.id)
         self.groupId = schema.groupId
         self.title = schema.title
         self.color = schema.color
@@ -68,7 +68,7 @@ extension CommentBoxViewModel: SchemaObserver {
 
     func createSchema() -> CommentBoxData {
         CommentBoxData(
-            id: self.id,
+            id: self.id.value,
             groupId: self.groupId,
             title: self.title,
             color: self.color,
@@ -106,8 +106,8 @@ struct CommentExpansionBox: Equatable, Hashable {
 extension CommentBoxesDict {
     mutating func sync(from commentBoxesData: [CommentBoxData]) {
         commentBoxesData.forEach { data in
-            if let existingViewModel = self.get(data.id) {
-
+            if let existingViewModel = self.get(.init(data.id)) {
+                fatalErrorIfDebugOnly("Not implemented?")
             }
         }
     }

--- a/Stitch/Graph/Node/Component/ComponentNavBarView.swift
+++ b/Stitch/Graph/Node/Component/ComponentNavBarView.swift
@@ -14,7 +14,7 @@ struct ComponentNavBarView: View {
     @Bindable var store: StitchStore
     
     var componentId: UUID {
-        self.graph.id
+        self.graph.id.value
     }
     
     func getLocalComponent() -> StitchMasterComponent? {
@@ -111,7 +111,7 @@ extension StitchDocumentViewModel {
             // Set new ID in save location, which determines URLs
             let _saveLocation = component.saveLocation.localComponentPath
             assertInDebug(_saveLocation != nil)
-            var saveLocation = _saveLocation ?? GraphDocumentPath(docId: self.id,
+            var saveLocation = _saveLocation ?? GraphDocumentPath(docId: self.id.value,
                                                                   componentId: newId,
                                                                   componentsPath: [])
             
@@ -153,7 +153,7 @@ extension StitchDocumentViewModel {
         self.allComponents.forEach { componentNode in
             if componentNode.componentId == from {
                 componentNode.componentId = to
-                componentNode.graph.id = to
+                componentNode.graph.id = .init(to)
             }
         }
     }

--- a/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
+++ b/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
@@ -316,7 +316,8 @@ extension GraphState {
         assertInDebug(!self.saveLocation.isEmpty)
         
         guard let parentGraph = self.parentGraph,
-              let node = parentGraph.nodes.get(self.id),
+              // TODO: is this accurate? we're using a GraphState.id to retrieve a node in the parentGraph?
+              let node = parentGraph.nodes.get(self.id.value),
               let componentNode = node.componentNode else {
             fatalErrorIfDebug()
                   return

--- a/Stitch/Graph/Node/Model/GraphCopyable.swift
+++ b/Stitch/Graph/Node/Model/GraphCopyable.swift
@@ -399,7 +399,7 @@ extension StitchDocumentViewModel {
         self.visibleGraph.createComponent(componentId: componentId,
                                           groupNodeFocused: groupNodeFocused,
                                           selectedNodeIds: selectedNodeIds) { graph in
-            let newPath = GraphDocumentPath(docId: self.id,
+            let newPath = GraphDocumentPath(docId: self.id.value,
                                             componentId: componentId,
                                             componentsPath: self.visibleGraph.saveLocation)
             return StitchComponent(saveLocation: .localComponent(newPath),

--- a/Stitch/Graph/Node/Util/NodeDeletedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeDeletedAction.swift
@@ -228,8 +228,9 @@ extension GraphState {
             }
         }
 
+        // TODO: come back here; we're not passing in the proper box.id
         // Update comment box data
-        self.deleteCommentBox(id)
+        // self.deleteCommentBox(id)
         
         // Delete media from file manager if it's the "source" media and unused elsewhere
         node.inputs.findImportedMediaKeys().forEach { mediaKey in

--- a/Stitch/Graph/PrototypePreview/Frame/View/FloatingWindowView.swift
+++ b/Stitch/Graph/PrototypePreview/Frame/View/FloatingWindowView.swift
@@ -47,7 +47,7 @@ struct FloatingWindowView: View {
         previewWindowSizing.dimensions
     }
 
-    var projectId: ProjectId {
+    var projectId: GraphId {
         document.projectId
     }
 

--- a/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
+++ b/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
@@ -262,7 +262,7 @@ extension GraphState {
             // Update save location for components
             let components = decodedFiles.components.map { component in
                 var component = component
-                component.saveLocation = .localComponent(.init(docId: document.id,
+                component.saveLocation = .localComponent(.init(docId: document.id.value,
                                                                componentId: component.id,
                                                                componentsPath: self.saveLocation))
                 return component

--- a/Stitch/Graph/View/ProjectToolbar.swift
+++ b/Stitch/Graph/View/ProjectToolbar.swift
@@ -20,7 +20,7 @@ struct ProjectToolbarViewModifier: ViewModifier {
     @Bindable var document: StitchDocumentViewModel
     @Bindable var graph: GraphState
     let projectName: String
-    let projectId: ProjectId
+    let projectId: GraphId
     @Binding var isFullScreen: Bool
     
     @AppStorage(LLM_RECORDING_MODE_KEY_NAME) private var llmRecordingMode: Bool = false

--- a/Stitch/Graph/ViewModel/GraphDelegate.swift
+++ b/Stitch/Graph/ViewModel/GraphDelegate.swift
@@ -9,6 +9,41 @@ import Foundation
 import StitchSchemaKit
 import StitchEngine
 
+
+//struct ProjectId: Hashable, Codable, Equatable, Identifiable {
+//    var id: UUID { self.value }
+//    
+//    let value: UUID
+//    
+//    init(_ value: UUID = UUID()) {
+//        self.value = value
+//    }
+//}
+
+// TODO: do we need separate id types for Project (Document) vs the several graph states contained within a single project?
+struct GraphId: Hashable, Codable, Equatable, Identifiable{
+    
+    var description: String
+    
+    var id: UUID { self.value }
+    
+    let value: UUID
+    
+    init(_ value: UUID = UUID()) {
+        self.value = value
+        self.description = value.uuidString
+    }
+}
+
+// TODO: what is this empty initializer for?
+extension GraphId: StitchDocumentIdentifiable {
+    init() {
+        let value = UUID()
+        self.value = value
+        self.description = value.uuidString
+    }
+}
+
 extension GraphState {
     @MainActor
     func children(of parent: NodeId) -> NodeViewModels {
@@ -19,7 +54,7 @@ extension GraphState {
     
     // TODO: use a specific GraphId
     @MainActor
-    var projectId: UUID { self.id }
+    var projectId: GraphId { self.id }
                 
     // TODO: remove
     @MainActor var graphMovement: GraphMovementObserver {

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -30,7 +30,7 @@ final class GraphState: Sendable {
     
     let saveLocation: [UUID]
     
-    @MainActor var id = UUID()
+    @MainActor var id = GraphId()
     @MainActor var name: String = STITCH_PROJECT_DEFAULT_NAME
     @MainActor var migrationWarning: StringIdentifiable?
     
@@ -135,7 +135,7 @@ final class GraphState: Sendable {
         self.visibleNodesViewModel = VisibleNodesViewModel(localPosition: localPosition)
         self.lastEncodedDocument = schema
         self.saveLocation = saveLocation
-        self.id = schema.id
+        self.id = .init(schema.id)
         self.name = schema.name
         self.layersSidebarViewModel = .init()
         self.topologicalData = .init()
@@ -417,7 +417,7 @@ extension GraphState {
             .map { $0.createSchema() }
         let commentBoxes = self.commentBoxesDict.values.map { $0.createSchema() }
         
-        let graph = GraphEntity(id: self.projectId,
+        let graph = GraphEntity(id: self.projectId.value,
                                 name: self.name,
                                 nodes: nodes,
                                 orderedSidebarLayers: self.layersSidebarViewModel.createdOrderedEncodedData(),
@@ -469,7 +469,7 @@ extension GraphState {
     
     @MainActor
     private func updateSynchronousProperties(from schema: GraphEntity) {
-        assertInDebug(self.id == schema.id)
+        assertInDebug(self.id.value == schema.id)
         
         if self.name != schema.name {
             self.name = schema.name

--- a/Stitch/Graph/ViewModel/HomescreenProjectSelectionState.swift
+++ b/Stitch/Graph/ViewModel/HomescreenProjectSelectionState.swift
@@ -11,7 +11,7 @@ import StitchSchemaKit
 
 struct HomescreenProjectSelectionState: Equatable, Codable, Hashable {
     var isSelecting = false
-    var selections: Set<ProjectId> = .init()
+    var selections: Set<GraphId> = .init()
 }
 
 struct HomescreenProjectSelectionToggled: StitchStoreEvent {
@@ -29,7 +29,7 @@ struct HomescreenProjectSelectionToggled: StitchStoreEvent {
 }
 
 struct ProjectTappedDuringHomescreenSelection:  StitchStoreEvent {
-    let projectId: ProjectId
+    let projectId: GraphId
     
     func handle(store: StitchStore) -> ReframeResponse<NoState> {
         withAnimation(.linear(duration: 0.2)) {
@@ -46,8 +46,8 @@ struct ProjectTappedDuringHomescreenSelection:  StitchStoreEvent {
 struct DeleteHomescreenSelectedProjects: StitchStoreEvent {
     
     func handle(store: StitchStore) -> ReframeResponse<NoState> {
-        store.homescreenProjectSelectionState.selections.forEach { (selectedProject: ProjectId) in
-            if let project = store.allProjectUrls.first(where: { $0.loadedDocument?.0.id == selectedProject }),
+        store.homescreenProjectSelectionState.selections.forEach { (selectedProject: GraphId) in
+            if let project = store.allProjectUrls.first(where: { $0.loadedDocument?.0.id == selectedProject.value }),
                let (loadedDocument, _) = project.loadedDocument {
                 
                 store.deleteProject(document: loadedDocument)

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -25,7 +25,9 @@ struct GraphUpdaterId: Equatable, Hashable, Sendable, Codable {
 
 @Observable
 final class StitchDocumentViewModel: Sendable {
-    let rootId: UUID
+    // TODO: what kind of id is this? Per data flow, it's from StitchDocumentViewModel.id which is from document.graphId i.e. it's the id for the document's root
+    let rootId: UUID // Previously was just `UUID`, taken from StitchDocument.id which was from
+    
     let isDebugMode: Bool
     let graph: GraphState
     let graphStepManager = GraphStepManager()
@@ -353,12 +355,12 @@ extension StitchDocumentViewModel: DocumentEncodableDelegate {
 
 extension StitchDocumentViewModel {
     @MainActor
-    var id: UUID {
+    var id: GraphId {
         self.graph.id
     }
     
     @MainActor
-    var projectId: UUID {
+    var projectId: GraphId {
         self.id
     }
     

--- a/Stitch/Home/Util/ProjectDestructiveActions.swift
+++ b/Stitch/Home/Util/ProjectDestructiveActions.swift
@@ -36,16 +36,16 @@ extension StitchStore {
         case .success:
             log("StitchStore: deleteProject: success")
             // If undo is called, re-import the project from recently deleted
-            let undoEvents: [Action] = [UndoDeleteProject(projectId: projectId) ]
+            let undoEvents: [Action] = [UndoDeleteProject(projectId: .init(projectId)) ]
             let redoEvents: [Action] = [ProjectDeleted(document: document)]
 
             // Displays toast UI on projects screen
             
             // TODO: fix 'Undo Delete' on iPhone
             if !Stitch.isPhoneDevice {
-                self.alertState.deletedProjectId = projectId
+                self.alertState.deletedGraphId = .init(projectId)
             }
-            // self.alertState.deletedProjectId = projectId
+            // self.alertState.deletedGraphId = projectId
 
             self.saveProjectDeletionUndoHistory(undoActions: undoEvents,
                                                 redoActions: redoEvents)
@@ -59,13 +59,13 @@ extension StitchStore {
     /// Clears undo button toast UI on projects screen.
     @MainActor
     func projectDeleteToastExpired() {
-        self.alertState.deletedProjectId = nil
+        self.alertState.deletedGraphId = nil
     }
 }
 
 extension StitchStore {
     @MainActor
-    func undoDeleteProject(projectId: ProjectId) {
+    func undoDeleteProject(projectId: GraphId) {
         // Find URL from recently deleted
         let deletedProjectURL = StitchFileManager.recentlyDeletedURL
             .appendingStitchProjectDataPath("\(projectId)")
@@ -84,7 +84,7 @@ extension StitchStore {
 
             await MainActor.run { [weak self] in
                 // Remove toast on projects screen
-                self?.alertState.deletedProjectId = nil
+                self?.alertState.deletedGraphId = nil
             }
         }
     }

--- a/Stitch/Home/View/ProjectItem/ProjectsListItemView.swift
+++ b/Stitch/Home/View/ProjectItem/ProjectsListItemView.swift
@@ -134,7 +134,7 @@ struct ProjectsListItemView: View {
                 .onTapGesture {
 #if DEV_DEBUG
                     if store.homescreenProjectSelectionState.isSelecting {
-                        dispatch(ProjectTappedDuringHomescreenSelection(projectId: document.id))
+                        dispatch(ProjectTappedDuringHomescreenSelection(projectId: .init(document.id)))
                     } else {
                         self.openProject(document: document, inDebug: false)
                     }
@@ -146,7 +146,7 @@ struct ProjectsListItemView: View {
 #if DEV_DEBUG
                 .overlay {
                     
-                    if store.homescreenProjectSelectionState.selections.contains(document.id) {
+                    if store.homescreenProjectSelectionState.selections.contains(.init(document.id)) {
                         RoundedRectangle(cornerRadius: 8)
                             .fill(.clear)
                             .stroke(LinearGradient(colors: [.red, .indigo, .purple, .blue, .cyan, .green, .yellow, .orange],

--- a/Stitch/Home/View/ProjectsHomeView.swift
+++ b/Stitch/Home/View/ProjectsHomeView.swift
@@ -38,10 +38,10 @@ struct ProjectsHomeView: View {
 
     @MainActor
     private func undoToastTapped() {
-        guard let deletedProjectId = self.alertState.deletedProjectId else {
+        guard let deletedGraphId = self.alertState.deletedGraphId else {
             return
         }
-        store.undoDeleteProject(projectId: deletedProjectId)
+        store.undoDeleteProject(projectId: deletedGraphId)
     }
 
     var body: some View {
@@ -97,8 +97,8 @@ struct ProjectsHomeView: View {
         .modifier(SampleAppsSheet(showSampleAppsSheet: alertState.showSampleAppsSheet,
                                   namespace: namespace))
         // Shows undo delete toast when GraphUI state has recenetly deleted project ID
-        // Should onExpireAction only fire an action if alertState.deletedProjectId still defined ?
-        .toast(willShow: alertState.deletedProjectId.isDefined,
+        // Should onExpireAction only fire an action if alertState.deletedGraphId still defined ?
+        .toast(willShow: alertState.deletedGraphId.isDefined,
                messageLeft: "File Deleted",
                messageRight: "Undo",
                onTapAction: self.undoToastTapped,
@@ -114,8 +114,8 @@ struct ProjectsHomeView: View {
     }
 }
 
-extension ProjectId {
-    static let mockProjectId = ProjectId()
+extension GraphId {
+    static let mockGraphId = GraphId()
 }
 
 // struct ProjectsList_Previews: PreviewProvider {
@@ -123,14 +123,14 @@ extension ProjectId {
 //     @Namespace static var mockNamespace
 
 //     static let projectsDict: ProjectsDict = [
-//         .mockProjectId: .loaded(ProjectSchema(
+//         .mockGraphId: .loaded(ProjectSchema(
 //                                     metadata: ProjectMetadata(name: "Test"),
 //                                     schema: GraphSchema()))
 //     ]
 
 //     static let projectsState = StitchProjects(
 //         projectsDict: projectsDict,
-//         sortedProjectIds: [.mockProjectId])
+//         sortedGraphIds: [.mockGraphId])
 
 //     static var previews: some View {
 //         projectsHomeView

--- a/StitchTests/TestUtils/MockFileManager.swift
+++ b/StitchTests/TestUtils/MockFileManager.swift
@@ -27,7 +27,7 @@ class MockFileManager: FileManager {
     }
 
     func removeStitchMedia(at URL: URL,
-                           currentProjectId: ProjectId,
+                           currentGraphId: GraphId,
                            permanently: Bool = false) async -> StitchFileVoidResult {
         self._storage.removeValue(forKey: MediaKey(URL))
         return .success

--- a/StitchTests/TestUtils/TestStateUtils.swift
+++ b/StitchTests/TestUtils/TestStateUtils.swift
@@ -43,7 +43,7 @@ import XCTest
 //                                   state: appState)
 // }
 
-// let MOCK_APP_STATE_PROJECT_SELECTED = AppState(currentProjectId: devDefaultProject().id)
+// let MOCK_APP_STATE_PROJECT_SELECTED = AppState(currentGraphId: devDefaultProject().id)
 
 // extension GraphState {
 //    static func getTestState(_ nodes: [any Node],


### PR DESCRIPTION
In the past when we have switched a method from `extension NodeViewModel` to `extension GraphState` (or vice-versa), we introduced bugs wherever a `self.id` was not updated to be e.g. `graph.id` or `node.id`; 
e.g. we ended up trying to retrieve some part of the node view model using a graph id!

Example from this refactor: we had made comment box methods on `extension StitchDocument` and were referencing `id` i.e. `self.id` when trying to retrieve a comment box. This is total non-sense. 

Type-safe identifiers make these mistakes impossible.

Longer explanation: https://www.rea-group.com/about-us/news-and-insights/blog/the-abject-failure-of-weak-typing/