### PR TITLE
Use synchronous initializers for GraphState and StitchDocumentViewModel

### DIFF
--- a/Stitch/App/Serialization/DocumentEncodableUtil.swift
+++ b/Stitch/App/Serialization/DocumentEncodableUtil.swift
@@ -20,6 +20,7 @@ extension DocumentEncodable {
         }
     }
 
+    @MainActor
     /// Called when GraphState is initialized to build library data and then run first calc.
     func getDecodedFiles() -> GraphDecodedFiles? {
         do {

--- a/Stitch/App/Serialization/DocumentLoading/DocumentLoader.swift
+++ b/Stitch/App/Serialization/DocumentLoading/DocumentLoader.swift
@@ -149,61 +149,68 @@ extension DocumentLoader {
                           isProjectImport: Bool,
                           isPhoneDevice: Bool,
                           store: StitchStore) async throws {
-        let projectLoader = try await self.installDocument(document: document)
         
-        await self.updateStorage(with: projectLoader,
-                                 url: document.rootUrl)
-        
-        let documentViewModel = await StitchDocumentViewModel(
-            from: document,
+        if let (projectLoader, documentViewModel) = try createNewProjectWithoutDocumentLoaderUpdate(
+            isProjectImport: isProjectImport,
             isPhoneDevice: isPhoneDevice,
-            projectLoader: projectLoader,
-            store: store,
-            isDebugMode: false
-        )
-        
-        documentViewModel?.didDocumentChange = true // creates fresh thumbnail
-        
-        // TODO: why and how can this fail? Should we have a `fatalErrorIfDebug here?
-        guard let documentViewModel = documentViewModel else { return }
-        
-        projectLoader.loadingDocument = .loaded(document, nil)
-        
-        if isProjectImport {
-            documentViewModel.previewSizeDevice = document.previewSizeDevice
-            documentViewModel.previewWindowSize = document.previewWindowSize
-        } else {
-            // Get latest preview window size
-            guard let previewDevice = PreviewWindowDevice(rawValue: UserDefaults.standard.string(forKey: DEFAULT_PREVIEW_WINDOW_DEVICE_KEY_NAME) ??
-                                                          PreviewWindowDevice.defaultPreviewWindowDevice.rawValue) else {
-                fatalErrorIfDebug()
-                return
-            }
-            documentViewModel.previewSizeDevice = previewDevice
-            documentViewModel.previewWindowSize = previewDevice.previewWindowDimensions
+            store: store) {
+            
+            // Note: `async` because it uses a different Actor.
+            // `DocumentLoader` lives on StitchStore, but passing
+            // the ProjectLoader class in an action risks a retain cycle?
+            await self.updateStorage(with: projectLoader,
+                                     url: document.rootUrl)
         }
-        
-        projectLoader.documentViewModel = documentViewModel
-        store.navPath = [projectLoader]
     }
+}
 
-    func installDocument(document: StitchDocument) async throws -> ProjectLoader {
-        let rootUrl = document.rootUrl
-        let projectLoader = await ProjectLoader(url: rootUrl)
-        
-        try document.installDocument()
-        
-        await MainActor.run { [weak projectLoader] in
-            projectLoader?.encoder = .init(document: document)
-            projectLoader?.loadingDocument = .loaded(document, nil)
+@MainActor
+func createNewProjectWithoutDocumentLoaderUpdate(from document: StitchDocument = .init(),
+                                                 isProjectImport: Bool,
+                                                 isPhoneDevice: Bool,
+                                                 store: StitchStore) throws -> (ProjectLoader, StitchDocumentViewModel)? {
+    
+    let projectLoader = ProjectLoader(url: document.rootUrl)
+    try document.installDocument()
+    projectLoader.encoder = .init(document: document)
+    projectLoader.loadingDocument = .loaded(document, nil)
+            
+    let documentViewModel = StitchDocumentViewModel(
+        from: document,
+        isPhoneDevice: isPhoneDevice,
+        projectLoader: projectLoader,
+        store: store,
+        isDebugMode: false
+    )
+    
+    documentViewModel?.didDocumentChange = true // creates fresh thumbnail
+    
+    // TODO: why and how can this fail? Should we have a `fatalErrorIfDebug here?
+    guard let documentViewModel = documentViewModel else {
+        log("DocumentLoader.createNewProject: did not have a document view model")
+        return nil
+    }
+            
+    if isProjectImport {
+        documentViewModel.previewSizeDevice = document.previewSizeDevice
+        documentViewModel.previewWindowSize = document.previewWindowSize
+    } else {
+        // Get latest preview window size
+        guard let previewDevice = PreviewWindowDevice(rawValue: UserDefaults.standard.string(forKey: DEFAULT_PREVIEW_WINDOW_DEVICE_KEY_NAME) ??
+                                                      PreviewWindowDevice.defaultPreviewWindowDevice.rawValue) else {
+            fatalErrorIfDebug()
+            return nil
         }
-
-        self.storage.updateValue(projectLoader,
-                                 forKey: rootUrl)
-        return projectLoader
+        documentViewModel.previewSizeDevice = previewDevice
+        documentViewModel.previewWindowSize = previewDevice.previewWindowDimensions
     }
     
+    projectLoader.documentViewModel = documentViewModel
+    store.navPath = [projectLoader]
+    
+    return (projectLoader, documentViewModel)
 }
+
 
 extension StitchDocumentEncodable {
     func installDocument() throws {        

--- a/Stitch/App/Serialization/StitchFileManagerProject.swift
+++ b/Stitch/App/Serialization/StitchFileManagerProject.swift
@@ -55,6 +55,7 @@ extension DocumentEncodable {
         return mainResources + tempResources
     }
     
+    @MainActor
     func readAllImportedFiles() throws -> StitchDocumentDirectory {
         try Self.readAllImportedFiles(rootUrl: self.rootUrl)
     }

--- a/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
+++ b/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
@@ -147,8 +147,8 @@ final class StitchComponentViewModel: Sendable {
                      componentEntity: ComponentEntity,
                      encodedComponent: StitchComponent,
                      parentGraphPath: [UUID],
-                     componentEncoder: ComponentEncoder) async {
-        let graph = await GraphState(from: encodedComponent.graph,
+                     componentEncoder: ComponentEncoder) {
+        let graph = GraphState(from: encodedComponent.graph,
                                      // TODO: ComponentEntity or GraphEntity should persist their own localPosition?
                                      localPosition: ABSOLUTE_GRAPH_CENTER,
                                      saveLocation: parentGraphPath + [componentEntity.componentId],

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModel.swift
@@ -79,8 +79,8 @@ final class NodeViewModel: Sendable {
     @MainActor
     convenience init(from schema: NodeEntity,
                      components: [UUID : StitchMasterComponent],
-                     parentGraphPath: [UUID]) async {
-        let nodeType = await NodeViewModelType(from: schema.nodeTypeEntity,
+                     parentGraphPath: [UUID]) {
+        let nodeType = NodeViewModelType(from: schema.nodeTypeEntity,
                                                nodeId: schema.id,
                                                components: components,
                                                parentGraphPath: parentGraphPath)

--- a/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
@@ -49,7 +49,7 @@ extension NodeViewModelType {
     init(from nodeType: NodeTypeEntity,
          nodeId: NodeId,
          components: [UUID: StitchMasterComponent],
-         parentGraphPath: [UUID]) async {
+         parentGraphPath: [UUID])  {
         switch nodeType {
         case .patch, .layer, .group:
             self = .init(from: nodeType,
@@ -67,7 +67,7 @@ extension NodeViewModelType {
                 return
             }
             
-            let component = await StitchComponentViewModel(
+            let component = StitchComponentViewModel(
                 nodeId: nodeId,
                 componentEntity: componentEntity,
                 encodedComponent: masterComponent.lastEncodedDocument,

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -165,8 +165,9 @@ extension GraphState {
     convenience init(from schema: GraphEntity,
                      localPosition: CGPoint,
                      saveLocation: [UUID],
-                     encoder: (any DocumentEncodable)) async {
-        guard let decodedFiles = await encoder.getDecodedFiles() else {
+                     encoder: (any DocumentEncodable)) {
+//        guard let decodedFiles = await encoder.getDecodedFiles() else {
+        guard let decodedFiles = encoder.getDecodedFiles() else {
             fatalErrorIfDebug()
             self.init()
             return
@@ -176,7 +177,7 @@ extension GraphState {
         
         var nodes = NodesViewModelDict()
         for nodeEntity in schema.nodes {
-            let newNode = await NodeViewModel(from: nodeEntity,
+            let newNode = NodeViewModel(from: nodeEntity,
                                               components: components,
                                               parentGraphPath: saveLocation)
             nodes.updateValue(newNode, forKey: newNode.id)

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -199,13 +199,13 @@ final class StitchDocumentViewModel: Sendable {
                       isPhoneDevice: Bool,
                       projectLoader: ProjectLoader,
                       store: StitchStore,
-                      isDebugMode: Bool) async {
+                      isDebugMode: Bool) {
         let documentEncoder = DocumentEncoder(document: schema)
-
-        let graph = await GraphState(from: schema.graph,
-                                     localPosition: ABSOLUTE_GRAPH_CENTER, // schema.localPosition,
-                                     saveLocation: [],
-                                     encoder: documentEncoder)
+        
+        let graph = GraphState(from: schema.graph,
+                               localPosition: ABSOLUTE_GRAPH_CENTER, // schema.localPosition,
+                               saveLocation: [],
+                               encoder: documentEncoder)
                 
         self.init(from: schema,
                   graph: graph,
@@ -545,23 +545,18 @@ extension StitchDocumentViewModel {
     
     // TODO: this still doesn't quite have the correct projectLoader/encoderDelegate needed for all uses in the app
     @MainActor
-    static func createTestFriendlyDocument() async -> StitchDocumentViewModel {
+    static func createTestFriendlyDocument() -> StitchDocumentViewModel {
         let store = StitchStore()
         
-        await store.createNewProject(isProjectImport: false,
-                                     isPhoneDevice: false)
-        
-        guard let projectLoader = store.navPath.first,
-              let documentViewModel = projectLoader.documentViewModel else {
+        guard let (_, documentViewModel) = try? createNewProjectWithoutDocumentLoaderUpdate(
+            isProjectImport: false,
+            isPhoneDevice: false,
+            store: store) else {
             fatalError()
         }
-        
-        documentViewModel.documentEncoder = projectLoader.encoder!
-        documentViewModel.graph.documentEncoderDelegate = documentViewModel.documentEncoder
-        
-        assert(documentViewModel.documentEncoder.isDefined)
-        assert(documentViewModel.graph.documentEncoderDelegate.isDefined)
-        
+
+        assert(store.navPath.first?.loadedDocument?.0.id == documentViewModel.id.value)
+      
         return documentViewModel
     }
     

--- a/Stitch/Home/Util/ProjectCreatedActions.swift
+++ b/Stitch/Home/Util/ProjectCreatedActions.swift
@@ -23,7 +23,7 @@ extension StitchStore {
                                          isPhoneDevice: isPhoneDevice)
         }
     }
-    
+        
     func createNewProject(from document: StitchDocument = .init(),
                           isProjectImport: Bool,
                           isPhoneDevice: Bool) async {

--- a/StitchTests/evalTests.swift
+++ b/StitchTests/evalTests.swift
@@ -15,7 +15,6 @@ import XCTest
 class EvalTests: XCTestCase {
     @MainActor var store = StitchStore()
     
-    // Cannot be async, so cannot be used to create a document
     @MainActor
     override func setUp() {
         self.store = StitchStore() // wipe the store
@@ -23,9 +22,9 @@ class EvalTests: XCTestCase {
     
     @MainActor
     func loopSelectEval(inputs: PortValuesList,
-                        outputs: PortValuesList) async -> PortValuesList {
+                        outputs: PortValuesList) -> PortValuesList {
         
-        let document = await StitchDocumentViewModel.createTestFriendlyDocument()
+        let document = StitchDocumentViewModel.createTestFriendlyDocument()
         let graphState = document.visibleGraph
         
         
@@ -51,8 +50,8 @@ class EvalTests: XCTestCase {
 
     /// Runs all evals to make sure nodes can initialize.
     @MainActor
-    func testRunAllEvals() async throws {
-        let document = await StitchDocumentViewModel.createTestFriendlyDocument()
+    func testRunAllEvals() throws {
+        let document = StitchDocumentViewModel.createTestFriendlyDocument()
         let graphState = document.visibleGraph
         
         graphState.graphStepManager.graphTimeCurrent = 4
@@ -652,7 +651,7 @@ class EvalTests: XCTestCase {
 
     // single value selection
     @MainActor
-    func testLoopSelectEvalSingleSelection() async throws {
+    func testLoopSelectEvalSingleSelection() throws {
 
         // "input"
         let input1: PortValues = [.string(.init("apple")), .string(.init("carrot")), .string(.init("orange"))]
@@ -666,7 +665,7 @@ class EvalTests: XCTestCase {
         // "output index"
         let expectedOutput2: PortValues = [.number(0)]
 
-        let result: PortValuesList = await loopSelectEval(
+        let result: PortValuesList = loopSelectEval(
             inputs: [input1, input2],
             outputs: [] // none, starting out
         )
@@ -676,7 +675,7 @@ class EvalTests: XCTestCase {
     }
 
     @MainActor
-    func testLoopSelectEvalNegativeSingleSelection() async throws {
+    func testLoopSelectEvalNegativeSingleSelection() throws {
 
         let apple = "apple"
         let carrot = "carrot"
@@ -693,78 +692,78 @@ class EvalTests: XCTestCase {
         let input2: PortValues = [.number(-1)]
 
         let getResult = { (index: Int) -> PortValuesList in
-            await self.loopSelectEval(inputs: [input1,
+            self.loopSelectEval(inputs: [input1,
                                          [.number(Double(index))]],
                                 outputs: [])
         }
 
         // POSITIVE INDICES
-        let _result0 = await getResult(0)
+        let _result0 = getResult(0)
         XCTAssertEqual(_result0.first!, [.string(.init(apple))])
         XCTAssertEqual(_result0[1], [.number(0)])
 
-        let _result1 = await getResult(1)
+        let _result1 = getResult(1)
         XCTAssertEqual(_result1.first!, [.string(.init(carrot))])
         XCTAssertEqual(_result1[1], [.number(0)])
 
-        let _result2 = await getResult(2)
+        let _result2 = getResult(2)
         XCTAssertEqual(_result2.first!, [.string(.init(orange))])
         XCTAssertEqual(_result2[1], [.number(0)])
 
-        let _result3 = await getResult(3)
+        let _result3 = getResult(3)
         XCTAssertEqual(_result3.first!, [.string(.init(apple))])
         XCTAssertEqual(_result3[1], [.number(0)])
 
-        let _result4 = await getResult(4)
+        let _result4 = getResult(4)
         XCTAssertEqual(_result4.first!, [.string(.init(carrot))])
         XCTAssertEqual(_result4[1], [.number(0)])
 
-        let _result5 = await getResult(5)
+        let _result5 = getResult(5)
         XCTAssertEqual(_result5.first!, [.string(.init(orange))])
         XCTAssertEqual(_result5[1], [.number(0)])
 
-        let _result6 = await getResult(6)
+        let _result6 = getResult(6)
         XCTAssertEqual(_result6.first!, [.string(.init(apple))])
         XCTAssertEqual(_result6[1], [.number(0)])
 
-        let _result7 = await getResult(7)
+        let _result7 = getResult(7)
         XCTAssertEqual(_result7.first!, [.string(.init(carrot))])
         XCTAssertEqual(_result7[1], [.number(0)])
 
         // NEGATIVE INDICES
 
         // index = -1 currently giving us "apple", whereas we expect "orange"
-        let result1 = await getResult(-1)
+        let result1 = getResult(-1)
         XCTAssertEqual(result1.first!, [.string(.init(orange))])
         XCTAssertEqual(result1[1], [.number(0)])
 
         // index = -2
-        let result2 = await getResult(-2)
+        let result2 = getResult(-2)
         XCTAssertEqual(result2.first!, [.string(.init(carrot))])
         XCTAssertEqual(result2[1], [.number(0)])
 
         // index = -3
-        let result3 = await getResult(-3)
+        let result3 = getResult(-3)
         XCTAssertEqual(result3.first!, [.string(.init(apple))])
         XCTAssertEqual(result3[1], [.number(0)])
 
         // index = -4
-        let result4 = await getResult(-4)
+        let result4 = getResult(-4)
         XCTAssertEqual(result4.first!, [.string(.init(orange))])
         XCTAssertEqual(result4[1], [.number(0)])
 
         // index = -5
-        let result5 = await getResult(-5)
+        let result5 = getResult(-5)
         XCTAssertEqual(result5.first!, [.string(.init(carrot))])
         XCTAssertEqual(result5[1], [.number(0)])
 
         // index = -6
-        let result6 = await getResult(-6)
+        let result6 = getResult(-6)
         XCTAssertEqual(result6.first!, [.string(.init(apple))])
         XCTAssertEqual(result6[1], [.number(0)])
 
         // index = -4
-        let result7 = await getResult(-7)
+        let result7 = getResult(-7)
         XCTAssertEqual(result7.first!, [.string(.init(orange))])
         XCTAssertEqual(result7[1], [.number(0)])
 
@@ -774,7 +773,7 @@ class EvalTests: XCTestCase {
 
     // see for details: https://origami.design/documentation/patches/builtin.loop.selectReorder.html
     @MainActor
-    func testLoopSelectEvalMultiSelection() async throws {
+    func testLoopSelectEvalMultiSelection() throws {
 
         // "input"
         let input1: PortValues = [.string(.init("apple")), .string(.init("carrot")), .string(.init("orange"))]
@@ -788,7 +787,7 @@ class EvalTests: XCTestCase {
         // "output index"
         let expectedOutput2: PortValues = [.number(0), .number(1), .number(2)]
 
-        let result: PortValuesList = await loopSelectEval(
+        let result: PortValuesList = loopSelectEval(
             inputs: [input1, input2],
             outputs: [] // none, starting out
         )
@@ -798,7 +797,7 @@ class EvalTests: XCTestCase {
     }
 
     @MainActor
-    func testLoopSelectEvalMultiSelectionUnequalLength() async throws {
+    func testLoopSelectEvalMultiSelectionUnequalLength() throws {
 
         // "input"
         let input1: PortValues = [.string(.init("apple")), .string(.init("carrot")), .string(.init("orange"))]
@@ -812,7 +811,7 @@ class EvalTests: XCTestCase {
         // "output index"
         let expectedOutput2: PortValues = [.number(0), .number(1)]
 
-        let result: PortValuesList = await loopSelectEval(
+        let result: PortValuesList = loopSelectEval(
             inputs: [input1, input2],
             outputs: [] // none, starting out
         )

--- a/StitchTests/loopTests.swift
+++ b/StitchTests/loopTests.swift
@@ -36,12 +36,12 @@ final class loopTests: XCTestCase {
     }
     
     @MainActor
-    func testJSONArray() async throws {
+    func testJSONArray() throws {
         /*
          Old bug: JSONArray was adding its output to the list of inputs to turn into an array.
          Not caught by existing JSONArrayFromValues test because the bug came from `nodeViewModel.loopedEval` helper.
          */
-        let document = await StitchDocumentViewModel.createTestFriendlyDocument()
+        let document = StitchDocumentViewModel.createTestFriendlyDocument()
         if let node = document.nodeInserted(choice: .patch(.jsonArray)) {
             
             // How many inputs does the JSONArray node have?

--- a/StitchTests/nodeTypeTests.swift
+++ b/StitchTests/nodeTypeTests.swift
@@ -12,8 +12,8 @@ import StitchSchemaKit
 final class nodeTypeTests: XCTestCase {
 
     @MainActor
-    func testNodeTypeChange() async throws {
-        let document = await StitchDocumentViewModel.createTestFriendlyDocument()
+    func testNodeTypeChange() throws {
+        let document = StitchDocumentViewModel.createTestFriendlyDocument()
         let node = try XCTUnwrap(document.nodeInserted(choice: .patch(.add)))
         
         let numberInputs = node.inputsObservers.allSatisfy { (input: InputNodeRowObserver) in


### PR DESCRIPTION
Given where/how `DocumentLoader.getDecodedFiles` is called, seems fine to do it on the MainActor.

The only remaining `async` is because of a cross actor update (MainActor vs DocumentLoader actor) in the createNewProject function. That logic is isolated now; we can compose these functions, which let me use less asynchronous logic in the tests.

QA'd on Humane and creating new project.

All tests pass.