### PR TITLE
Better placement of project title edit view on Catalyst

### DIFF
--- a/Stitch/App/View/StitchRootView.swift
+++ b/Stitch/App/View/StitchRootView.swift
@@ -64,47 +64,12 @@ struct StitchRootView: View {
                 splitView
 //#if targetEnvironment(macCatalyst)
                     .overlay(alignment: .center) {
-                        
-                        if let document = store.currentDocument {
-
-#if targetEnvironment(macCatalyst)
-                            if document.showCatalystProjectTitleModal {
-                                logInView("will show modal view at top level")
-                                ZStack {
-                                    
-                                    MODAL_BACKGROUND_COLOR
-                                        .ignoresSafeArea([.all, .keyboard])
-                                        .onTapGesture {
-                                            dispatch(CatalystProjectTitleModalClosed())
-                                        }
-                                    
-                                    VStack(alignment: .leading) {
-                                        StitchTextView(string: "Edit Project Title")
-                                        CatalystProjectTitleModalView(graph: document.visibleGraph,
-                                                                      document: document)
-                                    }
-                                    .padding()
-                                    //                                .frame(width: 260, alignment: .leading)
-                                    .frame(width: 360, alignment: .leading)
-                                    .background(
-                                        Color(uiColor: .systemGray5)
-                                        // NOTE: strangely we need `[.all, .keyboard]` on BOTH the background color AND the StitchHostingControllerView
-                                            .ignoresSafeArea([.all, .keyboard])
-                                            .cornerRadius(4)
-                                    )
-                                    
-                                    
-                                }
-                            } // if document
-#endif
-                            if showMenu {
-                                InsertNodeMenuWrapper(document: document)
-                            }
+                        if let document = store.currentDocument, showMenu {
+                            InsertNodeMenuWrapper(document: document)
                         } // if let document
                     } // .overlay
             }
         }    
-//        .coordinateSpace(name: Self.STITCH_ROOT_VIEW_COORDINATE_SPACE)
         .modifier(StitchRootModifier())
         .onAppear {
             // TODO: move this to the start of StitchStore instead?

--- a/Stitch/Graph/LayerInspector/FlyoutUtils.swift
+++ b/Stitch/Graph/LayerInspector/FlyoutUtils.swift
@@ -100,6 +100,7 @@ struct LeftSidebarSet: StitchDocumentEvent {
     func handle(state: StitchDocumentViewModel) {
         // Reset flyout
         state.visibleGraph.closeFlyout()
+        state.showCatalystProjectTitleModal = false
         
         state.leftSidebarOpen = open
     }

--- a/Stitch/Graph/View/ContentView.swift
+++ b/Stitch/Graph/View/ContentView.swift
@@ -119,6 +119,9 @@ struct ContentView: View, KeyboardReadable {
                 .overlay {
                     flyout
                 }
+                .overlay {
+                    catalystProjectTitleEditView
+                }
                 
                 // NOTE: APPARENTLY NOT NEEDED ANYMORE?
 //                // Note: we want the floating preview window to 'ignore safe areas' (e.g. the keyboard rising up should not affect preview window's size or position):
@@ -167,5 +170,35 @@ struct ContentView: View, KeyboardReadable {
     var flyout: some View {
         OpenFlyoutView(document: document,
                        graph: document.visibleGraph)
+    }
+    
+    @ViewBuilder
+    var catalystProjectTitleEditView: some View {
+#if targetEnvironment(macCatalyst)
+        if document.showCatalystProjectTitleModal {
+            VStack(alignment: .leading) {
+                StitchTextView(string: "Edit Project Title")
+                CatalystProjectTitleModalView(graph: document.visibleGraph,
+                                              document: document)
+            }
+            .padding()
+            .frame(width: 360, alignment: .leading)
+            .background(
+                Color(uiColor: .systemGray5)
+                // NOTE: strangely we need `[.all, .keyboard]` on BOTH the background color AND the StitchHostingControllerView
+                    .ignoresSafeArea([.all, .keyboard])
+                    .cornerRadius(4)
+            )
+            .position(
+                x: 180 // half width of edit view itself, so its left-edge sits at screen's left-edge
+                + 16 // padding
+                // + 330 // traffic lifts, sidebar button
+                + 158
+                + (document.leftSidebarOpen ? (-SIDEBAR_WIDTH/2 + 38) : 0)
+                
+                , y: 52)
+                
+        } // if document
+#endif
     }
 }


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7097

TextField still broken on Catalyst: repeated char entry after deleting a char. 

Improvement on our alternative: 

https://github.com/user-attachments/assets/402c136d-92b8-46a1-ab67-073258348a6d

