### PR TITLE
Visually indicate actively edited sidebar name; defocus redux field in sidebar item selected

### DIFF
--- a/Stitch/Graph/Node/Port/View/Field/InputView/CommonEditingView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/CommonEditingView.swift
@@ -312,7 +312,7 @@ struct CommonEditingView: View {
 #if targetEnvironment(macCatalyst)
         .offset(y: -0.5) // slight adjustment required
 #endif
-        .modifier(InputViewBackground(
+        .modifier(InputFieldBackground(
             show: true, // always show background for a focused input
             hasDropdown: self.hasPicker,
             forPropertySidebar: isForLayerInspector,
@@ -383,7 +383,7 @@ struct CommonEditingView: View {
 }
 
 // TODO: per Elliot, this is actually a perf-expensive view?
-struct InputViewBackground: ViewModifier {
+struct InputFieldBackground: ViewModifier {
     
     @Environment(\.appTheme) var theme
     
@@ -431,5 +431,3 @@ struct InputViewBackground: ViewModifier {
             .contentShape(Rectangle())
     }
 }
-
-

--- a/Stitch/Graph/Node/Port/View/Field/InputView/CommonEditingViewReadOnly.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/CommonEditingViewReadOnly.swift
@@ -46,7 +46,7 @@ struct CommonEditingViewReadOnly: View {
         StitchTextView(string: displayString,
                        font: STITCH_FONT,
                        fontColor: isSelectedInspectorRow ? theme.fontColor : STITCH_FONT_GRAY_COLOR)
-        .modifier(InputViewBackground(
+        .modifier(InputFieldBackground(
             show: self.isHovering || self.forPropertySidebar,
             hasDropdown: self.hasPicker,
             forPropertySidebar: forPropertySidebar,

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
@@ -19,13 +19,16 @@ extension ProjectSidebarObservable {
                            document: StitchDocumentViewModel) {
         // log("sidebarItemTapped: id: \(id)")
         // log("sidebarItemTapped: shiftHeld: \(shiftHeld)")
-        
+            
         let originalSelections = self.selectionState.primary
         
         // Set sidebar to be focused:
         if !self.isSidebarFocused {
             self.isSidebarFocused = true            
         }
+        
+        // Wipe redux field
+        document.reduxFocusedField = nil
         
         // log("sidebarItemTapped: originalSelections: \(originalSelections)")
         

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListLabelView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListLabelView.swift
@@ -32,10 +32,7 @@ struct SidebarListItemLeftLabelView<SidebarViewModel>: View where SidebarViewMod
             SidebarListItemChevronView(sidebarViewModel: sidebarViewModel,
                                        item: itemViewModel,
                                        fontColor: fontColor)
-//                                           isHidden: isHidden)
             .opacity(itemViewModel.isGroup ? 1 : 0)
-                // .border(.green)
-//            }
   
             Image(systemName: itemViewModel.sidebarLeftSideIcon)
                 .scaledToFit()
@@ -140,12 +137,19 @@ struct SidebarListLabelEditView<ItemViewModel>: View where ItemViewModel: Sideba
                                            isCommitting: isCommitting,
                                            graph: graph)
                 })
+                .padding(2)
+                .background {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color.COMMON_EDITING_VIEW_READ_ONLY_BACKGROUND_COLOR)
+                }
+                .contentShape(Rectangle()) // Not needed?
             } else {
                 StitchTextView(string: edit + debugId,
                                font: SIDEBAR_LIST_ITEM_FONT,
                                fontColor: fontColor)
                 .padding(.top, 1)
-            }
+                .padding(2)
+            }       
         }
          // Not just initialization but also e.g. whenever canvas item updates the layer node's title
         .onChange(of: self.item.name, initial: true) { oldValue, newValue in
@@ -158,9 +162,14 @@ struct SidebarListLabelEditView<ItemViewModel>: View where ItemViewModel: Sideba
                 self.edit = self.item.name
             }
         }
-        .onTapGesture(count: 2) {
-            dispatch(ReduxFieldFocused(focusedField: .sidebarLayerTitle(self.item.id.description)))
-        }
+        .simultaneousGesture(TapGesture(count: 2)
+            .onEnded({ _ in
+                // log("sidebar item double tapped: \(self.item.id.description)")
+                // Focus the redux field
+                dispatch(ReduxFieldFocused(focusedField: .sidebarLayerTitle(self.item.id.description)))
+                
+            })
+        )
     }
     
 }

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListLabelView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SidebarListLabelView.swift
@@ -149,7 +149,7 @@ struct SidebarListLabelEditView<ItemViewModel>: View where ItemViewModel: Sideba
                                fontColor: fontColor)
                 .padding(.top, 1)
                 .padding(2)
-            }       
+            }
         }
          // Not just initialization but also e.g. whenever canvas item updates the layer node's title
         .onChange(of: self.item.name, initial: true) { oldValue, newValue in
@@ -162,14 +162,11 @@ struct SidebarListLabelEditView<ItemViewModel>: View where ItemViewModel: Sideba
                 self.edit = self.item.name
             }
         }
-        .simultaneousGesture(TapGesture(count: 2)
-            .onEnded({ _ in
-                // log("sidebar item double tapped: \(self.item.id.description)")
-                // Focus the redux field
-                dispatch(ReduxFieldFocused(focusedField: .sidebarLayerTitle(self.item.id.description)))
-                
-            })
-        )
+        .onTapGesture(count: 2) {
+            // log("sidebar item double tapped: \(self.item.id.description)")
+            // Focus the redux field
+            dispatch(ReduxFieldFocused(focusedField: .sidebarLayerTitle(self.item.id.description)))
+        }
     }
     
 }

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeInnerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeInnerView.swift
@@ -132,35 +132,35 @@ struct SidebarListItemSwipeInnerView<SidebarViewModel>: View where SidebarViewMo
     var fontColor: Color {
         let selection = self.selectionStatus
 
-#if DEV_DEBUG
-        if itemViewModel.isHidden {
-            return .purple
-        }
-#endif
+//#if DEV_DEBUG
+//        if itemViewModel.isHidden {
+//            return .purple
+//        }
+//#endif
 
         // Any 'focused' (doesn't have to be 'actively selected') layer uses white text
         if !self.isBeingEdited && itemViewModel.isSelected(sidebar: self.sidebarViewModel) {
-#if DEV_DEBUG
-            return .red
-#else
+//#if DEV_DEBUG
+//            return .red
+//#else
             return .white
-#endif
+//#endif
         }
 
-#if DEV_DEBUG
-        // Easier to see secondary selections for debug
-        //        return selection.color(isHidden)
-
-        switch selection {
-        case .primary:
-            return .brown
-        case .secondary:
-            return .green
-        case .none:
-            return .blue
-        }
-
-#endif
+//#if DEV_DEBUG
+//        // Easier to see secondary selections for debug
+//        //        return selection.color(isHidden)
+//
+//        switch selection {
+//        case .primary:
+//            return .brown
+//        case .secondary:
+//            return .green
+//        case .none:
+//            return .blue
+//        }
+//
+//#endif
 
         if isBeingEdited || isHidden {
             return self.getColor()


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7106


https://github.com/user-attachments/assets/1853dca7-0fcd-4d8d-a979-89c314ce11f9

