### PR TITLE
Don't pass down Document and Graph just to kickoff state changes from the UI

### DIFF
--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -563,8 +563,7 @@ extension StitchDocumentViewModel {
                               graph: GraphState) {
         // Defined canvas item id = we're already on the canvas
         if let canvasItemId = canvasItemId {
-            graph.jumpToCanvasItem(id: canvasItemId,
-                                   document: self)
+            dispatch(JumpToCanvasItem(id: canvasItemId))
         }
         
         // Else select/de-select the property

--- a/Stitch/Graph/Node/Port/View/Field/WirelessPortView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/WirelessPortView.swift
@@ -10,8 +10,6 @@ import StitchSchemaKit
 
 struct WirelessPortView: View {
 
-    @Bindable var graph: GraphState
-    @Bindable var document: StitchDocumentViewModel
     let isOutput: Bool
     let id: NodeId
 
@@ -25,8 +23,7 @@ struct WirelessPortView: View {
             .offset(x: isOutput ? -12 : 12)
             .onTapGesture {
                 if !isOutput {
-                    graph.jumpToAssignedBroadcaster(wirelessReceiverNodeId: id,
-                                                    document: document)
+                    dispatch(JumpToWirelessBroadcaster(wirelessReceiverNodeId: id))
                 }
             }
         #if targetEnvironment(macCatalyst)

--- a/Stitch/Graph/Node/Port/View/LayerInspectorRowButton.swift
+++ b/Stitch/Graph/Node/Port/View/LayerInspectorRowButton.swift
@@ -85,8 +85,7 @@ struct LayerInspectorRowButton: View {
             
             // If we're already on the canvas, jump to that canvas item
             if let canvasItemId = canvasItemId {
-                graph.jumpToCanvasItem(id: canvasItemId,
-                                       document: document)
+                dispatch(JumpToCanvasItem(id: canvasItemId))
             }
             
             // Else we're adding an input (whole or field) or an output to the canvas

--- a/Stitch/Graph/Node/View/NodeTag/NodeTagMenuButtonsView.swift
+++ b/Stitch/Graph/Node/View/NodeTag/NodeTagMenuButtonsView.swift
@@ -216,8 +216,7 @@ struct NodeTagMenuButtonsView: View {
         if isWirelessReceiver,
            let assignedBroadcaster = node.currentBroadcastChoiceId {
             nodeTagMenuButton(label: "Jump to Assigned Broadcaster") {
-                graph.jumpToCanvasItem(id: .node(assignedBroadcaster),
-                                       document: document)
+                dispatch(JumpToCanvasItem(id: .node(assignedBroadcaster)))
             }
         }
     }

--- a/Stitch/Graph/Node/View/NodeView.swift
+++ b/Stitch/Graph/Node/View/NodeView.swift
@@ -166,9 +166,7 @@ struct NodeView: View {
         VStack(alignment: .leading,
                spacing: SPACING_BETWEEN_NODE_ROWS) {
             if self.stitch.patch == .wirelessReceiver {
-                WirelessPortView(graph: graph,
-                                 document: document,
-                                 isOutput: false,
+                WirelessPortView(isOutput: false,
                                  id: stitch.id)
                 .padding(.trailing, NODE_BODY_SPACING)
             } else if let layerNode: LayerNodeViewModel = self.stitch.layerNode,
@@ -198,9 +196,7 @@ struct NodeView: View {
                spacing: SPACING_BETWEEN_NODE_ROWS) {
             
             if self.stitch.patch == .wirelessBroadcaster {
-                WirelessPortView(graph: graph,
-                                 document: document,
-                                 isOutput: true,
+                WirelessPortView(isOutput: true,
                                  id: stitch.id)
                 .padding(.leading, NODE_BODY_SPACING)
             } else {

--- a/Stitch/Graph/Sidebar/Util/JumpToCanvasItem.swift
+++ b/Stitch/Graph/Sidebar/Util/JumpToCanvasItem.swift
@@ -13,51 +13,46 @@ struct JumpToCanvasItem: StitchDocumentEvent {
     let id: CanvasItemId
     
     func handle(state: StitchDocumentViewModel) {
-        state.visibleGraph.jumpToCanvasItem(id: id, document: state)
+        state.panGraphToNodeLocation(id: id)
     }
 }
 
-extension GraphState {
-    @MainActor
-    func jumpToCanvasItem(id: CanvasItemId,
-                          document: StitchDocumentViewModel) {
-        self.panGraphToNodeLocation(id: id,
-                                    document: document)
-    }
+struct JumpToWirelessBroadcaster: StitchDocumentEvent {
+    let wirelessReceiverNodeId: NodeId
     
-    @MainActor
-    func jumpToAssignedBroadcaster(wirelessReceiverNodeId: NodeId,
-                                   document: StitchDocumentViewModel) {
-        if let assignedBroadcaster = self.getNodeViewModel(wirelessReceiverNodeId)?.currentBroadcastChoiceId {
-            self.panGraphToNodeLocation(id: .node(assignedBroadcaster),
-                                        document: document)
+    func handle(state: StitchDocumentViewModel) {
+        if let assignedBroadcaster = state.visibleGraph.getNodeViewModel(wirelessReceiverNodeId)?.currentBroadcastChoiceId {
+            state.panGraphToNodeLocation(id: .node(assignedBroadcaster))
         }
     }
-    
-    @MainActor
-    func findSomeCanvasItemOnGraph(document: StitchDocumentViewModel) {
+}
+
+struct FindSomeCanvasItemOnGraph: StitchDocumentEvent {
+    func handle(state: StitchDocumentViewModel) {
         if let canvasItem = GraphState.westernMostNode(
-            document.groupNodeFocused?.groupNodeId,
-            canvasItems: self.getCanvasItemsAtTraversalLevel(groupNodeFocused: document.groupNodeFocused?.groupNodeId)) {
+            state.groupNodeFocused?.groupNodeId,
+            canvasItems: state.visibleGraph.getCanvasItemsAtTraversalLevel(groupNodeFocused: state.groupNodeFocused?.groupNodeId)) {
             
-            self.panGraphToNodeLocation(id: canvasItem.id,
-                                        document: document)
+            state.panGraphToNodeLocation(id: canvasItem.id)
         }
     }
-    
+}
+
+extension StitchDocumentViewModel {
     // TODO: anywhere this isn't being used but should be?
     @MainActor
-    func panGraphToNodeLocation(id: CanvasItemId,
-                                document: StitchDocumentViewModel) {
+    func panGraphToNodeLocation(id: CanvasItemId) {
+        
+        let graph = self.visibleGraph
         
         // log("panGraphToNodeLocation: called for id: \(id)")
         
-        guard let canvasItem = self.getCanvasItem(id) else {
+        guard let canvasItem = graph.getCanvasItem(id) else {
             fatalErrorIfDebug("panGraphToNodeLocation: no canvasItem found")
             return
         }
         
-        let currentTraversalLevel = document.groupNodeFocused?.groupNodeId
+        let currentTraversalLevel = self.groupNodeFocused?.groupNodeId
         let canvasItemTraversalLevel = canvasItem.parentGroupNodeId
         // log("panGraphToNodeLocation: currentTraversalLevel: \(currentTraversalLevel)")
         // log("panGraphToNodeLocation: canvasItemTraversalLevel: \(canvasItemTraversalLevel)")
@@ -65,23 +60,23 @@ extension GraphState {
         // If the canvas item is not at this traversal level (e.g. a layer input that is on the canvas but inside another group),
         // then we have to find which traversal level to jump to, along with the proper breadcrumb path.
         guard canvasItemTraversalLevel == currentTraversalLevel else {
-            let result = self.getBreadcrumbs(
+            let result = graph.getBreadcrumbs(
                 startingPoint: currentTraversalLevel.map(GroupNodeType.groupNode),
                 destination: canvasItem.id)
             
             // log("panGraphToNodeLocation: result: \(result)")
   
             // if tapped canvas item has a shorter breadcrumb path than the current item, just replace the current breadcrumb path
-            if result.count <= document.groupNodeBreadcrumbs.count {
+            if result.count <= self.groupNodeBreadcrumbs.count {
                 // log("panGraphToNodeLocation: replacing current breadcrumbs")
-                document.groupNodeBreadcrumbs = result
+                self.groupNodeBreadcrumbs = result
             } else {
                 // log("panGraphToNodeLocation: appending to current breadcrumbs")
                 // Update the breadcrumbs
-                document.groupNodeBreadcrumbs.append(contentsOf: result)
+                self.groupNodeBreadcrumbs.append(contentsOf: result)
                 
                 // Updates graph data
-                document.refreshGraphUpdaterId()
+                self.refreshGraphUpdaterId()
             }
             
             // Allow us to enter the traversal level,
@@ -89,32 +84,31 @@ extension GraphState {
             // then attempt to pan again
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 // log("panGraphToNodeLocation: async")
-                self.panGraphToNodeLocation(id: id,
-                                            document: document)
+                self.panGraphToNodeLocation(id: id)
             }
             
             return
         }
         
-        guard let jumpPosition = self.visibleNodesViewModel.getNodeGraphPanLocation(
+        guard let jumpPosition = graph.visibleNodesViewModel.getNodeGraphPanLocation(
             id: id,
-            documentZoomData: document.graphMovement.zoomData,
-            documentFrame: document.frame) else {
+            documentZoomData: self.graphMovement.zoomData,
+            documentFrame: self.frame) else {
             // log("panGraphToNodeLocation: could not retrieve jump location")
             return
         }
         
-        self.canvasJumpLocation = jumpPosition
+        graph.canvasJumpLocation = jumpPosition
         
-        self.selection = GraphUISelectionState()
-        self.resetSelectedCanvasItems()
-        self.selectCanvasItem(id)
+        graph.selection = GraphUISelectionState()
+        graph.resetSelectedCanvasItems()
+        graph.selectCanvasItem(id)
         
         // Update focused group ONLY IF CHANGED (important to avoid didSet)
         if let canvasItemTraversalLevel = canvasItemTraversalLevel,
            currentTraversalLevel != canvasItemTraversalLevel {
             // TODO: need panning logic for component
-            document
+            self
                 .groupNodeBreadcrumbs
                 .append(.groupNode(canvasItemTraversalLevel))
         }

--- a/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
+++ b/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
@@ -156,8 +156,7 @@ extension String {
 // TODO: update iPad graph view as well
 struct CatalystTopBarGraphButtons: View {
 
-    let document: StitchDocumentViewModel
-    let graph: GraphState
+    let isDebugMode: Bool
     let hasActiveGroupFocused: Bool
     let isFullscreen: Bool // = false
     let isPreviewWindowShown: Bool // = true
@@ -189,10 +188,8 @@ struct CatalystTopBarGraphButtons: View {
             }
             
             // TODO: should be a toast only shows up when no nodes are on-screen?
-            CatalystNavBarButton(.FIND_NODE_ON_GRAPH) { [weak graph, weak document] in
-                if let document = document {
-                    graph?.findSomeCanvasItemOnGraph(document: document)
-                }
+            CatalystNavBarButton(.FIND_NODE_ON_GRAPH) {
+                dispatch(FindSomeCanvasItemOnGraph())
             }
 
             // TODO: implement
@@ -204,7 +201,7 @@ struct CatalystTopBarGraphButtons: View {
 //            CatalystNavBarButton(.TOGGLE_PREVIEW_WINDOW_SF_SYMBOL_NAME,
 //                                 rotationZ: isPreviewWindowShown ? 0 : 180) {
             
-            if !document.isDebugMode {
+            if !isDebugMode {
                 CatalystNavBarButton(isPreviewWindowShown ? .HIDE_PREVIEW_WINDOW_SF_SYMBOL_NAME : .SHOW_PREVIEW_WINDOW_SF_SYMBOL_NAME) {
                     dispatch(TogglePreviewWindow())
                 }

--- a/Stitch/Graph/Toolbar/View/TopBarButtonView.swift
+++ b/Stitch/Graph/Toolbar/View/TopBarButtonView.swift
@@ -84,8 +84,7 @@ struct TopBarImageButton: View {
 
 struct iPadGraphTopBarButtons: View {
 
-    @Bindable var document: StitchDocumentViewModel
-    @Bindable var graph: GraphState
+    let isDebugMode: Bool
     let hasActiveGroupFocused: Bool
     let isFullscreen: Bool // = false
     let isPreviewWindowShown: Bool // = true
@@ -104,7 +103,7 @@ struct iPadGraphTopBarButtons: View {
                              iconName: .sfSymbol(.GO_UP_ONE_TRAVERSAL_LEVEL_SF_SYMBOL_NAME))
             .opacity(hasActiveGroupFocused ? 1 : 0)
             
-            if !document.isDebugMode {
+            if !isDebugMode {
                 // toggle preview window
                 iPadNavBarButton(
                     action: PREVIEW_SHOW_TOGGLE_ACTION,
@@ -129,8 +128,6 @@ struct iPadGraphTopBarButtons: View {
 
             // the misc (...) button
             iPadGraphTopBarMiscMenu(
-                document: document,
-                graph: graph,
                 llmRecordingModeActive: llmRecordingModeActive,
                 llmRecordingModeEnabled: llmRecordingModeEnabled)
             
@@ -142,8 +139,6 @@ struct iPadGraphTopBarButtons: View {
 }
 
 struct iPadGraphTopBarMiscMenu: View {
-    @Bindable var document: StitchDocumentViewModel
-    @Bindable var graph: GraphState
     let llmRecordingModeActive: Bool
     let llmRecordingModeEnabled: Bool
     
@@ -161,11 +156,7 @@ struct iPadGraphTopBarMiscMenu: View {
 //                             iconName: .sfSymbol(.ADD_NODE_SF_SYMBOL_NAME),
 //                             label: "Insert Node")
             
-            iPadTopBarButton(action: { [weak graph, weak document] in
-                if let document = document {
-                    graph?.findSomeCanvasItemOnGraph(document: document)
-                }
-            },
+            iPadTopBarButton(action: { dispatch(FindSomeCanvasItemOnGraph())},
                              iconName: .sfSymbol(.FIND_NODE_ON_GRAPH),
                              label: "Find Node")
             

--- a/Stitch/Graph/View/ProjectToolbar.swift
+++ b/Stitch/Graph/View/ProjectToolbar.swift
@@ -84,8 +84,7 @@ struct ProjectToolbarViewModifier: ViewModifier {
                 // .secondaryAction = center
                 ToolbarItemGroup(placement: .primaryAction) {
                     iPadGraphTopBarButtons(
-                        document: document,
-                        graph: graph,
+                        isDebugMode: document.isDebugMode,
                         hasActiveGroupFocused: document.groupNodeFocused.isDefined,
                         isFullscreen: document.isFullScreenMode,
                         isPreviewWindowShown: document.showPreviewWindow,
@@ -121,8 +120,7 @@ struct ProjectToolbarViewModifier: ViewModifier {
 
                 ToolbarItemGroup(placement: .primaryAction) {
                     CatalystTopBarGraphButtons(
-                        document: document,
-                        graph: graph,
+                        isDebugMode: document.isDebugMode,
                         hasActiveGroupFocused: document.groupNodeFocused.isDefined,
                         isFullscreen: document.isFullScreenMode,
                         isPreviewWindowShown: document.showPreviewWindow,


### PR DESCRIPTION
Actions are a way to kickoff a state change from a view without having to pass down the entire relevant state to that view.

Defining an action can admittedly be a pain (requires writing a couple more lines of code); but passing down more state than necessary to a view makes the view's dependencies unclear -- e.g. was `WirelessPortView` actually relying on graph state and document for its UI, or was that just for the state change?

Actions let us separate view deps from state changes.

We also opened more opportunities for mistakes -- supposed we had not marked `graph` and `document` as `weak`? Would we have potentially introduced a retain cycle?