### PR TITLE
Cleanup document encodable delegate

### DIFF
--- a/Stitch/App/Serialization/DocumentLoading/DocumentEncodable.swift
+++ b/Stitch/App/Serialization/DocumentLoading/DocumentEncodable.swift
@@ -30,9 +30,7 @@ protocol DocumentEncodableDelegate: Observable, AnyObject, Sendable {
     
     @MainActor func willEncodeProject(schema: CodableDocument)
     
-    @MainActor func didEncodeProject(schema: CodableDocument)
-    
-    @MainActor var storeDelegate: StitchStore? { get }
+    @MainActor func didEncodeProject(schema: CodableDocument)    
 }
 
 extension DocumentEncodableDelegate {

--- a/Stitch/App/ViewModel/StitchStore.swift
+++ b/Stitch/App/ViewModel/StitchStore.swift
@@ -21,7 +21,6 @@ final class StitchStore: Sendable {
     @MainActor var allProjectUrls = [ProjectLoader]()
     let documentLoader = DocumentLoader()
     let clipboardEncoder = ClipboardEncoder()
-    let clipboardDelegate = ClipboardEncoderDelegate()
     
     @MainActor var alertState: ProjectAlertState
     
@@ -62,7 +61,6 @@ final class StitchStore: Sendable {
         
         self.environment.dirObserver.delegate = self
         self.environment.store = self
-        self.clipboardEncoder.delegate = self.clipboardDelegate
     }
 }
 

--- a/Stitch/App/ViewModel/StitchStore.swift
+++ b/Stitch/App/ViewModel/StitchStore.swift
@@ -63,7 +63,6 @@ final class StitchStore: Sendable {
         self.environment.dirObserver.delegate = self
         self.environment.store = self
         self.clipboardEncoder.delegate = self.clipboardDelegate
-        self.clipboardDelegate.store = self
     }
 }
 
@@ -82,7 +81,6 @@ extension StitchStore {
 
 final class ClipboardEncoderDelegate: DocumentEncodableDelegate {
     var lastEncodedDocument: StitchClipboardContent
-    @MainActor weak var store: StitchStore?
     
     init() {
         self.lastEncodedDocument = .init()
@@ -97,10 +95,6 @@ final class ClipboardEncoderDelegate: DocumentEncodableDelegate {
     func update(from schema: StitchClipboardContent, rootUrl: URL?) { }
     
     func updateAsync(from schema: StitchClipboardContent) async { }
-    
-    var storeDelegate: StitchStore? {
-        self.store
-    }
 }
 
 extension StitchStore {

--- a/Stitch/Graph/Node/Model/GraphCopyable.swift
+++ b/Stitch/Graph/Node/Model/GraphCopyable.swift
@@ -556,7 +556,7 @@ extension GraphState {
 
         Task { [weak self] in
             guard let store = self?.storeDelegate else { return }
-            
+
             // Delete all existing items in clipboard
             try? await store.clipboardEncoder.removeContents()
             
@@ -565,7 +565,7 @@ extension GraphState {
     }
 }
 
-extension DocumentEncodable {
+extension ClipboardEncoder {
     nonisolated func processGraphCopyAction(_ copiedComponentResult: StitchComponentCopiedResult<StitchClipboardContent>) async throws {
         // Create directories if it doesn't exist
         let rootUrl = copiedComponentResult.component.rootUrl
@@ -577,7 +577,9 @@ extension DocumentEncodable {
         let pasteboard = UIPasteboard.general
         pasteboard.url = rootUrl.appendingVersionedSchemaPath()
     }
-    
+}
+
+extension DocumentEncodable {
     nonisolated func encodeNewComponent<T>(_ result: StitchComponentCopiedResult<T>) throws where T: StitchComponentable {
         result.component.createUnzippedFileWrapper()
         

--- a/Stitch/Graph/Util/GraphActions.swift
+++ b/Stitch/Graph/Util/GraphActions.swift
@@ -34,21 +34,10 @@ struct CloseGraph: StitchStoreEvent {
     }
 }
 
-extension GraphState: DocumentEncodableDelegate {
+extension GraphState {
     @MainActor
     func updateOnUndo(schema: GraphEntity) {
         self.update(from: schema)
-    }
-    
-    func willEncodeProject(schema: GraphEntity) {
-        
-        // Updates thumbnail
-         if let document = self.documentDelegate {
-             // Updates graph data when changed
-             document.refreshGraphUpdaterId()
-             
-             document.encodeProjectInBackground(willUpdateUndoHistory: false)
-         }
     }
         
     @MainActor


### PR DESCRIPTION
Had we made `GraphState` implement `DocumentEncodableDelegate` because previously we had called `graphState.saveUndoHistory` (whereas now we call that on store) ?

... So, if we had been using pure functions, or even just better referential transparency, we would not have had to implement certain methods on GraphState?


Also: `processGraphCopyAction` is for copy-paste i.e. clipboard, not `any DocumentEncodable`