### PR TITLE
Revert "Use synchronous initializers for GraphState and StitchDocumentViewModel"

### DIFF
--- a/Stitch/App/Serialization/DocumentEncodableUtil.swift
+++ b/Stitch/App/Serialization/DocumentEncodableUtil.swift
@@ -20,7 +20,6 @@ extension DocumentEncodable {
         }
     }
 
-    @MainActor
     /// Called when GraphState is initialized to build library data and then run first calc.
     func getDecodedFiles() -> GraphDecodedFiles? {
         do {

--- a/Stitch/App/Serialization/StitchFileManagerProject.swift
+++ b/Stitch/App/Serialization/StitchFileManagerProject.swift
@@ -55,7 +55,6 @@ extension DocumentEncodable {
         return mainResources + tempResources
     }
     
-    @MainActor
     func readAllImportedFiles() throws -> StitchDocumentDirectory {
         try Self.readAllImportedFiles(rootUrl: self.rootUrl)
     }

--- a/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
+++ b/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
@@ -143,8 +143,8 @@ final class StitchComponentViewModel: Sendable {
                      componentEntity: ComponentEntity,
                      encodedComponent: StitchComponent,
                      parentGraphPath: [UUID],
-                     componentEncoder: ComponentEncoder) {
-        let graph = GraphState(from: encodedComponent.graph,
+                     componentEncoder: ComponentEncoder) async {
+        let graph = await GraphState(from: encodedComponent.graph,
                                      // TODO: ComponentEntity or GraphEntity should persist their own localPosition?
                                      localPosition: ABSOLUTE_GRAPH_CENTER,
                                      saveLocation: parentGraphPath + [componentEntity.componentId],

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModel.swift
@@ -79,8 +79,8 @@ final class NodeViewModel: Sendable {
     @MainActor
     convenience init(from schema: NodeEntity,
                      components: [UUID : StitchMasterComponent],
-                     parentGraphPath: [UUID]) {
-        let nodeType = NodeViewModelType(from: schema.nodeTypeEntity,
+                     parentGraphPath: [UUID]) async {
+        let nodeType = await NodeViewModelType(from: schema.nodeTypeEntity,
                                                nodeId: schema.id,
                                                components: components,
                                                parentGraphPath: parentGraphPath)

--- a/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
@@ -46,7 +46,7 @@ extension NodeViewModelType {
     init(from nodeType: NodeTypeEntity,
          nodeId: NodeId,
          components: [UUID: StitchMasterComponent],
-         parentGraphPath: [UUID])  {
+         parentGraphPath: [UUID]) async {
         switch nodeType {
         case .patch, .layer, .group:
             self = .init(from: nodeType,
@@ -64,7 +64,7 @@ extension NodeViewModelType {
                 return
             }
             
-            let component = StitchComponentViewModel(
+            let component = await StitchComponentViewModel(
                 nodeId: nodeId,
                 componentEntity: componentEntity,
                 encodedComponent: masterComponent.lastEncodedDocument,

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -165,9 +165,8 @@ extension GraphState {
     convenience init(from schema: GraphEntity,
                      localPosition: CGPoint,
                      saveLocation: [UUID],
-                     encoder: (any DocumentEncodable)) {
-//        guard let decodedFiles = await encoder.getDecodedFiles() else {
-        guard let decodedFiles = encoder.getDecodedFiles() else {
+                     encoder: (any DocumentEncodable)) async {
+        guard let decodedFiles = await encoder.getDecodedFiles() else {
             fatalErrorIfDebug()
             self.init()
             return
@@ -177,7 +176,7 @@ extension GraphState {
         
         var nodes = NodesViewModelDict()
         for nodeEntity in schema.nodes {
-            let newNode = NodeViewModel(from: nodeEntity,
+            let newNode = await NodeViewModel(from: nodeEntity,
                                               components: components,
                                               parentGraphPath: saveLocation)
             nodes.updateValue(newNode, forKey: newNode.id)

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -199,13 +199,13 @@ final class StitchDocumentViewModel: Sendable {
                       isPhoneDevice: Bool,
                       projectLoader: ProjectLoader,
                       store: StitchStore,
-                      isDebugMode: Bool) {
+                      isDebugMode: Bool) async {
         let documentEncoder = DocumentEncoder(document: schema)
-        
-        let graph = GraphState(from: schema.graph,
-                               localPosition: ABSOLUTE_GRAPH_CENTER, // schema.localPosition,
-                               saveLocation: [],
-                               encoder: documentEncoder)
+
+        let graph = await GraphState(from: schema.graph,
+                                     localPosition: ABSOLUTE_GRAPH_CENTER, // schema.localPosition,
+                                     saveLocation: [],
+                                     encoder: documentEncoder)
                 
         self.init(from: schema,
                   graph: graph,
@@ -545,18 +545,23 @@ extension StitchDocumentViewModel {
     
     // TODO: this still doesn't quite have the correct projectLoader/encoderDelegate needed for all uses in the app
     @MainActor
-    static func createTestFriendlyDocument() -> StitchDocumentViewModel {
+    static func createTestFriendlyDocument() async -> StitchDocumentViewModel {
         let store = StitchStore()
         
-        guard let (_, documentViewModel) = try? createNewProjectWithoutDocumentLoaderUpdate(
-            isProjectImport: false,
-            isPhoneDevice: false,
-            store: store) else {
+        await store.createNewProject(isProjectImport: false,
+                                     isPhoneDevice: false)
+        
+        guard let projectLoader = store.navPath.first,
+              let documentViewModel = projectLoader.documentViewModel else {
             fatalError()
         }
-
-        assert(store.navPath.first?.loadedDocument?.0.id == documentViewModel.id.value)
-      
+        
+        documentViewModel.documentEncoder = projectLoader.encoder!
+        documentViewModel.graph.documentEncoderDelegate = documentViewModel.documentEncoder
+        
+        assert(documentViewModel.documentEncoder.isDefined)
+        assert(documentViewModel.graph.documentEncoderDelegate.isDefined)
+        
         return documentViewModel
     }
     

--- a/Stitch/Home/Util/ProjectCreatedActions.swift
+++ b/Stitch/Home/Util/ProjectCreatedActions.swift
@@ -23,7 +23,7 @@ extension StitchStore {
                                          isPhoneDevice: isPhoneDevice)
         }
     }
-        
+    
     func createNewProject(from document: StitchDocument = .init(),
                           isProjectImport: Bool,
                           isPhoneDevice: Bool) async {

--- a/StitchTests/evalTests.swift
+++ b/StitchTests/evalTests.swift
@@ -15,6 +15,7 @@ import XCTest
 class EvalTests: XCTestCase {
     @MainActor var store = StitchStore()
     
+    // Cannot be async, so cannot be used to create a document
     @MainActor
     override func setUp() {
         self.store = StitchStore() // wipe the store
@@ -22,9 +23,9 @@ class EvalTests: XCTestCase {
     
     @MainActor
     func loopSelectEval(inputs: PortValuesList,
-                        outputs: PortValuesList) -> PortValuesList {
+                        outputs: PortValuesList) async -> PortValuesList {
         
-        let document = StitchDocumentViewModel.createTestFriendlyDocument()
+        let document = await StitchDocumentViewModel.createTestFriendlyDocument()
         let graphState = document.visibleGraph
         
         
@@ -50,8 +51,8 @@ class EvalTests: XCTestCase {
 
     /// Runs all evals to make sure nodes can initialize.
     @MainActor
-    func testRunAllEvals() throws {
-        let document = StitchDocumentViewModel.createTestFriendlyDocument()
+    func testRunAllEvals() async throws {
+        let document = await StitchDocumentViewModel.createTestFriendlyDocument()
         let graphState = document.visibleGraph
         
         graphState.graphStepManager.graphTimeCurrent = 4
@@ -651,7 +652,7 @@ class EvalTests: XCTestCase {
 
     // single value selection
     @MainActor
-    func testLoopSelectEvalSingleSelection() throws {
+    func testLoopSelectEvalSingleSelection() async throws {
 
         // "input"
         let input1: PortValues = [.string(.init("apple")), .string(.init("carrot")), .string(.init("orange"))]
@@ -665,7 +666,7 @@ class EvalTests: XCTestCase {
         // "output index"
         let expectedOutput2: PortValues = [.number(0)]
 
-        let result: PortValuesList = loopSelectEval(
+        let result: PortValuesList = await loopSelectEval(
             inputs: [input1, input2],
             outputs: [] // none, starting out
         )
@@ -675,7 +676,7 @@ class EvalTests: XCTestCase {
     }
 
     @MainActor
-    func testLoopSelectEvalNegativeSingleSelection() throws {
+    func testLoopSelectEvalNegativeSingleSelection() async throws {
 
         let apple = "apple"
         let carrot = "carrot"
@@ -692,78 +693,78 @@ class EvalTests: XCTestCase {
         let input2: PortValues = [.number(-1)]
 
         let getResult = { (index: Int) -> PortValuesList in
-            self.loopSelectEval(inputs: [input1,
+            await self.loopSelectEval(inputs: [input1,
                                          [.number(Double(index))]],
                                 outputs: [])
         }
 
         // POSITIVE INDICES
-        let _result0 = getResult(0)
+        let _result0 = await getResult(0)
         XCTAssertEqual(_result0.first!, [.string(.init(apple))])
         XCTAssertEqual(_result0[1], [.number(0)])
 
-        let _result1 = getResult(1)
+        let _result1 = await getResult(1)
         XCTAssertEqual(_result1.first!, [.string(.init(carrot))])
         XCTAssertEqual(_result1[1], [.number(0)])
 
-        let _result2 = getResult(2)
+        let _result2 = await getResult(2)
         XCTAssertEqual(_result2.first!, [.string(.init(orange))])
         XCTAssertEqual(_result2[1], [.number(0)])
 
-        let _result3 = getResult(3)
+        let _result3 = await getResult(3)
         XCTAssertEqual(_result3.first!, [.string(.init(apple))])
         XCTAssertEqual(_result3[1], [.number(0)])
 
-        let _result4 = getResult(4)
+        let _result4 = await getResult(4)
         XCTAssertEqual(_result4.first!, [.string(.init(carrot))])
         XCTAssertEqual(_result4[1], [.number(0)])
 
-        let _result5 = getResult(5)
+        let _result5 = await getResult(5)
         XCTAssertEqual(_result5.first!, [.string(.init(orange))])
         XCTAssertEqual(_result5[1], [.number(0)])
 
-        let _result6 = getResult(6)
+        let _result6 = await getResult(6)
         XCTAssertEqual(_result6.first!, [.string(.init(apple))])
         XCTAssertEqual(_result6[1], [.number(0)])
 
-        let _result7 = getResult(7)
+        let _result7 = await getResult(7)
         XCTAssertEqual(_result7.first!, [.string(.init(carrot))])
         XCTAssertEqual(_result7[1], [.number(0)])
 
         // NEGATIVE INDICES
 
         // index = -1 currently giving us "apple", whereas we expect "orange"
-        let result1 = getResult(-1)
+        let result1 = await getResult(-1)
         XCTAssertEqual(result1.first!, [.string(.init(orange))])
         XCTAssertEqual(result1[1], [.number(0)])
 
         // index = -2
-        let result2 = getResult(-2)
+        let result2 = await getResult(-2)
         XCTAssertEqual(result2.first!, [.string(.init(carrot))])
         XCTAssertEqual(result2[1], [.number(0)])
 
         // index = -3
-        let result3 = getResult(-3)
+        let result3 = await getResult(-3)
         XCTAssertEqual(result3.first!, [.string(.init(apple))])
         XCTAssertEqual(result3[1], [.number(0)])
 
         // index = -4
-        let result4 = getResult(-4)
+        let result4 = await getResult(-4)
         XCTAssertEqual(result4.first!, [.string(.init(orange))])
         XCTAssertEqual(result4[1], [.number(0)])
 
         // index = -5
-        let result5 = getResult(-5)
+        let result5 = await getResult(-5)
         XCTAssertEqual(result5.first!, [.string(.init(carrot))])
         XCTAssertEqual(result5[1], [.number(0)])
 
         // index = -6
-        let result6 = getResult(-6)
+        let result6 = await getResult(-6)
         XCTAssertEqual(result6.first!, [.string(.init(apple))])
         XCTAssertEqual(result6[1], [.number(0)])
 
         // index = -4
-        let result7 = getResult(-7)
+        let result7 = await getResult(-7)
         XCTAssertEqual(result7.first!, [.string(.init(orange))])
         XCTAssertEqual(result7[1], [.number(0)])
 
@@ -773,7 +774,7 @@ class EvalTests: XCTestCase {
 
     // see for details: https://origami.design/documentation/patches/builtin.loop.selectReorder.html
     @MainActor
-    func testLoopSelectEvalMultiSelection() throws {
+    func testLoopSelectEvalMultiSelection() async throws {
 
         // "input"
         let input1: PortValues = [.string(.init("apple")), .string(.init("carrot")), .string(.init("orange"))]
@@ -787,7 +788,7 @@ class EvalTests: XCTestCase {
         // "output index"
         let expectedOutput2: PortValues = [.number(0), .number(1), .number(2)]
 
-        let result: PortValuesList = loopSelectEval(
+        let result: PortValuesList = await loopSelectEval(
             inputs: [input1, input2],
             outputs: [] // none, starting out
         )
@@ -797,7 +798,7 @@ class EvalTests: XCTestCase {
     }
 
     @MainActor
-    func testLoopSelectEvalMultiSelectionUnequalLength() throws {
+    func testLoopSelectEvalMultiSelectionUnequalLength() async throws {
 
         // "input"
         let input1: PortValues = [.string(.init("apple")), .string(.init("carrot")), .string(.init("orange"))]
@@ -811,7 +812,7 @@ class EvalTests: XCTestCase {
         // "output index"
         let expectedOutput2: PortValues = [.number(0), .number(1)]
 
-        let result: PortValuesList = loopSelectEval(
+        let result: PortValuesList = await loopSelectEval(
             inputs: [input1, input2],
             outputs: [] // none, starting out
         )

--- a/StitchTests/loopTests.swift
+++ b/StitchTests/loopTests.swift
@@ -36,12 +36,12 @@ final class loopTests: XCTestCase {
     }
     
     @MainActor
-    func testJSONArray() throws {
+    func testJSONArray() async throws {
         /*
          Old bug: JSONArray was adding its output to the list of inputs to turn into an array.
          Not caught by existing JSONArrayFromValues test because the bug came from `nodeViewModel.loopedEval` helper.
          */
-        let document = StitchDocumentViewModel.createTestFriendlyDocument()
+        let document = await StitchDocumentViewModel.createTestFriendlyDocument()
         if let node = document.nodeInserted(choice: .patch(.jsonArray)) {
             
             // How many inputs does the JSONArray node have?

--- a/StitchTests/nodeTypeTests.swift
+++ b/StitchTests/nodeTypeTests.swift
@@ -12,8 +12,8 @@ import StitchSchemaKit
 final class nodeTypeTests: XCTestCase {
 
     @MainActor
-    func testNodeTypeChange() throws {
-        let document = StitchDocumentViewModel.createTestFriendlyDocument()
+    func testNodeTypeChange() async throws {
+        let document = await StitchDocumentViewModel.createTestFriendlyDocument()
         let node = try XCTUnwrap(document.nodeInserted(choice: .patch(.add)))
         
         let numberInputs = node.inputsObservers.allSatisfy { (input: InputNodeRowObserver) in


### PR DESCRIPTION
Reverts StitchDesign/Stitch#1058

https://github.com/StitchDesign/Stitch/pull/1058/files

This commit clearly broke project import e.g. of the Humane demo. Not sure why -- it appeared from the compiler that we were only async in part of the function because we crossed actors (Main vs DocumentLoader). 

Low priority, but would love to understand why and how this broke things without compiler properly warning us. Maybe have to go through the original PR's changes line-by-line.

Would love to have a sync-option for creating a new document (e.g. for tests, for in the Xcode previews). Project import can still be asynchronous since we're reading from the file system.