### PR TITLE
Reduce usage of `NodeRowObserver.nodeDelegate`

### DIFF
--- a/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
+++ b/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
@@ -130,7 +130,7 @@ final class StitchComponentViewModel: Sendable {
         let splitterOutputs = Self.getOutputSplitters(graph: graph)
         let outputsObservers = splitterOutputs.enumerated().map { index, splitterOutput in
             if let existingOutput = existingOutputsObservers[safe: index] {
-                existingOutput.updateValuesInOutput(splitterOutput.values)
+                existingOutput.updateValuesInOutput(splitterOutput.values, graph: graph)
                 return existingOutput
             }
             
@@ -189,8 +189,8 @@ extension StitchComponentViewModel {
                                       documentEncoderDelegate: masterComponent.encoder)
         
         // Updates inputs and outputs
-        self.inputsObservers.forEach { $0.initializeDelegate(node) }
-        self.outputsObservers.forEach { $0.initializeDelegate(node) }
+        self.inputsObservers.forEach { $0.initializeDelegate(node, graph: self.graph) }
+        self.outputsObservers.forEach { $0.initializeDelegate(node, graph: self.graph) }
         
         // Refresh port data
         self.refreshPorts()
@@ -278,7 +278,7 @@ extension StitchComponentViewModel {
         
         // Update outputs here after graph calculation
         zip(splitterOutputs, self.outputsObservers).forEach { splitter, output in
-            output.updateValuesInOutput(splitter.allLoopedValues)
+            output.updateValuesInOutput(splitter.allLoopedValues, graph: self.graph)
         }
         
         return .init(outputsValues: self.outputsObservers.map(\.allLoopedValues))

--- a/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
+++ b/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
@@ -134,13 +134,9 @@ final class OutputLayerNodeRowData: LayerNodeRowData, Identifiable {
     
     // initialization of inspector row view model needs active index and row obseerver
     @MainActor
-    func initializeDelegate(_ node: NodeViewModel) {
-        guard let graph = self.rowObserver.nodeDelegate?.graphDelegate,
-                let document = graph.documentDelegate else {
-            fatalErrorIfDebug()
-            return
-        }
-        
+    func initializeDelegate(_ node: NodeViewModel,
+                            graph: GraphState,
+                            document: StitchDocumentViewModel) {
         self.rowObserver.initializeDelegate(node, graph: graph)
         let rowDelegate = self.rowObserver
         

--- a/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
+++ b/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
@@ -135,21 +135,20 @@ final class OutputLayerNodeRowData: LayerNodeRowData, Identifiable {
     // initialization of inspector row view model needs active index and row obseerver
     @MainActor
     func initializeDelegate(_ node: NodeViewModel) {
-        self.rowObserver.initializeDelegate(node)
-        
-        let rowDelegate = self.rowObserver
-        guard let document = self.rowObserver.nodeDelegate?.graphDelegate?.documentDelegate else {
+        guard let graph = self.rowObserver.nodeDelegate?.graphDelegate,
+                let document = graph.documentDelegate else {
             fatalErrorIfDebug()
             return
         }
+        
+        self.rowObserver.initializeDelegate(node, graph: graph)
+        let rowDelegate = self.rowObserver
         
         self.canvasObserver?.initializeDelegate(node,
                                                 // Not relevant for output
                                                 unpackedPortParentFieldGroupType: nil,
                                                 unpackedPortIndex: nil)
-                
-       
-        
+                        
         self.inspectorRowViewModel.initializeDelegate(
             node, // for setting NodeViewModel on NodeRowViewModel
             initialValue: rowDelegate.getActiveValue(activeIndex: document.activeIndex),
@@ -164,21 +163,19 @@ extension LayerNodeRowData {
     @MainActor
     func initializeDelegate(_ node: NodeViewModel,
                             unpackedPortParentFieldGroupType: FieldGroupType?,
-                            unpackedPortIndex: Int?) {
-        self.rowObserver.initializeDelegate(node)
+                            unpackedPortIndex: Int?,
+                            activeIndex: ActiveIndex,
+                            graph: GraphState) {
+        self.rowObserver.initializeDelegate(node, graph: graph)
         self.canvasObserver?.initializeDelegate(node,
                                                 unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
                                                 unpackedPortIndex: unpackedPortIndex)
         
         let rowDelegate = self.rowObserver
-        guard let document = self.rowObserver.nodeDelegate?.graphDelegate?.documentDelegate else {
-            fatalErrorIfDebug()
-            return
-        }
         
         self.inspectorRowViewModel.initializeDelegate(
             node,
-            initialValue: rowDelegate.getActiveValue(activeIndex: document.activeIndex),
+            initialValue: rowDelegate.getActiveValue(activeIndex: activeIndex),
             unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
             unpackedPortIndex: unpackedPortIndex,
             layerInput: rowDelegate.id.layerInput?.layerInput)

--- a/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
+++ b/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
@@ -489,7 +489,9 @@ extension LayerNodeViewModel: SchemaObserver {
 
 extension LayerNodeViewModel {
     @MainActor
-    func initializeDelegate(_ node: NodeViewModel) {
+    func initializeDelegate(_ node: NodeViewModel,
+                            graph: GraphState,
+                            document: StitchDocumentViewModel) {
         self.nodeDelegate = node
         
         // Reset known input canvas items
@@ -497,7 +499,7 @@ extension LayerNodeViewModel {
         
         // Set up outputs
         self.outputPorts.forEach {
-            $0.initializeDelegate(node)
+            $0.initializeDelegate(node, graph: graph, document: document)
         }
         
         self.resetInputCanvasItemsCache()

--- a/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
+++ b/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
@@ -505,7 +505,9 @@ extension LayerNodeViewModel {
     
     @MainActor
     func resetInputCanvasItemsCache() {
-        guard let node = self.nodeDelegate else {
+        guard let node = self.nodeDelegate,
+              let graph = node.graphDelegate,
+              let activeIndex = graph.documentDelegate?.activeIndex else {
             fatalErrorIfDebug()
             return
         }
@@ -519,10 +521,10 @@ extension LayerNodeViewModel {
             self._inputCanvasIds = self._inputCanvasIds.union(inputCanvasItems)
             
             layerInput.initializeDelegate(node,
-                                          layer: self.layer)
+                                          layer: self.layer,
+                                          activeIndex: activeIndex,
+                                          graph: graph)
         }
-        
-        let activeIndex = node.graphDelegate?.documentDelegate?.activeIndex ?? .init(.zero)
         
         // Set blocked fields after all fields have been initialized
         self.forEachInput { layerInput in

--- a/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
+++ b/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
@@ -143,15 +143,15 @@ extension PatchNodeViewModel: SchemaObserver {
 
 extension PatchNodeViewModel {
     @MainActor
-    func initializeDelegate(_ node: PatchNodeViewModelDelegate) {
+    func initializeDelegate(_ node: PatchNodeViewModelDelegate, graph: GraphState) {
         self.delegate = node
         
         self.inputsObservers.forEach {
-            $0.initializeDelegate(node)
+            $0.initializeDelegate(node, graph: graph)
         }
         
         self.outputsObservers.forEach {
-            $0.initializeDelegate(node)
+            $0.initializeDelegate(node, graph: graph)
         }
         
         // Assign weak for group canvas if group splitter node
@@ -163,13 +163,14 @@ extension PatchNodeViewModel {
     
     // Other inits better for public accesss
     @MainActor private convenience init(id: NodeId,
-                             patch: Patch,
-                             inputs: [NodePortInputEntity],
-                             canvasEntity: CanvasNodeEntity,
-                             userVisibleType: UserVisibleType? = nil,
-                             mathExpression: String?,
-                             splitterNode: SplitterNodeEntity?,
-                             delegate: PatchNodeViewModelDelegate) {
+                                        patch: Patch,
+                                        inputs: [NodePortInputEntity],
+                                        canvasEntity: CanvasNodeEntity,
+                                        userVisibleType: UserVisibleType? = nil,
+                                        mathExpression: String?,
+                                        splitterNode: SplitterNodeEntity?,
+                                        delegate: PatchNodeViewModelDelegate,
+                                        graph: GraphState) {
         let entity = PatchNodeEntity(id: id,
                                      patch: patch,
                                      inputs: inputs,
@@ -178,17 +179,18 @@ extension PatchNodeViewModel {
                                      splitterNode: splitterNode,
                                      mathExpression: mathExpression)
         self.init(from: entity)
-        self.initializeDelegate(delegate)
+        self.initializeDelegate(delegate, graph: graph)
         self.delegate = delegate
         self.splitterNode = splitterNode
     }
 
     @MainActor convenience init(id: NodeId,
-                     patch: Patch,
-                     inputs: [NodePortInputEntity],
-                     canvasEntity: CanvasNodeEntity,
-                     userVisibleType: UserVisibleType? = nil,
-                     delegate: PatchNodeViewModelDelegate) {
+                                patch: Patch,
+                                inputs: [NodePortInputEntity],
+                                canvasEntity: CanvasNodeEntity,
+                                userVisibleType: UserVisibleType? = nil,
+                                delegate: PatchNodeViewModelDelegate,
+                                graph: GraphState) {
         self.init(id: id,
                   patch: patch,
                   inputs: inputs,
@@ -196,7 +198,8 @@ extension PatchNodeViewModel {
                   userVisibleType: userVisibleType,
                   mathExpression: nil,
                   splitterNode: nil,
-                  delegate: delegate)
+                  delegate: delegate,
+                  graph: graph)
     }
 
     @MainActor

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
@@ -323,7 +323,7 @@ extension GraphState {
             
             // portValuesList is the full outputs etc.;
             // set new outputs in node
-            node.updateOutputsObservers(newValuesList: portValuesList)
+            node.updateOutputsObservers(newValuesList: portValuesList, graph: graph)
             
             // We just manually set new outputs on the media node.
             // Now we need to flow those new outputs to any downstream nodes,

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
@@ -282,12 +282,16 @@ extension LayerInputObserver {
      
     @MainActor
     func initializeDelegate(_ node: NodeViewModel,
-                            layer: Layer) {
+                            layer: Layer,
+                            activeIndex: ActiveIndex,
+                            graph: GraphState) {
                 
         self._packedData.initializeDelegate(node,
                                             // Not relevant for packed data
                                             unpackedPortParentFieldGroupType: nil,
-                                            unpackedPortIndex: nil)
+                                            unpackedPortIndex: nil,
+                                            activeIndex: activeIndex,
+                                            graph: graph)
                 
         let layerInput: LayerInputPort = self.port
                 
@@ -303,7 +307,9 @@ extension LayerInputObserver {
         self._unpackedData.allPorts.enumerated().forEach { fieldIndex, port in
             port.initializeDelegate(node,
                                     unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                                    unpackedPortIndex: fieldIndex)
+                                    unpackedPortIndex: fieldIndex,
+                                    activeIndex: activeIndex,
+                                    graph: graph)
         }
     }
     

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/InputNodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/InputNodeRowObserver.swift
@@ -90,9 +90,12 @@ extension InputNodeRowObserver {
          In such cases, we assume the incoming value is the correct type and set them directly.
          */
         // TODO: Pass down NodeViewModel and `currentGraphTime` directly? Greater referential transparency and avoids confusion about where/when delegates have been set / not yet set.
+                
         guard let node = self.nodeDelegate,
               let graph = node.graphDelegate else {
-            self.setValuesInRowObserver(incomingValues)
+            self.setValuesInRowObserver(incomingValues,
+                                        selectedEdges: .init(),
+                                        drawingObserver: .init())
             return
         }
 
@@ -111,11 +114,14 @@ extension InputNodeRowObserver {
         }
         
         // Set the coerced values in the input
-        self.setValuesInRowObserver(newValues)
+        self.setValuesInRowObserver(newValues,
+                                    selectedEdges: graph.selectedEdges,
+                                    drawingObserver: graph.edgeDrawingObserver)
         
         // Update other parts of graph state in response to input change
         self.inputPostProcessing(oldValues: oldValues,
-                                 newValues: newValues)
+                                 newValues: newValues,
+                                 graph: graph)
     }
     
     // ONLY called by StitchEngine
@@ -302,12 +308,14 @@ extension [InputNodeRowObserver] {
     init(values: PortValuesList,
          id: NodeId,
          nodeIO: NodeIO,
-         nodeDelegate: NodeViewModel) {
+         nodeDelegate: NodeViewModel,
+         graph: GraphState) {
         self = values.enumerated().map { portId, values in
             Element(values: values,
                     id: NodeIOCoordinate(portId: portId, nodeId: id),
                     upstreamOutputCoordinate: nil,
-                    nodeDelegate: nodeDelegate)
+                    nodeDelegate: nodeDelegate,
+                    graph: graph)
         }
     }
 }

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -177,30 +177,28 @@ extension NodeRowObserver {
     init(values: PortValues,
          id: NodeIOCoordinate,
          upstreamOutputCoordinate: NodeIOCoordinate?,
-         nodeDelegate: NodeViewModel) {
+         nodeDelegate: NodeViewModel,
+         graph: GraphState) {
         self.init(values: values,
                   id: id,
                   upstreamOutputCoordinate: upstreamOutputCoordinate)
-        self.initializeDelegate(nodeDelegate)
+        self.initializeDelegate(nodeDelegate, graph: graph)
     }
     
     @MainActor
-    func initializeDelegate(_ node: NodeViewModel) {
+    func initializeDelegate(_ node: NodeViewModel, graph: GraphState) {
         self.nodeDelegate = node
                 
         // TODO: why do we handle post-processing when we've assigned the nodeDelegate? ... is it just because post-processing requires a nodeDelegate?
         switch Self.nodeIOType {
         case .input:
-            self.inputPostProcessing(oldValues: [], newValues: self.values)
+            self.inputPostProcessing(oldValues: [],
+                                     newValues: self.values,
+                                     graph: graph)
         case .output:
-            self.outputPostProcessing()
+            self.outputPostProcessing(graph)
         }
-        
-        // TODO: pass in GraphState? We ought to already have it when doing anything with a row observer
-        guard let graph = node.graphDelegate else {
-            return
-        }
-            
+                    
         // Update visual color data
         self.allRowViewModels.forEach {
             $0.updatePortColor(hasEdge: self.hasEdge,

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverPostProcessing.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverPostProcessing.swift
@@ -18,15 +18,16 @@ extension NodeRowObserver {
     // TODO: define exclusively on `InputNodeRowObserver`
     @MainActor
     func inputPostProcessing(oldValues: PortValues,
-                             newValues: PortValues) {
+                             newValues: PortValues,
+                             // Can this graph ever be other than than visible graph?
+                             graph: GraphState) {
         
         guard Self.nodeIOType == .input else {
             fatalErrorIfDebug() // called incorrectly
             return
         }
         
-        guard let node = self.nodeDelegate,
-              let graph = node.graphDelegate,
+        guard let node = graph.getNode(self.id.nodeId),
               let document = graph.documentDelegate else {
             return
         }
@@ -45,7 +46,8 @@ extension NodeRowObserver {
         }
         
         // Potentially update interactiojn data
-        self.updateInteractionCaches(
+        graph.updateInteractionCaches(
+            self,
             oldValues: oldValues,
             newValues: newValues)
         
@@ -59,23 +61,13 @@ extension NodeRowObserver {
         // Update view ports
         graph.portsToUpdate.insert(NodePortType.input(self.id))
     }
-
-    
-    // When an interaction patch node's first input changes,
-    // we may need to update our interactions caches on GraphState.
-    // fka `NodeRowObserver.updateInteractionNodeData`
-    @MainActor
-    private func updateInteractionCaches(oldValues: PortValues,
-                                 newValues: PortValues) {
-        self.nodeDelegate?
-            .graphDelegate?
-            .updateInteractionCaches(self,
-                                     oldValues: oldValues,
-                                     newValues: newValues)
-    }
 }
 
 extension GraphState {
+
+    // When an interaction patch node's first input changes,
+    // we may need to update our interactions caches on GraphState.
+    // fka `NodeRowObserver.updateInteractionNodeData`
     
     // Better as a method on GraphState, since only the interaction-cachese on GraphState are actually being mutated
     // TODO: some way to read T without the possibility of modifying it?
@@ -166,18 +158,13 @@ extension GraphState {
 
 extension NodeRowObserver {
     @MainActor
-    func outputPostProcessing() {
-        guard let node = self.nodeDelegate,
-              let graph = node.graphDelegate else {
-            return
-        }
-        
+    func outputPostProcessing(_ graph: GraphState) {        
         guard Self.nodeIOType == .output else {
             fatalErrorIfDebug()
             return
         }
         
-        self.updatePulsedOutputsForThisGraphStep()
+        self.updatePulsedOutputsForThisGraphStep(graph)
         
         // TODO: do we need to do this or not?
         // graph.portsToUpdate.insert(.allOutputs(node.id))
@@ -185,12 +172,7 @@ extension NodeRowObserver {
     
     // fka `didValuesUpdate`; but only actually used for pulse reversion
     @MainActor
-    private func updatePulsedOutputsForThisGraphStep() {
-        
-        guard let graph = self.nodeDelegate?.graphDelegate else {
-            fatalErrorIfDebug()
-            return
-        }
+    private func updatePulsedOutputsForThisGraphStep(_ graph: GraphState) {
         
         // TODO: should be by output-coordinate + loop-index, not just output-coordinate?
         if self.allLoopedValues.didSomeLoopIndexPulse(graph.graphStepState.graphTime) {

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverSchemaObserverIdentifiable.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverSchemaObserverIdentifiable.swift
@@ -67,8 +67,13 @@ extension InputNodeRowObserver: SchemaObserverIdentifiable {
             return
         }
         
+        guard let node = self.nodeDelegate else {
+            fatalErrorIfDebug()
+            return
+        }
+        
         let defaultInputs: NodeInputDefinitions = self.nodeKind
-            .rowDefinitions(for: self.userVisibleType)
+            .rowDefinitions(for: node.userVisibleType)
             .inputs
         
         guard let defaultValues = getDefaultValueForPatchNodeInput(portId,

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/OutputNodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/OutputNodeRowObserver.swift
@@ -50,7 +50,11 @@ final class OutputNodeRowObserver: NodeRowObserver {
 
     // Implements StitchEngine protocol
     func updateOutputValues(_ values: [PortValue]) {
-        self.updateValuesInOutput(values)
+        guard let graph = self.nodeDelegate?.graphDelegate else {
+            fatalErrorIfDebug()
+            return
+        }
+        self.updateValuesInOutput(values, graph: graph)
     }
 }
 
@@ -63,15 +67,18 @@ func updateRowObservers(rowObservers: [OutputNodeRowObserver],
             log("Could not retrieve output observer for portId \(portId)")
             return
         }
+        
         observer.updateOutputValues(newValues)
     }
 }
 
 extension OutputNodeRowObserver {
     @MainActor
-    func updateValuesInOutput(_ newValues: PortValues) {
-        self.setValuesInRowObserver(newValues)
-        self.outputPostProcessing()
+    func updateValuesInOutput(_ newValues: PortValues, graph: GraphState) {
+        self.setValuesInRowObserver(newValues,
+                                    selectedEdges: graph.selectedEdges,
+                                    drawingObserver: graph.edgeDrawingObserver)
+        self.outputPostProcessing(graph)
     }
     
     @MainActor

--- a/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
@@ -88,7 +88,7 @@ extension NodeViewModelType {
                 return
             }
             
-            patchNodeViewModel.initializeDelegate(patchDelegate)
+            patchNodeViewModel.initializeDelegate(patchDelegate, graph: document.graph)
         case .layer(let layerNodeViewModel):
             layerNodeViewModel.initializeDelegate(node)
         case .group(let canvasItemViewModel):

--- a/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
@@ -81,16 +81,17 @@ extension NodeViewModelType {
     func initializeDelegate(_ node: NodeViewModel,
                             components: [UUID: StitchMasterComponent],
                             document: StitchDocumentViewModel) {
+        let graph = document.graph
+        
         switch self {
         case .patch(let patchNodeViewModel):
             guard let patchDelegate = node as? PatchNodeViewModelDelegate else {
                 fatalErrorIfDebug()
                 return
             }
-            
-            patchNodeViewModel.initializeDelegate(patchDelegate, graph: document.graph)
+            patchNodeViewModel.initializeDelegate(patchDelegate, graph: graph)
         case .layer(let layerNodeViewModel):
-            layerNodeViewModel.initializeDelegate(node)
+            layerNodeViewModel.initializeDelegate(node, graph: graph, document: document)
         case .group(let canvasItemViewModel):
             canvasItemViewModel.initializeDelegate(node,
                                                    // Not relevant

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/Node/StitchAINodeUtils.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/Node/StitchAINodeUtils.swift
@@ -85,9 +85,8 @@ extension StitchAINodeSectionDescription {
                 
                 // Calculate node to get outputs values
                 if let evalResult = defaultNode.evaluate() {
-                    defaultNode.updateOutputsObservers(newValuesList: evalResult.outputsValues)
+                    defaultNode.updateOutputsObservers(newValuesList: evalResult.outputsValues, graph: graph)
                 }
-                
                 
                 let outputs: [StitchAIPortValueDescription] = defaultNode.outputsObservers.map { outputObserver in
                     StitchAIPortValueDescription(label: outputObserver

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -964,7 +964,7 @@ extension GraphState {
             nodeIdsToRecalculate = nodeIdsToRecalculate.union(changedNodeIds)
         } // (portId, newOutputValue) in portValues.enumerated()
      
-        node.updateOutputsObservers(newValuesList: outputsToUpdate)
+        node.updateOutputsObservers(newValuesList: outputsToUpdate, graph: self)
         
         // Recalculate graph
         self.scheduleForNextGraphStep(nodeIdsToRecalculate)


### PR DESCRIPTION
In most contexts we had the node immediately available; in others, we actually just needed e.g. the `GraphState`.