### PR TITLE
Clarify node row view model properties

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -116,7 +116,7 @@
 		B55500B62C1B98B00081C3F1 /* SingleDropdownKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55500B52C1B98B00081C3F1 /* SingleDropdownKind.swift */; };
 		B55500BB2C1B99810081C3F1 /* FieldViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55500BA2C1B99810081C3F1 /* FieldViewModelType.swift */; };
 		B55500BD2C1B9A1B0081C3F1 /* JSONReplViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55500BC2C1B9A1B0081C3F1 /* JSONReplViews.swift */; };
-		B55500C02C1B9D890081C3F1 /* FieldGroupTypeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55500BF2C1B9D890081C3F1 /* FieldGroupTypeData.swift */; };
+		B55500C02C1B9D890081C3F1 /* FieldGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55500BF2C1B9D890081C3F1 /* FieldGroup.swift */; };
 		B55500C22C1B9DF30081C3F1 /* FieldValueUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55500C12C1B9DF30081C3F1 /* FieldValueUtils.swift */; };
 		B55500C42C1B9E300081C3F1 /* FieldViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55500C32C1B9E300081C3F1 /* FieldViewModel.swift */; };
 		B55500C62C1B9F9D0081C3F1 /* FieldValueMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55500C52C1B9F9D0081C3F1 /* FieldValueMedia.swift */; };
@@ -1103,7 +1103,7 @@
 		B55500B52C1B98B00081C3F1 /* SingleDropdownKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleDropdownKind.swift; sourceTree = "<group>"; };
 		B55500BA2C1B99810081C3F1 /* FieldViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldViewModelType.swift; sourceTree = "<group>"; };
 		B55500BC2C1B9A1B0081C3F1 /* JSONReplViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONReplViews.swift; sourceTree = "<group>"; };
-		B55500BF2C1B9D890081C3F1 /* FieldGroupTypeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldGroupTypeData.swift; sourceTree = "<group>"; };
+		B55500BF2C1B9D890081C3F1 /* FieldGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldGroup.swift; sourceTree = "<group>"; };
 		B55500C12C1B9DF30081C3F1 /* FieldValueUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldValueUtils.swift; sourceTree = "<group>"; };
 		B55500C32C1B9E300081C3F1 /* FieldViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldViewModel.swift; sourceTree = "<group>"; };
 		B55500C52C1B9F9D0081C3F1 /* FieldValueMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldValueMedia.swift; sourceTree = "<group>"; };
@@ -2322,7 +2322,7 @@
 				B50192072C6D100000A048ED /* Layer */,
 				EC8C1AA92D7799890058D969 /* NodeRowViewModel */,
 				EC3A6C452C20C23200CCBACC /* NodeRowObserver */,
-				B55500BF2C1B9D890081C3F1 /* FieldGroupTypeData.swift */,
+				B55500BF2C1B9D890081C3F1 /* FieldGroup.swift */,
 				B55500C32C1B9E300081C3F1 /* FieldViewModel.swift */,
 				B5CA9D2D2A77503B00B4E431 /* NumberFormatterObserver.swift */,
 			);
@@ -4971,7 +4971,7 @@
 				EC1A357A2C25CE8100E5A6D8 /* LayerInspectorActions.swift in Sources */,
 				ECF387C9280B5C4C0075F0E5 /* NodeInputOutputView.swift in Sources */,
 				ECE35EF227CEE9AE00CB8F5C /* InputCommittedActions.swift in Sources */,
-				B55500C02C1B9D890081C3F1 /* FieldGroupTypeData.swift in Sources */,
+				B55500C02C1B9D890081C3F1 /* FieldGroup.swift in Sources */,
 				EC0DE03E2973A57D0026A39C /* PreviewElementTrackpadPanView.swift in Sources */,
 				ECB8778C2C7D56D0004ACF60 /* LayerMultiselect.swift in Sources */,
 				EC8891A52C82388D002390F8 /* CommonEditingViewReadOnly.swift in Sources */,

--- a/Stitch/Graph/GraphStep/GraphStepIncrementer.swift
+++ b/Stitch/Graph/GraphStep/GraphStepIncrementer.swift
@@ -104,7 +104,7 @@ extension Array where Element: NodeRowViewModel {
     @MainActor
     func allFieldObserverValues() -> FieldValues {
         self.flatMap {
-            $0.fieldValueTypes.flatMap {
+            $0.cachedFieldValueTypes.flatMap {
                 $0.fieldObservers.map {
                     $0.fieldValue
                 }

--- a/Stitch/Graph/GraphStep/GraphStepIncrementer.swift
+++ b/Stitch/Graph/GraphStep/GraphStepIncrementer.swift
@@ -104,7 +104,7 @@ extension Array where Element: NodeRowViewModel {
     @MainActor
     func allFieldObserverValues() -> FieldValues {
         self.flatMap {
-            $0.cachedFieldValueTypes.flatMap {
+            $0.cachedFieldValueGroups.flatMap {
                 $0.fieldObservers.map {
                     $0.fieldValue
                 }

--- a/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
@@ -51,7 +51,7 @@ struct GenericFlyoutView: View {
     var hasIncomingEdge: Bool = false
     let layerInput: LayerInputPort
     
-    var fieldValueTypes: [FieldGroupTypeData] {
+    var fieldValueTypes: [FieldGroup] {
         layerInputObserver.fieldValueTypes
     }
         

--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -127,7 +127,7 @@ struct InspectorLayerInputView: View {
         return layerInput.showsLabelForInspector
     }
     
-    var fieldValueTypes: [FieldGroupTypeData] {
+    var fieldValueTypes: [FieldGroup] {
         self.layerInputObserver.fieldValueTypes
     }
     
@@ -176,7 +176,7 @@ struct LayerInputFieldsView: View {
     @Bindable var node: NodeViewModel
     @Bindable var rowObserver: InputNodeRowObserver
     @Bindable var rowViewModel: InputNodeRowViewModel
-    let fieldValueTypes: [FieldGroupTypeData]
+    let fieldValueTypes: [FieldGroup]
     let layerInputObserver: LayerInputObserver
     let isNodeSelected: Bool
         
@@ -258,7 +258,7 @@ struct LayerInputFieldsView: View {
     }
     
     var body: some View {
-        ForEach(fieldValueTypes) { (fieldGroupViewModel: FieldGroupTypeData) in
+        ForEach(fieldValueTypes) { (fieldGroupViewModel: FieldGroup) in
             
             let multipleFieldsPerGroup = fieldGroupViewModel.fieldObservers.count > 1
             
@@ -296,7 +296,7 @@ struct LayerInputFieldsView: View {
     }
     
     @ViewBuilder
-    func fieldsView(fieldGroupViewModel: FieldGroupTypeData,
+    func fieldsView(fieldGroupViewModel: FieldGroup,
                     isMultifield: Bool) -> some View {
         ForEach(fieldGroupViewModel.fieldObservers) { fieldViewModel in
             let isBlocked = self.blockedFields.map { fieldViewModel.isBlocked($0) } ?? false
@@ -307,7 +307,7 @@ struct LayerInputFieldsView: View {
         }
     }
     
-    func isAllFieldsBlockedOut(fieldGroupViewModel: FieldGroupTypeData) -> Bool {
+    func isAllFieldsBlockedOut(fieldGroupViewModel: FieldGroup) -> Bool {
         if let blockedFields = blockedFields {
             return fieldGroupViewModel.fieldObservers.allSatisfy {
                 $0.isBlocked(blockedFields)
@@ -389,7 +389,7 @@ struct LayerInspectorOutputPortView: View {
                                  isSelectedInspectorRow: propertyRowIsSelected)
                 Spacer()
                 
-                LayerOutputFieldsView(fieldValueTypes: rowViewModel.cachedFieldValueTypes,
+                LayerOutputFieldsView(fieldValueTypes: rowViewModel.cachedFieldValueGroups,
                                       valueEntryView: valueEntryView)
             } // HStack
         }
@@ -405,11 +405,11 @@ struct LayerInspectorOutputPortView: View {
 struct LayerOutputFieldsView<ValueEntry>: View where ValueEntry: View {
     typealias ValueEntryViewBuilder = (OutputFieldViewModel, Bool) -> ValueEntry
     
-    let fieldValueTypes: [FieldGroupTypeData]
+    let fieldValueTypes: [FieldGroup]
     @ViewBuilder var valueEntryView: ValueEntryViewBuilder
 
     var body: some View {
-        ForEach(fieldValueTypes) { (fieldGroupViewModel: FieldGroupTypeData) in
+        ForEach(fieldValueTypes) { (fieldGroupViewModel: FieldGroup) in
             let isMultifield = fieldGroupViewModel.fieldObservers.count > 1
             
             if let fieldGroupLabel = fieldGroupViewModel.groupLabel {

--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -389,7 +389,7 @@ struct LayerInspectorOutputPortView: View {
                                  isSelectedInspectorRow: propertyRowIsSelected)
                 Spacer()
                 
-                LayerOutputFieldsView(fieldValueTypes: rowViewModel.fieldValueTypes,
+                LayerOutputFieldsView(fieldValueTypes: rowViewModel.cachedFieldValueTypes,
                                       valueEntryView: valueEntryView)
             } // HStack
         }

--- a/Stitch/Graph/LayerInspector/LayerMultiselect.swift
+++ b/Stitch/Graph/LayerInspector/LayerMultiselect.swift
@@ -26,7 +26,7 @@ extension NodeRowViewModel {
     }
 }
 
-extension FieldGroupTypeData {
+extension FieldGroup {
     var layerInput: LayerInputPort? {
         self.id.rowId.portType.keyPath?.layerInput
     }
@@ -119,7 +119,7 @@ extension LayerInputPort {
             observer
                 ._packedData // TODO: do not assume packed
                 .inspectorRowViewModel // Only interested in inspector view models
-                .cachedFieldValueTypes.first? // .first = ignore the shape command case
+                .cachedFieldValueGroups.first? // .first = ignore the shape command case
             
             // "Does every multi-selected layer have the same value at this input-field?"
             // (Note: NOT "Does every field in this input have same value?")

--- a/Stitch/Graph/LayerInspector/LayerMultiselect.swift
+++ b/Stitch/Graph/LayerInspector/LayerMultiselect.swift
@@ -119,7 +119,7 @@ extension LayerInputPort {
             observer
                 ._packedData // TODO: do not assume packed
                 .inspectorRowViewModel // Only interested in inspector view models
-                .fieldValueTypes.first? // .first = ignore the shape command case
+                .cachedFieldValueTypes.first? // .first = ignore the shape command case
             
             // "Does every multi-selected layer have the same value at this input-field?"
             // (Note: NOT "Does every field in this input have same value?")

--- a/Stitch/Graph/Node/Port/Model/Field/FocusedUserEditField.swift
+++ b/Stitch/Graph/Node/Port/Model/Field/FocusedUserEditField.swift
@@ -67,7 +67,7 @@ enum FocusedUserEditField: Equatable, Hashable {
         let nodeId = rowId.nodeId
         
         if let rowViewModel = graph.getInputRowViewModel(for: rowId, nodeId: nodeId),
-           let fieldObserver = rowViewModel.cachedFieldValueTypes.first?.fieldObservers[safeIndex: focusedField.fieldIndex] {
+           let fieldObserver = rowViewModel.cachedFieldValueGroups.first?.fieldObservers[safeIndex: focusedField.fieldIndex] {
             return fieldObserver.fieldValue.isNumberForArrowKeyIncrementAndDecrement
         }
         return false

--- a/Stitch/Graph/Node/Port/Model/Field/FocusedUserEditField.swift
+++ b/Stitch/Graph/Node/Port/Model/Field/FocusedUserEditField.swift
@@ -67,7 +67,7 @@ enum FocusedUserEditField: Equatable, Hashable {
         let nodeId = rowId.nodeId
         
         if let rowViewModel = graph.getInputRowViewModel(for: rowId, nodeId: nodeId),
-           let fieldObserver = rowViewModel.fieldValueTypes.first?.fieldObservers[safeIndex: focusedField.fieldIndex] {
+           let fieldObserver = rowViewModel.cachedFieldValueTypes.first?.fieldObservers[safeIndex: focusedField.fieldIndex] {
             return fieldObserver.fieldValue.isNumberForArrowKeyIncrementAndDecrement
         }
         return false

--- a/Stitch/Graph/Node/Port/Util/Field/TabKeyPressActions.swift
+++ b/Stitch/Graph/Node/Port/Util/Field/TabKeyPressActions.swift
@@ -75,8 +75,8 @@ extension Array where Element: InputNodeRowViewModel {
                 
                 // Note: PortValue.ShapeCommand is an interesting case where we have multiple field-groupings; the first field-grouping is just the dropdown, and then second is for the actual x-y fields
                 guard let fields = (input.cachedActiveValue.shapeCommand.isDefined
-                                    ?  input.fieldValueTypes[safe: 1]?.fieldObservers
-                                    : input.fieldValueTypes.first?.fieldObservers) else {
+                                    ?  input.cachedFieldValueTypes[safe: 1]?.fieldObservers
+                                    : input.cachedFieldValueTypes.first?.fieldObservers) else {
                     return []
                 }
 
@@ -455,6 +455,6 @@ extension NodeRowViewModel {
         // but this is [[field]] ?
         // is that because at one point we thought an input could have multiple rows?
         // Yeah, seems so.
-        (self.fieldValueTypes.first?.fieldObservers.count ?? 1) - 1
+        (self.cachedFieldValueTypes.first?.fieldObservers.count ?? 1) - 1
     }
 }

--- a/Stitch/Graph/Node/Port/Util/Field/TabKeyPressActions.swift
+++ b/Stitch/Graph/Node/Port/Util/Field/TabKeyPressActions.swift
@@ -75,8 +75,8 @@ extension Array where Element: InputNodeRowViewModel {
                 
                 // Note: PortValue.ShapeCommand is an interesting case where we have multiple field-groupings; the first field-grouping is just the dropdown, and then second is for the actual x-y fields
                 guard let fields = (input.cachedActiveValue.shapeCommand.isDefined
-                                    ?  input.cachedFieldValueTypes[safe: 1]?.fieldObservers
-                                    : input.cachedFieldValueTypes.first?.fieldObservers) else {
+                                    ?  input.cachedFieldValueGroups[safe: 1]?.fieldObservers
+                                    : input.cachedFieldValueGroups.first?.fieldObservers) else {
                     return []
                 }
 
@@ -455,6 +455,6 @@ extension NodeRowViewModel {
         // but this is [[field]] ?
         // is that because at one point we thought an input could have multiple rows?
         // Yeah, seems so.
-        (self.cachedFieldValueTypes.first?.fieldObservers.count ?? 1) - 1
+        (self.cachedFieldValueGroups.first?.fieldObservers.count ?? 1) - 1
     }
 }

--- a/Stitch/Graph/Node/Port/Util/Field/TabKeyPressActions.swift
+++ b/Stitch/Graph/Node/Port/Util/Field/TabKeyPressActions.swift
@@ -67,14 +67,14 @@ extension Array where Element: InputNodeRowViewModel {
                 let portId = item.offset
                 
                 // We are only interested in inputs that use text-fields
-                guard input.activeValue.inputUsesTextField(
+                guard input.cachedActiveValue.inputUsesTextField(
                         layerInputPort: input.id.layerInputPort,
                         isLayerInputInspector: isLayerInputInspector) else {
                     return []
                 }
                 
                 // Note: PortValue.ShapeCommand is an interesting case where we have multiple field-groupings; the first field-grouping is just the dropdown, and then second is for the actual x-y fields
-                guard let fields = (input.activeValue.shapeCommand.isDefined
+                guard let fields = (input.cachedActiveValue.shapeCommand.isDefined
                                     ?  input.fieldValueTypes[safe: 1]?.fieldObservers
                                     : input.fieldValueTypes.first?.fieldObservers) else {
                     return []

--- a/Stitch/Graph/Node/Port/ViewModel/FieldGroup.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/FieldGroup.swift
@@ -9,9 +9,9 @@ import Foundation
 import SwiftUI
 import StitchSchemaKit
 
-typealias FieldGroupTypeDataList = [FieldGroupTypeData]
+typealias FieldGroupList = [FieldGroup]
 
-struct FieldGroupTypeData: Identifiable {
+struct FieldGroup: Identifiable {
     let id: FieldCoordinate
     let type: FieldGroupType
     // Only used for ShapeCommand cases? e.g. `.curveTo` has "PointTo", "CurveFrom" etc. 'groups of fields'
@@ -144,7 +144,7 @@ extension NodeRowViewModel {
                             nodeIO: NodeIO,
                             unpackedPortParentFieldGroupType: FieldGroupType?,
                             unpackedPortIndex: Int?,
-                            layerInput: LayerInputPort?) -> [FieldGroupTypeData] {
+                            layerInput: LayerInputPort?) -> [FieldGroup] {
         
         let rowViewModel = self
         let fieldValuesList: [FieldValues] = value.createFieldValuesList(
@@ -483,7 +483,7 @@ extension NodeRowViewModel {
                                nodeIO: NodeIO,
                                unpackedPortParentFieldGroupType: FieldGroupType?,
                                unpackedPortIndex: Int?,
-                               layerInput: LayerInputPort?) -> [FieldGroupTypeData] {
+                               layerInput: LayerInputPort?) -> [FieldGroup] {
         self.getFieldValueTypes(
             value: initialValue,
             nodeIO: nodeIO,

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
@@ -143,7 +143,7 @@ extension LayerInputObserver {
     @MainActor
     var fieldValueTypes: [FieldGroupTypeData] {
         let allFields = self.allInputData.flatMap { (portData: InputLayerNodeRowData) in
-            portData.inspectorRowViewModel.fieldValueTypes
+            portData.inspectorRowViewModel.cachedFieldValueTypes
         }
         
         switch self.mode {
@@ -156,7 +156,7 @@ extension LayerInputObserver {
             
             // Groupings are gone in unpacked mode so we just need the fields
             let flattenedFields = allFields.flatMap { $0.fieldObservers }
-            let fieldGroupsFromPacked = self._packedData.inspectorRowViewModel.fieldValueTypes
+            let fieldGroupsFromPacked = self._packedData.inspectorRowViewModel.cachedFieldValueTypes
             
             // Create nested array for label groupings (used for 3D model)
             return groupings.enumerated().map { fieldGroupIndex, labelData in

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
@@ -122,7 +122,7 @@ extension LayerInputObserver {
     // Currently, spacing
     @MainActor
     func usesGridMultifieldArrangement() -> Bool {
-        self._packedData.inspectorRowViewModel.activeValue.getPadding.isDefined
+        self._packedData.inspectorRowViewModel.cachedActiveValue.getPadding.isDefined
     }
     
     // The overall-label for the port, e.g. "Size" (not "W" or "H") for the size property

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
@@ -141,9 +141,9 @@ extension LayerInputObserver {
     
     // Returns all fields, regardless of packed vs unpacked
     @MainActor
-    var fieldValueTypes: [FieldGroupTypeData] {
+    var fieldValueTypes: [FieldGroup] {
         let allFields = self.allInputData.flatMap { (portData: InputLayerNodeRowData) in
-            portData.inspectorRowViewModel.cachedFieldValueTypes
+            portData.inspectorRowViewModel.cachedFieldValueGroups
         }
         
         switch self.mode {
@@ -156,7 +156,7 @@ extension LayerInputObserver {
             
             // Groupings are gone in unpacked mode so we just need the fields
             let flattenedFields = allFields.flatMap { $0.fieldObservers }
-            let fieldGroupsFromPacked = self._packedData.inspectorRowViewModel.cachedFieldValueTypes
+            let fieldGroupsFromPacked = self._packedData.inspectorRowViewModel.cachedFieldValueGroups
             
             // Create nested array for label groupings (used for 3D model)
             return groupings.enumerated().map { fieldGroupIndex, labelData in

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -91,7 +91,7 @@ extension NodeRowViewModel {
         // Create new field value observers if the row type changed
         // This can happen on various input changes
         guard !nodeRowTypeChanged else {
-            self.fieldValueTypes = self.createFieldValueTypes(
+            self.cachedFieldValueTypes = self.createFieldValueTypes(
                 initialValue: newValue,
                 nodeIO: nodeIO,
                 // Node Row Type change is only when a patch node changes its node type; can't happen for layer nodes
@@ -113,12 +113,12 @@ extension NodeRowViewModel {
         let newFieldsByGroup = newValue.createFieldValuesList(nodeIO: nodeIO, rowViewModel: self)
         
         // Assert equal array counts
-        guard newFieldsByGroup.count == self.fieldValueTypes.count else {
+        guard newFieldsByGroup.count == self.cachedFieldValueTypes.count else {
             log("NodeRowObserver error: incorrect counts of groups.")
             return
         }
         
-        zip(self.fieldValueTypes, newFieldsByGroup).forEach { fieldObserverGroup, newFields in
+        zip(self.cachedFieldValueTypes, newFieldsByGroup).forEach { fieldObserverGroup, newFields in
             
             // If existing field observer group's count does not match the new fields count,
             // reset the fields on this input/output.
@@ -130,7 +130,7 @@ extension NodeRowViewModel {
             let willUpdateFieldsCount = newFields.count != fieldObserversCount // || isMediaField
             
             if willUpdateFieldsCount {
-                self.fieldValueTypes = self.createFieldValueTypes(
+                self.cachedFieldValueTypes = self.createFieldValueTypes(
                     initialValue: newValue,
                     nodeIO: nodeIO,
                     // Note: this is only for a patch node whose node-type has changed (?); does not happen with layer nodes, a layer input being packed or unpacked is irrelevant here etc.

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -91,7 +91,7 @@ extension NodeRowViewModel {
         // Create new field value observers if the row type changed
         // This can happen on various input changes
         guard !nodeRowTypeChanged else {
-            self.cachedFieldValueTypes = self.createFieldValueTypes(
+            self.cachedFieldValueGroups = self.createFieldValueTypes(
                 initialValue: newValue,
                 nodeIO: nodeIO,
                 // Node Row Type change is only when a patch node changes its node type; can't happen for layer nodes
@@ -113,12 +113,12 @@ extension NodeRowViewModel {
         let newFieldsByGroup = newValue.createFieldValuesList(nodeIO: nodeIO, rowViewModel: self)
         
         // Assert equal array counts
-        guard newFieldsByGroup.count == self.cachedFieldValueTypes.count else {
+        guard newFieldsByGroup.count == self.cachedFieldValueGroups.count else {
             log("NodeRowObserver error: incorrect counts of groups.")
             return
         }
         
-        zip(self.cachedFieldValueTypes, newFieldsByGroup).forEach { fieldObserverGroup, newFields in
+        zip(self.cachedFieldValueGroups, newFieldsByGroup).forEach { fieldObserverGroup, newFields in
             
             // If existing field observer group's count does not match the new fields count,
             // reset the fields on this input/output.
@@ -130,7 +130,7 @@ extension NodeRowViewModel {
             let willUpdateFieldsCount = newFields.count != fieldObserversCount // || isMediaField
             
             if willUpdateFieldsCount {
-                self.cachedFieldValueTypes = self.createFieldValueTypes(
+                self.cachedFieldValueGroups = self.createFieldValueTypes(
                     initialValue: newValue,
                     nodeIO: nodeIO,
                     // Note: this is only for a patch node whose node-type has changed (?); does not happen with layer nodes, a layer input being packed or unpacked is irrelevant here etc.

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
@@ -22,7 +22,7 @@ final class InputNodeRowViewModel: NodeRowViewModel {
     // MARK: cached ui-data derived from underlying row observer
     
     @MainActor var cachedActiveValue: PortValue
-    @MainActor var cachedFieldValueTypes = FieldGroupTypeDataList()
+    @MainActor var cachedFieldValueGroups = FieldGroupList()
     @MainActor var connectedCanvasItems: Set<CanvasItemId> = .init()
     
     

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
@@ -16,14 +16,26 @@ final class InputNodeRowViewModel: NodeRowViewModel {
     static let nodeIO: NodeIO = .input
     
     let id: NodeRowViewModelId
+    
     @MainActor var viewCache: NodeLayoutCache?
-    @MainActor var activeValue: PortValue // = .number(.zero)
+    
+    // MARK: cached ui-data derived from underlying row observer
+    
+    @MainActor var activeValue: PortValue
     @MainActor var fieldValueTypes = FieldGroupTypeDataList()
     @MainActor var connectedCanvasItems: Set<CanvasItemId> = .init()
+    
+    
+    // MARK: data specific to a draggable port on the canvas; not derived from underlying row observer and not applicable to row view models in the inspector
+    
     @MainActor var anchorPoint: CGPoint?
     @MainActor var portColor: PortColor = .noEdge
     @MainActor var isDragging = false
     @MainActor var portViewData: PortViewType?
+    
+    
+    // MARK: delegates, weak references to parents
+    
     @MainActor weak var nodeDelegate: NodeViewModel?
     @MainActor weak var rowDelegate: InputNodeRowObserver?
     

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
@@ -21,7 +21,7 @@ final class InputNodeRowViewModel: NodeRowViewModel {
     
     // MARK: cached ui-data derived from underlying row observer
     
-    @MainActor var activeValue: PortValue
+    @MainActor var cachedActiveValue: PortValue
     @MainActor var fieldValueTypes = FieldGroupTypeDataList()
     @MainActor var connectedCanvasItems: Set<CanvasItemId> = .init()
     
@@ -48,7 +48,7 @@ final class InputNodeRowViewModel: NodeRowViewModel {
          rowDelegate: InputNodeRowObserver?,
          canvasItemDelegate: CanvasItemViewModel?) {
         self.id = id
-        self.activeValue = initialValue
+        self.cachedActiveValue = initialValue
         self.nodeDelegate = nodeDelegate
         self.rowDelegate = rowDelegate
         self.canvasItemDelegate = canvasItemDelegate

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
@@ -22,7 +22,7 @@ final class InputNodeRowViewModel: NodeRowViewModel {
     // MARK: cached ui-data derived from underlying row observer
     
     @MainActor var cachedActiveValue: PortValue
-    @MainActor var fieldValueTypes = FieldGroupTypeDataList()
+    @MainActor var cachedFieldValueTypes = FieldGroupTypeDataList()
     @MainActor var connectedCanvasItems: Set<CanvasItemId> = .init()
     
     

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
@@ -21,7 +21,7 @@ protocol NodeRowViewModel: StitchLayoutCachable, Observable, Identifiable {
     // MARK: cached ui-data derived from underlying row observer
     
     @MainActor var cachedActiveValue: PortValue { get set }
-    @MainActor var cachedFieldValueTypes: [FieldGroupTypeData] { get set } // fields
+    @MainActor var cachedFieldValueGroups: [FieldGroup] { get set } // fields
     @MainActor var connectedCanvasItems: Set<CanvasItemId> { get set }
     
     
@@ -93,7 +93,7 @@ extension NodeRowViewModel {
         // Why must we set the delegate
         self.nodeDelegate = node
         
-        if self.cachedFieldValueTypes.isEmpty {
+        if self.cachedFieldValueGroups.isEmpty {
             self.initializeValues(
                 unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
                 unpackedPortIndex: unpackedPortIndex,
@@ -138,10 +138,10 @@ extension NodeRowViewModel {
             unpackedPortIndex: unpackedPortIndex,
             layerInput: rowObserverLayerInput)
         
-        let didFieldsChange = !zip(self.cachedFieldValueTypes, fields).allSatisfy { $0.id == $1.id }
+        let didFieldsChange = !zip(self.cachedFieldValueGroups, fields).allSatisfy { $0.id == $1.id }
         
-        if self.cachedFieldValueTypes.isEmpty || didFieldsChange {
-            self.cachedFieldValueTypes = fields
+        if self.cachedFieldValueGroups.isEmpty || didFieldsChange {
+            self.cachedFieldValueGroups = fields
         }
     }
     

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
@@ -21,7 +21,7 @@ protocol NodeRowViewModel: StitchLayoutCachable, Observable, Identifiable {
     // MARK: cached ui-data derived from underlying row observer
     
     @MainActor var cachedActiveValue: PortValue { get set }
-    @MainActor var fieldValueTypes: [FieldGroupTypeData] { get set } // fields
+    @MainActor var cachedFieldValueTypes: [FieldGroupTypeData] { get set } // fields
     @MainActor var connectedCanvasItems: Set<CanvasItemId> { get set }
     
     
@@ -93,7 +93,7 @@ extension NodeRowViewModel {
         // Why must we set the delegate
         self.nodeDelegate = node
         
-        if self.fieldValueTypes.isEmpty {
+        if self.cachedFieldValueTypes.isEmpty {
             self.initializeValues(
                 unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
                 unpackedPortIndex: unpackedPortIndex,
@@ -138,10 +138,10 @@ extension NodeRowViewModel {
             unpackedPortIndex: unpackedPortIndex,
             layerInput: rowObserverLayerInput)
         
-        let didFieldsChange = !zip(self.fieldValueTypes, fields).allSatisfy { $0.id == $1.id }
+        let didFieldsChange = !zip(self.cachedFieldValueTypes, fields).allSatisfy { $0.id == $1.id }
         
-        if self.fieldValueTypes.isEmpty || didFieldsChange {
-            self.fieldValueTypes = fields
+        if self.cachedFieldValueTypes.isEmpty || didFieldsChange {
+            self.cachedFieldValueTypes = fields
         }
     }
     

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
@@ -16,42 +16,36 @@ protocol NodeRowViewModel: StitchLayoutCachable, Observable, Identifiable {
     
     var id: NodeRowViewModelId { get }
     
-    // View-specific value that only updates when visible
-    // separate propety for perf reasons:
-    @MainActor var activeValue: PortValue { get set }
-    
-    // Holds view models for fields
-    @MainActor var fieldValueTypes: [FieldGroupTypeData] { get set }
-    
-    @MainActor var connectedCanvasItems: Set<CanvasItemId> { get set }
-    
-    @MainActor var anchorPoint: CGPoint? { get set }
-    
-    @MainActor var portColor: PortColor { get set }
-    
-    @MainActor var portViewData: PortViewType? { get set }
-    
-    @MainActor var isDragging: Bool { get set }
-    
-    @MainActor var nodeDelegate: NodeViewModel? { get set }
-    
-    @MainActor var rowDelegate: RowObserver? { get set }
-    
-    @MainActor var canvasItemDelegate: CanvasItemViewModel? { get set }
-    
     static var nodeIO: NodeIO { get }
     
-    @MainActor func portDragged(gesture: DragGesture.Value, graphState: GraphState)
+    // MARK: cached ui-data derived from underlying row observer
     
+    @MainActor var activeValue: PortValue { get set }
+    @MainActor var fieldValueTypes: [FieldGroupTypeData] { get set } // fields
+    @MainActor var connectedCanvasItems: Set<CanvasItemId> { get set }
+    
+    
+    // MARK: data specific to a draggable port on the canvas; not derived from underlying row observer and not applicable to row view models in the inspector
+    
+    @MainActor var anchorPoint: CGPoint? { get set }
+    @MainActor var portColor: PortColor { get set }
+    @MainActor var portViewData: PortViewType? { get set }
+    @MainActor var isDragging: Bool { get set }
+    @MainActor func portDragged(gesture: DragGesture.Value, graphState: GraphState)
     @MainActor func portDragEnded(graphState: GraphState)
-        
     @MainActor func findConnectedCanvasItems(rowObserver: Self.RowObserver) -> CanvasItemIdSet
-        
     @MainActor func calculatePortColor(hasEdge: Bool,
                                        hasLoop: Bool,
                                        selectedEdges: Set<PortEdgeUI>,
                                        // output only
                                        drawingObserver: EdgeDrawingObserver) -> PortColor
+
+    
+    // MARK: delegates, weak references to parents
+    
+    @MainActor var nodeDelegate: NodeViewModel? { get set }
+    @MainActor var rowDelegate: RowObserver? { get set }
+    @MainActor var canvasItemDelegate: CanvasItemViewModel? { get set }
     
     @MainActor
     init(id: NodeRowViewModelId,

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
@@ -54,40 +54,35 @@ protocol NodeRowViewModel: StitchLayoutCachable, Observable, Identifiable {
          canvasItemDelegate: CanvasItemViewModel?)
 }
 
-extension NodeRowViewModel {
-    @MainActor
-    func updateAnchorPoint() {
-        guard let canvas = self.canvasItemDelegate,
-              let node = canvas.nodeDelegate,
-              let size = canvas.sizeByLocalBounds else {
-            return
-        }
-        
-        let ioAdjustment: CGFloat = 10
-        let standardHeightAdjustment: CGFloat = 69
-        let ioConstraint: CGFloat = Self.nodeIO == .input ? ioAdjustment : -ioAdjustment
-        let titleHeightOffset: CGFloat = node.hasLargeCanvasTitleSpace ? 23 : 0
-        
-        // Offsets needed because node position uses its center location
-        let offsetX: CGFloat = canvas.position.x + ioConstraint - size.width / 2
-        let offsetY: CGFloat = canvas.position.y - size.height / 2 + standardHeightAdjustment + titleHeightOffset
-        
-        let anchorY = offsetY + CGFloat(self.id.portId) * 28
-        
-        switch Self.nodeIO {
-        case .input:
-            let newAnchorPoint = CGPoint(x: offsetX, y: anchorY)
-            if self.anchorPoint != newAnchorPoint {
-                self.anchorPoint = newAnchorPoint
-            }
-        case .output:
-            let newAnchorPoint = CGPoint(x: offsetX + size.width, y: anchorY)
-            if self.anchorPoint != newAnchorPoint {
-                self.anchorPoint = newAnchorPoint
-            }
-        }
+
+@MainActor
+func getNewAnchorPoint(canvasPosition: CGPoint,
+                       canvasSize: CGSize,
+                       hasLargeCanvasTitle: Bool,
+                       nodeIO: NodeIO,
+                       portId: Int) -> CGPoint {
+    
+    let ioAdjustment: CGFloat = 10
+    let standardHeightAdjustment: CGFloat = 69
+    let ioConstraint: CGFloat = nodeIO == .input ? ioAdjustment : -ioAdjustment
+    let titleHeightOffset: CGFloat = hasLargeCanvasTitle ? 23 : 0
+    
+    // Offsets needed because node position uses its center location
+    let offsetX: CGFloat = canvasPosition.x + ioConstraint - canvasSize.width / 2
+    let offsetY: CGFloat = canvasPosition.y - canvasSize.height / 2 + standardHeightAdjustment + titleHeightOffset
+    
+    let anchorY = offsetY + CGFloat(portId) * 28
+    
+    switch nodeIO {
+    case .input:
+        return CGPoint(x: offsetX, y: anchorY)
+    case .output:
+        return CGPoint(x: offsetX + canvasSize.width, y: anchorY)
     }
-     
+}
+
+extension NodeRowViewModel {
+
     @MainActor
     func initializeDelegate(_ node: NodeViewModel,
                             initialValue: PortValue,

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
@@ -20,7 +20,7 @@ protocol NodeRowViewModel: StitchLayoutCachable, Observable, Identifiable {
     
     // MARK: cached ui-data derived from underlying row observer
     
-    @MainActor var activeValue: PortValue { get set }
+    @MainActor var cachedActiveValue: PortValue { get set }
     @MainActor var fieldValueTypes: [FieldGroupTypeData] { get set } // fields
     @MainActor var connectedCanvasItems: Set<CanvasItemId> { get set }
     
@@ -127,8 +127,8 @@ extension NodeRowViewModel {
                           unpackedPortIndex: Int?,
                           initialValue: PortValue,
                           rowObserverLayerInput: LayerInputPort?) {
-        if initialValue != self.activeValue {
-            self.activeValue = initialValue
+        if initialValue != self.cachedActiveValue {
+            self.cachedActiveValue = initialValue
         }
         
         let fields = self.createFieldValueTypes(
@@ -152,7 +152,7 @@ extension NodeRowViewModel {
                 
         let isLayerFocusedInPropertySidebar = layerFocusedInPropertyInspector == self.id.nodeId
         
-        let oldViewValue = self.activeValue // the old cached value
+        let oldViewValue = self.cachedActiveValue // the old cached value
         let newViewValue = PortValue.getActiveValue(allLoopedValues: values,
                                                     activeIndex: activeIndex)
         let didViewValueChange = oldViewValue != newViewValue
@@ -166,7 +166,7 @@ extension NodeRowViewModel {
         let shouldUpdate = didViewValueChange || isLayerFocusedInPropertySidebar
 
         if shouldUpdate {
-            self.activeValue = newViewValue
+            self.cachedActiveValue = newViewValue
 
             self.activeValueChanged(oldValue: oldViewValue,
                                     newValue: newViewValue)

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputNodeRowViewModel.swift
@@ -10,19 +10,32 @@ import Foundation
 
 @Observable
 final class OutputNodeRowViewModel: NodeRowViewModel {
-    
     typealias PortViewType = OutputPortViewData
-    static let nodeIO: NodeIO = .output
     
+    static let nodeIO: NodeIO = .output
+
     let id: NodeRowViewModelId
+    
     @MainActor var viewCache: NodeLayoutCache?
+    
+    
+    // MARK: cached ui-data derived from underlying row observer
+    
     @MainActor var activeValue: PortValue
     @MainActor var fieldValueTypes = FieldGroupTypeDataList()
     @MainActor var connectedCanvasItems: Set<CanvasItemId> = .init()
+    
+    
+    // MARK: data specific to a draggable port on the canvas; not derived from underlying row observer and not applicable to row view models in the inspector
+    
     @MainActor var anchorPoint: CGPoint?
     @MainActor var portColor: PortColor = .noEdge
     @MainActor var isDragging = false
     @MainActor var portViewData: PortViewType?
+    
+    
+    // MARK: delegates, weak references to parents
+    
     @MainActor weak var nodeDelegate: NodeViewModel?
     @MainActor weak var rowDelegate: OutputNodeRowObserver?
     @MainActor weak var canvasItemDelegate: CanvasItemViewModel?

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputNodeRowViewModel.swift
@@ -22,7 +22,7 @@ final class OutputNodeRowViewModel: NodeRowViewModel {
     // MARK: cached ui-data derived from underlying row observer
     
     @MainActor var cachedActiveValue: PortValue
-    @MainActor var fieldValueTypes = FieldGroupTypeDataList()
+    @MainActor var cachedFieldValueTypes = FieldGroupTypeDataList()
     @MainActor var connectedCanvasItems: Set<CanvasItemId> = .init()
     
     

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputNodeRowViewModel.swift
@@ -22,7 +22,7 @@ final class OutputNodeRowViewModel: NodeRowViewModel {
     // MARK: cached ui-data derived from underlying row observer
     
     @MainActor var cachedActiveValue: PortValue
-    @MainActor var cachedFieldValueTypes = FieldGroupTypeDataList()
+    @MainActor var cachedFieldValueGroups = FieldGroupList()
     @MainActor var connectedCanvasItems: Set<CanvasItemId> = .init()
     
     

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputNodeRowViewModel.swift
@@ -21,7 +21,7 @@ final class OutputNodeRowViewModel: NodeRowViewModel {
     
     // MARK: cached ui-data derived from underlying row observer
     
-    @MainActor var activeValue: PortValue
+    @MainActor var cachedActiveValue: PortValue
     @MainActor var fieldValueTypes = FieldGroupTypeDataList()
     @MainActor var connectedCanvasItems: Set<CanvasItemId> = .init()
     
@@ -45,7 +45,7 @@ final class OutputNodeRowViewModel: NodeRowViewModel {
          rowDelegate: OutputNodeRowObserver?,
          canvasItemDelegate: CanvasItemViewModel?) {
         self.id = id
-        self.activeValue = initialValue
+        self.cachedActiveValue = initialValue
         self.nodeDelegate = nodeDelegate
         self.rowDelegate = rowDelegate
         self.canvasItemDelegate = canvasItemDelegate

--- a/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
+++ b/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
@@ -62,7 +62,7 @@ extension CanvasItemViewModel {
         // log("updateCanvasItemOnDragged self.position is now: \(self.position)")
         
         // updates port locations for edges
-        self.updatePortLocations()
+        self.updateAnchorPoints()
     }
 
     // fka `updateNodeOnGraphDragged`
@@ -252,7 +252,7 @@ extension StitchDocumentViewModel {
             log("handleNodeMoveEnded: canvasItem id \(canvasItem.id) is now at position \(canvasItem.position)")
             
             // Refresh ports
-            canvasItem.updatePortLocations()
+            canvasItem.updateAnchorPoints()
             
 //            let diff = canvasItem.position - positionAtStart
 //            self.maybeCreateLLMMoveNode(canvasItem: canvasItem,

--- a/Stitch/Graph/Node/View/CanvasLayerInputView.swift
+++ b/Stitch/Graph/Node/View/CanvasLayerInputView.swift
@@ -45,7 +45,7 @@ struct CanvasLayerInputView: View {
                                  node: node,
                                  rowObserver: inputRowObserver,
                                  rowViewModel: inputRowViewModel,
-                                 fieldValueTypes: inputRowViewModel.cachedFieldValueTypes,
+                                 fieldValueTypes: inputRowViewModel.cachedFieldValueGroups,
                                  layerInputObserver: layerInputObserver,
                                  isNodeSelected: isNodeSelected)
         }

--- a/Stitch/Graph/Node/View/CanvasLayerInputView.swift
+++ b/Stitch/Graph/Node/View/CanvasLayerInputView.swift
@@ -45,7 +45,7 @@ struct CanvasLayerInputView: View {
                                  node: node,
                                  rowObserver: inputRowObserver,
                                  rowViewModel: inputRowViewModel,
-                                 fieldValueTypes: inputRowViewModel.fieldValueTypes,
+                                 fieldValueTypes: inputRowViewModel.cachedFieldValueTypes,
                                  layerInputObserver: layerInputObserver,
                                  isNodeSelected: isNodeSelected)
         }

--- a/Stitch/Graph/Node/View/NodeView.swift
+++ b/Stitch/Graph/Node/View/NodeView.swift
@@ -120,7 +120,7 @@ struct NodeView: View {
         }
         .onChange(of: self.node.sizeByLocalBounds) {
             // also a useful hack for updating node layout after type changes
-            self.node.updatePortLocations()
+            self.node.updateAnchorPoints()
         }
         .overlay {
             let isLayerInvisible = !(stitch.layerNode?.hasSidebarVisibility ?? true)

--- a/Stitch/Graph/Node/View/NodeViewType.swift
+++ b/Stitch/Graph/Node/View/NodeViewType.swift
@@ -95,7 +95,7 @@ struct DefaultNodeInputsView: View {
                        nodeIO: .input) { rowViewModel in
             if let rowObserver = node.getInputRowObserverForUI(for: rowViewModel.id.portType, graph) {
                 
-                let isMultiField = (rowViewModel.fieldValueTypes.first?.fieldObservers.count ?? 0) > 1
+                let isMultiField = (rowViewModel.cachedFieldValueTypes.first?.fieldObservers.count ?? 0) > 1
                 
                 HStack(alignment: .center) {
                     NodeRowPortView(graph: graph,
@@ -112,7 +112,7 @@ struct DefaultNodeInputsView: View {
                                          fontColor: STITCH_FONT_GRAY_COLOR,
                                          isSelectedInspectorRow: false)
                         
-                        ForEach(rowViewModel.fieldValueTypes) { fieldGroupViewModel in
+                        ForEach(rowViewModel.cachedFieldValueTypes) { fieldGroupViewModel in
                             ForEach(fieldGroupViewModel.fieldObservers) { fieldViewModel in
                                 self.valueEntryView(rowObserver: rowObserver,
                                                     rowViewModel: rowViewModel,
@@ -173,11 +173,11 @@ struct DefaultNodeOutputsView: View {
                        nodeIO: .output) { rowViewModel in
             if let portId = rowViewModel.id.portType.portId,
                let rowObserver = node.getOutputRowObserverForUI(for: portId, graph) {
-                let isMultiField = (rowViewModel.fieldValueTypes.first?.fieldObservers.count ?? 0) > 1
+                let isMultiField = (rowViewModel.cachedFieldValueTypes.first?.fieldObservers.count ?? 0) > 1
                 
                 HStack {
                     if showOutputFields {
-                        ForEach(rowViewModel.fieldValueTypes) { fieldGroupViewModel in
+                        ForEach(rowViewModel.cachedFieldValueTypes) { fieldGroupViewModel in
                             ForEach(fieldGroupViewModel.fieldObservers) { fieldViewModel in
                                 OutputValueEntry(graph: graph,
                                                  document: document,
@@ -279,7 +279,7 @@ struct DefaultNodeRowsView<RowViewModel, RowView>: View where RowViewModel: Node
                     self.rowView(rowViewModel)
                     // fixes issue where ports could have inconsistent height with no label
                         .modifier(CanvasPortHeightModifier())
-                        .onChange(of: rowViewModel.fieldValueTypes.first?.type) {
+                        .onChange(of: rowViewModel.cachedFieldValueTypes.first?.type) {
                             // Resets node sizing data when either node or portvalue types change
                             canvas.resetViewSizingCache()
                             

--- a/Stitch/Graph/Node/View/NodeViewType.swift
+++ b/Stitch/Graph/Node/View/NodeViewType.swift
@@ -95,7 +95,7 @@ struct DefaultNodeInputsView: View {
                        nodeIO: .input) { rowViewModel in
             if let rowObserver = node.getInputRowObserverForUI(for: rowViewModel.id.portType, graph) {
                 
-                let isMultiField = (rowViewModel.cachedFieldValueTypes.first?.fieldObservers.count ?? 0) > 1
+                let isMultiField = (rowViewModel.cachedFieldValueGroups.first?.fieldObservers.count ?? 0) > 1
                 
                 HStack(alignment: .center) {
                     NodeRowPortView(graph: graph,
@@ -112,7 +112,7 @@ struct DefaultNodeInputsView: View {
                                          fontColor: STITCH_FONT_GRAY_COLOR,
                                          isSelectedInspectorRow: false)
                         
-                        ForEach(rowViewModel.cachedFieldValueTypes) { fieldGroupViewModel in
+                        ForEach(rowViewModel.cachedFieldValueGroups) { fieldGroupViewModel in
                             ForEach(fieldGroupViewModel.fieldObservers) { fieldViewModel in
                                 self.valueEntryView(rowObserver: rowObserver,
                                                     rowViewModel: rowViewModel,
@@ -173,11 +173,11 @@ struct DefaultNodeOutputsView: View {
                        nodeIO: .output) { rowViewModel in
             if let portId = rowViewModel.id.portType.portId,
                let rowObserver = node.getOutputRowObserverForUI(for: portId, graph) {
-                let isMultiField = (rowViewModel.cachedFieldValueTypes.first?.fieldObservers.count ?? 0) > 1
+                let isMultiField = (rowViewModel.cachedFieldValueGroups.first?.fieldObservers.count ?? 0) > 1
                 
                 HStack {
                     if showOutputFields {
-                        ForEach(rowViewModel.cachedFieldValueTypes) { fieldGroupViewModel in
+                        ForEach(rowViewModel.cachedFieldValueGroups) { fieldGroupViewModel in
                             ForEach(fieldGroupViewModel.fieldObservers) { fieldViewModel in
                                 OutputValueEntry(graph: graph,
                                                  document: document,
@@ -279,7 +279,7 @@ struct DefaultNodeRowsView<RowViewModel, RowView>: View where RowViewModel: Node
                     self.rowView(rowViewModel)
                     // fixes issue where ports could have inconsistent height with no label
                         .modifier(CanvasPortHeightModifier())
-                        .onChange(of: rowViewModel.cachedFieldValueTypes.first?.type) {
+                        .onChange(of: rowViewModel.cachedFieldValueGroups.first?.type) {
                             // Resets node sizing data when either node or portvalue types change
                             canvas.resetViewSizingCache()
                             

--- a/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
@@ -52,7 +52,7 @@ extension LayerNodeViewModel {
         let port = self[keyPath: key.layerNodeKeyPath]
         
         return port.allInputData.flatMap { inputData in
-            inputData.inspectorRowViewModel.fieldValueTypes.flatMap {
+            inputData.inspectorRowViewModel.cachedFieldValueTypes.flatMap {
                 $0.fieldObservers
             }
         }

--- a/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/PreviewGridData.swift
@@ -52,7 +52,7 @@ extension LayerNodeViewModel {
         let port = self[keyPath: key.layerNodeKeyPath]
         
         return port.allInputData.flatMap { inputData in
-            inputData.inspectorRowViewModel.cachedFieldValueTypes.flatMap {
+            inputData.inspectorRowViewModel.cachedFieldValueGroups.flatMap {
                 $0.fieldObservers
             }
         }

--- a/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
+++ b/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
@@ -379,7 +379,7 @@ extension VisibleNodesViewModel {
         // Fixes issues where new rows don't have port locations
         for node in self.nodes.values {
             // NOTE: what about layer canvas inputs' ?
-            node.patchCanvasItem?.updatePortLocations()
+            node.patchCanvasItem?.updateAnchorPoints()
         }
     }
 }


### PR DESCRIPTION
I had thought row view model was only for caching data derived from the row observer, but it actually contains its own non-row-observer data like `anchorPoint`.

This PR:
- adds some comments about roles of various properties on row view model. 
- better name for field ui groupings. 
- moves `updateAnchorPoints` to canvas item view model since only a canvas item's row view models can have anchor points 

