### PR TITLE
Fixed media import support for loop builder

### DIFF
--- a/Stitch/App/Model/ProjectAlertState.swift
+++ b/Stitch/App/Model/ProjectAlertState.swift
@@ -44,15 +44,15 @@ final class ProjectAlertState: Sendable {
 
 /// A boolean wrapper which reflects the visibile state of the import file sheet. Provides an optional "destination" input
 /// coordiante if import will overwrite an existing node's input.
-enum FileImportState: Codable, Equatable {
+enum FileImportState {
     case importing(NodeMediaImportPayload? = nil)
     case notImporting
 }
 
 /// Payload used for import scenarios where imported media is added to an existing node
-struct NodeMediaImportPayload: Codable, Equatable {
+struct NodeMediaImportPayload {
     let destinationInputs: [InputCoordinate] // more than 1 if edited from layer inspector via multiselect
-    let mediaFormat: SupportedMediaFormat
+    let mediaFormat: NodeMediaSupport
 }
 
 extension FileImportState {

--- a/Stitch/App/Serialization/StitchFileManagerProject.swift
+++ b/Stitch/App/Serialization/StitchFileManagerProject.swift
@@ -110,12 +110,16 @@ extension DocumentEncodable {
 
     static func createMediaFileURL(from mediaKey: MediaKey,
                                    importedFilesURL: URL) -> URLResult {
+        guard let mediaType = mediaKey.getMediaType() else {
+            return .failure(.mediaFileUnsupported(mediaKey.fileExtension))
+        }
+        
         // Create ImportedFiles url if it doesn't exist
         let _ = try? StitchFileManager.createDirectories(at: importedFilesURL,
                                                          withIntermediate: true)
 
         let uniqueName = createUniqueFilename(filename: mediaKey.filename,
-                                              mediaType: mediaKey.getMediaType(),
+                                              mediaType: mediaType,
                                               mediaDirectory: importedFilesURL)
 
         let newURL = importedFilesURL

--- a/Stitch/App/Util/URL/URLExtensionUtils.swift
+++ b/Stitch/App/Util/URL/URLExtensionUtils.swift
@@ -15,18 +15,24 @@ extension URL {
         MediaKey(self)
     }
 
-    func getMediaType() -> SupportedMediaFormat {
+    func getMediaType() -> SupportedMediaFormat? {
         SupportedMediaFormat.findType(by: self.pathExtension)
     }
 
-    func supports(mediaFormat: SupportedMediaFormat) -> Bool {
-        self.getMediaType() == mediaFormat
+    func supports(mediaFormat: NodeMediaSupport) -> Bool {
+        switch mediaFormat {
+        case .single(let supportedMediaFormat):
+            return self.getMediaType() == supportedMediaFormat
+            
+        case .all:
+            return true
+        }
     }
 
     func trimMedia(startTime: TimeInterval,
                    endTime: TimeInterval) async -> MediaObjectResult {
 
-        guard let mediaType = self.getMediaType().avMediaType else {
+        guard let mediaType = self.getMediaType()?.avMediaType else {
             return .failure(.mediaFileUnsupported(self.pathExtension))
         }
 

--- a/Stitch/Graph/Menu/FileImportView.swift
+++ b/Stitch/Graph/Menu/FileImportView.swift
@@ -31,23 +31,17 @@ struct FileImportView: ViewModifier {
                     return
                 }
                 
-                Task.detached { [weak store] in
-                        guard let store = store else {
-                            return
-                        }
-                        
-                        // If a node import payload is set then we're supposed to set the media to an existing node
-                        if let nodeImportPayload = fileImportState.nodeImportPayload {
-                            //                logInView("FileImportView: existing node: nodeImportPayload: \(nodeImportPayload)")
-                            await store.mediaFilesImportedToExistingNode(selectedFiles: urls,
-                                                                         nodeImportPayload: nodeImportPayload)
-                        } else {
-                            //                logInView("FileImportView: new node: urls: \(urls)")
-                            await store.mediaFilesImportedToNewNode(selectedFiles: urls,
-                                                                    centerPostion: center)
-                        }
-                    }
+                // If a node import payload is set then we're supposed to set the media to an existing node
+                if let nodeImportPayload = fileImportState.nodeImportPayload {
+                    //                logInView("FileImportView: existing node: nodeImportPayload: \(nodeImportPayload)")
+                    store.mediaFilesImportedToExistingNode(selectedFiles: urls,
+                                                           nodeImportPayload: nodeImportPayload)
+                } else {
+                    //                logInView("FileImportView: new node: urls: \(urls)")
+                    store.mediaFilesImportedToNewNode(selectedFiles: urls,
+                                                      centerPostion: center)
                 }
+            }
             )
     }
 }

--- a/Stitch/Graph/Node/Layer/Util/LayerUtils.swift
+++ b/Stitch/Graph/Node/Layer/Util/LayerUtils.swift
@@ -197,7 +197,7 @@ extension Layer {
         !self.hasMultiKeyPath(at: portId)
     }
     
-    var supportedMediaType: SupportedMediaFormat {
+    var supportedMediaType: SupportedMediaFormat? {
         switch self {
         case .video:
             return .video
@@ -206,7 +206,7 @@ extension Layer {
         case .model3D:
             return .model3D
         default:
-            return .unknown
+            return nil
         }
     }
     

--- a/Stitch/Graph/Node/Patch/Type/Loop/LoopBuilder.swift
+++ b/Stitch/Graph/Node/Patch/Type/Loop/LoopBuilder.swift
@@ -114,5 +114,3 @@ func loopBuilderEval(node: PatchNode,
     
     return result
 }
-
-

--- a/Stitch/Graph/Node/Patch/Util/PatchUtils.swift
+++ b/Stitch/Graph/Node/Patch/Util/PatchUtils.swift
@@ -420,7 +420,7 @@ extension Patch {
             return .single(.coreML)
         case .coreMLDetection:
             return .single(.coreML)
-        case .loopBuilder:
+        case .loopBuilder, .splitter:
             return .all
         default:
             return nil

--- a/Stitch/Graph/Node/Patch/Util/PatchUtils.swift
+++ b/Stitch/Graph/Node/Patch/Util/PatchUtils.swift
@@ -408,20 +408,22 @@ extension Patch {
         }
     }
 
-    var supportedMediaType: SupportedMediaFormat {
+    var supportedMediaType: NodeMediaSupport? {
         switch self {
         case .imageImport:
-            return .image
+            return .single(.image)
         case .videoImport:
-            return .video
+            return .single(.video)
         case .soundImport:
-            return .audio
+            return .single(.audio)
         case .coreMLClassify:
-            return .coreML
+            return .single(.coreML)
         case .coreMLDetection:
-            return .coreML
+            return .single(.coreML)
+        case .loopBuilder:
+            return .all
         default:
-            return .unknown
+            return nil
         }
     }
     

--- a/Stitch/Graph/Node/Port/Model/Field/FieldValueMedia.swift
+++ b/Stitch/Graph/Node/Port/Model/Field/FieldValueMedia.swift
@@ -55,7 +55,7 @@ extension FieldValueMedia {
 
     @MainActor
     func handleSelection(rowObserver: InputNodeRowObserver,
-                         mediaType: SupportedMediaFormat,
+                         mediaType: NodeMediaSupport,
                          isFieldInsideLayerInspector: Bool,
                          activeIndex: ActiveIndex,
                          graph: GraphState) {

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Import/SupportedMediaFormat.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Import/SupportedMediaFormat.swift
@@ -16,7 +16,6 @@ enum SupportedMediaFormat: String, Codable, Equatable, CaseIterable {
     case audio
     case coreML
     case model3D
-    case unknown
 }
 
 extension SupportedMediaFormat {
@@ -36,7 +35,7 @@ extension SupportedMediaFormat {
         }
     }
 
-    static func findType(by pathExtension: String) -> Self {
+    static func findType(by pathExtension: String) -> Self? {
         let pathExtension = pathExtension.uppercased()
 
         if isImageFile(pathExtension: pathExtension) {
@@ -55,10 +54,10 @@ extension SupportedMediaFormat {
             return .model3D
         }
 
-        return .unknown
+        return nil
     }
 
-    var nodeKind: NodeKind? {
+    var nodeKind: NodeKind {
         switch self {
         case .image:
             return .patch(.imageImport)
@@ -70,8 +69,6 @@ extension SupportedMediaFormat {
             return .patch(.coreMLClassify)
         case .model3D:
             return .layer(.model3D)
-        case .unknown:
-            return nil
         }
     }
 }

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaConstants.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaConstants.swift
@@ -69,27 +69,33 @@ extension DefaultMediaOption {
                                   isMediaCurrentlySelected: Bool) -> [FieldValueMedia] {
         
         switch nodeKind.mediaType {
-            
-        case .coreML:
-            guard let patch = nodeKind.getPatch else {
-                // Only patch nodes have default media options for coreML media-type
+        case .single(let mediaType):
+            switch mediaType {
+            case .coreML:
+                guard let patch = nodeKind.getPatch else {
+                    // Only patch nodes have default media options for coreML media-type
+                    return [.none]
+                }
+                
+                switch patch {
+                case .coreMLClassify:
+                    return [isMediaCurrentlySelected ? .none : .defaultMedia(.imageClassifierResnet)]
+                case .coreMLDetection:
+                    return [isMediaCurrentlySelected ? .none : .defaultMedia(.objectDetectionYolo)]
+                default:
+                    return []
+                }
+                
+            case .model3D:
+                return [isMediaCurrentlySelected ? .none : .defaultMedia(.model3dToyRobot)]
+                
+            default:
                 return [.none]
             }
             
-            switch patch {
-            case .coreMLClassify:
-                return [isMediaCurrentlySelected ? .none : .defaultMedia(.imageClassifierResnet)]
-            case .coreMLDetection:
-                return [isMediaCurrentlySelected ? .none : .defaultMedia(.objectDetectionYolo)]
-            default:
-                return []
-            }
-            
-        case .model3D:
-            return [isMediaCurrentlySelected ? .none : .defaultMedia(.model3dToyRobot)]
-            
+        // default empty for loop builder scenario
         default:
-            return [.none]
+            return []
         }
     }
     

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaKeyUtils.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaKeyUtils.swift
@@ -16,7 +16,7 @@ extension MediaKey {
         filename + "." + fileExtension
     }
     
-    func getMediaType() -> SupportedMediaFormat {
+    func getMediaType() -> SupportedMediaFormat? {
         SupportedMediaFormat.findType(by: self.fileExtension)
     }
 }

--- a/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
@@ -430,22 +430,30 @@ struct InputFieldValueView: View {
                 
                 
             case .media(let media):
-                MediaInputFieldValueView(
-                    viewModel: viewModel,
-                    rowObserver: rowObserver,
-                    node: node,
-                    isUpstreamValue: isUpstreamValue,
-                    media: media,
-                    mediaName: media.name,
-                    nodeKind: nodeKind,
-                    isInput: true,
-                    fieldIndex: fieldIndex,
-                    isNodeSelected: isCanvasItemSelected,
-                    isFieldInsideLayerInspector: isFieldInsideLayerInspector,
-                    isSelectedInspectorRow: isSelectedInspectorRow,
-                    isMultiselectInspectorInputWithHeterogenousValues: hasHeterogenousValues,
-                    graph: graph,
-                    document: document)
+                if let mediaType = self.nodeKind.mediaType {
+                    MediaInputFieldValueView(
+                        viewModel: viewModel,
+                        rowObserver: rowObserver,
+                        node: node,
+                        isUpstreamValue: isUpstreamValue,
+                        media: media,
+                        mediaName: media.name,
+                        nodeKind: nodeKind,
+                        isInput: true,
+                        fieldIndex: fieldIndex,
+                        isNodeSelected: isCanvasItemSelected,
+                        isFieldInsideLayerInspector: isFieldInsideLayerInspector,
+                        isSelectedInspectorRow: isSelectedInspectorRow,
+                        isMultiselectInspectorInputWithHeterogenousValues: hasHeterogenousValues,
+                        mediaType: mediaType,
+                        graph: graph,
+                        document: document)
+                } else {
+                    Color.clear
+                        .onAppear {
+                            fatalErrorIfDebug()
+                        }
+                }
                 
             case .color(let color):
                 ColorOrbValueButtonView(fieldViewModel: viewModel,

--- a/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerValueEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerValueEntry.swift
@@ -22,10 +22,7 @@ struct MediaPickerValueEntry: View {
     let isMultiselectInspectorInputWithHeterogenousValues: Bool
     let isSelectedInspectorRow: Bool
     let activeIndex: ActiveIndex
-    
-    var mediaType: SupportedMediaFormat {
-        nodeKind.mediaType
-    }
+    let mediaType: NodeMediaSupport
     
     var body: some View {
         let defaultOptions = DefaultMediaOption

--- a/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
@@ -43,6 +43,7 @@ struct MediaInputFieldValueView: View {
     let isFieldInsideLayerInspector: Bool
     let isSelectedInspectorRow: Bool
     let isMultiselectInspectorInputWithHeterogenousValues: Bool
+    let mediaType: NodeMediaSupport
     
     @Bindable var graph: GraphState
     let document: StitchDocumentViewModel
@@ -73,7 +74,8 @@ struct MediaInputFieldValueView: View {
                                   graph: graph,
                                   isMultiselectInspectorInputWithHeterogenousValues: isMultiselectInspectorInputWithHeterogenousValues,
                                   isSelectedInspectorRow: isSelectedInspectorRow,
-                                  activeIndex: document.activeIndex)
+                                  activeIndex: document.activeIndex,
+                                  mediaType: mediaType)
             .onChange(of: mediaName, initial: true) {
                 // log("media name in inner value view: \(mediaName)")
             }

--- a/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
@@ -76,9 +76,6 @@ struct MediaInputFieldValueView: View {
                                   isSelectedInspectorRow: isSelectedInspectorRow,
                                   activeIndex: document.activeIndex,
                                   mediaType: mediaType)
-            .onChange(of: mediaName, initial: true) {
-                // log("media name in inner value view: \(mediaName)")
-            }
             
             MediaFieldLabelView(viewModel: viewModel,
                                 inputType: viewModel.id.rowId.portType,

--- a/Stitch/Graph/Node/Port/View/Field/InputView/PickerValueEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/PickerValueEntry.swift
@@ -23,7 +23,7 @@ struct MediaPickerButtons: View {
     @Environment(\.appTheme) var theme
     
     let rowObserver: InputNodeRowObserver
-    let mediaType: SupportedMediaFormat
+    let mediaType: NodeMediaSupport
     let choices: [FieldValueMedia]
     let isFieldInsideLayerInspector: Bool
     let graph: GraphState

--- a/Stitch/Graph/Node/Util/NodeKindUtils.swift
+++ b/Stitch/Graph/Node/Util/NodeKindUtils.swift
@@ -9,16 +9,25 @@ import Foundation
 import SwiftUI
 import StitchSchemaKit
 
+enum NodeMediaSupport {
+    // almost all media nodes
+    case single(SupportedMediaFormat)
+    
+    // just loop builder, which supports all types
+    case all
+}
+
 extension NodeKind {
 
-    var mediaType: SupportedMediaFormat {
+    var mediaType: NodeMediaSupport? {
         switch self {
         case .patch(let patch):
             return patch.supportedMediaType
         case .layer(let layer):
-            return layer.supportedMediaType
+            guard let type = layer.supportedMediaType else { return nil }
+            return .single(type)
         case .group:
-            return .unknown
+            return nil
         }
     }
 
@@ -197,17 +206,6 @@ extension NodeKind {
             }
         default:
             return valuesList.longestLoopLength
-        }
-    }
-    
-    var supportedMediaType: SupportedMediaFormat? {
-        switch self {
-        case .patch(let patch):
-            return patch.supportedMediaType
-        case .layer(let layer):
-            return layer.supportedMediaType
-        default:
-            return nil
         }
     }
     


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7121

Loop builder and Splitter nodes needed support for handling any media type for import. Some new logic in our code was needed for supporting all media types, vs. a single media type as needed for most nodes.