### PR TITLE
Fixed sizing constraints for image and video layers

### DIFF
--- a/Stitch/Graph/Node/Layer/Type/Media/VisualMediaLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/VisualMediaLayerNode.swift
@@ -103,7 +103,8 @@ struct ImageLayerView: View {
             parentSize: parentSize,
             parentDisablesPosition: parentDisablesPosition,
             parentIsScrollableGrid: parentIsScrollableGrid,
-            isClipped: viewModel.isClipped.getBool ?? false)
+            isClipped: viewModel.isClipped.getBool ?? false,
+            sizingScenario: viewModel.getSizingScenario)
     }
 }
 

--- a/Stitch/Graph/Node/Port/View/Field/Media/ValueImageView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/Media/ValueImageView.swift
@@ -34,7 +34,8 @@ struct ValueImageView: View {
             imageDisplaySize: INLINE_IMAGE_DISPLAY_SIZE,
             opacity: IMAGE_INLINE_DISPLAY_OPACITY,
             fitStyle: .fit,
-            isClipped: IMAGE_INLINE_DISPLAY_CLIPPED)
+            isClipped: IMAGE_INLINE_DISPLAY_CLIPPED,
+            sizingScenario: .auto)
             // white background for parts of display area not covered
             // due to image's aspect ratio.
             .background(.white)

--- a/Stitch/Graph/Node/Port/View/Field/Media/VideoDisplayView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/Media/VideoDisplayView.swift
@@ -56,7 +56,8 @@ struct VideoDisplayView: View {
                         resourceSize: image.size),
                     opacity: opacity,
                     fitStyle: fitStyle,
-                    isClipped: isClipped)
+                    isClipped: isClipped,
+                    sizingScenario: layerViewModel.getSizingScenario)
             } else {
                 ScrubbedVideoView(videoPlayer: videoPlayer,
                                   fitStyle: fitStyle,

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewImage.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewImage.swift
@@ -126,7 +126,9 @@ struct ImageDisplayView: View {
     // TODO: separate out this PortView thumbnail-display case; there everything should be much simpler, since we always have a static size and always .fit the image with preserverd aspect ratio
     var fitStyle: VisualMediaFitStyle? // nil when used by PortView to display thumbnail
     
-    var isClipped: Bool
+    let isClipped: Bool
+    
+    let sizingScenario: SizingScenario
 
     var body: some View {
         let image = imageView // set aspectRatio, frame dimensions etc.
@@ -149,7 +151,8 @@ struct ImageDisplayView: View {
         switch imageDisplaySize.scenario {
 
         case .autoDimensions:
-            if let fitStyle = fitStyle {
+            if let fitStyle = fitStyle,
+               sizingScenario == .auto {
                 return view
                     .aspectRatio(contentMode: fitStyle.asContentMode)
                 // Use the explicit `imageDisplaySize`, since that was used for positioning and already correctly reflects the resource's size
@@ -227,7 +230,8 @@ struct NilImageView: View {
                          imageDisplaySize: INLINE_IMAGE_DISPLAY_SIZE,
                          opacity: IMAGE_INLINE_DISPLAY_OPACITY,
                          fitStyle: .fit,
-                         isClipped: IMAGE_INLINE_DISPLAY_CLIPPED)
+                         isClipped: IMAGE_INLINE_DISPLAY_CLIPPED,
+                         sizingScenario: .auto)
     }
 }
 
@@ -266,6 +270,7 @@ struct PreviewImageLayer: View {
     let parentIsScrollableGrid: Bool
     
     let isClipped: Bool
+    let sizingScenario: SizingScenario
 
     var imageDisplaySize: ImageDisplaySize {
         // actual calculated size at which we're displaying the image
@@ -292,14 +297,15 @@ struct PreviewImageLayer: View {
                          imageDisplaySize: imageDisplaySize,
                          opacity: opacity,
                          fitStyle: fitStyle,
-                         isClipped: isClipped)
+                         isClipped: isClipped,
+                         sizingScenario: sizingScenario)
         .modifier(LayerSizeReader(viewModel: layerViewModel,
                                  isPinnedViewRendering: isPinnedViewRendering))
         .modifier(PreviewWindowCoordinateSpaceReader(
             viewModel: layerViewModel,
             isPinnedViewRendering: isPinnedViewRendering,
             pinMap: graph.pinMap))
-        .modifier(PreviewCommonModifierWithoutFrame(
+        .modifier(PreviewCommonModifier(
             document: document,
             graph: graph,
             layerViewModel: layerViewModel,

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewVideo.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/PreviewVideo.swift
@@ -67,7 +67,7 @@ struct PreviewVideoLayer: View {
                          volume: volume)
             
         // .frame is set VideoDisplayView
-        .modifier(PreviewCommonModifierWithoutFrame(
+        .modifier(PreviewCommonModifier(
             document: document,
             graph: graph,
             layerViewModel: layerViewModel,


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7122

Image + video layers now use `PreviewCommonModifier` which contained the logic for constraining height and width.

An alternate solution might be possible that brings over sizing logic into the image child views directly. This approach is more clean by using the same logic across all non-group layers.