### PR TITLE
Access `GraphMovement` directly `Document`, not indirectly via `GraphState`

### DIFF
--- a/Stitch/Graph/CommentBox/Util/CommentBoxActions.swift
+++ b/Stitch/Graph/CommentBox/Util/CommentBoxActions.swift
@@ -20,6 +20,12 @@ extension GraphState {
     @MainActor
     func commentBoxCreated(nodeId: CanvasItemId,
                            groupNodeFocused: NodeId?) {
+        
+        guard let graphMovement = self.documentDelegate?.graphMovement else {
+            fatalErrorIfDebug()
+            return
+        }
+        
         var selectedNodes = self.selectedCanvasItems
 
         // Alternatively?: always add this id to selectedNodes in StitchDocumentViewModel, so that we start it selected.
@@ -35,7 +41,7 @@ extension GraphState {
 
         let box = CommentBoxViewModel(
             zIndex: self.highestZIndex + 1,
-            scale: self.graphMovement.zoomData,
+            scale: graphMovement.zoomData,
             nodes: visibleSelectedNodes)
 
         self.commentBoxesDict.updateValue(box, forKey: box.id)

--- a/Stitch/Graph/CommentBox/Util/CommentBoxGestureActions.swift
+++ b/Stitch/Graph/CommentBox/Util/CommentBoxGestureActions.swift
@@ -45,8 +45,13 @@ extension GraphState {
     func commentBoxPositionDragged(id: CommentBoxId,
                                    value: DragGesture.Value) {
 
+        guard let graphMovement = self.documentDelegate?.graphMovement else {
+            fatalErrorIfDebug()
+            return
+        }
+        
         // log("CommentBoxPositionDragged called")
-        let zoom: CGFloat = self.graphMovement.zoomData
+        let zoom: CGFloat = graphMovement.zoomData
 
         // log("CommentBoxPositionDragged: value.translation: \(value.translation)")
         // log("CommentBoxPositionDragged: value.translation / zoom: \(value.translation / zoom)")
@@ -166,7 +171,7 @@ extension GraphState {
                                     value: DragGesture.Value) {
         self.selection.selectedCommentBoxes = Set([box.id])
 
-        let zoom = self.graphMovement.zoomData
+        // let zoom = self.graphMovement.zoomData
 
         // STEP 1: UPDATE THE COMMENT BOX ITSELF
         box.expansionBox.startPoint = box.position

--- a/Stitch/Graph/Edge/Util/EdgeEditingActions.swift
+++ b/Stitch/Graph/Edge/Util/EdgeEditingActions.swift
@@ -23,6 +23,11 @@ extension GraphState {
                        groupNodeFocused: NodeId?) {
         // log("outputHovered fired")
         
+        guard let graphMovement = self.documentDelegate?.graphMovement else {
+            fatalErrorIfDebug()
+            return
+        }
+        
         if self.edgeDrawingObserver.drawingGesture != nil {
             // log("OutputHovered called during edge drawing gesture; exiting")
             self.edgeAnimationEnabled = false
@@ -30,7 +35,7 @@ extension GraphState {
             return
         }
         
-        if self.graphMovement.canvasItemIsDragged || self.nodeIsMoving {
+        if graphMovement.canvasItemIsDragged || self.nodeIsMoving {
             // log("OutputHovered called during node drag; exiting")
             self.edgeAnimationEnabled = false
             self.edgeEditingState = nil

--- a/Stitch/Graph/Edge/View/EditMode/EdgeEditModeOutputHoverView.swift
+++ b/Stitch/Graph/Edge/View/EditMode/EdgeEditModeOutputHoverView.swift
@@ -52,9 +52,14 @@ struct EdgeEditModeOutputHoverViewModifier: ViewModifier {
             }
 
             .onHover { isHovering in
+                guard let graphMovement = graph.documentDelegate?.graphMovement else {
+                    fatalErrorIfDebug()
+                    return
+                }
+                
                 // Make sure the graph isn't in movement
-                guard !graph.graphMovement.graphIsDragged,
-                      !graph.graphMovement.canvasItemIsDragged else {
+                guard !graphMovement.graphIsDragged,
+                      !graphMovement.canvasItemIsDragged else {
                     log("EdgeEditModeOutputHoverViewModifier: graph is in movement; doing nothing")
                     return
                 }

--- a/Stitch/Graph/Gesture/Util/GraphUICursorSelectionActions.swift
+++ b/Stitch/Graph/Gesture/Util/GraphUICursorSelectionActions.swift
@@ -33,12 +33,17 @@ struct GraphBackgroundLongPressEnded: GraphEvent {
     
     @MainActor
     func handle(state: GraphState) {
+        guard let graphMovement = state.documentDelegate?.graphMovement else {
+            fatalErrorIfDebug()
+            return
+        }
+        
         log("GraphBackgroundLongPressEnded called")
         state.selection.dragStartLocation = nil
         state.selection.dragCurrentLocation = nil
         state.selection.expansionBox = nil
         state.selection.isSelecting = false
-        state.graphMovement.localPreviousPosition = state.graphMovement.localPosition
+        graphMovement.localPreviousPosition = graphMovement.localPosition
     }
 }
 

--- a/Stitch/Graph/Gesture/Util/GraphUIScrollActions.swift
+++ b/Stitch/Graph/Gesture/Util/GraphUIScrollActions.swift
@@ -154,22 +154,27 @@ extension GraphState {
 //            self.graphMovement.graphIsDragged = true
 //        }
 
+        guard let graphMovement = self.documentDelegate?.graphMovement else {
+            fatalErrorIfDebug()
+            return
+        }
+        
         // If we don't have an active first gesture,
         // and node isn't already dragging,
         // then set graph-drag as active first gesture
-        if self.graphMovement.firstActive == .none {
-            if !self.graphMovement.canvasItemIsDragged {
+        if graphMovement.firstActive == .none {
+            if !graphMovement.canvasItemIsDragged {
                 log("graphDrag onChanged: will set .graph as active first gesture")
-                self.graphMovement.firstActive = .graph
+                graphMovement.firstActive = .graph
             }
         }
 
-        self.graphMovement.runningGraphTranslation = translation
+        graphMovement.runningGraphTranslation = translation
 
         // If we're simultaneously dragging the node,
         // add inverse graph translation to node's position,
         // so that node stays under our finger:
-        if self.graphMovement.canvasItemIsDragged {
+        if graphMovement.canvasItemIsDragged {
 
             self.getSelectedCanvasItems(groupNodeFocused: document.groupNodeFocused?.groupNodeId)
                 .forEach { node in
@@ -177,14 +182,14 @@ extension GraphState {
                 node.updateNodeOnGraphDragged(
                     translation,
                     self.highestZIndex + 1,
-                    zoom: self.graphMovement.zoomData,
-                    state: self.graphMovement)
+                    zoom: graphMovement.zoomData,
+                    state: graphMovement)
             }
 
             //    log("handleGraphScrolled: state.graphMovement.localPosition is now: \(state.graphMovement.localPosition)")
         }
         
-        self.graphMovement.wasTrackpadScroll = wasTrackpadScroll
+        graphMovement.wasTrackpadScroll = wasTrackpadScroll
     }
 
     // `handleGraphScrolled` is kept relatively pure and separate;
@@ -279,8 +284,11 @@ extension GraphState {
 
         //    log("handleTrackpadGraphDragEnded called")
 
-        let graphMovement = self.graphMovement
-
+        guard let graphMovement = self.documentDelegate?.graphMovement else {
+            fatalErrorIfDebug()
+            return
+        }
+        
         // DO NOT reset selected nodes themselves
         self.selection.expansionBox = nil
         self.selection.isSelecting = false
@@ -303,9 +311,10 @@ extension GraphState {
                         wasScreenDrag: Bool,
                         frame: CGRect) {
 
-        let graphMovement = self.graphMovement
-
-        let doNotStartMomentum = wasScreenDrag && self.selection.isSelecting
+        guard let graphMovement = self.documentDelegate?.graphMovement else {
+            fatalErrorIfDebug()
+            return
+        }
 
         // always set start and current location of drag gesture
         self.selection.dragStartLocation = nil

--- a/Stitch/Graph/Node/Patch/Type/DeviceInfoNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/DeviceInfoNode.swift
@@ -170,6 +170,7 @@ func deviceInfoEval(node: PatchNode,
     let deviceType = UIDevice().type // UIDevice.current.model
 
     let safeAreaInsets = state.documentDelegate?.safeAreaInsets ?? .init()
+    let zoomData = state.documentDelegate?.graphMovement.zoomData ?? 1.0
     
     //    #if DEV_DEBUG
     //    log("deviceInfoEval: deviceSize: \(deviceSize)")
@@ -185,7 +186,7 @@ func deviceInfoEval(node: PatchNode,
 
     let outputs: PortValuesList = [
         [.size(deviceSize.toLayerSize)],
-        [.number(state.graphMovement.zoomData)],
+        [.number(zoomData)],
         [.deviceOrientation(orientation.toStitchDeviceOrientation)],
         [.string(.init(deviceType.rawValue))],
         [.string(.init(state.documentDelegate?.colorScheme.description ?? ""))],

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
@@ -127,11 +127,11 @@ extension GraphState {
                               store: StitchStore) {
         guard let document = store.currentDocument else { return }
         
-        var droppedLocation = nodeLocation
-        let localPosition = self.localPosition
-        let graphScale = self.graphMovement.zoomData
-
-        let originalNodeLocation = nodeLocation.toCGSize
+        let droppedLocation = nodeLocation
+        //        let localPosition = self.localPosition
+        //        let graphScale = document.graphMovement.zoomData
+        //
+        //        let originalNodeLocation = nodeLocation.toCGSize
 
         // Add media key to computed node state
         self.mediaLibrary.updateValue(newURL, forKey: newURL.mediaKey)

--- a/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
+++ b/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
@@ -15,10 +15,14 @@ extension GraphState {
     @MainActor
     func updateCanvasItemOnDragged(_ canvasItem: CanvasItemViewModel,
                                    translation: CGSize) {
+        guard let graphMovement = self.documentDelegate?.graphMovement else {
+            fatalErrorIfDebug()
+            return
+        }
+        
         canvasItem.updateCanvasItemOnDragged(translation: translation,
                                              highestZIndex: self.highestZIndex + 1,
-                                             zoom: self.graphMovement.zoomData,
-                                             state: self.graphMovement)
+                                             state: graphMovement)
     }
 }
 
@@ -30,8 +34,10 @@ extension CanvasItemViewModel {
     @MainActor
     func updateCanvasItemOnDragged(translation: CGSize,
                                    highestZIndex: ZIndex?,
-                                   zoom: CGFloat,
                                    state: GraphMovementObserver) {
+        
+        // let zoom = state.zoomData
+        
         // log("updateCanvasItemOnDragged self.position was: \(self.position)")
         // Set z-index once on node movement
         if !self.isMoving,
@@ -161,15 +167,20 @@ extension GraphState {
             return
         }
 
-        self.graphMovement.lastCanvasItemTranslation = translation
+        guard let graphMovement = self.documentDelegate?.graphMovement else {
+            fatalErrorIfDebug()
+            return
+        }
+        
+        graphMovement.lastCanvasItemTranslation = translation
 
-        if self.graphMovement.firstActive == .graph {
+        if graphMovement.firstActive == .graph {
 
-            if !self.graphMovement.runningGraphTranslationBeforeNodeDragged.isDefined {
-                log("canvasItemMoved: setting runningGraphTranslationBeforeNodeDragged to be self.graphMovement.runningGraphTranslation: \(self.graphMovement.runningGraphTranslation)")
-                self.graphMovement
+            if !graphMovement.runningGraphTranslationBeforeNodeDragged.isDefined {
+                log("canvasItemMoved: setting runningGraphTranslationBeforeNodeDragged to be graphMovement.runningGraphTranslation: \(graphMovement.runningGraphTranslation)")
+                graphMovement
                     .runningGraphTranslationBeforeNodeDragged = (
-                        self.graphMovement.runningGraphTranslation ?? .zero) / self.graphMovement.zoomData
+                        graphMovement.runningGraphTranslation ?? .zero) / graphMovement.zoomData
             }
         }
 

--- a/Stitch/Graph/Node/Util/NodeDeletedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeDeletedAction.swift
@@ -62,6 +62,11 @@ extension GraphState {
     @MainActor
     func selectedGraphNodesDeleted(selectedNodes: CanvasItemIdSet) {
 
+        guard let graphMovement = self.documentDelegate?.graphMovement else {
+            fatalErrorIfDebug()
+            return
+        }
+        
         selectedNodes.forEach { canvasItemId in
             self.deleteCanvasItem(canvasItemId)
         }
@@ -74,7 +79,7 @@ extension GraphState {
         // and so deleting the selected nodes means de-selecting those associated edges)
         self.selectedEdges = .init()
 
-        self.graphMovement.draggedCanvasItem = nil
+        graphMovement.draggedCanvasItem = nil
         
         self.updateGraphData()
     }

--- a/Stitch/Graph/Node/View/CanvasItemPositionHandler.swift
+++ b/Stitch/Graph/Node/View/CanvasItemPositionHandler.swift
@@ -61,16 +61,21 @@ struct CanvasItemDragHandler: UIGestureRecognizerRepresentable {
                                          context: Context) {
         let translation = recognizer.translation(in: recognizer.view).toCGSize
 
+        guard let graphMovement = graph.documentDelegate?.graphMovement else {
+            fatalErrorIfDebug()
+            return
+        }
+        
         // log("CanvasItemDragHandler: handleUIGestureRecognizerAction")
         switch recognizer.state {
         case .began:
             // If we don't have an active first gesture,
             // and graph isn't already dragging,
             // then set node-drag as active first gesture
-            if graph.graphMovement.firstActive == .none {
-                if !graph.graphMovement.graphIsDragged {
+            if graphMovement.firstActive == .none {
+                if !graphMovement.graphIsDragged {
                     // log("canvasItemMoved: will set .node as active first gesture")
-                    graph.graphMovement.firstActive = .node
+                    graphMovement.firstActive = .node
                 }
             }
             
@@ -88,7 +93,7 @@ struct CanvasItemDragHandler: UIGestureRecognizerRepresentable {
                     return
                 }
                 
-                graph.graphMovement.draggedCanvasItem = canvasItemId
+                graphMovement.draggedCanvasItem = canvasItemId
                 
                 // Dragging an unselected node selects that node
                 // and de-selects all other nodes.

--- a/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
+++ b/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
@@ -234,10 +234,11 @@ extension GraphState {
             destinationGraphInfo: isCopyPaste ?
                 .init(destinationGraphOffset: self.localPosition,
                       destinationGraphFrame: document.frame,
-                      destinationGraphScale: self.graphMovement.zoomData,
+                      destinationGraphScale: document.graphMovement.zoomData,
                       destinationGraphTraversalLevel: document.groupNodeFocused?.groupNodeId) : nil
         )
         
+        // TODO: what does this mean -- we received a `document` parameter but then we also check for a documentDelegate on the GraphState?
         guard let document = self.documentDelegate else {
             return
         }

--- a/Stitch/Graph/ViewModel/GraphDelegate.swift
+++ b/Stitch/Graph/ViewModel/GraphDelegate.swift
@@ -52,12 +52,6 @@ extension GraphState {
         }
     }
     
-    // TODO: use a specific GraphId
     @MainActor
     var projectId: GraphId { self.id }
-                
-    // TODO: remove
-    @MainActor var graphMovement: GraphMovementObserver {
-        self.documentDelegate?.graphMovement ?? .init()
-    }
 }

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -170,14 +170,19 @@ extension GraphState {
         }
         #endif
 
+        guard let graphMovement = self.documentDelegate?.graphMovement else {
+            fatalErrorIfDebug()
+            return
+        }
+        
         self.selectedEdges = .init()
 
         // if we tap the graph, we're no longer dragging either nodes or graph
         // TODO: should we also reset graphMovement.firstActive etc.? Otherwise we can get in an improper state?
-        self.graphMovement.draggedCanvasItem = nil
+        graphMovement.draggedCanvasItem = nil
         
-        if self.graphMovement.graphIsDragged {
-            self.graphMovement.graphIsDragged = false            
+        if graphMovement.graphIsDragged {
+            graphMovement.graphIsDragged = false
         }
 
         if self.selection != GraphUISelectionState.zero {


### PR DESCRIPTION
This accessor method was convenient but total nonsense: graph movement lives on the document, not graph state, and if we don't have a document then we cannot access graph movement. 

Do not give representation to illegal state. 

<img width="707" alt="Screenshot 2025-04-09 at 9 00 20 PM" src="https://github.com/user-attachments/assets/8302f1b8-a41c-49fc-80a9-a5f26c73782e" />
