### PR TITLE
Fixed custom shape patch node edits

### DIFF
--- a/Stitch/Graph/LayerInspector/Model/LayerInspectorSection.swift
+++ b/Stitch/Graph/LayerInspector/Model/LayerInspectorSection.swift
@@ -13,6 +13,7 @@ enum LayerInspectorSection: String, CaseIterable, Identifiable {
     case geometry3D = "3D Geometry"
     case realityTransformation = "3D Transformation"
     case gestures3D = "3D Gestures"
+    case shape = "Shape"
     case sizing = "Sizing"
     case positioning = "Positioning"
     case common = "Common"
@@ -54,6 +55,13 @@ extension LayerInspectorSection {
                 .offsetInGroup
             ]
         
+        case .shape:
+            return [
+                // Shape layer node
+                .shape,
+                .coordinateSystem
+            ]
+            
         case .common:
             return [
                 
@@ -75,10 +83,6 @@ extension LayerInspectorSection {
                 .sfSymbol,
                 
                 .color, // Text color vs Rectangle color
-                
-                // Shape layer node
-                .shape,
-                .coordinateSystem,
                 
         //        .init(.shadow, layer.supportsShadowInputs ? Self.shadow : []),
                 

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Shapes/CustomShapeView.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Shapes/CustomShapeView.swift
@@ -54,13 +54,11 @@ struct CustomShapeView: View {
     func baseView(_ color: Color) -> some View {
         Rectangle()
             .fill(color)
-            .frame(self.shape.baseFrame.size)
     }
 
     @ViewBuilder
     func filledView(maskShape: Path) -> some View {
         baseView(shapeLayerNodeColor)
-            .frame(self.shape.baseFrame.size)
             .mask(maskShape.fill(style: .init(eoFill: true)))
     }
 
@@ -68,7 +66,6 @@ struct CustomShapeView: View {
     func trimmedView(maskShape: Path,
                      strokeScale: CGFloat) -> some View {
         baseView(strokeData.color)
-            .frame(self.shape.baseFrame.size)
             .mask(maskShape
                     // stroke progress: 0 -> 1
                     .trimmedPath(from: strokeData.strokeStart,
@@ -99,6 +96,5 @@ struct CustomShapeInnerView<T: View, U: View>: View {
             }
         }
         .offset(x: xOffset, y: yOffset)
-        .scaleEffect(x: xScale, y: yScale)
     }
 }


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/6956

Unclear how long this has been broken but possibly a while. Removing frame and scale effect view modifiers seemed to fix the issue. It's unclear why they exist.

Draft PR until stroke inside/outside setting works again.