### PR TITLE
Fixed direct media imports on Loop Builder

### DIFF
--- a/Stitch/Graph/Node/Patch/Type/Media/ImageNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Media/ImageNode.swift
@@ -50,7 +50,7 @@ func imageImportEval(node: PatchNode) -> EvalResult {
                 return .init(from: [.asyncMedia(nil), .size(.zero)])
             }
             
-            let computedMediaValue = AsyncMediaValue(id: .init(),
+            let computedMediaValue = AsyncMediaValue(id: media.id,
                                                      dataType: .computed,
                                                      label: mediaValue.label)
             return .init(values: [


### PR DESCRIPTION
Completing the job started by #1049

Problem here being we needed logic to create a media object if source media was added directly.

Also fixed here is image import eval unnecessarily changing the `.id` property on media—this ID should remain static for the source media.