### PR TITLE
Do not crash if we're missing store and/or document encoder when encoding project

### DIFF
--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -590,7 +590,8 @@ extension GraphState {
                                    willUpdateUndoHistory: Bool = true) {
         guard let store = self.storeDelegate,
               let documentEncoder = self.documentEncoderDelegate else {
-            fatalErrorIfDebug()
+            // fatalErrorIfDebug()
+            log("encodeProjectInBackground: missing store and/or decoder delegates")
             return
         }
         

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -402,7 +402,8 @@ extension StitchDocumentViewModel {
                                    willUpdateUndoHistory: Bool = true) {
         guard let store = self.storeDelegate,
               let documentEncoder = self.documentEncoder else {
-            fatalErrorIfDebug()
+            log("encodeProjectInBackground: missing store and/or decoder delegates")
+            // fatalErrorIfDebug()
             return
         }
         

--- a/StitchTests/TestUtils/TestUtils.swift
+++ b/StitchTests/TestUtils/TestUtils.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 extension Patch {
     @MainActor
-    func createDefaultTestNode(graph: GraphState? = nil) -> NodeViewModel {
+    func createDefaultTestNode(graph: GraphState) -> NodeViewModel {
         self.defaultNode(id: .init(),
                          position: .zero,
                          zIndex: .zero,
@@ -22,7 +22,7 @@ extension Patch {
 
 extension Layer {
     @MainActor
-    func createDefaultTestNode(graph: GraphState? = nil) -> NodeViewModel {
+    func createDefaultTestNode(graph: GraphState) -> NodeViewModel {
         self.defaultNode(id: .init(),
                          position: .zero,
                          zIndex: .zero,

--- a/StitchTests/nodeTypeTests.swift
+++ b/StitchTests/nodeTypeTests.swift
@@ -40,8 +40,9 @@ final class nodeTypeTests: XCTestCase {
     @MainActor
     func testPatchNodeUserVisibleType() throws {
 
+        let graph = GraphState()
         Patch.allCases.forEach { patch in
-            let node = patch.createDefaultTestNode()
+            let node = patch.createDefaultTestNode(graph: graph)
 
             // If the patch has non-empty lists of available node types,
             // ... but the created node has no node type,


### PR DESCRIPTION
Fixes test crash.

All tests pass now.