### PR TITLE
Pass document to `updateGraphData`, update tests

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -86,7 +86,7 @@
 		B5386FB02C9A929B00AD8065 /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = B5386FAF2C9A929B00AD8065 /* StitchEngine */; };
 		B539C2E62B92BDA900C6CEC3 /* CameraFeedActor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B539C2E52B92BDA900C6CEC3 /* CameraFeedActor.swift */; };
 		B539C2EA2B92BF3D00C6CEC3 /* DocumentEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B539C2E92B92BF3D00C6CEC3 /* DocumentEncodable.swift */; };
-		B53A92292A7D80CC00192E86 /* GraphMovementViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53A92282A7D80CC00192E86 /* GraphMovementViewModifier.swift */; };
+		B53A92292A7D80CC00192E86 /* UpdateVisibleNodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53A92282A7D80CC00192E86 /* UpdateVisibleNodes.swift */; };
 		B53AA6402D9B1683008D5C23 /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = B53AA63F2D9B1683008D5C23 /* StitchEngine */; };
 		B53B1D96289E265900489652 /* StitchVideoPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53B1D95289E265900489652 /* StitchVideoPlayer.swift */; };
 		B53E0BEC2D35B5E00072FD43 /* BoxLayerNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53E0BEB2D35B5DD0072FD43 /* BoxLayerNode.swift */; };
@@ -604,6 +604,7 @@
 		EC6C68D42937D27A0023B700 /* ArrayCountNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6C68D32937D27A0023B700 /* ArrayCountNode.swift */; };
 		EC6DF0A929FA04F60052545E /* StitchJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6DF0A829FA04F60052545E /* StitchJSON.swift */; };
 		EC6DF0AB29FA050F0052545E /* jsonPerfTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6DF0AA29FA050F0052545E /* jsonPerfTests.swift */; };
+		EC6E69B42DA9930400C3A017 /* Readers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6E69B32DA9930400C3A017 /* Readers.swift */; };
 		EC6EDC2D27FF907300843E62 /* SidebarListItemSelectionActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6EDC2C27FF907300843E62 /* SidebarListItemSelectionActions.swift */; };
 		EC6EDC3227FF93CF00843E62 /* SidebarSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6EDC3127FF93CF00843E62 /* SidebarSelectionState.swift */; };
 		EC6EDC3427FF943700843E62 /* SidebarVisibilityState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6EDC3327FF943700843E62 /* SidebarVisibilityState.swift */; };
@@ -1071,7 +1072,7 @@
 		B53857AF2B50682400428962 /* NodeDefinitionKinds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeDefinitionKinds.swift; sourceTree = "<group>"; };
 		B539C2E52B92BDA900C6CEC3 /* CameraFeedActor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraFeedActor.swift; sourceTree = "<group>"; };
 		B539C2E92B92BF3D00C6CEC3 /* DocumentEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentEncodable.swift; sourceTree = "<group>"; };
-		B53A92282A7D80CC00192E86 /* GraphMovementViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphMovementViewModifier.swift; sourceTree = "<group>"; };
+		B53A92282A7D80CC00192E86 /* UpdateVisibleNodes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateVisibleNodes.swift; sourceTree = "<group>"; };
 		B53B1D95289E265900489652 /* StitchVideoPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StitchVideoPlayer.swift; sourceTree = "<group>"; };
 		B53B54F62D507A60007A52AF /* Stitch.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Stitch.xctestplan; sourceTree = "<group>"; };
 		B53E0BEB2D35B5DD0072FD43 /* BoxLayerNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxLayerNode.swift; sourceTree = "<group>"; };
@@ -1572,6 +1573,7 @@
 		EC6C68D32937D27A0023B700 /* ArrayCountNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayCountNode.swift; sourceTree = "<group>"; };
 		EC6DF0A829FA04F60052545E /* StitchJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StitchJSON.swift; sourceTree = "<group>"; };
 		EC6DF0AA29FA050F0052545E /* jsonPerfTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = jsonPerfTests.swift; sourceTree = "<group>"; };
+		EC6E69B32DA9930400C3A017 /* Readers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Readers.swift; sourceTree = "<group>"; };
 		EC6EDC2C27FF907300843E62 /* SidebarListItemSelectionActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarListItemSelectionActions.swift; sourceTree = "<group>"; };
 		EC6EDC3127FF93CF00843E62 /* SidebarSelectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarSelectionState.swift; sourceTree = "<group>"; };
 		EC6EDC3327FF943700843E62 /* SidebarVisibilityState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarVisibilityState.swift; sourceTree = "<group>"; };
@@ -2891,7 +2893,7 @@
 			isa = PBXGroup;
 			children = (
 				B555012E2C1BFD280081C3F1 /* ViewController */,
-				B53A92282A7D80CC00192E86 /* GraphMovementViewModifier.swift */,
+				B53A92282A7D80CC00192E86 /* UpdateVisibleNodes.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -3264,6 +3266,7 @@
 			isa = PBXGroup;
 			children = (
 				205E6DDD25AFCB23001C5C27 /* GraphState.swift */,
+				EC6E69B32DA9930400C3A017 /* Readers.swift */,
 				EC0F334B2BED93EF008093BC /* GraphDelegate.swift */,
 				8B77BA782713CED300255C40 /* GraphUI.swift */,
 				ECBB94722D60007A005311D5 /* HomescreenProjectSelectionState.swift */,
@@ -5197,7 +5200,7 @@
 				B5D689BF275836390086C297 /* ProjectAlertActions.swift in Sources */,
 				ECECF3DD2C095A8F004A4D10 /* TabKeyPressActions.swift in Sources */,
 				ECB5A8162657230600D46D3E /* SampleHoldNode.swift in Sources */,
-				B53A92292A7D80CC00192E86 /* GraphMovementViewModifier.swift in Sources */,
+				B53A92292A7D80CC00192E86 /* UpdateVisibleNodes.swift in Sources */,
 				B5ECCB0E2CC94F9600585F1D /* SidebarItemSwipable.swift in Sources */,
 				EC28CC9A287E347A00987792 /* PatchEvaluateExtensions.swift in Sources */,
 				ECCEB26A2963928D007E35D1 /* UnionNode.swift in Sources */,
@@ -5461,6 +5464,7 @@
 				B55501052C1BC8890081C3F1 /* SidebarSwipeSetting.swift in Sources */,
 				EC3420E22AF9C2EC00EBD896 /* CommentBoxHelpers.swift in Sources */,
 				B5EFD5B32D5E57AD006A68FB /* StitchAINodeUtils.swift in Sources */,
+				EC6E69B42DA9930400C3A017 /* Readers.swift in Sources */,
 				ECDFF6302A0E994700729D2A /* ShapeToCommandsNode.swift in Sources */,
 				ECE2AFEA2C0A43D200F5FE87 /* InsertNodeMenuActions.swift in Sources */,
 				ECCF23512D4C6C5A00BC2F2F /* StepTypeAction.swift in Sources */,

--- a/Stitch/Graph/Edge/Util/EdgeEditingActions.swift
+++ b/Stitch/Graph/Edge/Util/EdgeEditingActions.swift
@@ -293,7 +293,7 @@ extension CGPoint {
 
 extension VisibleNodesViewModel {
     @MainActor
-    func nodePageDataAtCurrentTraversalLevel(_ focusedGroup: NodeId?) -> NodePageData? {
+    func nodePageDataAtThisTraversalLevel(_ focusedGroup: NodeId?) -> NodePageData? {
         self.nodesByPage.get(focusedGroup.map(NodePageType.group) ?? NodePageType.root)
     }
 }

--- a/Stitch/Graph/LayerInspector/LayerInspectorActions.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorActions.swift
@@ -108,7 +108,7 @@ extension GraphState {
         // Reset graph cache to get new nodes to appear
         // Dispatch needed for fix
         DispatchQueue.main.async { [weak self] in
-            self?.visibleNodesViewModel.resetCache()
+            self?.visibleNodesViewModel.resetVisibleCanvasItemsCache()
         }
     }
 }

--- a/Stitch/Graph/Node/Group/GroupNodeCreationActions.swift
+++ b/Stitch/Graph/Node/Group/GroupNodeCreationActions.swift
@@ -250,7 +250,7 @@ extension StitchDocumentViewModel {
         self.graphMovement.stopNodeMovement()
 
         // Recalculate graph
-        self.graph.updateGraphData()
+        self.graph.updateGraphData(self)
         
         self.visibleGraph.encodeProjectInBackground()
     }

--- a/Stitch/Graph/Node/Patch/Type/Value/SplitterTypeActions.swift
+++ b/Stitch/Graph/Node/Patch/Type/Value/SplitterTypeActions.swift
@@ -39,7 +39,7 @@ struct SplitterTypeChanged: StitchDocumentEvent {
             activeIndex: state.activeIndex)
         
         // Forces group port view models to update
-        graph.updateGraphData()
+        graph.updateGraphData(state)
 
         // Recalculate the graph, since we may have flattened an input on a splitter node and so that output should be flat as well (happens via node eval).
         graph.calculateFullGraph()

--- a/Stitch/Graph/Node/Port/Util/InputEdit/InputEditedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/InputEdit/InputEditedActions.swift
@@ -98,7 +98,13 @@ extension InputNodeRowObserver {
             // graph.connectedEdges = graph.getVisualEdgeData(groupNodeFocused: graph.documentDelegate?.groupNodeFocused?.groupNodeId)
             
             // Note: need to do full update, since upstream output's port-color needs to change as well
-            graph.updateGraphData()
+            // TODO: APRIL 11: do we really need to do this?!
+            guard let document = graph.documentDelegate else {
+                fatalErrorIfDebug()
+                return
+            }
+            graph.updateGraphData(document)
+             
             
             self.setValuesInInput([newValue])
             self.immediatelyUpdateFieldObserversAfterInputEdit(newValue)

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
@@ -326,7 +326,8 @@ extension LayerInputObserver {
     @MainActor 
     func wasPackModeToggled() {
                 
-        guard let graph = self.graphDelegate else {
+        guard let graph = self.graphDelegate,
+              let document = graph.documentDelegate else {
             fatalErrorIfDebug("wasPackModeToggled: did not have graph delegate")
             return
         }
@@ -366,7 +367,8 @@ extension LayerInputObserver {
             self._packedData.rowObserver.setValuesInInput(values)
         }
         
-        graph.updateGraphData()
+        // TODO: why do we need to do this? Is it updating the UI?
+        graph.updateGraphData(document)
     }
     
     /// Helper only intended for use with ports that don't support unpacked mode.

--- a/Stitch/Graph/Node/Util/NodeCreatedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeCreatedAction.swift
@@ -125,7 +125,7 @@ extension StitchDocumentViewModel {
         self.visibleGraph.calculateFullGraph()
         
         // Reset nodes layout cache
-        self.visibleGraph.visibleNodesViewModel.resetCache()
+        self.visibleGraph.visibleNodesViewModel.resetVisibleCanvasItemsCache()
         
         // Reset doubleTapLocation
         // TODO: where else would we need to reset this?

--- a/Stitch/Graph/Node/Util/NodeDeletedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeDeletedAction.swift
@@ -81,7 +81,12 @@ extension GraphState {
 
         graphMovement.draggedCanvasItem = nil
         
-        self.updateGraphData()
+         // TODO: APRIL 11: should not be necessary anymore? since causes a persistence change
+        guard let document = self.documentDelegate else {
+            fatalErrorIfDebug()
+            return
+        }
+        self.updateGraphData(document)
     }
     
     // Varies by node vs LayerInputOnGraph vs comment box

--- a/Stitch/Graph/Node/View/StitchUIScrollHelpers.swift
+++ b/Stitch/Graph/Node/View/StitchUIScrollHelpers.swift
@@ -46,7 +46,7 @@ struct GraphScrollDataUpdated: StitchDocumentEvent {
         }
         
         // Update which nodes are visible in frame
-        graph.updateVisibleNodes()
+        state.updateVisibleCanvasItems()
     }
     
 }

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarGroupUncreated.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarGroupUncreated.swift
@@ -57,6 +57,11 @@ extension LayersSidebarViewModel {
         graph.deleteNode(id: groupId, willDeleteLayerGroupChildren: false)
 
         // update legacy sidebar data
-        graph.updateGraphData()
+        // TODO: APRIL 11: should not be necessary anymore? since causes a persistence change
+        guard let document = graph.documentDelegate else {
+            fatalErrorIfDebug()
+            return
+        }
+        graph.updateGraphData(document)
     }
 }

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarListItemSelectionActions.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarListItemSelectionActions.swift
@@ -120,13 +120,12 @@ extension ProjectSidebarObservable {
     }
 }
 
-extension GraphState {
+extension StitchDocumentViewModel {
     // When an individual sidebar item is deleted via the swipe menu
     @MainActor
     func sidebarItemDeleted(itemId: SidebarListItemId) {
-        self.deleteNode(id: itemId)
-                
-        self.updateGraphData()
-        self.encodeProjectInBackground()
+        self.visibleGraph.deleteNode(id: itemId)
+        self.visibleGraph.updateGraphData(self)
+        self.visibleGraph.encodeProjectInBackground()
     }
 }

--- a/Stitch/Graph/Sidebar/ViewModel/SidebarItemGestureViewModel.swift
+++ b/Stitch/Graph/Sidebar/ViewModel/SidebarItemGestureViewModel.swift
@@ -137,7 +137,7 @@ extension SidebarItemGestureViewModel {
     
     @MainActor
     func didDeleteItem() {
-        self.graphDelegate?.sidebarItemDeleted(itemId: self.id)
+        self.graphDelegate?.documentDelegate?.sidebarItemDeleted(itemId: self.id)
     }
     
     @MainActor
@@ -190,6 +190,6 @@ extension SidebarItemGestureViewModel {
     
     @MainActor
     func sidebarItemDeleted(itemId: SidebarListItemId) {
-        self.graphDelegate?.sidebarItemDeleted(itemId: itemId)
+        self.graphDelegate?.documentDelegate?.sidebarItemDeleted(itemId: itemId)
     }
 }

--- a/Stitch/Graph/Util/GraphUIActions.swift
+++ b/Stitch/Graph/Util/GraphUIActions.swift
@@ -120,7 +120,7 @@ struct ToggleFullScreenEvent: StitchDocumentEvent {
             state.visibleGraph.visibleNodesViewModel.visibleCanvasIds = .init()
         }  else {
             // Mark all nodes as visible, will correct later
-            state.visibleGraph.visibleNodesViewModel.setAllNodesVisible()
+            state.visibleGraph.visibleNodesViewModel.setAllCanvasItemsVisible()
         }
     }
 }

--- a/Stitch/Graph/Util/NodeSelection/CopyAndPasteNodesActions.swift
+++ b/Stitch/Graph/Util/NodeSelection/CopyAndPasteNodesActions.swift
@@ -36,8 +36,12 @@ struct SelectedGraphItemsCut: StitchDocumentEvent {
             graph.deleteCanvasItem($0)
         }
 
-        graph.updateGraphData()
+        // TODO: APRIL 11: should not be necessary anymore? since causes a persistence change
+         graph.updateGraphData(state)
+        
         state.encodeProjectInBackground()
+        
+        
     }
 }
 

--- a/Stitch/Graph/View/InfiniteCanvas.swift
+++ b/Stitch/Graph/View/InfiniteCanvas.swift
@@ -93,7 +93,7 @@ struct InfiniteCanvas: Layout {
             graph?.visibleNodesViewModel.infiniteCanvasCache = cache
             
             // Update visible nodes (fixes init case)
-            graph?.updateVisibleNodes()
+            graph?.documentDelegate?.updateVisibleCanvasItems()
         }
         
         return cache

--- a/Stitch/Graph/View/ProjectNavigationView.swift
+++ b/Stitch/Graph/View/ProjectNavigationView.swift
@@ -34,7 +34,7 @@ struct ProjectNavigationView: View {
         }
         .onChange(of: document.graphUpdaterId) {
             // log("ProjectNavigationView: .onChange(of: document.visibleGraph.graphUpdaterId)")
-            document.visibleGraph.updateGraphData()
+            document.visibleGraph.updateGraphData(document)
         }
         .onChange(of: document.isCameraEnabled) { _, isCameraEnabled in
             if !isCameraEnabled {

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -196,7 +196,6 @@ extension GraphState {
         
         self.documentDelegate = document
         self.documentEncoderDelegate = documentEncoderDelegate
-        let focusedGroupNode = self.documentDelegate?.groupNodeFocused?.groupNodeId
         
         self.layersSidebarViewModel.initializeDelegate(graph: self)
         
@@ -253,7 +252,7 @@ extension GraphState {
         
         
         // Update edges after everything else
-        let newEdges = self.getVisualEdgeData(groupNodeFocused: focusedGroupNode)
+        let newEdges = self.getVisualEdgeData(groupNodeFocused: document.groupNodeFocused?.groupNodeId)
 
         // HOT FIX: when we reapply llm-actions, the old and new connected edges are equal per ConnectedEdge's == implementation,
         // so we don't re-render GraphConnectedEdgesView even though the input row view model's port color changed.
@@ -359,6 +358,7 @@ extension GraphState {
     func updateGraphData(_ document: StitchDocumentViewModel) {
         // TODO: What's the difference between a document's documentEncoder and a graph's documentEncoderDelegate?
         guard let documentEncoder = self.documentEncoderDelegate else {
+            // TODO: `createTestFriendlyDocument` sets an encoder on both document and graph, but by the time the test runs it gets wiped some how? For now we use
             fatalErrorIfDebug()
             return
         }

--- a/Stitch/Graph/ViewModel/Readers.swift
+++ b/Stitch/Graph/ViewModel/Readers.swift
@@ -1,0 +1,42 @@
+//
+//  CanvasItemReader.swift
+//  Stitch
+//
+//  Created by Christian J Clampitt on 4/11/25.
+//
+
+import Foundation
+
+// Protocol for functions that only need to retrieve certain objects from GraphState
+
+protocol GraphReader {
+    @MainActor func getCanvasItem(_ id: CanvasItemId) -> CanvasItemViewModel?
+    @MainActor func getInputRowObserver(_ id: InputCoordinate) -> InputNodeRowObserver?
+    @MainActor func getOutputRowObserver(_ id: OutputCoordinate) -> OutputNodeRowObserver?
+}
+
+extension GraphState: GraphReader { }
+
+extension GraphReader {
+    @MainActor
+    func updateCanvasItemFields(canvasItemId: CanvasItemId,
+                                activeIndex: ActiveIndex) {
+        guard let canvasItem = self.getCanvasItem(canvasItemId) else {
+            // Crashes in some valid examples
+            // fatalErrorIfDebug()
+            return
+        }
+        
+        canvasItem.inputViewModels.forEach {
+            if let observer = self.getInputRowObserver($0.nodeIOCoordinate) {
+                $0.updateFields(observer.getActiveValue(activeIndex: activeIndex))
+            }
+        }
+        
+        canvasItem.outputViewModels.forEach {
+            if let observer = self.getOutputRowObserver($0.nodeIOCoordinate) {
+                $0.updateFields(observer.getActiveValue(activeIndex: activeIndex))
+            }
+        }
+    }
+}

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -173,7 +173,7 @@ final class StitchDocumentViewModel: Sendable {
         self.storeDelegate = store
         
         guard let documentEncoder = self.documentEncoder else {
-//            fatalErrorIfDebug()
+            // fatalErrorIfDebug()
             return
         }
         
@@ -547,12 +547,21 @@ extension StitchDocumentViewModel {
     @MainActor
     static func createTestFriendlyDocument() async -> StitchDocumentViewModel {
         let store = StitchStore()
+        
         await store.createNewProject(isProjectImport: false,
                                      isPhoneDevice: false)
+        
         guard let projectLoader = store.navPath.first,
               let documentViewModel = projectLoader.documentViewModel else {
             fatalError()
         }
+        
+        documentViewModel.documentEncoder = projectLoader.encoder
+        documentViewModel.graph.documentEncoderDelegate = documentViewModel.documentEncoder
+        
+        assert(documentViewModel.documentEncoder.isDefined)
+        assert(documentViewModel.graph.documentEncoderDelegate.isDefined)
+        
         return documentViewModel
     }
     

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -556,7 +556,7 @@ extension StitchDocumentViewModel {
             fatalError()
         }
         
-        documentViewModel.documentEncoder = projectLoader.encoder
+        documentViewModel.documentEncoder = projectLoader.encoder!
         documentViewModel.graph.documentEncoderDelegate = documentViewModel.documentEncoder
         
         assert(documentViewModel.documentEncoder.isDefined)

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -190,7 +190,7 @@ final class StitchDocumentViewModel: Sendable {
         if isInitialization {
             // Need all nodes to render initially
             let visibleGraph = self.visibleGraph
-            visibleGraph.visibleNodesViewModel.setAllNodesVisible()
+            visibleGraph.visibleNodesViewModel.setAllCanvasItemsVisible()
         }
     }
     

--- a/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
+++ b/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
@@ -366,7 +366,7 @@ extension VisibleNodesViewModel {
     }
    
     @MainActor
-    func setAllNodesVisible() {
+    func setAllCanvasItemsVisible() {
         let newIds = self.allViewModels.map(\.id).toSet
         if self.visibleCanvasIds != newIds {
             self.visibleCanvasIds = newIds
@@ -375,11 +375,11 @@ extension VisibleNodesViewModel {
     
     @MainActor
     /// Updates node visibility data.
-    func resetCache() {
+    func resetVisibleCanvasItemsCache() {
         if !self.needsInfiniteCanvasCacheReset {
             self.needsInfiniteCanvasCacheReset = true
         }
-        self.setAllNodesVisible()
+        self.setAllCanvasItemsVisible()
         
         // Fixes issues where new rows don't have port locations
         for node in self.nodes.values {

--- a/StitchTests/loopTests.swift
+++ b/StitchTests/loopTests.swift
@@ -11,6 +11,8 @@ import SwiftyJSON
 
 final class loopTests: XCTestCase {
 
+    @MainActor var store = StitchStore()
+    
     func testLoopInsertFriendlyIndices() throws {
 
         // for e.g. a loop like `[a, b, c]`
@@ -34,12 +36,13 @@ final class loopTests: XCTestCase {
     }
     
     @MainActor
-    func testJSONArray() throws {
+    func testJSONArray() async throws {
         /*
          Old bug: JSONArray was adding its output to the list of inputs to turn into an array.
          Not caught by existing JSONArrayFromValues test because the bug came from `nodeViewModel.loopedEval` helper.
          */
-        if let node = StitchDocumentViewModel.createEmpty().nodeInserted(choice: .patch(.jsonArray)) {
+        let document = await StitchDocumentViewModel.createTestFriendlyDocument()
+        if let node = document.nodeInserted(choice: .patch(.jsonArray)) {
             
             // How many inputs does the JSONArray node have?
             let inputCount = node.inputs.count


### PR DESCRIPTION
Was unclear if `updateGraphData` could be called without a document; by using proper function parameters, we can see it can't.

Also renamed `updateVisibleNodes` to be a little more clear what's going: it's really only for a visible graph, and for canvas items.

QA'd on Humane demo. 

All tests pass after some finagling so that the StitchStore lives long enough and the documentEncoderDelegate references don't die. Hat tip Elliot.