### PR TITLE
In NodeRowObserver contexts, access NodeViewModel explicitly

### DIFF
--- a/Stitch/Graph/CommentBox/ViewModel/CommentBoxViewModel.swift
+++ b/Stitch/Graph/CommentBox/ViewModel/CommentBoxViewModel.swift
@@ -79,7 +79,7 @@ extension CommentBoxViewModel: SchemaObserver {
         )
     }
     
-    func onPrototypeRestart() { }
+    func onPrototypeRestart(document: StitchDocumentViewModel) { }
 }
 
 // TODO: move to view

--- a/Stitch/Graph/Edge/Util/EdgeUtils.swift
+++ b/Stitch/Graph/Edge/Util/EdgeUtils.swift
@@ -115,11 +115,13 @@ extension GraphState {
         }
 
         connectedInputs.forEach { inputs in
-            guard let inputObserver = self.getInputObserver(coordinate: inputs) else {
+            guard let inputObserver = self.getInputObserver(coordinate: inputs),
+            let inputObserverNode = self.getNode(inputObserver.id.nodeId) else {
                 return
             }
             
-            inputObserver.removeUpstreamConnection(isVisible: isNodeVisible)
+            inputObserver.removeUpstreamConnection(isVisible: isNodeVisible,
+                                                   node: inputObserverNode)
         }
     }
 }

--- a/Stitch/Graph/Edge/Util/EdgeUtils.swift
+++ b/Stitch/Graph/Edge/Util/EdgeUtils.swift
@@ -116,7 +116,7 @@ extension GraphState {
 
         connectedInputs.forEach { inputs in
             guard let inputObserver = self.getInputObserver(coordinate: inputs),
-            let inputObserverNode = self.getNode(inputObserver.id.nodeId) else {
+                  let inputObserverNode = self.getNode(inputObserver.id.nodeId) else {
                 return
             }
             

--- a/Stitch/Graph/Edge/Util/PortActions.swift
+++ b/Stitch/Graph/Edge/Util/PortActions.swift
@@ -9,13 +9,23 @@ import Foundation
 import SwiftUI
 import StitchSchemaKit
 
+extension NodeViewModel {
+    @MainActor
+    func getComputedMediaObjects() -> [StitchMediaObject] {
+        self.ephemeralObservers?.compactMap {
+            ($0 as? MediaEvalOpObservable)?.computedMedia?.mediaObject
+        } ?? []
+    }
+}
+
 extension InputNodeRowObserver {
     /// Removes edges to some observer and conducts the following steps;
     /// 1. Removes connection by deleting reference to upstream output observer.
     /// 2. Flattens values.
     /// 3. Returns side effects for media which needs to be cleared.
     @MainActor
-    func removeUpstreamConnection(isVisible: Bool? = nil) {
+    func removeUpstreamConnection(isVisible: Bool? = nil,
+                                  node: NodeViewModel) {
         
         guard let upstreamOutputObserver = self.upstreamOutputObserver else {
             log("InputNodeRowObserver: removeUpstreamConnection: could not find upstream output observer")
@@ -34,12 +44,12 @@ extension InputNodeRowObserver {
 
         // Remove videos for disconnected visual media layers.
         // Check if the input coordinate of the removed edge came from an image or video layer.
-        if self.nodeKind.isVisualMediaLayerNode,
+        if node.kind.isVisualMediaLayerNode,
            // Only look at this input if it is the media input
            self.id.isMediaSelectorLocation {
             if willUpstreamBeDisconnected,
                let upstreamOutputObserver = self.upstreamOutputObserver {
-                upstreamOutputObserver.getComputedMediaObjects().forEach {
+                node.getComputedMediaObjects().forEach {
                     if let video = $0.video {
                         video.muteSound()
                     }
@@ -123,8 +133,11 @@ extension GraphState {
         }
 
         // Runs logic to disconnect existing media conntected by edge
-        if downstreamInputObserver.upstreamOutputCoordinate != nil {
-            downstreamInputObserver.removeUpstreamConnection()
+        if downstreamInputObserver.upstreamOutputCoordinate != nil,
+           // TODO: just reuse the `downstreamNode`?
+           let downstreamInputObserverNode = self.getNode(downstreamInputObserver.id.nodeId) {
+            downstreamInputObserver.removeUpstreamConnection(
+                node: downstreamInputObserverNode)
         }
         
         // Sets edge
@@ -160,12 +173,16 @@ extension NodeViewModel {
     @MainActor
     func removeIncomingEdge(at coordinate: NodeIOCoordinate,
                             graph: GraphState) {
-        guard let inputObserver = self.getInputRowObserver(for: coordinate.portType) else {
+        guard let inputObserver = self.getInputRowObserver(for: coordinate.portType),
+              let node = graph.getNode(coordinate.nodeId) else {
             log("NodeViewModel: removeIncomingEdge: could not find observer for input \(coordinate)")
             return
         }
         
-        inputObserver.removeUpstreamConnection(isVisible: self.isVisibleInFrame(graph.visibleCanvasIds, graph.selectedSidebarLayers))
+        inputObserver.removeUpstreamConnection(
+            isVisible: self.isVisibleInFrame(graph.visibleCanvasIds,
+                                             graph.selectedSidebarLayers),
+            node: node)
     }
 }
 

--- a/Stitch/Graph/Edge/Util/PortActions.swift
+++ b/Stitch/Graph/Edge/Util/PortActions.swift
@@ -61,7 +61,7 @@ extension InputNodeRowObserver {
         }
 
         // Remove audio from disconnected speaker nodes.
-        else if self.nodeKind.isSpeakerNode,
+        else if node.kind.isSpeakerNode,
                 // Only look at this input if it is the media input
                 self.id.isMediaSelectorLocation,
                 let upstreamObserverNode = upstreamOutputObserver.nodeDelegate {

--- a/Stitch/Graph/Edge/Util/PortDragActions.swift
+++ b/Stitch/Graph/Edge/Util/PortDragActions.swift
@@ -50,7 +50,7 @@ extension InputNodeRowViewModel {
     @MainActor
     func portDragEnded(graphState: GraphState) {
         guard let drawingGesture = graphState.edgeDrawingObserver.drawingGesture,
-              let sourceNodeId = drawingGesture.output.computationNode?.id,
+              let fromRowObserver = graphState.getOutputRowObserver(drawingGesture.output.nodeIOCoordinate),
               let nearestEligibleInput = graphState.edgeDrawingObserver.nearestEligibleInput else {
             log("InputDragEnded: drag ended, but could not create new edge")
             graphState.edgeDrawingObserver.reset()
@@ -67,6 +67,8 @@ extension InputNodeRowViewModel {
         
         graphState.edgeDrawingObserver.reset()
 
+        let sourceNodeId = fromRowObserver.id.nodeId
+        
         graphState.createEdgeFromEligibleInput(
             from: from,
             to: to,
@@ -210,9 +212,7 @@ extension OutputNodeRowViewModel {
         
         guard let from = graphState.edgeDrawingObserver.drawingGesture?.output,
               let to = graphState.edgeDrawingObserver.nearestEligibleInput,
-              // Get node delegate from row in case edge drag is for group,
-              // we want the splitter node delegate not the group node delegate
-              let sourceNodeId = from.computationNode?.id else {
+              let fromRowObserver = graphState.getOutputRowObserver(from.nodeIOCoordinate) else {
             log("OutputDragEnded: No active output drag or eligible input ...")
             graphState.edgeDrawingObserver.reset()
             
@@ -224,6 +224,11 @@ extension OutputNodeRowViewModel {
         }
         
         graphState.edgeDrawingObserver.reset()
+        
+        // TODO: is the below still necessary?
+        // Get node id from row observer, not row view model, in case edge drag is for group,
+        // we want the splitter node delegate not the group node delegate
+        let sourceNodeId = fromRowObserver.id.nodeId
         
         graphState.createEdgeFromEligibleInput(
             from: from.portViewData,

--- a/Stitch/Graph/Edge/Util/PortDragActions.swift
+++ b/Stitch/Graph/Edge/Util/PortDragActions.swift
@@ -16,6 +16,11 @@ extension InputNodeRowViewModel {
         let dragLocation = gesture.location
         graphState.edgeAnimationEnabled = true
 
+        guard let node = graphState.getNode(self.id.nodeId) else {
+            fatalErrorIfDebug()
+            return
+        }
+        
         guard var existingDrawingGesture = graphState.edgeDrawingObserver.drawingGesture else {
             log("InputDragged: started")
             
@@ -30,7 +35,7 @@ extension InputNodeRowViewModel {
                                                                               dragLocation: dragLocation,
                                                                               startingDiffFromCenter: .zero)
 
-            self.rowDelegate?.removeUpstreamConnection()
+            self.rowDelegate?.removeUpstreamConnection(node: node)
             self.nodeDelegate?.calculate()
             graphState.encodeProjectInBackground()
             

--- a/Stitch/Graph/Node/Component/StitchMasterComponent.swift
+++ b/Stitch/Graph/Node/Component/StitchMasterComponent.swift
@@ -54,7 +54,7 @@ extension StitchMasterComponent {
         return component
     }
     
-    func onPrototypeRestart() { }
+    func onPrototypeRestart(document: StitchDocumentViewModel) { }
     
     @MainActor func initializeDelegate(parentGraph: GraphState) {
         self.parentGraph = parentGraph

--- a/Stitch/Graph/Node/Eval/AsyncSingletonMediaEval.swift
+++ b/Stitch/Graph/Node/Eval/AsyncSingletonMediaEval.swift
@@ -33,7 +33,7 @@ actor SingletonMediaNodeCoordinator: NodeEphemeralObservable, MediaEvalOpViewabl
 }
 
 extension SingletonMediaNodeCoordinator {
-    nonisolated func onPrototypeRestart() { }
+    nonisolated func onPrototypeRestart(document: StitchDocumentViewModel) { }
 }
 
 /// Used for nodes like location and camera.

--- a/Stitch/Graph/Node/Eval/EphemeralObserver/NodeEphemeralObservable.swift
+++ b/Stitch/Graph/Node/Eval/EphemeralObserver/NodeEphemeralObservable.swift
@@ -21,7 +21,7 @@ protocol NodeEphemeralObservable: AnyObject {
                          newType: UserVisibleType,
                          kind: NodeKind)
     
-    @MainActor func onPrototypeRestart()
+    @MainActor func onPrototypeRestart(document: StitchDocumentViewModel)
 }
 
 extension NodeEphemeralObservable {
@@ -57,7 +57,7 @@ final class ComputedNodeState: NodeEphemeralObservable {
 }
 
 extension ComputedNodeState {
-    func onPrototypeRestart() {
+    func onPrototypeRestart(document: StitchDocumentViewModel) {
         self.previousValue = nil
         self.preservedValues = .init()
         self.stopwatchIsRunning = false

--- a/Stitch/Graph/Node/Eval/MediaEvalOpObservable.swift
+++ b/Stitch/Graph/Node/Eval/MediaEvalOpObservable.swift
@@ -30,7 +30,7 @@ final class MediaReferenceObserver: MediaEvalOpViewable {
         self.mediaViewModel = .init()
     }
     
-    func onPrototypeRestart() { }
+    func onPrototypeRestart(document: StitchDocumentViewModel) { }
 }
 
 final class MediaEvalOpObserver: MediaEvalOpObservable {
@@ -55,7 +55,7 @@ final class VisionOpObserver: MediaEvalOpObservable {
         self.mediaViewModel = .init()
     }
 
-    func onPrototypeRestart() { }
+    func onPrototypeRestart(document: StitchDocumentViewModel) { }
 }
 
 final class ImageClassifierOpObserver: MediaEvalOpObservable {
@@ -69,11 +69,11 @@ final class ImageClassifierOpObserver: MediaEvalOpObservable {
         self.mediaViewModel = .init()
     }
     
-    func onPrototypeRestart() { }
+    func onPrototypeRestart(document: StitchDocumentViewModel) { }
 }
 
 extension MediaEvalOpObserver {
-    @MainActor func onPrototypeRestart() {
+    @MainActor func onPrototypeRestart(document: StitchDocumentViewModel) {
         // MARK: commenting out to fix flashing media, which seems to still reset properly
 //        self.resetMedia()
         

--- a/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
+++ b/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
@@ -480,9 +480,9 @@ extension LayerNodeViewModel: SchemaObserver {
         return schema
     }
     
-    func onPrototypeRestart() {
+    func onPrototypeRestart(document: StitchDocumentViewModel) {
         self.previewLayerViewModels.forEach {
-            $0.onPrototypeRestart()
+            $0.onPrototypeRestart(document: document)
         }
     }
 }

--- a/Stitch/Graph/Node/Patch/Type/Delay/DelayNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Delay/DelayNode.swift
@@ -70,7 +70,7 @@ final class NodeTimerEphemeralObserver: MediaEvalOpViewable {
 }
 
 extension NodeTimerEphemeralObserver {
-    @MainActor func onPrototypeRestart() {
+    @MainActor func onPrototypeRestart(document: StitchDocumentViewModel) {
         self.runningTimers = .init()
         self.prevDelayInputValue = nil
     }

--- a/Stitch/Graph/Node/Patch/Type/DelayOneNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/DelayOneNode.swift
@@ -65,7 +65,7 @@ final class DelayOneEvalObserver: NodeEphemeralObservable {
 }
 
 extension DelayOneEvalObserver {
-    func onPrototypeRestart() {
+    func onPrototypeRestart(document: StitchDocumentViewModel) {
         self.nextOutput = DelayOneNode.defaultUserVisibleType.defaultPortValue
     }
 }

--- a/Stitch/Graph/Node/Patch/Type/Interaction/DragInteractionPatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/DragInteractionPatchNode.swift
@@ -85,7 +85,7 @@ final class DragInteractionNodeState: NodeEphemeralObservable {
     // Updates whenever drag ends so a new drag increments from here, fixing issue where values could constantly increment
     var prevPositionStart: CGPoint = .zero
     
-    func onPrototypeRestart() {
+    func onPrototypeRestart(document: StitchDocumentViewModel) {
         self.momentum = .init()
         self.reset = .init()
         self.wasDragging = false

--- a/Stitch/Graph/Node/Patch/Type/Interaction/MouseInteractionNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/MouseInteractionNode.swift
@@ -42,7 +42,7 @@ final class MouseNodeState: NodeEphemeralObservable {
     var position: CGPoint = .zero
     var velocity: CGPoint = .zero
     
-    func onPrototypeRestart() {
+    func onPrototypeRestart(document: StitchDocumentViewModel) {
         self.isDown = false
         self.position = .zero
         self.velocity = .zero

--- a/Stitch/Graph/Node/Patch/Type/Interaction/PressInteractionPatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/PressInteractionPatchNode.swift
@@ -70,7 +70,7 @@ final class PressInteractionNodeObserver: NodeEphemeralObservable, Sendable {
 
 extension PressInteractionNodeObserver {
     @MainActor
-    func onPrototypeRestart() {
+    func onPrototypeRestart(document: StitchDocumentViewModel) {
         self.prevTapTime = nil
     }
 }

--- a/Stitch/Graph/Node/Patch/Type/Interaction/Scroll/ScrollData.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/Scroll/ScrollData.swift
@@ -20,7 +20,7 @@ final class ScrollInteractionState: NodeEphemeralObservable {
 }
 
 extension ScrollInteractionState {
-    func onPrototypeRestart() {
+    func onPrototypeRestart(document: StitchDocumentViewModel) {
         self.lastDragStartingPoint = nil
         self.reset()
     }

--- a/Stitch/Graph/Node/Patch/Type/Loop/LoopInsert.swift
+++ b/Stitch/Graph/Node/Patch/Type/Loop/LoopInsert.swift
@@ -61,7 +61,7 @@ final class LoopingEphemeralObserver: NodeEphemeralObservable {
 }
 
 extension LoopingEphemeralObserver {
-    func onPrototypeRestart() { }
+    func onPrototypeRestart(document: StitchDocumentViewModel) { }
 }
 
 extension PortValues {

--- a/Stitch/Graph/Node/Patch/Type/Media/ARAnchorNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Media/ARAnchorNode.swift
@@ -54,7 +54,7 @@ final class ARAnchorObserver: MediaEvalOpObservable {
 }
 
 extension ARAnchorObserver {
-    func onPrototypeRestart() { }
+    func onPrototypeRestart(document: StitchDocumentViewModel) { }
 }
 
 @MainActor

--- a/Stitch/Graph/Node/Patch/Type/Value/SplitterTypeActions.swift
+++ b/Stitch/Graph/Node/Patch/Type/Value/SplitterTypeActions.swift
@@ -70,7 +70,8 @@ extension GraphState {
             } else if currentType == .input {
                 if let inputObserver = splitterNode.getInputRowObserver(for: .portIndex(0)) {
                     inputObserver
-                        .removeUpstreamConnection(isVisible: splitterNode.isVisibleInFrame(self.visibleCanvasIds, self.selectedSidebarLayers))
+                        .removeUpstreamConnection(isVisible: splitterNode.isVisibleInFrame(self.visibleCanvasIds, self.selectedSidebarLayers),
+                                                  node: splitterNode)
                 }
             }
 
@@ -88,7 +89,8 @@ extension GraphState {
             if currentType == .input {
                 if let inputObserver = splitterNode.getInputRowObserver(for: .portIndex(0)) {
                     inputObserver
-                        .removeUpstreamConnection(isVisible: splitterNode.isVisibleInFrame(self.visibleCanvasIds, self.selectedSidebarLayers))
+                        .removeUpstreamConnection(isVisible: splitterNode.isVisibleInFrame(self.visibleCanvasIds, self.selectedSidebarLayers),
+                                                  node: splitterNode)
                 }
             }
         }

--- a/Stitch/Graph/Node/Patch/Util/WirelessReceiver.swift
+++ b/Stitch/Graph/Node/Patch/Util/WirelessReceiver.swift
@@ -38,7 +38,8 @@ struct SetBroadcastForWirelessReceiver: StitchDocumentEvent {
             // Note 2: removeAnyEdges already recalculates the graph from the `to` node of the removed edge.
 
             receiverNodeInputObserver.removeUpstreamConnection(
-                isVisible: receiverNode.isVisibleInFrame(graphState.visibleCanvasIds, graphState.selectedSidebarLayers))
+                isVisible: receiverNode.isVisibleInFrame(graphState.visibleCanvasIds, graphState.selectedSidebarLayers),
+                node: receiverNode)
             
             graphState.scheduleForNextGraphStep(receiverNodeId)
             

--- a/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
+++ b/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
@@ -138,7 +138,7 @@ extension PatchNodeViewModel: SchemaObserver {
                         mathExpression: self.mathExpression)
     }
     
-    func onPrototypeRestart() { }
+    func onPrototypeRestart(document: StitchDocumentViewModel) { }
 }
 
 extension PatchNodeViewModel {

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/InputNodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/InputNodeRowObserver.swift
@@ -284,23 +284,6 @@ extension InputNodeRowObserver {
         // We set this to false on default above
         connectedOutputObserver.containsDownstreamConnection = true
     }
-    
-    @MainActor
-    var currentBroadcastChoiceId: NodeId? {
-        guard self.nodeKind == .patch(.wirelessReceiver),
-              self.id.portId == 0,
-              Self.nodeIOType == .input else {
-            // log("NodeRowObserver: currentBroadcastChoice: did not have wireless node: returning nil")
-            return nil
-        }
-        
-        // the id of the connected wireless broadcast node
-        // TODO: why was there an `upstreamOutputCoordinate` but not a `upstreamOutputObserver` ?
-        //        let wirelessBroadcastId = self.upstreamOutputObserver?.id.nodeId
-        let wirelessBroadcastId = self.upstreamOutputCoordinate?.nodeId
-        // log("NodeRowObserver: currentBroadcastChoice: wirelessBroadcastId: \(wirelessBroadcastId)")
-        return wirelessBroadcastId
-    }
 }
 
 extension [InputNodeRowObserver] {

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -44,10 +44,7 @@ protocol NodeRowObserver: AnyObject, Observable, Identifiable, Sendable, NodeRow
     static var nodeIOType: NodeIO { get }
     
     @MainActor var allRowViewModels: [RowViewModelType] { get }
-    
-    @MainActor
-    var nodeDelegate: NodeViewModel? { get set }
-        
+            
     @MainActor
     var hasLoopedValues: Bool { get set }
         
@@ -174,7 +171,6 @@ extension NodeRowObserver {
     
     @MainActor
     func initializeDelegate(_ node: NodeViewModel, graph: GraphState) {
-        self.nodeDelegate = node
                 
         // TODO: why do we handle post-processing when we've assigned the nodeDelegate? ... is it just because post-processing requires a nodeDelegate?
         switch Self.nodeIOType {

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -60,19 +60,6 @@ protocol NodeRowObserver: AnyObject, Observable, Identifiable, Sendable, NodeRow
          upstreamOutputCoordinate: NodeIOCoordinate?)
 }
 
-extension NodeRowObserver {
-    @MainActor
-    var nodeKind: NodeKind {
-        guard let nodeKind = self.nodeDelegate?.kind else {
-            // Gets called on layer deletion, commenting out fatal error
-//            fatalErrorIfDebug()
-            return .patch(.splitter)
-        }
-        
-        return nodeKind
-    }
-}
-
 extension NodeRowViewModel {
     var isLayerInspector: Bool {
         self.id.graphItemType.isLayerInspector

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
@@ -122,13 +122,6 @@ extension NodeRowObserver {
         self.allLoopedValues[safe: activeIndex.adjustedIndex(self.allLoopedValues.count)] ?? .none
     }
             
-    @MainActor
-    func getComputedMediaObjects() -> [StitchMediaObject] {
-        self.nodeDelegate?.ephemeralObservers?.compactMap {
-            ($0 as? MediaEvalOpObservable)?.computedMedia?.mediaObject
-        } ?? []
-    }
-    
     // MARK: change args here if working
     @MainActor
     func label(useShortLabel: Bool = false,

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverPostProcessing.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverPostProcessing.swift
@@ -46,10 +46,13 @@ extension NodeRowObserver {
         }
         
         // Potentially update interactiojn data
-        graph.updateInteractionCaches(
-            self,
-            oldValues: oldValues,
-            newValues: newValues)
+        if let patch = node.kind.getPatch,
+           patch.isInteractionPatchNode {
+            graph.updateInteractionCaches(self,
+                                          oldValues: oldValues,
+                                          newValues: newValues,
+                                          patch: patch)
+        }
         
         // Potentially update assigned layers
         if node.kind.isLayer,
@@ -74,15 +77,15 @@ extension GraphState {
     @MainActor
     func updateInteractionCaches<T: NodeRowObserver>(_ input: T,
                                                      oldValues: PortValues,
-                                                     newValues: PortValues) {
+                                                     newValues: PortValues,
+                                                     patch: Patch) {
         
         guard T.nodeIOType == .input else {
             fatalErrorIfDebug() // called incorrectly
             return
         }
                         
-        guard let patch = input.nodeKind.getPatch,
-              patch.isInteractionPatchNode,
+        guard patch.isInteractionPatchNode,
               input.id.portId == 0 else {
             return
         }

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverSchemaObserverIdentifiable.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverSchemaObserverIdentifiable.swift
@@ -59,20 +59,16 @@ extension InputNodeRowObserver: SchemaObserverIdentifiable {
     
     // Set connected inputs to defaultValue
     @MainActor
-    func onPrototypeRestart() {
-        
+    func onPrototypeRestart(document: StitchDocumentViewModel) {
+                
         guard self.upstreamOutputCoordinate.isDefined,
-              let patch = self.nodeKind.getPatch,
+              let node = document.visibleGraph.getNode(self.id.nodeId),
+              let patch = node.kind.getPatch,
               let portId = self.id.portId else {
             return
         }
-        
-        guard let node = self.nodeDelegate else {
-            fatalErrorIfDebug()
-            return
-        }
-        
-        let defaultInputs: NodeInputDefinitions = self.nodeKind
+                
+        let defaultInputs: NodeInputDefinitions = node.kind
             .rowDefinitions(for: node.userVisibleType)
             .inputs
         
@@ -91,7 +87,7 @@ extension InputNodeRowObserver: SchemaObserverIdentifiable {
 
 extension OutputNodeRowObserver {
     @MainActor
-    func onPrototypeRestart() {
+    func onPrototypeRestart(document: StitchDocumentViewModel) {
         // Set outputs to be empty
         // MARK: no longer seems necessary, removing for fixing flashing media on restart
 //        self.allLoopedValues = []

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
@@ -92,12 +92,6 @@ extension NodeRowViewModel {
             }
         }
     }
-    
-    /// Ignores group nodes to ensure computation logic still works.
-    @MainActor
-    var computationNode: NodeViewModel? {
-        self.rowDelegate?.nodeDelegate
-    }
      
     @MainActor
     func initializeDelegate(_ node: NodeViewModel,

--- a/Stitch/Graph/Node/Util/NodeViewModelUtils.swift
+++ b/Stitch/Graph/Node/Util/NodeViewModelUtils.swift
@@ -114,7 +114,21 @@ extension NodeViewModel {
     
     @MainActor
     var currentBroadcastChoiceId: NodeId? {
-        self.getInputRowObserver(0)?.currentBroadcastChoiceId
+        
+        guard self.kind == .patch(.wirelessReceiver) else {
+            return nil
+        }
+              
+        guard let firstInput = self.getInputRowObserver(0) else {
+            fatalErrorIfDebug()
+            return nil
+        }
+    
+        // the id of the connected wireless broadcast node
+        // TODO: why was there an `upstreamOutputCoordinate` but not a `upstreamOutputObserver` ?
+        let wirelessBroadcastId = firstInput.upstreamOutputCoordinate?.nodeId
+        // log("NodeRowObserver: currentBroadcastChoice: wirelessBroadcastId: \(wirelessBroadcastId)")
+        return wirelessBroadcastId
     }
 
     @MainActor

--- a/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
@@ -186,7 +186,7 @@ extension CanvasItemViewModel {
         }
     }
     
-    func onPrototypeRestart() { }
+    func onPrototypeRestart(document: StitchDocumentViewModel) { }
 }
 
 extension CanvasItemViewModel {

--- a/Stitch/Graph/Node/ViewModel/InteractionLayer.swift
+++ b/Stitch/Graph/Node/ViewModel/InteractionLayer.swift
@@ -53,7 +53,7 @@ extension InteractiveLayer {
     }
     
     @MainActor
-    func onPrototypeRestart() {
+    func onPrototypeRestart(document: StitchDocumentViewModel) {
         self.firstPressEnded = nil
         self.secondPressEnded = nil
         self.lastTappedLocation = nil

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModel.swift
@@ -527,19 +527,19 @@ extension NodeViewModel {
                    title: self.title)
     }
     
-    @MainActor func onPrototypeRestart() {
+    @MainActor func onPrototypeRestart(document: StitchDocumentViewModel) {
         // Reset ephemeral observers
         self.ephemeralObservers?.forEach {
-            $0.onPrototypeRestart()
+            $0.onPrototypeRestart(document: document)
         }
         
         // Reset outputs
         // TODO: should we really be resetting inputs?
-        self.getAllInputsObservers().onPrototypeRestart()
-        self.getAllOutputsObservers().forEach { $0.onPrototypeRestart() }
+        self.getAllInputsObservers().onPrototypeRestart(document: document)
+        self.getAllOutputsObservers().forEach { $0.onPrototypeRestart(document: document) }
         
         // Reset properties specific to the node's actual type (patch vs layer vs component vs group)
-        self.nodeType.onPrototypeRestart()
+        self.nodeType.onPrototypeRestart(document: document)
     }
 }
 

--- a/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
@@ -147,7 +147,7 @@ extension NodeViewModelType {
         }
     }
     
-    @MainActor func onPrototypeRestart() {
+    @MainActor func onPrototypeRestart(document: StitchDocumentViewModel) {
         switch self {
         case .patch(let patchNode):
             // Flatten interaction nodes' outputs when graph reset
@@ -156,10 +156,10 @@ extension NodeViewModelType {
             }
             
         case .layer(let layerNode):
-            layerNode.onPrototypeRestart()
+            layerNode.onPrototypeRestart(document: document)
             
         case .component(let component):
-            component.graph.onPrototypeRestart()
+            component.graph.onPrototypeRestart(document: document)
             
         case .group:
             return

--- a/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
@@ -523,9 +523,9 @@ extension LayerViewModel {
     }
     
     @MainActor
-    func onPrototypeRestart() {
+    func onPrototypeRestart(document: StitchDocumentViewModel) {
         // Rest interaction state values
-        self.interactiveLayer.onPrototypeRestart()
+        self.interactiveLayer.onPrototypeRestart(document: document)
         
         if let model3D = self.mediaObject?.model3DEntity,
            let transform = model3D.transform {

--- a/Stitch/Graph/Util/PrototypeActions.swift
+++ b/Stitch/Graph/Util/PrototypeActions.swift
@@ -9,13 +9,9 @@ import Foundation
 import SwiftUI
 import StitchSchemaKit
 
-struct PrototypeRestartedAction: GraphEvent {
-    func handle(state: GraphState) {
+struct PrototypeRestartedAction: StitchDocumentEvent {
+    func handle(state: StitchDocumentViewModel) {
         log("PrototypeRestartedAction called")
-        if let documentDelegate = state.documentDelegate {
-            documentDelegate.onPrototypeRestart()
-        } else {
-            fatalErrorIfDebug()
-        }
+        state.onPrototypeRestart(document: state)
     }
 }

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -531,8 +531,8 @@ extension GraphState {
                     rootUrl: self.documentEncoderDelegate?.rootUrl)
     }
     
-    @MainActor func onPrototypeRestart() {
-        self.nodes.values.forEach { $0.onPrototypeRestart() }
+    @MainActor func onPrototypeRestart(document: StitchDocumentViewModel) {
+        self.nodes.values.forEach { $0.onPrototypeRestart(document: document) }
         self.initializeGraphComputation()
     }
     

--- a/Stitch/Graph/ViewModel/SchemaObserver.swift
+++ b/Stitch/Graph/ViewModel/SchemaObserver.swift
@@ -20,7 +20,7 @@ protocol SchemaObserver: AnyObject, Identifiable {
     func createSchema() -> CodableSchema
     
     @MainActor
-    func onPrototypeRestart()
+    func onPrototypeRestart(document: StitchDocumentViewModel)
 }
 
 protocol SchemaObserverIdentifiable: SchemaObserver where CodableSchema: CodableIdentifiable,
@@ -135,7 +135,7 @@ extension Array where Element: Identifiable & AnyObject {
 
 extension Array where Element: SchemaObserver {
     @MainActor
-    func onPrototypeRestart() {
-        self.forEach { $0.onPrototypeRestart() }
+    func onPrototypeRestart(document: StitchDocumentViewModel) {
+        self.forEach { $0.onPrototypeRestart(document: document) }
     }
 }

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -529,10 +529,10 @@ extension StitchDocumentViewModel {
         self.createSchema()
     }
     
-    @MainActor func onPrototypeRestart() {
+    @MainActor func onPrototypeRestart(document: StitchDocumentViewModel) {
         self.graphStepManager.resetGraphStepState()
         
-        self.graph.onPrototypeRestart()
+        self.graph.onPrototypeRestart(document: document)
         
         // Defocus the preview window's TextField layer
         if self.reduxFocusedField?.getTextFieldLayerInputEdit.isDefined ?? false {


### PR DESCRIPTION
In every caller context where we accessed row observer's node delegate, we either already had the node itself or had state nearby to retrieve it. 

It's now much clearer what properties belong to the row observer vs node (e.g. kind).