### PR TITLE
Require PortValue when creating row view model from row observer; don't initialize with nonsense default

### DIFF
--- a/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
+++ b/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
@@ -51,13 +51,15 @@ final class StitchComponentViewModel: Sendable {
     }
     
     @MainActor
-    func refreshPorts(schemaInputs: [NodeConnectionType]? = nil) {
+    func refreshPorts(schemaInputs: [NodeConnectionType]? = nil,
+                      activeIndex: ActiveIndex) {
         let schemaInputs = schemaInputs ?? self.createSchema().inputs
         
         self.inputsObservers = self.refreshInputs(schemaInputs: schemaInputs)
         self.outputsObservers = self.refreshOutputs()
         self.canvas.syncRowViewModels(inputRowObservers: inputsObservers,
-                                      outputRowObservers: outputsObservers)
+                                      outputRowObservers: outputsObservers,
+                                      activeIndex: activeIndex)
     }
     
     @MainActor
@@ -189,7 +191,7 @@ extension StitchComponentViewModel {
         self.outputsObservers.forEach { $0.initializeDelegate(node, graph: self.graph) }
         
         // Refresh port data
-        self.refreshPorts()
+        self.refreshPorts(activeIndex: document.activeIndex)
     }
     
     @MainActor func createSchema() -> ComponentEntity {
@@ -202,7 +204,8 @@ extension StitchComponentViewModel {
     }
     
     @MainActor func update(from schema: ComponentEntity,
-                           components: [UUID : StitchMasterComponent]) {
+                           components: [UUID : StitchMasterComponent],
+                           activeIndex: ActiveIndex) {
         self.componentId = schema.componentId
         
         guard let masterComponent = components.get(self.componentId) else {
@@ -214,16 +217,19 @@ extension StitchComponentViewModel {
         
         // Refresh after graph update
         self.canvas.update(from: schema.canvasEntity)
-        self.refreshPorts(schemaInputs: schema.inputs)
+        self.refreshPorts(schemaInputs: schema.inputs,
+                          activeIndex: activeIndex)
     }
     
-    @MainActor func syncPorts(schemaInputs: [NodeConnectionType]? = nil) {
+    @MainActor func syncPorts(schemaInputs: [NodeConnectionType]? = nil,
+                              activeIndex: ActiveIndex) {
         let schemaInputs = schemaInputs ?? self.createSchema().inputs
         
         self.inputsObservers = self.refreshInputs(schemaInputs: schemaInputs)
         self.outputsObservers = self.refreshOutputs()
         self.canvas.syncRowViewModels(inputRowObservers: self.inputsObservers,
-                                      outputRowObservers: self.outputsObservers)
+                                      outputRowObservers: self.outputsObservers,
+                                      activeIndex: activeIndex)
     }
     
     @MainActor

--- a/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
+++ b/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
@@ -74,6 +74,7 @@ final class InputLayerNodeRowData: LayerNodeRowData, Identifiable {
     
     @MainActor
     init(rowObserver: InputNodeRowObserver,
+         activeIndex: ActiveIndex,
          canvasObserver: CanvasItemViewModel? = nil,
          nodeDelegate: NodeViewModel? = nil) {
         let keyPath = rowObserver.id.keyPath
@@ -96,6 +97,7 @@ final class InputLayerNodeRowData: LayerNodeRowData, Identifiable {
                                                      nodeId: rowObserver.id.nodeId,
                                                      // Why portId=0 ?
                                                      portId: 0),
+                                           initialValue: rowObserver.getActiveValue(activeIndex: activeIndex),
                                            rowDelegate: rowObserver,
                                            // specifically not a row view model for canvas
                                            canvasItemDelegate: nil)
@@ -111,6 +113,7 @@ final class OutputLayerNodeRowData: LayerNodeRowData, Identifiable {
     
     @MainActor
     init(rowObserver: OutputNodeRowObserver,
+         activeIndex: ActiveIndex,
          canvasObserver: CanvasItemViewModel? = nil) {
         self.id = rowObserver.id
         self.rowObserver = rowObserver
@@ -127,6 +130,7 @@ final class OutputLayerNodeRowData: LayerNodeRowData, Identifiable {
         self.inspectorRowViewModel = .init(id: .init(graphItemType: itemType,
                                                      nodeId: rowObserver.id.nodeId,
                                                      portId: 0),
+                                           initialValue: rowObserver.getActiveValue(activeIndex: activeIndex),
                                            rowDelegate: rowObserver,
                                            // specifically not a row view model for canvas
                                            canvasItemDelegate: nil)

--- a/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
+++ b/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
@@ -211,7 +211,8 @@ final class LayerNodeViewModel {
         
         self.outputPorts = rowDefinitions
             .createEmptyOutputLayerPorts(schema: schema,
-                                    valuesList: rowDefinitions.outputs.defaultList)
+                                         activeIndex: .defaultActiveIndex,
+                                         valuesList: rowDefinitions.outputs.defaultList)
         
         self.positionPort = .init(from: schema, port: .position)
         self.sizePort = .init(from: schema, port: .size)

--- a/Stitch/Graph/Node/Model/SchemaNodesUtil.swift
+++ b/Stitch/Graph/Node/Model/SchemaNodesUtil.swift
@@ -121,6 +121,7 @@ extension NodeRowDefinitions {
     // Used when initializing layer's outputs upon Graph Open. We start with `allLoopedValues = []` just as we do in Graph Reset.
     @MainActor
     func createEmptyOutputLayerPorts(schema: LayerNodeEntity,
+                                     activeIndex: ActiveIndex,
                                      // Pass in values directly from eval
                                      valuesList: PortValuesList) -> [OutputLayerNodeRowData] {
         let nodeId = schema.id
@@ -145,6 +146,7 @@ extension NodeRowDefinitions {
             }
             
             let outputData = OutputLayerNodeRowData(rowObserver: observer,
+                                                    activeIndex: activeIndex,
                                                     canvasObserver: canvasObserver)
             
             outputData.inspectorRowViewModel.canvasItemDelegate = outputData.canvasObserver

--- a/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
+++ b/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
@@ -240,7 +240,8 @@ extension PatchNodeViewModel {
     
     @MainActor
     func updateMathExpressionNodeInputs(newExpression: String,
-                                        node: NodeViewModel) {
+                                        node: NodeViewModel,
+                                        activeIndex: ActiveIndex) {
         // Always set math-expr on node for its eval and (default) title
         if self.mathExpression != newExpression {
             self.mathExpression = newExpression            
@@ -284,7 +285,8 @@ extension PatchNodeViewModel {
         // Update input row view models in canvas
         self.canvasObserver
             .syncRowViewModels(with: self._inputsObservers,
-                               keyPath: \.inputViewModels)
+                               keyPath: \.inputViewModels,
+                               activeIndex: activeIndex)
     }
 }
 

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
@@ -17,7 +17,7 @@ final class InputNodeRowViewModel: NodeRowViewModel {
     
     let id: NodeRowViewModelId
     @MainActor var viewCache: NodeLayoutCache?
-    @MainActor var activeValue: PortValue = .number(.zero)
+    @MainActor var activeValue: PortValue // = .number(.zero)
     @MainActor var fieldValueTypes = FieldGroupTypeDataList()
     @MainActor var connectedCanvasItems: Set<CanvasItemId> = .init()
     @MainActor var anchorPoint: CGPoint?
@@ -32,9 +32,11 @@ final class InputNodeRowViewModel: NodeRowViewModel {
     
     @MainActor
     init(id: NodeRowViewModelId,
+         initialValue: PortValue,
          rowDelegate: InputNodeRowObserver?,
          canvasItemDelegate: CanvasItemViewModel?) {
         self.id = id
+        self.activeValue = initialValue
         self.nodeDelegate = nodeDelegate
         self.rowDelegate = rowDelegate
         self.canvasItemDelegate = canvasItemDelegate

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
@@ -55,6 +55,7 @@ protocol NodeRowViewModel: StitchLayoutCachable, Observable, Identifiable {
     
     @MainActor
     init(id: NodeRowViewModelId,
+         initialValue: PortValue,
          rowDelegate: RowObserver?,
          canvasItemDelegate: CanvasItemViewModel?)
 }
@@ -219,9 +220,8 @@ extension CanvasItemViewModel {
     /// Syncing logic as influced from `SchemaObserverIdentifiable`.
     @MainActor
     func syncRowViewModels<RowViewModel>(with newEntities: [RowViewModel.RowObserver],
-                                         keyPath: ReferenceWritableKeyPath<CanvasItemViewModel, [RowViewModel]>
-//                                         , graph: GraphReader
-    ) where RowViewModel: NodeRowViewModel {
+                                         keyPath: ReferenceWritableKeyPath<CanvasItemViewModel, [RowViewModel]>,
+                                         activeIndex: ActiveIndex) where RowViewModel: NodeRowViewModel {
         
         let canvas = self
         let incomingIds = newEntities.map { $0.id }.toSet
@@ -260,6 +260,7 @@ extension CanvasItemViewModel {
                                                    portId: portIndex)
                     
                     let rowViewModel = RowViewModel(id: rowId,
+                                                    initialValue: newEntity.getActiveValue(activeIndex: activeIndex),
                                                     rowDelegate: newEntity,
                                                     canvasItemDelegate: canvas)
                     

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputNodeRowViewModel.swift
@@ -16,7 +16,7 @@ final class OutputNodeRowViewModel: NodeRowViewModel {
     
     let id: NodeRowViewModelId
     @MainActor var viewCache: NodeLayoutCache?
-    @MainActor var activeValue: PortValue = .number(.zero)
+    @MainActor var activeValue: PortValue
     @MainActor var fieldValueTypes = FieldGroupTypeDataList()
     @MainActor var connectedCanvasItems: Set<CanvasItemId> = .init()
     @MainActor var anchorPoint: CGPoint?
@@ -28,9 +28,11 @@ final class OutputNodeRowViewModel: NodeRowViewModel {
     @MainActor weak var canvasItemDelegate: CanvasItemViewModel?
     
     init(id: NodeRowViewModelId,
+         initialValue: PortValue,
          rowDelegate: OutputNodeRowObserver?,
          canvasItemDelegate: CanvasItemViewModel?) {
         self.id = id
+        self.activeValue = initialValue
         self.nodeDelegate = nodeDelegate
         self.rowDelegate = rowDelegate
         self.canvasItemDelegate = canvasItemDelegate

--- a/Stitch/Graph/Node/Title/View/MathExpressionSubmenuButtonView.swift
+++ b/Stitch/Graph/Node/Title/View/MathExpressionSubmenuButtonView.swift
@@ -10,14 +10,14 @@ import StitchSchemaKit
 import OrderedCollections
 
 
-struct MathExpressionFormulaEdited: GraphEvent {
+struct MathExpressionFormulaEdited: StitchDocumentEvent {
     let id: NodeId // pass the reference instead?
     let newExpression: String
     
-    func handle(state: GraphState) {
+    func handle(state: StitchDocumentViewModel) {
         
         // Can fail when e.g. used in node view; that's okay.
-        guard let node = state.getNodeViewModel(id) else {
+        guard let node = state.visibleGraph.getNode(id) else {
             log("MathExpressionFormulaEdited: no math expression defined for node \(id)")
             return
         }
@@ -25,7 +25,8 @@ struct MathExpressionFormulaEdited: GraphEvent {
         assertInDebug(node.kind.getPatch == .mathExpression)
         
         node.patchNode?.updateMathExpressionNodeInputs(newExpression: newExpression, 
-                                                       node: node)
+                                                       node: node,
+                                                       activeIndex: state.activeIndex)
         node.calculate()
     }
 }

--- a/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
@@ -107,20 +107,25 @@ final class CanvasItemViewModel: Identifiable, StitchLayoutCachable, Sendable {
         
         // Instantiate input and output row view models
         self.syncRowViewModels(inputRowObservers: inputRowObservers,
-                               outputRowObservers: outputRowObservers)
+                               outputRowObservers: outputRowObservers,
+                               // Assume .zero when initially creating the row view model value?
+                               activeIndex: .defaultActiveIndex)
     }
 }
 
 extension CanvasItemViewModel {
     @MainActor
     func syncRowViewModels(inputRowObservers: [InputNodeRowObserver],
-                           outputRowObservers: [OutputNodeRowObserver]) {
+                           outputRowObservers: [OutputNodeRowObserver],
+                           activeIndex: ActiveIndex) {
         
         self.syncRowViewModels(with: inputRowObservers,
-                               keyPath: \.inputViewModels)
+                               keyPath: \.inputViewModels,
+                               activeIndex: activeIndex)
         
         self.syncRowViewModels(with: outputRowObservers,
-                               keyPath: \.outputViewModels)
+                               keyPath: \.outputViewModels,
+                               activeIndex: activeIndex)
     }
     
     @MainActor
@@ -301,12 +306,13 @@ extension InputLayerNodeRowData {
     static func empty(_ layerInputType: LayerInputType,
                       nodeId: UUID,
                       layer: Layer) -> Self {
-        // Take the data from the schema!! 
+        // Take the data from the schema!!
         let rowObserver = InputNodeRowObserver(values: [layerInputType.getDefaultValue(for: layer)],
                                                id: .init(portType: .keyPath(layerInputType),
                                                          nodeId: nodeId),
                                                upstreamOutputCoordinate: nil)
         return .init(rowObserver: rowObserver,
+                     activeIndex: .defaultActiveIndex, // b/c empty i.e. fake
                      canvasObserver: nil)
     }
 }

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModel.swift
@@ -494,9 +494,11 @@ extension NodeViewModel {
     // MARK: main actor needed to prevent view updates from background thread
     @MainActor
     func update(from schema: NodeEntity,
-                components: [UUID : StitchMasterComponent]) async {
+                components: [UUID : StitchMasterComponent],
+                activeIndex: ActiveIndex) async {
         await self.nodeType.update(from: schema.nodeTypeEntity,
-                                   components: components)
+                                   components: components,
+                                   activeIndex: activeIndex)
         
         self.updateTitle(newTitle: schema.title)
     }
@@ -649,6 +651,7 @@ extension NodeViewModel {
         
         let newInputViewModel = InputNodeRowViewModel(
             id: newRowId,
+            initialValue: newInputObserver.getActiveValue(activeIndex: document.activeIndex),
             rowDelegate: newInputObserver,
             canvasItemDelegate: patchNode.canvasObserver)
         

--- a/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
@@ -121,11 +121,13 @@ extension NodeViewModelType {
     
     @MainActor
     func update(from schema: NodeTypeEntity,
-                components: [UUID: StitchMasterComponent]) async {
+                components: [UUID: StitchMasterComponent],
+                activeIndex: ActiveIndex) async {
         switch (self, schema) {
         case (.component(let componentViewModel), .component(let component)):
             await componentViewModel.update(from: component,
-                                            components: components)
+                                            components: components,
+                                            activeIndex: activeIndex)
         default:
             self.update(from: schema)
         }

--- a/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
+++ b/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
@@ -150,7 +150,8 @@ extension VisibleNodesViewModel {
             case .patch(let patchNode):
                 // Syncs ports if nodes had inputs added/removed
                 patchNode.canvasObserver.syncRowViewModels(inputRowObservers: patchNode.inputsObservers,
-                                                           outputRowObservers: patchNode.outputsObservers)
+                                                           outputRowObservers: patchNode.outputsObservers,
+                                                           activeIndex: activeIndex)
                 
             case .group(let canvasGroup):
                 // Create port view models for group nodes once row observers have been established
@@ -158,7 +159,8 @@ extension VisibleNodesViewModel {
                 let outputRowObservers = self.getSplitterOutputRowObservers(for: node.id)
                 // Note: What is `syncRowViewModels` vs `NodeRowViewModel.initialize`?
                 canvasGroup.syncRowViewModels(inputRowObservers: inputRowObservers,
-                                              outputRowObservers: outputRowObservers)
+                                              outputRowObservers: outputRowObservers,
+                                              activeIndex: activeIndex)
                 
                 // Initializes view models for canvas
                 guard let node = canvasGroup.nodeDelegate else {
@@ -178,7 +180,8 @@ extension VisibleNodesViewModel {
             case .component(let componentViewModel):
                 // Similar logic to patch nodes, where we have inputs/outputs observers stored directly in component
                 componentViewModel.canvas.syncRowViewModels(inputRowObservers: componentViewModel.inputsObservers,
-                                                            outputRowObservers: componentViewModel.outputsObservers)
+                                                            outputRowObservers: componentViewModel.outputsObservers,
+                                                            activeIndex: activeIndex)
 
             case .layer(let layerNode):
                 // Special case: we must re-initialize the group orientation input, since its first initialization happens before we have constructed the layer view models that can tell us all the parent's children


### PR DESCRIPTION
A row view model is a ui-data cache for an underlying row observer. The row VM's activeValue reflects the row observer's, so long as the row VM is "visible" (= on screen).

Initializing with `activeValue: PortValue = number(0)` was just nonsense, e.g. row observer with color type could never have number type row VM.