### PR TITLE
Minor perf improvements for layer scenarios

### DIFF
--- a/Stitch/Graph/Node/Patch/Type/Shape/LayerInfoNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Shape/LayerInfoNode.swift
@@ -41,7 +41,7 @@ extension GraphState {
     // TODO: cache these?
     @MainActor
     func layerListeningPatchNodes(assignedTo id: LayerNodeId) -> IdSet {
-        self.patchNodes.reduce(into: .init(), { partialResult, kv in
+        self.nodes.reduce(into: .init(), { partialResult, kv in
             let node = kv.value
             if node.patch?.listensToAssignedLayer ?? false,
                node.getInteractionId() == id {

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeView.swift
@@ -86,9 +86,13 @@ struct SidebarListItemSwipeView<SidebarViewModel>: View where SidebarViewModel: 
             
             gestureViewModel.isHovered = hovering
             if hovering {
-                self.sidebarViewModel.highlightedSidebarLayers.insert(gestureViewModel.id)
+                if !self.sidebarViewModel.highlightedSidebarLayers.contains(gestureViewModel.id) {
+                    self.sidebarViewModel.highlightedSidebarLayers.insert(gestureViewModel.id)
+                }
             } else {
-                self.sidebarViewModel.highlightedSidebarLayers.remove(gestureViewModel.id)
+                if self.sidebarViewModel.highlightedSidebarLayers.contains(gestureViewModel.id) {
+                    self.sidebarViewModel.highlightedSidebarLayers.remove(gestureViewModel.id)
+                }
             }
         }
         


### PR DESCRIPTION
Tagging https://github.com/StitchDesign/Stitch--Old/issues/7111 which sees some improvement.

Fixes:
1. Using `.nodes` instead of `.patchNodes` removes an unnecessary filtering check for nodes. Unnecessary because logic already filters for patches.
2. Reduces render cycles caused by layer highlighting.