### PR TITLE
Removed sizing scenario inputs for visual media layers

### DIFF
--- a/Stitch/Graph/Node/Layer/Type/Media/VideoLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/VideoLayerNode.swift
@@ -32,12 +32,14 @@ struct VideoLayerNode: LayerNodeDefinition {
         .zIndex,
         .clipped,
         .masks,
-        .volume 
+        .volume,
+        .size
     ])
         .union(.layerEffects)
         .union(.strokeInputs)
-        .union(.aspectRatio)
-        .union(.sizing).union(.pinning).union(.layerPaddingAndMargin).union(.offsetInGroup)
+        .union(.pinning)
+        .union(.layerPaddingAndMargin)
+        .union(.offsetInGroup)
     
     static func content(document: StitchDocumentViewModel,
                         graph: GraphState,

--- a/Stitch/Graph/Node/Layer/Type/Media/VisualMedia.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/VisualMedia.swift
@@ -29,12 +29,11 @@ struct ImageLayerNode: LayerNodeDefinition {
         .shadowColor,
         .shadowOpacity,
         .shadowRadius,
-        .shadowOffset
+        .shadowOffset,
+        .size
     ])
         .union(.layerEffects)
         .union(.strokeInputs)
-        .union(.aspectRatio)
-        .union(.sizing)
         .union(.pinning)
         .union(.layerPaddingAndMargin)
         .union(.offsetInGroup)


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7122

Removing sizing scenario inputs for image + video layers as there's no support currently and non-trivial to do at this moment.