### PR TITLE
Fixes drag gesture reset if group orientation changes

### DIFF
--- a/Stitch/Graph/PrototypePreview/Frame/View/PreviewWindowElementUIKitGestures.swift
+++ b/Stitch/Graph/PrototypePreview/Frame/View/PreviewWindowElementUIKitGestures.swift
@@ -58,7 +58,8 @@ struct PreviewWindowElementSwiftUIGestures: ViewModifier {
                 // log("PreviewWindowElementGestures: DragGesture: id: \(interactiveLayer.id) onEnded")
                 graph.layerDragEnded(interactiveLayer: interactiveLayer,
                                      parentSize: parentSize,
-                                     childSize: sizeForAnchoringAndGestures)
+                                     childSize: sizeForAnchoringAndGestures,
+                                     document: document)
             }
     }
     

--- a/Stitch/Graph/PrototypePreview/Frame/View/PreviewWindowElementUIKitGestures.swift
+++ b/Stitch/Graph/PrototypePreview/Frame/View/PreviewWindowElementUIKitGestures.swift
@@ -56,15 +56,23 @@ struct PreviewWindowElementSwiftUIGestures: ViewModifier {
             }
             .onEnded {  _ in
                 // log("PreviewWindowElementGestures: DragGesture: id: \(interactiveLayer.id) onEnded")
-                graph.layerDragEnded(interactiveLayer: interactiveLayer,
-                                     parentSize: parentSize,
-                                     childSize: sizeForAnchoringAndGestures,
-                                     document: document)
+                self.dragEnded()
             }
+    }
+    
+    func dragEnded() {
+        graph.layerDragEnded(interactiveLayer: interactiveLayer,
+                             parentSize: parentSize,
+                             childSize: sizeForAnchoringAndGestures,
+                             document: document)
     }
     
     func body(content: Content) -> some View {
         return content
+            .onDisappear {
+                // Fixes race condition where gesture state gets stuck if triggering group orientation views, causing views to tear down befor dragEnded can be called
+                self.dragEnded()
+            }
         // SwiftUI gestures need to come AFTER UIKit gestures
             .simultaneousGesture(self.dragGesture)
         

--- a/Stitch/Graph/PrototypePreview/Layer/Util/LayerDragEndedActions.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Util/LayerDragEndedActions.swift
@@ -21,14 +21,12 @@ extension GraphState {
     @MainActor
     func layerDragEnded(interactiveLayer: InteractiveLayer,
                         parentSize: CGSize,
-                        childSize: CGSize) {
+                        childSize: CGSize,
+                        document: StitchDocumentViewModel) {
         // log("layerDragEnded: interactiveLayer.id: \(interactiveLayer.id)")
          // log("layerDragEnded CALLED")
 
-        guard let previewWindowSize = self.documentDelegate?.previewWindowSize else {
-            fatalErrorIfDebug("layerDragEnded: Must have preview window size")
-            return
-        }
+        let previewWindowSize = document.previewWindowSize
         
         var nodesToRecalculate = NodeIdSet()
         
@@ -41,7 +39,7 @@ extension GraphState {
         // Nodes to recalculate initialize with mouse nodes
         let mouseNodeIds: NodeIdSet = self.mouseNodes
 
-        self.documentDelegate?
+        document
             .updateMouseNodesPosition(mouseNodeIds: mouseNodeIds,
                                       gestureLocation: nil,
                                       velocity: nil,

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonModifierWithoutFrame.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonModifierWithoutFrame.swift
@@ -138,4 +138,3 @@ struct PreviewCommonModifierWithoutFrame: ViewModifier {
                 minimumDragDistance: minimumDragDistance))
     }
 }
-


### PR DESCRIPTION
Press interaction node could get stuck as press down if some change causes the interactive view to get recreated. In my scenario, a group orientation change when triggered by gesture changes creates this race condition.

The fix is using an `onDisappear` view modifier to trigger drag ended helpers.