### PR TITLE
Introduce sync init for document

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -566,6 +566,7 @@
 		EC5A2DE3263202FC00D8DEE5 /* VisualMediaLayerNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5A2DE2263202FC00D8DEE5 /* VisualMediaLayerNode.swift */; };
 		EC5BC3DF2D681331000DF722 /* JSONCoercionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5BC3DE2D681331000DF722 /* JSONCoercionUtils.swift */; };
 		EC5C6C3A2C2DAE690023D0C0 /* LLMActionRecording.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5C6C392C2DAE690023D0C0 /* LLMActionRecording.swift */; };
+		EC5D34342DAB770E00B093C3 /* SynchronousDocumentViewModelInitializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5D34332DAB770E00B093C3 /* SynchronousDocumentViewModelInitializer.swift */; };
 		EC5E3A1828188DF5001E156F /* ProjectDestructiveActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5E3A1728188DF5001E156F /* ProjectDestructiveActions.swift */; };
 		EC5E6C872B717F0800B4CACC /* AnimatableCircuitLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5E6C862B717F0800B4CACC /* AnimatableCircuitLine.swift */; };
 		EC5E6C892B71839600B4CACC /* AnimatableForwardCircuitLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5E6C882B71839600B4CACC /* AnimatableForwardCircuitLine.swift */; };
@@ -1535,6 +1536,7 @@
 		EC5A2DE2263202FC00D8DEE5 /* VisualMediaLayerNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualMediaLayerNode.swift; sourceTree = "<group>"; };
 		EC5BC3DE2D681331000DF722 /* JSONCoercionUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONCoercionUtils.swift; sourceTree = "<group>"; };
 		EC5C6C392C2DAE690023D0C0 /* LLMActionRecording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMActionRecording.swift; sourceTree = "<group>"; };
+		EC5D34332DAB770E00B093C3 /* SynchronousDocumentViewModelInitializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronousDocumentViewModelInitializer.swift; sourceTree = "<group>"; };
 		EC5E3A1728188DF5001E156F /* ProjectDestructiveActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectDestructiveActions.swift; sourceTree = "<group>"; };
 		EC5E6C862B717F0800B4CACC /* AnimatableCircuitLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatableCircuitLine.swift; sourceTree = "<group>"; };
 		EC5E6C882B71839600B4CACC /* AnimatableForwardCircuitLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatableForwardCircuitLine.swift; sourceTree = "<group>"; };
@@ -3075,6 +3077,7 @@
 				8B0A6B14271E7978002D6BD9 /* DirectoryObserver.swift */,
 				B51523B92B8C2F79000042CF /* ProjectLoader.swift */,
 				B51523BB2B8C2FB1000042CF /* DocumentLoader.swift */,
+				EC5D34332DAB770E00B093C3 /* SynchronousDocumentViewModelInitializer.swift */,
 				B539C2E92B92BF3D00C6CEC3 /* DocumentEncodable.swift */,
 				B5E0DDF728DA88090080BE71 /* StitchFileManager.swift */,
 			);
@@ -5144,6 +5147,7 @@
 				ECB9A8652AEB48A2006E65EE /* StitchColorPickerView.swift in Sources */,
 				B55500EF2C1BADB20081C3F1 /* PreviewCommonMisc.swift in Sources */,
 				ECF93A322697462B000AA85A /* ScrubbedVideoView.swift in Sources */,
+				EC5D34342DAB770E00B093C3 /* SynchronousDocumentViewModelInitializer.swift in Sources */,
 				EC4D95A126B4908600AD5AB4 /* PrototypeActions.swift in Sources */,
 				EC15CDE12C49D68A007CE763 /* StitchSpacingUtils.swift in Sources */,
 				E40B2F502CB86D21005F5479 /* StitchAIEvents.swift in Sources */,

--- a/Stitch/App/Serialization/DocumentLoading/DocumentLoader.swift
+++ b/Stitch/App/Serialization/DocumentLoading/DocumentLoader.swift
@@ -174,11 +174,10 @@ extension DocumentLoader {
             documentViewModel.previewWindowSize = document.previewWindowSize
         } else {
             // Get latest preview window size
-            guard let previewDevice = PreviewWindowDevice(rawValue: UserDefaults.standard.string(forKey: DEFAULT_PREVIEW_WINDOW_DEVICE_KEY_NAME) ??
-                                                          PreviewWindowDevice.defaultPreviewWindowDevice.rawValue) else {
-                fatalErrorIfDebug()
-                return
-            }
+            let previewDevice = UserDefaults.standard.string(forKey: DEFAULT_PREVIEW_WINDOW_DEVICE_KEY_NAME)
+                .flatMap { PreviewWindowDevice(rawValue: $0) }
+            ?? PreviewWindowDevice.defaultPreviewWindowDevice
+            
             documentViewModel.previewSizeDevice = previewDevice
             documentViewModel.previewWindowSize = previewDevice.previewWindowDimensions
         }

--- a/Stitch/App/Serialization/DocumentLoading/DocumentLoader.swift
+++ b/Stitch/App/Serialization/DocumentLoading/DocumentLoader.swift
@@ -147,7 +147,6 @@ extension DocumentLoader {
     @MainActor
     func createNewProject(from document: StitchDocument = .init(),
                           isProjectImport: Bool,
-                          isPhoneDevice: Bool,
                           store: StitchStore) async throws {
         let projectLoader = try await self.installDocument(document: document)
         
@@ -156,7 +155,6 @@ extension DocumentLoader {
         
         let documentViewModel = await StitchDocumentViewModel(
             from: document,
-            isPhoneDevice: isPhoneDevice,
             projectLoader: projectLoader,
             store: store,
             isDebugMode: false

--- a/Stitch/App/Serialization/DocumentLoading/SynchronousDocumentViewModelInitializer.swift
+++ b/Stitch/App/Serialization/DocumentLoading/SynchronousDocumentViewModelInitializer.swift
@@ -1,0 +1,118 @@
+//
+//  SynchronousDocumentViewModelInitializer.swift
+//  Stitch
+//
+//  Created by Christian J Clampitt on 4/12/25.
+//
+
+import Foundation
+
+/*
+ Primarily intended for test contexts, but could be used in main app.
+ 
+ TODO: Why didn't we have a sync initializer already?: https://github.com/StitchDesign/Stitch--Old/issues/7134
+ */
+
+@MainActor
+func createNewEmptyProject(store: StitchStore) throws -> (ProjectLoader, StitchDocumentViewModel) {
+    
+    // Create document schema
+    let documentSchema = StitchDocument()
+    
+    // "Install" the document
+    try documentSchema.installDocument()
+    
+    // Create the project loader
+    let projectLoader = ProjectLoader(url: documentSchema.rootUrl)
+    projectLoader.encoder = .init(document: documentSchema)
+    projectLoader.loadingDocument = .loaded(documentSchema, nil)
+    
+    let documentEncoder = DocumentEncoder(document: documentSchema)
+    
+    let graph: GraphState = .getNewEmptyGraphState(from: documentSchema.graph,
+                                                   saveLocation: [],
+                                                   encoder: documentEncoder)
+    
+    let document: StitchDocumentViewModel = .init(from: documentSchema,
+                                                  graph: graph,
+                                                  isPhoneDevice: false, // parameter no longer used
+                                                  projectLoader: projectLoader,
+                                                  store: store,
+                                                  isDebugMode: false)
+    
+
+    // TODO: why do we need to set the previewWindow on the document?
+    let previewDevice = UserDefaults.standard.string(forKey: DEFAULT_PREVIEW_WINDOW_DEVICE_KEY_NAME)
+        .flatMap { PreviewWindowDevice(rawValue: $0) }
+    ?? PreviewWindowDevice.defaultPreviewWindowDevice
+    
+    document.previewSizeDevice = previewDevice
+    document.previewWindowSize = previewDevice.previewWindowDimensions
+    
+    // After both GraphState and StitchDocumentViewModel have been created,
+    // initialize the delegates on node view models
+    document.graph.nodes.values.forEach { (node: NodeViewModel) in
+        node.initializeDelegate(graph: graph, document: document)
+    }
+
+    
+    projectLoader.documentViewModel = document
+    
+    document.didDocumentChange = true
+    
+    store.navPath = [projectLoader]
+    
+    return (projectLoader, document)
+}
+
+extension GraphState {
+    
+    // NOTE: delegates NOT yet initialized
+    @MainActor
+    static func getNewEmptyGraphState(from schema: GraphEntity,
+                                      localPosition: CGPoint = ABSOLUTE_GRAPH_CENTER,
+                                      saveLocation: [UUID],
+                                      encoder: (any DocumentEncodable)) -> Self {
+        
+        var nodes = NodesViewModelDict()
+        
+        for nodeEntity in schema.nodes {
+
+            switch nodeEntity.nodeTypeEntity {
+
+            case .component:
+                continue
+
+            case .patch, .layer, .group:
+                let nodeType = NodeViewModelType(from: nodeEntity.nodeTypeEntity, nodeId: nodeEntity.id)
+                let newNode = NodeViewModel(from: nodeEntity, nodeType: nodeType)
+                nodes.updateValue(newNode, forKey: newNode.id)
+            }
+        }
+        
+        return .init(from: schema,
+                     localPosition: localPosition,
+                     nodes: nodes,
+                     components: [:],
+                     mediaFiles: [],
+                     saveLocation: saveLocation)
+    }
+}
+
+extension NodeViewModel {
+    @MainActor
+    convenience init?(from schema: NodeEntity) {
+        
+        switch schema.nodeTypeEntity {
+            
+        case .patch, .layer, .group:
+            self.init(from: schema,
+                      nodeType: NodeViewModelType(from: schema.nodeTypeEntity, nodeId: schema.id))
+            return
+            
+        case .component:
+            fatalErrorIfDebug()
+            return nil
+        }
+    }
+}

--- a/Stitch/App/Serialization/DocumentLoading/SynchronousDocumentViewModelInitializer.swift
+++ b/Stitch/App/Serialization/DocumentLoading/SynchronousDocumentViewModelInitializer.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /*
- Primarily intended for test contexts, but could be used in main app.
+ Primarily intended for test contexts, but could be used in main app if connected properly with DocumentLoader ?
  
  TODO: Why didn't we have a sync initializer already?: https://github.com/StitchDesign/Stitch--Old/issues/7134
  */
@@ -35,11 +35,9 @@ func createNewEmptyProject(store: StitchStore) throws -> (ProjectLoader, StitchD
     
     let document: StitchDocumentViewModel = .init(from: documentSchema,
                                                   graph: graph,
-                                                  isPhoneDevice: false, // parameter no longer used
                                                   projectLoader: projectLoader,
                                                   store: store,
                                                   isDebugMode: false)
-    
 
     // TODO: why do we need to set the previewWindow on the document?
     let previewDevice = UserDefaults.standard.string(forKey: DEFAULT_PREVIEW_WINDOW_DEVICE_KEY_NAME)

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -172,7 +172,7 @@ extension GraphState {
             return
         }
         
-        let components =  decodedFiles.components.createComponentsDict(parentGraph: nil)
+        let components = decodedFiles.components.createComponentsDict(parentGraph: nil)
         
         var nodes = NodesViewModelDict()
         for nodeEntity in schema.nodes {

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -545,20 +545,11 @@ extension StitchDocumentViewModel {
     
     // TODO: this still doesn't quite have the correct projectLoader/encoderDelegate needed for all uses in the app
     @MainActor
-    static func createTestFriendlyDocument() async -> StitchDocumentViewModel {
-        let store = StitchStore()
-        
-        await store.createNewProject(isProjectImport: false,
-                                     isPhoneDevice: false)
-        
-        guard let projectLoader = store.navPath.first,
-              let documentViewModel = projectLoader.documentViewModel else {
-            fatalError()
-        }
-        
-        documentViewModel.documentEncoder = projectLoader.encoder!
-        documentViewModel.graph.documentEncoderDelegate = documentViewModel.documentEncoder
-        
+    static func createTestFriendlyDocument(_ store: StitchStore) -> StitchDocumentViewModel {
+//        let store = StitchStore()
+        let (projectLoader, documentViewModel) = try! createNewEmptyProject(store: store)
+        store.navPath = [projectLoader]
+                
         assert(documentViewModel.documentEncoder.isDefined)
         assert(documentViewModel.graph.documentEncoderDelegate.isDefined)
         

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -131,7 +131,6 @@ final class StitchDocumentViewModel: Sendable {
     @MainActor
     init(from schema: StitchDocument,
          graph: GraphState,
-         isPhoneDevice: Bool,
          projectLoader: ProjectLoader,
          store: StitchStore,
          isDebugMode: Bool) {
@@ -196,7 +195,6 @@ final class StitchDocumentViewModel: Sendable {
     
     @MainActor
     convenience init?(from schema: StitchDocument,
-                      isPhoneDevice: Bool,
                       projectLoader: ProjectLoader,
                       store: StitchStore,
                       isDebugMode: Bool) async {
@@ -209,7 +207,6 @@ final class StitchDocumentViewModel: Sendable {
                 
         self.init(from: schema,
                   graph: graph,
-                  isPhoneDevice: isPhoneDevice,
                   projectLoader: projectLoader,
                   store: store,
                   isDebugMode: isDebugMode)
@@ -563,7 +560,6 @@ extension StitchDocumentViewModel {
         
         return .init(from: doc,
                      graph: .init(),
-                     isPhoneDevice: false,
                      projectLoader: loader,
                      store: store,
                      isDebugMode: false)

--- a/Stitch/Home/Util/ProjectCreatedActions.swift
+++ b/Stitch/Home/Util/ProjectCreatedActions.swift
@@ -14,24 +14,20 @@ extension StitchStore {
     @MainActor
     func createNewProjectSideEffect(from document: StitchDocument = .init(),
                                     isProjectImport: Bool) {
-        let isPhoneDevice = StitchDocumentViewModel.isPhoneDevice
-        
+
         Task(priority: .high) { [weak self] in
             guard let store = self else { return }
             await store.createNewProject(from: document,
-                                         isProjectImport: isProjectImport,
-                                         isPhoneDevice: isPhoneDevice)
+                                         isProjectImport: isProjectImport)
         }
     }
     
     func createNewProject(from document: StitchDocument = .init(),
-                          isProjectImport: Bool,
-                          isPhoneDevice: Bool) async {
+                          isProjectImport: Bool) async {
         do {
             try await self.documentLoader.createNewProject(
                 from: document,
                 isProjectImport: isProjectImport,
-                isPhoneDevice: isPhoneDevice,
                 store: self)
         } catch {
             log("StitchStore.createNewProject error: \(error.localizedDescription)")

--- a/Stitch/Home/View/ProjectItem/ProjectsListItemLoadedView.swift
+++ b/Stitch/Home/View/ProjectItem/ProjectsListItemLoadedView.swift
@@ -98,7 +98,6 @@ extension StitchStore {
     @MainActor
     func handleProjectTapped(projectLoader: ProjectLoader,
                              document: StitchDocument,
-                             isPhoneDevice: Bool,
                              isDebugMode: Bool,
                              loadedCallback: @MainActor @Sendable @escaping () -> ()) {
         Task { [weak projectLoader] in
@@ -106,7 +105,6 @@ extension StitchStore {
             
             let documentViewModel = await StitchDocumentViewModel(
                 from: document,
-                isPhoneDevice: isPhoneDevice,
                 projectLoader: projectLoader,
                 store: self,
                 isDebugMode: isDebugMode

--- a/Stitch/Home/View/ProjectItem/ProjectsListItemView.swift
+++ b/Stitch/Home/View/ProjectItem/ProjectsListItemView.swift
@@ -109,7 +109,6 @@ struct ProjectsListItemView: View {
         
         store.handleProjectTapped(projectLoader: self.projectLoader,
                                   document: document,
-                                  isPhoneDevice: StitchDocumentViewModel.isPhoneDevice,
                                   isDebugMode: inDebug) {
             self.isLoadingForPresentation = false
         }

--- a/StitchTests/evalTests.swift
+++ b/StitchTests/evalTests.swift
@@ -23,9 +23,9 @@ class EvalTests: XCTestCase {
     
     @MainActor
     func loopSelectEval(inputs: PortValuesList,
-                        outputs: PortValuesList) async -> PortValuesList {
+                        outputs: PortValuesList) -> PortValuesList {
         
-        let document = await StitchDocumentViewModel.createTestFriendlyDocument()
+        let document = StitchDocumentViewModel.createTestFriendlyDocument(store)
         let graphState = document.visibleGraph
         
         
@@ -52,7 +52,7 @@ class EvalTests: XCTestCase {
     /// Runs all evals to make sure nodes can initialize.
     @MainActor
     func testRunAllEvals() async throws {
-        let document = await StitchDocumentViewModel.createTestFriendlyDocument()
+        let document = StitchDocumentViewModel.createTestFriendlyDocument(store)
         let graphState = document.visibleGraph
         
         graphState.graphStepManager.graphTimeCurrent = 4
@@ -652,7 +652,7 @@ class EvalTests: XCTestCase {
 
     // single value selection
     @MainActor
-    func testLoopSelectEvalSingleSelection() async throws {
+    func testLoopSelectEvalSingleSelection() throws {
 
         // "input"
         let input1: PortValues = [.string(.init("apple")), .string(.init("carrot")), .string(.init("orange"))]
@@ -666,7 +666,7 @@ class EvalTests: XCTestCase {
         // "output index"
         let expectedOutput2: PortValues = [.number(0)]
 
-        let result: PortValuesList = await loopSelectEval(
+        let result: PortValuesList = loopSelectEval(
             inputs: [input1, input2],
             outputs: [] // none, starting out
         )
@@ -676,7 +676,7 @@ class EvalTests: XCTestCase {
     }
 
     @MainActor
-    func testLoopSelectEvalNegativeSingleSelection() async throws {
+    func testLoopSelectEvalNegativeSingleSelection() throws {
 
         let apple = "apple"
         let carrot = "carrot"
@@ -693,78 +693,78 @@ class EvalTests: XCTestCase {
         let input2: PortValues = [.number(-1)]
 
         let getResult = { (index: Int) -> PortValuesList in
-            await self.loopSelectEval(inputs: [input1,
+            self.loopSelectEval(inputs: [input1,
                                          [.number(Double(index))]],
                                 outputs: [])
         }
 
         // POSITIVE INDICES
-        let _result0 = await getResult(0)
+        let _result0 = getResult(0)
         XCTAssertEqual(_result0.first!, [.string(.init(apple))])
         XCTAssertEqual(_result0[1], [.number(0)])
 
-        let _result1 = await getResult(1)
+        let _result1 = getResult(1)
         XCTAssertEqual(_result1.first!, [.string(.init(carrot))])
         XCTAssertEqual(_result1[1], [.number(0)])
 
-        let _result2 = await getResult(2)
+        let _result2 = getResult(2)
         XCTAssertEqual(_result2.first!, [.string(.init(orange))])
         XCTAssertEqual(_result2[1], [.number(0)])
 
-        let _result3 = await getResult(3)
+        let _result3 = getResult(3)
         XCTAssertEqual(_result3.first!, [.string(.init(apple))])
         XCTAssertEqual(_result3[1], [.number(0)])
 
-        let _result4 = await getResult(4)
+        let _result4 = getResult(4)
         XCTAssertEqual(_result4.first!, [.string(.init(carrot))])
         XCTAssertEqual(_result4[1], [.number(0)])
 
-        let _result5 = await getResult(5)
+        let _result5 = getResult(5)
         XCTAssertEqual(_result5.first!, [.string(.init(orange))])
         XCTAssertEqual(_result5[1], [.number(0)])
 
-        let _result6 = await getResult(6)
+        let _result6 = getResult(6)
         XCTAssertEqual(_result6.first!, [.string(.init(apple))])
         XCTAssertEqual(_result6[1], [.number(0)])
 
-        let _result7 = await getResult(7)
+        let _result7 = getResult(7)
         XCTAssertEqual(_result7.first!, [.string(.init(carrot))])
         XCTAssertEqual(_result7[1], [.number(0)])
 
         // NEGATIVE INDICES
 
         // index = -1 currently giving us "apple", whereas we expect "orange"
-        let result1 = await getResult(-1)
+        let result1 = getResult(-1)
         XCTAssertEqual(result1.first!, [.string(.init(orange))])
         XCTAssertEqual(result1[1], [.number(0)])
 
         // index = -2
-        let result2 = await getResult(-2)
+        let result2 = getResult(-2)
         XCTAssertEqual(result2.first!, [.string(.init(carrot))])
         XCTAssertEqual(result2[1], [.number(0)])
 
         // index = -3
-        let result3 = await getResult(-3)
+        let result3 = getResult(-3)
         XCTAssertEqual(result3.first!, [.string(.init(apple))])
         XCTAssertEqual(result3[1], [.number(0)])
 
         // index = -4
-        let result4 = await getResult(-4)
+        let result4 = getResult(-4)
         XCTAssertEqual(result4.first!, [.string(.init(orange))])
         XCTAssertEqual(result4[1], [.number(0)])
 
         // index = -5
-        let result5 = await getResult(-5)
+        let result5 = getResult(-5)
         XCTAssertEqual(result5.first!, [.string(.init(carrot))])
         XCTAssertEqual(result5[1], [.number(0)])
 
         // index = -6
-        let result6 = await getResult(-6)
+        let result6 = getResult(-6)
         XCTAssertEqual(result6.first!, [.string(.init(apple))])
         XCTAssertEqual(result6[1], [.number(0)])
 
         // index = -4
-        let result7 = await getResult(-7)
+        let result7 = getResult(-7)
         XCTAssertEqual(result7.first!, [.string(.init(orange))])
         XCTAssertEqual(result7[1], [.number(0)])
 
@@ -774,7 +774,7 @@ class EvalTests: XCTestCase {
 
     // see for details: https://origami.design/documentation/patches/builtin.loop.selectReorder.html
     @MainActor
-    func testLoopSelectEvalMultiSelection() async throws {
+    func testLoopSelectEvalMultiSelection() throws {
 
         // "input"
         let input1: PortValues = [.string(.init("apple")), .string(.init("carrot")), .string(.init("orange"))]
@@ -788,7 +788,7 @@ class EvalTests: XCTestCase {
         // "output index"
         let expectedOutput2: PortValues = [.number(0), .number(1), .number(2)]
 
-        let result: PortValuesList = await loopSelectEval(
+        let result: PortValuesList = loopSelectEval(
             inputs: [input1, input2],
             outputs: [] // none, starting out
         )
@@ -798,7 +798,7 @@ class EvalTests: XCTestCase {
     }
 
     @MainActor
-    func testLoopSelectEvalMultiSelectionUnequalLength() async throws {
+    func testLoopSelectEvalMultiSelectionUnequalLength() throws {
 
         // "input"
         let input1: PortValues = [.string(.init("apple")), .string(.init("carrot")), .string(.init("orange"))]
@@ -812,7 +812,7 @@ class EvalTests: XCTestCase {
         // "output index"
         let expectedOutput2: PortValues = [.number(0), .number(1)]
 
-        let result: PortValuesList = await loopSelectEval(
+        let result: PortValuesList = loopSelectEval(
             inputs: [input1, input2],
             outputs: [] // none, starting out
         )

--- a/StitchTests/loopTests.swift
+++ b/StitchTests/loopTests.swift
@@ -36,12 +36,12 @@ final class loopTests: XCTestCase {
     }
     
     @MainActor
-    func testJSONArray() async throws {
+    func testJSONArray() throws {
         /*
          Old bug: JSONArray was adding its output to the list of inputs to turn into an array.
          Not caught by existing JSONArrayFromValues test because the bug came from `nodeViewModel.loopedEval` helper.
          */
-        let document = await StitchDocumentViewModel.createTestFriendlyDocument()
+        let document = StitchDocumentViewModel.createTestFriendlyDocument(store)
         if let node = document.nodeInserted(choice: .patch(.jsonArray)) {
             
             // How many inputs does the JSONArray node have?

--- a/StitchTests/nodeTypeTests.swift
+++ b/StitchTests/nodeTypeTests.swift
@@ -11,9 +11,11 @@ import StitchSchemaKit
 
 final class nodeTypeTests: XCTestCase {
 
+    @MainActor var store = StitchStore()
+    
     @MainActor
-    func testNodeTypeChange() async throws {
-        let document = await StitchDocumentViewModel.createTestFriendlyDocument()
+    func testNodeTypeChange() throws {
+        let document = StitchDocumentViewModel.createTestFriendlyDocument(store)
         let node = try XCTUnwrap(document.nodeInserted(choice: .patch(.add)))
         
         let numberInputs = node.inputsObservers.allSatisfy { (input: InputNodeRowObserver) in

--- a/StitchTests/nodeUIGroupingTests.swift
+++ b/StitchTests/nodeUIGroupingTests.swift
@@ -32,27 +32,9 @@ class GroupNodeTests: XCTestCase {
     @MainActor
     func createSimpleGroupNode() async -> (StitchDocumentViewModel, NodeViewModel) {
                 
-        await store.createNewProject(isProjectImport: false,
-                                     isPhoneDevice: false)
+        let documentViewModel = StitchDocumentViewModel.createTestFriendlyDocument(store)
         
-        guard let projectLoader = store.navPath.first,
-              let documentViewModel = projectLoader.documentViewModel else {
-            fatalError()
-        }
-        
-        documentViewModel.documentEncoder = projectLoader.encoder!
-        documentViewModel.graph.documentEncoderDelegate = documentViewModel.documentEncoder
-        
-        assert(documentViewModel.documentEncoder.isDefined)
-        assert(documentViewModel.graph.documentEncoderDelegate.isDefined)
-        
-//        return documentViewModel
-        
-        
-//        let document = await StitchDocumentViewModel.createTestFriendlyDocument()
         let graphState = documentViewModel.graph
-
-        graphState.documentDelegate = documentViewModel
         
         // Create two Add nodes
         guard let node1 = documentViewModel.nodeInserted(choice: .patch(.add)),


### PR DESCRIPTION
Attempt to introduce a sync init for document (at least for tests); ignores DocumentLoader actor. 

All tests pass.

Related to https://github.com/StitchDesign/Stitch--Old/issues/7134