### PR TITLE
Fix TrimText crash and inaccuracy; leverage native Swift prefix method

### DIFF
--- a/Stitch/App/Util/TypeExtension/StringUtils.swift
+++ b/Stitch/App/Util/TypeExtension/StringUtils.swift
@@ -11,25 +11,9 @@ import StitchSchemaKit
 
 // https://stackoverflow.com/a/39677704/7170123
 extension String {
-
-    func index(from: Int) -> Index {
-        return self.index(startIndex, offsetBy: from)
-    }
-
     func substring(from: Int) -> String {
-        let fromIndex = index(from: from)
+        let fromIndex = self.index(self.startIndex, offsetBy: from)
         return String(self[fromIndex...])
-    }
-
-    func substring(to: Int) -> String {
-        let toIndex = index(from: to)
-        return String(self[..<toIndex])
-    }
-
-    func substring(with r: Range<Int>) -> String {
-        let startIndex = index(from: r.lowerBound)
-        let endIndex = index(from: r.upperBound)
-        return String(self[startIndex..<endIndex])
     }
 }
 

--- a/Stitch/Graph/Node/Patch/Type/Text/TextTrimNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Text/TextTrimNode.swift
@@ -41,37 +41,22 @@ func trimTextEval(inputs: PortValuesList,
 
     let op: Operation = { (values: PortValues) -> PortValue in
         let text: String = values[safe: 0]?.getString?.string ?? .empty
-        let position: Int = Int(values[safe: 1]?.getNumber ?? .zero)
+        var position: Int = Int(values[safe: 1]?.getNumber ?? .zero)
         let length: Int = Int(values[safe: 2]?.getNumber ?? .zero)
-
+        
         if position > (text.count - 1) {
-            // log("trimTextEval: position too far")
             return .string(.init(""))
-        } else if length > text.count {
-            // log("trimTextEval: length too large for text")
-            return .string(.init(text))
         } else {
-
-            // if length is too far for the position-started string,
-            // then return
-            let newSub = text.substring(from: position)
-
-            if length > newSub.count {
-                // log("trimTextEval: length too large for substring")
-                let s = newSub[newSub.startIndex...newSub.endIndex]
-                // log("trimTextEval: length too large for substring: s: \(s)")
-                return .string(.init(String(s)))
+            // Treat negative position as 0th index
+            if position < 0 {
+                position = 0
             }
-
-            // the part of the string starting at position, to the end
-            let endPosition = position + length
-            let sub = text.substring(
-                with: position..<endPosition)
-
-            // log("trimTextEval: position: \(position)")
-            // log("trimTextEval: endPosition: \(endPosition)")
-            // log("trimTextEval: sub: \(sub)")
-            return .string(.init(sub))
+            
+            let newSub = text
+                .substring(from: position)
+                .prefix(length)
+            
+            return .string(StitchStringValue(String(newSub)))
         }
     }
 


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7129

<img width="662" alt="Screenshot 2025-04-14 at 5 09 04 PM" src="https://github.com/user-attachments/assets/59fcfa05-d12c-4dac-a69e-76373c338d3b" />
