### PR TITLE
Cleaner signature for `syncRowViewModels`; fix runtime crash

### DIFF
--- a/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
@@ -300,9 +300,7 @@ extension GraphState {
         unpackedPort.update(from: unpackSchema,
                             layerInputType: unpackedPort.id,
                             layerNode: layerNode,
-                            nodeId: nodeId,
-                            unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                            unpackedPortIndex: fieldIndex)
+                            nodeId: nodeId)
         
         unpackedPort.canvasObserver?.initializeDelegate(
             node,
@@ -311,7 +309,7 @@ extension GraphState {
         
         let newPackMode = portObserver.mode
         if previousPackMode != newPackMode {
-            portObserver.wasPackModeToggled()
+            portObserver.wasPackModeToggled(document: document)
         }
         
         self.resetLayerInputsCache(layerNode: layerNode)

--- a/Stitch/Graph/LayerInspector/LayerInspectorActions.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorActions.swift
@@ -136,9 +136,7 @@ extension StitchDocumentViewModel {
             // Put newly-created LIG into graph's current traversal level
             parentGroupNodeId: self.groupNodeFocused?.asNodeId,
             inputRowObservers: [input.rowObserver],
-            outputRowObservers: [],
-            unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-            unpackedPortIndex: unpackedPortIndex)
+            outputRowObservers: [])
         
         input.canvasObserver?.initializeDelegate(node,
                                                  unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
@@ -209,9 +207,7 @@ extension GraphState {
             // Put newly-created LIG into graph's current traversal level
             parentGroupNodeId: groupNodeFocused,
             inputRowObservers: [],
-            outputRowObservers: [output.rowObserver],
-            unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-            unpackedPortIndex: unpackedPortIndex)
+            outputRowObservers: [output.rowObserver])
         
         output.canvasObserver?.initializeDelegate(node,
                                                   unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,

--- a/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
+++ b/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
@@ -44,9 +44,7 @@ final class StitchComponentViewModel: Sendable {
         self.canvas = .init(from: componentEntity.canvasEntity,
                             id: .node(nodeId),
                             inputRowObservers: inputsObservers,
-                            outputRowObservers: outputsObservers,
-                            unpackedPortParentFieldGroupType: nil,
-                            unpackedPortIndex: nil)
+                            outputRowObservers: outputsObservers)
             
         self.inputsObservers = inputsObservers
         self.outputsObservers = outputsObservers
@@ -59,9 +57,7 @@ final class StitchComponentViewModel: Sendable {
         self.inputsObservers = self.refreshInputs(schemaInputs: schemaInputs)
         self.outputsObservers = self.refreshOutputs()
         self.canvas.syncRowViewModels(inputRowObservers: inputsObservers,
-                                      outputRowObservers: outputsObservers,
-                                      unpackedPortParentFieldGroupType: nil,
-                                      unpackedPortIndex: nil)
+                                      outputRowObservers: outputsObservers)
     }
     
     @MainActor
@@ -227,9 +223,7 @@ extension StitchComponentViewModel {
         self.inputsObservers = self.refreshInputs(schemaInputs: schemaInputs)
         self.outputsObservers = self.refreshOutputs()
         self.canvas.syncRowViewModels(inputRowObservers: self.inputsObservers,
-                                      outputRowObservers: self.outputsObservers,
-                                      unpackedPortParentFieldGroupType: nil,
-                                      unpackedPortIndex: nil)
+                                      outputRowObservers: self.outputsObservers)
     }
     
     @MainActor

--- a/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
+++ b/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
@@ -221,9 +221,7 @@ extension InputLayerNodeRowData {
     func update(from schema: LayerInputDataEntity,
                 layerInputType: LayerInputType,
                 layerNode: LayerNodeViewModel,
-                nodeId: NodeId,
-                unpackedPortParentFieldGroupType: FieldGroupType?,
-                unpackedPortIndex: Int?) {
+                nodeId: NodeId) {
         assertInDebug(self.rowObserver.id.nodeId == nodeId)
                     
         if let canvas = schema.canvasItem {
@@ -238,9 +236,7 @@ extension InputLayerNodeRowData {
                 self.canvasObserver = .init(from: canvas,
                                             id: canvasId,
                                             inputRowObservers: [self.rowObserver],
-                                            outputRowObservers: [],
-                                            unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                                            unpackedPortIndex: unpackedPortIndex)
+                                            outputRowObservers: [])
 
                 // NOTE: DO NOT SET A CANVAS ITEM DELEGATE ON AN INSPECTOR ROW VIEW MODEL
 //                self.inspectorRowViewModel.canvasItemDelegate = self.canvasObserver
@@ -289,10 +285,7 @@ extension LayerInputObserver {
                                         layerInputType: .init(layerInput: layerInputType,
                                                               portType: .packed),
                                         layerNode: layerNode,
-                                        nodeId: nodeId,
-                                        // Not relevant
-                                        unpackedPortParentFieldGroupType: nil,
-                                        unpackedPortIndex: nil)
+                                        nodeId: nodeId)
         
         
         // Update unpacked data
@@ -317,9 +310,7 @@ extension LayerInputObserver {
                                         layerInputType: .init(layerInput: layerInputType,
                                                               portType: .unpacked(unpackedPortType)),
                                         layerNode: layerNode,
-                                        nodeId: nodeId,
-                                        unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                                        unpackedPortIndex: portId)
+                                        nodeId: nodeId)
             }
         }
         

--- a/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
+++ b/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
@@ -436,15 +436,13 @@ extension LayerNodeViewModel: SchemaObserver {
                         from: canvasEntity,
                         id: .layerOutput(coordinate),
                         inputRowObservers: [],
-                        outputRowObservers: [outputData.rowObserver],
+                        outputRowObservers: [outputData.rowObserver])
+                    
+                    outputData.canvasObserver?.initializeDelegate(
+                        node,
                         // Not relevant
                         unpackedPortParentFieldGroupType: nil,
                         unpackedPortIndex: nil)
-                    
-                    outputData.canvasObserver?.initializeDelegate(node,
-                                                                  // Not relevant
-                                                                  unpackedPortParentFieldGroupType: nil,
-                                                                  unpackedPortIndex: nil)
                 }
                 return
             }

--- a/Stitch/Graph/Node/Model/SchemaNodesUtil.swift
+++ b/Stitch/Graph/Node/Model/SchemaNodesUtil.swift
@@ -141,10 +141,7 @@ extension NodeRowDefinitions {
                     id: .layerOutput(.init(node: nodeId,
                                                   portId: portId)),
                     inputRowObservers: [],
-                    outputRowObservers: [observer],
-                    // Irrelevant for output
-                    unpackedPortParentFieldGroupType: nil,
-                    unpackedPortIndex: nil)
+                    outputRowObservers: [observer])
             }
             
             let outputData = OutputLayerNodeRowData(rowObserver: observer,

--- a/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
+++ b/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
@@ -79,9 +79,7 @@ final class PatchNodeViewModel: Sendable {
         self.canvasObserver = .init(from: schema.canvasEntity,
                                     id: .node(schema.id),
                                     inputRowObservers: inputsObservers,
-                                    outputRowObservers: outputsObservers,
-                                    unpackedPortParentFieldGroupType: nil,
-                                    unpackedPortIndex: nil)
+                                    outputRowObservers: outputsObservers)
         
         self.inputsObservers = inputsObservers
         self.outputsObservers = outputsObservers
@@ -286,10 +284,7 @@ extension PatchNodeViewModel {
         // Update input row view models in canvas
         self.canvasObserver
             .syncRowViewModels(with: self._inputsObservers,
-                               keyPath: \.inputViewModels,
-                               // Not relevant
-                               unpackedPortParentFieldGroupType: nil,
-                               unpackedPortIndex: nil)
+                               keyPath: \.inputViewModels)
     }
 }
 

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
@@ -330,13 +330,9 @@ extension LayerInputObserver {
     
     /// Called after the pack mode changes for some port.
     @MainActor 
-    func wasPackModeToggled() {
+    func wasPackModeToggled(document: StitchDocumentViewModel) {
                 
-        guard let graph = self.graphDelegate,
-              let document = graph.documentDelegate else {
-            fatalErrorIfDebug("wasPackModeToggled: did not have graph delegate")
-            return
-        }
+        let graph = document.visibleGraph
         
         guard let node = graph.getNodeViewModel(self.nodeId),
               let layerNode = node.layerNode else {

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -45,6 +45,8 @@ protocol NodeRowObserver: AnyObject, Observable, Identifiable, Sendable, NodeRow
     
     @MainActor var allRowViewModels: [RowViewModelType] { get }
             
+    @MainActor var nodeDelegate: NodeViewModel? { get set }
+    
     @MainActor
     var hasLoopedValues: Bool { get set }
         
@@ -171,7 +173,8 @@ extension NodeRowObserver {
     
     @MainActor
     func initializeDelegate(_ node: NodeViewModel, graph: GraphState) {
-                
+        self.nodeDelegate = node
+        
         // TODO: why do we handle post-processing when we've assigned the nodeDelegate? ... is it just because post-processing requires a nodeDelegate?
         switch Self.nodeIOType {
         case .input:

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -144,9 +144,9 @@ extension NodeRowViewModel {
         
         // Whenever we update ui-fields' values, we need to potentially block or unblock the same/other fields.
         // TODO: blocking or unblocking fields is only for a layer node; but requires reading from graph state etc.
-        if let layerInputForThisRow: LayerInputType = self.rowDelegate?.id.keyPath,
-           let node = self.nodeDelegate,
+        if let node = self.nodeDelegate,
            let document = node.graphDelegate?.documentDelegate,
+           let layerInputForThisRow = document.graph.getInputRowObserver(self.nodeIOCoordinate)?.id.keyPath,
            let layerNode = node.layerNodeViewModel {
             layerNode.blockOrUnblockFields(
                 newValue: newValue,

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
@@ -219,13 +219,18 @@ extension CanvasItemViewModel {
     /// Syncing logic as influced from `SchemaObserverIdentifiable`.
     @MainActor
     func syncRowViewModels<RowViewModel>(with newEntities: [RowViewModel.RowObserver],
-                                         keyPath: ReferenceWritableKeyPath<CanvasItemViewModel, [RowViewModel]>,
-                                         unpackedPortParentFieldGroupType: FieldGroupType?,
-                                         unpackedPortIndex: Int?) where RowViewModel: NodeRowViewModel {
+                                         keyPath: ReferenceWritableKeyPath<CanvasItemViewModel, [RowViewModel]>
+//                                         , graph: GraphReader
+    ) where RowViewModel: NodeRowViewModel {
         
         let canvas = self
         let incomingIds = newEntities.map { $0.id }.toSet
-        let currentIds = self[keyPath: keyPath].compactMap { $0.rowDelegate?.id }.toSet
+        let currentIds = self[keyPath: keyPath].compactMap {
+//            x.
+            $0.rowDelegate?.id
+//            graph.get
+        }.toSet
+        
         let entitiesToRemove = currentIds.subtracting(incomingIds)
 
         let currentEntitiesMap = self[keyPath: keyPath].reduce(into: [:]) { result, currentEntity in

--- a/Stitch/Graph/Node/Util/NodeDeletedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeDeletedAction.swift
@@ -115,7 +115,11 @@ extension GraphState {
             // Check if packed mode changed
             let newPackMode = inputPort.mode
             if prevPackMode != newPackMode {
-                inputPort.wasPackModeToggled()
+                guard let document = self.documentDelegate else {
+                    fatalErrorIfDebug()
+                    return
+                }
+                inputPort.wasPackModeToggled(document: document)
             }
             
         case .layerOutput(let x):

--- a/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
@@ -97,8 +97,6 @@ final class CanvasItemViewModel: Identifiable, StitchLayoutCachable, Sendable {
          parentGroupNodeId: NodeId?,
          inputRowObservers: [InputNodeRowObserver],
          outputRowObservers: [OutputNodeRowObserver],
-         unpackedPortParentFieldGroupType: FieldGroupType?,
-         unpackedPortIndex: Int?,
          nodeDelegate: NodeViewModel? = nil) {
         self.id = id
         self.position = position
@@ -109,45 +107,33 @@ final class CanvasItemViewModel: Identifiable, StitchLayoutCachable, Sendable {
         
         // Instantiate input and output row view models
         self.syncRowViewModels(inputRowObservers: inputRowObservers,
-                               outputRowObservers: outputRowObservers,
-                               unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                               unpackedPortIndex: unpackedPortIndex)
+                               outputRowObservers: outputRowObservers)
     }
 }
 
 extension CanvasItemViewModel {
     @MainActor
     func syncRowViewModels(inputRowObservers: [InputNodeRowObserver],
-                           outputRowObservers: [OutputNodeRowObserver],
-                           unpackedPortParentFieldGroupType: FieldGroupType?,
-                           unpackedPortIndex: Int?) {
+                           outputRowObservers: [OutputNodeRowObserver]) {
         
         self.syncRowViewModels(with: inputRowObservers,
-                               keyPath: \.inputViewModels,
-                               unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                               unpackedPortIndex: unpackedPortIndex)
+                               keyPath: \.inputViewModels)
         
         self.syncRowViewModels(with: outputRowObservers,
-                               keyPath: \.outputViewModels,
-                               unpackedPortParentFieldGroupType: nil,
-                               unpackedPortIndex: nil)
+                               keyPath: \.outputViewModels)
     }
     
     @MainActor
     convenience init(from canvasEntity: CanvasNodeEntity,
                      id: CanvasItemId,
                      inputRowObservers: [InputNodeRowObserver],
-                     outputRowObservers: [OutputNodeRowObserver],
-                     unpackedPortParentFieldGroupType: FieldGroupType?,
-                     unpackedPortIndex: Int?) {
+                     outputRowObservers: [OutputNodeRowObserver]) {
         self.init(id: id,
                   position: canvasEntity.position,
                   zIndex: canvasEntity.zIndex,
                   parentGroupNodeId: canvasEntity.parentGroupNodeId,
                   inputRowObservers: inputRowObservers,
-                  outputRowObservers: outputRowObservers,
-                  unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                  unpackedPortIndex: unpackedPortIndex)
+                  outputRowObservers: outputRowObservers)
     }
     
     @MainActor

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModel.swift
@@ -91,10 +91,10 @@ final class NodeViewModel: Sendable {
     @MainActor
     convenience init(from schema: NodeEntity,
                      graphDelegate: GraphState,
-                     document: StitchDocumentViewModel) async {
-        await self.init(from: schema,
-                        components: graphDelegate.components,
-                        parentGraphPath: graphDelegate.saveLocation)
+                     document: StitchDocumentViewModel) {
+        self.init(from: schema,
+                  components: graphDelegate.components,
+                  parentGraphPath: graphDelegate.saveLocation)
         self.initializeDelegate(graph: graphDelegate,
                                 document: document)
     }
@@ -131,10 +131,7 @@ extension NodeViewModel {
                                          zIndex: .zero,
                                          parentGroupNodeId: nil,
                                          inputRowObservers: [],
-                                         outputRowObservers: [],
-                                         unpackedPortParentFieldGroupType: nil,
-                                         unpackedPortIndex: nil))
-                  )
+                                         outputRowObservers: [])))
     }
     
     @MainActor

--- a/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
@@ -32,10 +32,7 @@ extension NodeViewModelType {
                                 id: .node(nodeId),
                                 // Initialize as empty since splitter row observers might not have yet been created
                                 inputRowObservers: [],
-                                outputRowObservers: [],
-                                // Irrelevant
-                                unpackedPortParentFieldGroupType: nil,
-                                unpackedPortIndex: nil))
+                                outputRowObservers: []))
         case .component(let component):
             self = .component(.init(nodeId: nodeId,
                                     componentEntity: component,

--- a/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
+++ b/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
@@ -150,10 +150,7 @@ extension VisibleNodesViewModel {
             case .patch(let patchNode):
                 // Syncs ports if nodes had inputs added/removed
                 patchNode.canvasObserver.syncRowViewModels(inputRowObservers: patchNode.inputsObservers,
-                                                           outputRowObservers: patchNode.outputsObservers,
-                                                           // Not relevant
-                                                           unpackedPortParentFieldGroupType: nil,
-                                                           unpackedPortIndex: nil)
+                                                           outputRowObservers: patchNode.outputsObservers)
                 
             case .group(let canvasGroup):
                 // Create port view models for group nodes once row observers have been established
@@ -161,10 +158,7 @@ extension VisibleNodesViewModel {
                 let outputRowObservers = self.getSplitterOutputRowObservers(for: node.id)
                 // Note: What is `syncRowViewModels` vs `NodeRowViewModel.initialize`?
                 canvasGroup.syncRowViewModels(inputRowObservers: inputRowObservers,
-                                              outputRowObservers: outputRowObservers,
-                                              // Not relevant
-                                              unpackedPortParentFieldGroupType: nil,
-                                              unpackedPortIndex: nil)
+                                              outputRowObservers: outputRowObservers)
                 
                 // Initializes view models for canvas
                 guard let node = canvasGroup.nodeDelegate else {
@@ -184,9 +178,7 @@ extension VisibleNodesViewModel {
             case .component(let componentViewModel):
                 // Similar logic to patch nodes, where we have inputs/outputs observers stored directly in component
                 componentViewModel.canvas.syncRowViewModels(inputRowObservers: componentViewModel.inputsObservers,
-                                                            outputRowObservers: componentViewModel.outputsObservers,
-                                                            unpackedPortParentFieldGroupType: nil,
-                                                            unpackedPortIndex: nil)
+                                                            outputRowObservers: componentViewModel.outputsObservers)
 
             case .layer(let layerNode):
                 // Special case: we must re-initialize the group orientation input, since its first initialization happens before we have constructed the layer view models that can tell us all the parent's children


### PR DESCRIPTION
We were passing two parameters to `syncRowViewModels` that weren't even being used. Now the signature and code is much cleaner. 

Also fixes runtime crash from `39bdf7de7599d7b7a2e6fd2dac089ee661174509`