### PR TITLE
Improved generic handling for looped evals

### DIFF
--- a/Stitch/Graph/Node/Eval/AnimationEvaluationHelpers.swift
+++ b/Stitch/Graph/Node/Eval/AnimationEvaluationHelpers.swift
@@ -17,7 +17,7 @@ struct ImpureEvalOpResult {
     var willRunAgain: Bool = false
 }
 
-extension ImpureEvalOpResult: NodeEvalOpResult {
+extension ImpureEvalOpResult: NodeEvalOpResultable {
     init(from values: PortValues) {
         self.outputs = values
     }

--- a/Stitch/Graph/Node/Eval/AsyncMediaImpureEvalResult.swift
+++ b/Stitch/Graph/Node/Eval/AsyncMediaImpureEvalResult.swift
@@ -17,7 +17,7 @@ enum AsyncMediaOutputs {
     case all(PortValuesList)
 }
 
-extension AsyncMediaOutputs: NodeEvalOpResult {
+extension AsyncMediaOutputs: NodeEvalOpResultable {
     static func createEvalResult(from results: [AsyncMediaOutputs],
                                  node: NodeViewModel) -> EvalResult {
         results.toImpureEvalResult()

--- a/Stitch/Graph/Node/Eval/AsyncSingletonMediaEval.swift
+++ b/Stitch/Graph/Node/Eval/AsyncSingletonMediaEval.swift
@@ -50,7 +50,7 @@ func asyncSingletonMediaEval(node: PatchNode,
         return []
     }
 
-    return node.loopedEval { values, loopIndex in
+    return node.getLoopedEvalResults { values, loopIndex in
         // Return synchronously if media object already exists
         if let singletonMedia = document[keyPath: mediaManagerKeyPath]?.loadedInstance {
             return mediaOp(values, singletonMedia, loopIndex)

--- a/Stitch/Graph/Node/Eval/LoopedEval.swift
+++ b/Stitch/Graph/Node/Eval/LoopedEval.swift
@@ -9,9 +9,9 @@ import Foundation
 import StitchSchemaKit
 
 typealias OpWithIndex<T> = (PortValues, Int) -> T
-typealias NodeEphemeralObservableOp<T, EphemeralObserver> = (PortValues, EphemeralObserver, Int) -> T where EphemeralObserver: NodeEphemeralObservable
+typealias NodeEphemeralObservableOp<OpResult, EphemeralObserver> = (PortValues, EphemeralObserver, Int) -> OpResult where OpResult: NodeEvalOpResultable, EphemeralObserver: NodeEphemeralObservable
 
-typealias NodeEphemeralObservableListOp<OpResult, EphemeralObserver> = (PortValuesList, EphemeralObserver) -> OpResult where OpResult: NodeEvalOpResult, EphemeralObserver: NodeEphemeralObservable
+typealias NodeEphemeralObservableListOp<OpResult, EphemeralObserver> = (PortValuesList, EphemeralObserver) -> OpResult where OpResult: NodeEvalOpResultable, EphemeralObserver: NodeEphemeralObservable
 
 typealias NodeEphemeralInteractiveOp<T, EphemeralObserver> = (PortValues, EphemeralObserver, InteractiveLayer, Int) -> T where EphemeralObserver: NodeEphemeralObservable
 
@@ -20,7 +20,7 @@ typealias NodeInteractiveOp<T> = (PortValues, InteractiveLayer, Int) -> T
 typealias NodeLayerViewModelInteractiveOp<T> = (LayerViewModel, InteractiveLayer, Int) -> T
 
 /// Allows for generic results while ensure there's some way to get default output values.
-protocol NodeEvalOpResult {
+protocol NodeEvalOpResultable {
     init(from values: PortValues)
     
     @MainActor
@@ -28,12 +28,45 @@ protocol NodeEvalOpResult {
                                  node: NodeViewModel) -> EvalResult
 }
 
+/// Default node eval op scenario. Can be leveraged by animation nodes to use run-again functionality.
+struct NodeEvalOpResult {
+    let values: PortValues
+    var willRunAgain = false
+}
+
+extension NodeEvalOpResult: NodeEvalOpResultable {
+    init(from values: PortValues) {
+        self.values = values
+    }
+
+    static func createEvalResult(from results: [NodeEvalOpResult],
+                                 node: NodeViewModel) -> EvalResult {
+        let _willRunAgain = results.contains { $0.willRunAgain }
+        return .init(outputsValues: results.map(\.values),
+                     runAgain: _willRunAgain)
+    }
+}
+
 extension NodeViewModel {
     /// Looped eval helper used for interaction patch nodes.
     @MainActor
-    func loopedEval<EvalOpResult: NodeEvalOpResult, EphemeralObserver>(_ ephemeralObserverType: EphemeralObserver.Type,
-                                                                       graphState: GraphState,
-                                                                       evalOp: @escaping NodeEphemeralInteractiveOp<EvalOpResult, EphemeralObserver>) -> [EvalOpResult] {
+    func loopedEval<EvalOpResult: NodeEvalOpResultable, EphemeralObserver>(_ ephemeralObserverType: EphemeralObserver.Type,
+                                                                           graphState: GraphState,
+                                                                           evalOp: @escaping NodeEphemeralInteractiveOp<EvalOpResult, EphemeralObserver>) -> EvalResult {
+        let results = self.getLoopedEvalResults(ephemeralObserverType,
+                                                graphState: graphState,
+                                                evalOp: evalOp)
+        
+        return EvalOpResult.createEvalResult(from: results,
+                                             node: self)
+    }
+    
+    /// Looped eval helper used for interaction patch nodes.
+    @MainActor
+    func getLoopedEvalResults<EvalOpResult: NodeEvalOpResultable,
+                              EphemeralObserver>(_ ephemeralObserverType: EphemeralObserver.Type,
+                                                 graphState: GraphState,
+                                                 evalOp: @escaping NodeEphemeralInteractiveOp<EvalOpResult, EphemeralObserver>) -> [EvalOpResult] {
         let inputsValues = self.inputs
         let loopCount = getLongestLoopLength(inputsValues)
 
@@ -48,7 +81,7 @@ extension NodeViewModel {
         let lengthenedPreviewLayers = adjustArrayLength(loop: layerNode.previewLayerViewModels,
                                                         length: max(loopCount, layerNode.previewLayerViewModels.count))
         
-        return self.loopedEval(ephemeralObserverType,
+        return self.getLoopedEvalResults(ephemeralObserverType,
                                minLoopCount: layerNode.previewLayerViewModels.count) { values, ephemeralObserver, loopIndex in
             guard let interactiveLayer = lengthenedPreviewLayers[safe: loopIndex]?.interactiveLayer else {
                 log("loopedEval: could not find interactive layer for loopIndex \(loopIndex) in lengthenedPreviewLayers \(lengthenedPreviewLayers)")
@@ -58,9 +91,22 @@ extension NodeViewModel {
         }
     }
     
-    // TODO: clean up this code, combine some of the logic into common functions
     @MainActor
-    func loopedEval<EvalOpResult: NodeEvalOpResult>(graphState: GraphState,
+    func loopedEval<EvalOpResult: NodeEvalOpResultable>(graphState: GraphState,
+                                                    // The layer node whose layer view models we will look at;
+                                                    // can be assigned-layer (interaction patch node) or layer itself (e.g. group layer scrolling)
+                                                    layerNodeId: NodeId,
+                                                                  evalOp: @escaping NodeLayerViewModelInteractiveOp<EvalOpResult>) -> EvalResult {
+        let results = self.getLoopedEvalResults(graphState: graphState,
+                                                layerNodeId: layerNodeId,
+                                                evalOp: evalOp)
+        
+        return EvalOpResult.createEvalResult(from: results,
+                                             node: self)
+    }
+    
+    @MainActor
+    func getLoopedEvalResults<EvalOpResult: NodeEvalOpResultable>(graphState: GraphState,
                                                     // The layer node whose layer view models we will look at;
                                                     // can be assigned-layer (interaction patch node) or layer itself (e.g. group layer scrolling)
                                                     layerNodeId: NodeId,
@@ -77,7 +123,7 @@ extension NodeViewModel {
         let lengthenedPreviewLayers = adjustArrayLength(loop: layerNode.previewLayerViewModels,
                                                         length: max(loopCount, layerNode.previewLayerViewModels.count))
         
-        return self.loopedEval(minLoopCount: layerNode.previewLayerViewModels.count) { values, loopIndex in
+        return self.getLoopedEvalResults(minLoopCount: layerNode.previewLayerViewModels.count) { values, loopIndex in
             guard let layerViewModel = lengthenedPreviewLayers[safe: loopIndex] else {
                 return .init(from: self.defaultOutputs)
             }
@@ -86,10 +132,26 @@ extension NodeViewModel {
     }
     
     @MainActor
-    func loopedEval<EvalOpResult: NodeEvalOpResult, EphemeralObserver>(_ ephemeralObserverType: EphemeralObserver.Type,
-                                                                       inputsValuesList: PortValuesList? = nil,
-                                                                       minLoopCount: Int = 0,
-                                                                       evalOp: @escaping NodeEphemeralObservableOp<EvalOpResult, EphemeralObserver>) -> [EvalOpResult] {
+    func loopedEval<EvalOpResult: NodeEvalOpResultable,
+                              EphemeralObserver>(_ ephemeralObserverType: EphemeralObserver.Type,
+                                                 inputsValuesList: PortValuesList? = nil,
+                                                 minLoopCount: Int = 0,
+                                                 evalOp: @escaping NodeEphemeralObservableOp<EvalOpResult, EphemeralObserver>) -> EvalResult {
+        let results = self.getLoopedEvalResults(ephemeralObserverType,
+                                                inputsValuesList: inputsValuesList,
+                                                minLoopCount: minLoopCount,
+                                                evalOp: evalOp)
+        
+        return EvalOpResult.createEvalResult(from: results,
+                                             node: self)
+    }
+    
+    @MainActor
+    func getLoopedEvalResults<EvalOpResult: NodeEvalOpResultable,
+                              EphemeralObserver>(_ ephemeralObserverType: EphemeralObserver.Type,
+                                                 inputsValuesList: PortValuesList? = nil,
+                                                 minLoopCount: Int = 0,
+                                                 evalOp: @escaping NodeEphemeralObservableOp<EvalOpResult, EphemeralObserver>) -> [EvalOpResult] {
         let inputsValues = inputsValuesList ?? self.inputs
         let longestLoopLength = max(getLongestLoopLength(inputsValues), minLoopCount)
         
@@ -113,38 +175,66 @@ extension NodeViewModel {
         
         assertInDebug(longestLoopLength == castedEphemeralObservers.count)
         
-        return self.loopedEval(inputsValues: inputsValues,
-                               minLoopCount: minLoopCount) { values, loopIndex in
+        return self.getLoopedEvalResults(inputsValues: inputsValues,
+                                         minLoopCount: minLoopCount) { values, loopIndex in
             let ephemeralObserver = castedEphemeralObservers[loopIndex]
             return evalOp(values, ephemeralObserver, loopIndex)
         }
     }
     
+//    @MainActor
+//    /// Looped eval for PortValues returning an EvalFlowResult.
+//    func loopedEval<T: NodeEphemeralObservable>(_ ephemeralObserverType: T.Type,
+//                                                evalOp: @escaping NodeEphemeralObservableOp<PortValues, T>) -> EvalResult {
+//        self.loopedEval(T.self) { values, ephemeralObserver, loopIndex in
+//            evalOp(values, ephemeralObserver, loopIndex)
+//        }
+//        .createPureEvalResult()
+//    }
+    
     @MainActor
     /// Looped eval for PortValues returning an EvalFlowResult.
-    func loopedEval<T: NodeEphemeralObservable>(_ ephemeralObserverType: T.Type,
-                                                evalOp: @escaping NodeEphemeralObservableOp<PortValues, T>) -> EvalResult {
-        self.loopedEval(T.self) { values, ephemeralObserver, loopIndex in
-            evalOp(values, ephemeralObserver, loopIndex)
+    func loopedEval<Result: NodeEvalOpResultable>(evalOp: @escaping OpWithIndex<Result>) -> EvalResult {
+        let results = self.getLoopedEvalResults { values, loopIndex in
+            evalOp(values, loopIndex)
         }
-        .createPureEvalResult()
+        
+        return Result.createEvalResult(from: results,
+                                       node: self)
     }
     
     @MainActor
     /// Looped eval for PortValues returning an EvalFlowResult.
-    func loopedEval<T: NodeEphemeralObservable>(_ ephemeralObserverType: T.Type,
-                                                evalOp: @escaping NodeEphemeralObservableOp<MediaEvalOpResult, T>) -> EvalResult {
-        self.loopedEval(T.self) { values, ephemeralObserver, loopIndex in
+    func loopedEval<Result: NodeEvalOpResultable,
+                    Observer: NodeEphemeralObservable>(_ ephemeralObserverType: Observer.Type,
+                                                evalOp: @escaping NodeEphemeralObservableOp<Result, Observer>) -> EvalResult {
+        let results = self.getLoopedEvalResults(Observer.self) { values, ephemeralObserver, loopIndex in
             evalOp(values, ephemeralObserver, loopIndex)
         }
-        .createPureEvalResult(node: self)
+        
+        return Result.createEvalResult(from: results,
+                                       node: self)
     }
     
     @MainActor
-    func loopedEval<EvalOpResult: NodeEvalOpResult>(inputsValues: PortValuesList? = nil,
-                                                    minLoopCount: Int = 0,
-                                                    shouldAddOutputs: Bool = true,
-                                                    evalOp: @escaping OpWithIndex<EvalOpResult>) -> [EvalOpResult] {
+    func loopedEval<EvalOpResult: NodeEvalOpResultable>(inputsValues: PortValuesList? = nil,
+                                                        minLoopCount: Int = 0,
+                                                        shouldAddOutputs: Bool = true,
+                                                        evalOp: @escaping OpWithIndex<EvalOpResult>) -> EvalResult {
+        let results = self.getLoopedEvalResults(inputsValues: inputsValues,
+                                                minLoopCount: minLoopCount,
+                                                shouldAddOutputs: shouldAddOutputs,
+                                                evalOp: evalOp)
+        
+        return EvalOpResult.createEvalResult(from: results,
+                                             node: self)
+    }
+    
+    @MainActor
+    func getLoopedEvalResults<EvalOpResult: NodeEvalOpResultable>(inputsValues: PortValuesList? = nil,
+                                                                minLoopCount: Int = 0,
+                                                                shouldAddOutputs: Bool = true,
+                                                                evalOp: @escaping OpWithIndex<EvalOpResult>) -> [EvalOpResult] {
         let inputsValues = inputsValues ?? self.inputs
         let outputsValues = self.outputs
         

--- a/Stitch/Graph/Node/Eval/LoopedEval.swift
+++ b/Stitch/Graph/Node/Eval/LoopedEval.swift
@@ -181,17 +181,7 @@ extension NodeViewModel {
             return evalOp(values, ephemeralObserver, loopIndex)
         }
     }
-    
-//    @MainActor
-//    /// Looped eval for PortValues returning an EvalFlowResult.
-//    func loopedEval<T: NodeEphemeralObservable>(_ ephemeralObserverType: T.Type,
-//                                                evalOp: @escaping NodeEphemeralObservableOp<PortValues, T>) -> EvalResult {
-//        self.loopedEval(T.self) { values, ephemeralObserver, loopIndex in
-//            evalOp(values, ephemeralObserver, loopIndex)
-//        }
-//        .createPureEvalResult()
-//    }
-    
+
     @MainActor
     /// Looped eval for PortValues returning an EvalFlowResult.
     func loopedEval<Result: NodeEvalOpResultable>(evalOp: @escaping OpWithIndex<Result>) -> EvalResult {

--- a/Stitch/Graph/Node/Layer/Type/GroupLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/GroupLayerNode.swift
@@ -195,10 +195,7 @@ func nativeScrollInteractionEval(node: NodeViewModel,
             parentSize: interactiveLayer.parentSize,
             currentGraphTime: state.graphStepState.graphTime,
             currentGraphFrameCount: state.graphStepState.graphFrameCount)
-        
-    }
-    .toImpureEvalResult()
-    
+    }    
 }
 
 @MainActor

--- a/Stitch/Graph/Node/Patch/Type/Animation/ClassicAnimation.swift
+++ b/Stitch/Graph/Node/Patch/Type/Animation/ClassicAnimation.swift
@@ -169,5 +169,4 @@ func classicAnimationEval(node: PatchNode,
                 fps: fps)
         }
     }
-    .toImpureEvalResult()
 }

--- a/Stitch/Graph/Node/Patch/Type/Animation/CubicBezierAnimationNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Animation/CubicBezierAnimationNode.swift
@@ -73,7 +73,6 @@ func cubicBezierAnimationEval(node: PatchNode,
             computedState: computedState,
             fps: state.estimatedFPS)
     }
-    .toImpureEvalResult()//defaultOutputs: [[defaultNumber], [defaultNumber]])
 }
 
 /*

--- a/Stitch/Graph/Node/Patch/Type/Animation/RepeatingAnimationNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Animation/RepeatingAnimationNode.swift
@@ -64,7 +64,6 @@ func repeatingAnimationEval(node: PatchNode,
             graphFrameCount: graphStep.graphFrameCount,
             fps: graphStep.estimatedFPS)
     }//defaultOutputs: [[defaultNumber]])
-    .toImpureEvalResult()
 }
 
 func repeatingAnimationEvalOpNumber(values: PortValues,

--- a/Stitch/Graph/Node/Patch/Type/Animation/SmoothValueNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Animation/SmoothValueNode.swift
@@ -54,7 +54,6 @@ func smoothValueEval(node: PatchNode,
             nodeId: node.id,
             graphTime: state.graphTime)
     }
-    .toImpureEvalResult()//defaultOutputs: [[numberDefaultFalse]])
 }
 
 // TODO: Remove SmoothValueAnimationState

--- a/Stitch/Graph/Node/Patch/Type/Animation/spring+and+pop+animations/PopAnimationNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Animation/spring+and+pop+animations/PopAnimationNode.swift
@@ -75,5 +75,4 @@ func popAnimationEval(node: PatchNode,
             fatalError()
         }
     }
-    .toImpureEvalResult()
 }

--- a/Stitch/Graph/Node/Patch/Type/Animation/spring+and+pop+animations/SpringAnimationNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Animation/spring+and+pop+animations/SpringAnimationNode.swift
@@ -81,6 +81,4 @@ func springAnimationEval(node: PatchNode,
             fatalError()
         }
     }
-    .toImpureEvalResult()
 }
-

--- a/Stitch/Graph/Node/Patch/Type/CoreMLClassifyNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/CoreMLClassifyNode.swift
@@ -67,11 +67,11 @@ extension CoreMLClassifyNode {
 func coreMLClassifyEval(node: PatchNode) -> EvalResult {
     let defaultOutputs = node.defaultOutputs
     
-    return node.loopedEval(ImageClassifierOpObserver.self) { values, mediaObserver, loopIndex in
+    return node.loopedEval(ImageClassifierOpObserver.self) { (values, mediaObserver, loopIndex) -> MediaEvalOpResult in
         mediaObserver.mediaEvalOpCoordinator(inputPortIndex: 0,
                                              values: values,
                                              loopIndex: loopIndex,
-                                             defaultOutputs: defaultOutputs) { media in
+                                             defaultOutputs: defaultOutputs) { media -> PortValues in
             guard let image = node.getInputMedia(portIndex: 1,
                                                  loopIndex: loopIndex,
                                                  mediaId: media.id)?.image else {

--- a/Stitch/Graph/Node/Patch/Type/Data/ArrayAppendNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Data/ArrayAppendNode.swift
@@ -30,7 +30,7 @@ struct ArrayAppendNode: PatchNodeDefinition {
 @MainActor
 func arrayAppendEval(node: NodeViewModel) -> EvalResult {
 
-    node.loopedEval(shouldAddOutputs: false) { values, loopIndex in
+    node.loopedEval(shouldAddOutputs: false) { (values, loopIndex) -> PortValues in
 
         guard let jsonArray: StitchJSON = values.first?.getStitchJSON,
               let item = values[safe: 1]?.getStitchJSON else {
@@ -51,5 +51,4 @@ func arrayAppendEval(node: NodeViewModel) -> EvalResult {
             return [.json(jsonArray)]
         }
     }
-    .createPureEvalResult()
 }

--- a/Stitch/Graph/Node/Patch/Type/Data/JSONArrayNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Data/JSONArrayNode.swift
@@ -33,7 +33,6 @@ func jsonArrayEval(node: NodeViewModel) -> EvalResult {
     node.loopedEval(shouldAddOutputs: false) { values, index in
         let j = JSON.jsonArrayFromValues(values)
         // log("jsonArrayEval: j: \(j)")
-        return [.json(.init(j))]
+        return PortValues([.json(.init(j))])
     }
-    .createPureEvalResult()
 }

--- a/Stitch/Graph/Node/Patch/Type/Data/JSONObjectNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Data/JSONObjectNode.swift
@@ -42,5 +42,4 @@ func jsonObjectEval(node: NodeViewModel) -> EvalResult {
         //        log("jsonObjectEval: j: \(j)")
         return [.json(j.toStitchJSON)]
     }
-    .createPureEvalResult()
 }

--- a/Stitch/Graph/Node/Patch/Type/Data/NetworkRequestNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Data/NetworkRequestNode.swift
@@ -138,7 +138,6 @@ func networkRequestEval(node: PatchNode,
         result.values[0] = .bool(true)
         return result
     }
-    .createPureEvalResult(node: node)
 }
 
 func networkRequestOp(type: UserVisibleType,

--- a/Stitch/Graph/Node/Patch/Type/Data/SetValueForKeyNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Data/SetValueForKeyNode.swift
@@ -47,7 +47,7 @@ func setValueForKeyNode(id: NodeId,
 
 @MainActor
 func setValueForKeyEval(node: NodeViewModel) -> EvalResult {
-    node.loopedEval { values, _ in
+    node.loopedEval { (values, _) -> PortValues in
         let jsonObject = values.first?.getJSON ?? .emptyJSONObject
         let key = values[safe: 1]?.getString?.string ?? ""
         
@@ -64,5 +64,4 @@ func setValueForKeyEval(node: NodeViewModel) -> EvalResult {
         let j = jsonObject.setValueForKey(key, value)
         return [.json(j.toStitchJSON)]
     }
-    .createPureEvalResult()
 }

--- a/Stitch/Graph/Node/Patch/Type/DelayOneNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/DelayOneNode.swift
@@ -34,7 +34,8 @@ struct DelayOneNode: PatchNodeDefinition {
     static func eval(node: NodeViewModel) -> EvalResult {
         node.loopedEval(DelayOneEvalObserver.self) { values, observer, _ in
             guard let value = values.first else {
-                return .init(outputs: [DelayOneNode.defaultUserVisibleType.defaultPortValue], willRunAgain: true)
+                return NodeEvalOpResult(values: [DelayOneNode.defaultUserVisibleType.defaultPortValue],
+                             willRunAgain: true)
             }
             
             let output = observer.nextOutput
@@ -44,9 +45,9 @@ struct DelayOneNode: PatchNodeDefinition {
             
             // Mark node as needing to be calcuated for next frame if values changed
             let shouldRunOnNextFrame = output != value
-            return .init(outputs: [output], willRunAgain: shouldRunOnNextFrame)
+            return NodeEvalOpResult(values: [output],
+                                    willRunAgain: shouldRunOnNextFrame)
         }
-        .toImpureEvalResult()
     }
     
     static let description = """

--- a/Stitch/Graph/Node/Patch/Type/Interaction/DragInteractionPatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/DragInteractionPatchNode.swift
@@ -104,8 +104,8 @@ final class DragInteractionNodeState: NodeEphemeralObservable {
 func dragInteractionEval(node: PatchNode,
                          graphState: GraphState) -> ImpureEvalResult {
 
-    return node.loopedEval(DragInteractionNodeState.self,
-                           graphState: graphState) { values, dragState, interactiveLayer, loopIndex in
+    node.loopedEval(DragInteractionNodeState.self,
+                    graphState: graphState) { values, dragState, interactiveLayer, loopIndex in
         dragInteractionEvalOp(
             values: values,
             loopIndex: loopIndex,
@@ -114,7 +114,6 @@ func dragInteractionEval(node: PatchNode,
             graphTime: graphState.graphStepState.graphTime,
             fps: graphState.graphStepState.estimatedFPS)
     }
-                           .toImpureEvalResult()
 }
 
 // We should pulse whenever the time in the input and the time on the graph are the same,

--- a/Stitch/Graph/Node/Patch/Type/Interaction/Keyboard/KeyboardNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/Keyboard/KeyboardNode.swift
@@ -39,7 +39,6 @@ func keyboardEval(node: PatchNode,
         let character = values.first?.getString?.string ?? ""
         // log("keyboardEval: op: character: \(character)")
         // log("keyboardEval: op: keypressState.characters: \(keypressState.characters)")
-        return [.bool(keypressState.characters.contains(character))]
+        return PortValues([.bool(keypressState.characters.contains(character))])
     }
-    .createPureEvalResult()
 }

--- a/Stitch/Graph/Node/Patch/Type/Interaction/PressInteractionPatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/PressInteractionPatchNode.swift
@@ -115,7 +115,6 @@ func pressInteractionEval(node: NodeViewModel,
             interactiveLayer: interactiveLayer,
             graph: graph)
     }
-    .toImpureEvalResult()
 }
 
 @MainActor

--- a/Stitch/Graph/Node/Patch/Type/Interaction/Scroll/ScrollInteractionNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/Scroll/ScrollInteractionNode.swift
@@ -143,8 +143,8 @@ struct ScrollInteractionNode: PatchNodeDefinition {
 func scrollInteractionEval(node: NodeViewModel,
                            graphState: GraphState) -> ImpureEvalResult {
     
-    node.loopedEval(ScrollInteractionState.self,
-                    graphState: graphState) { values, scrollState, interactiveLayer, _ in
+    node.getLoopedEvalResults(ScrollInteractionState.self,
+                              graphState: graphState) { values, scrollState, interactiveLayer, _ in
         let directionLockingEnabled = values[safeIndex: ScrollNodeInputLocations.directionLocking]?
                    .getBool ?? false
         let xScrollMode: ScrollMode = values[safeIndex: ScrollNodeInputLocations.xScrollMode]?.getScrollMode ?? .disabled

--- a/Stitch/Graph/Node/Patch/Type/Loop/LoopBuilder.swift
+++ b/Stitch/Graph/Node/Patch/Type/Loop/LoopBuilder.swift
@@ -77,8 +77,8 @@ func loopBuilderEval(node: PatchNode,
         return valueForIndex
     }
     
-    let result = node.loopedEval(MediaEvalOpObserver.self,
-                           inputsValuesList: [flattenedInputs]) { (values, mediaObserver, index) -> MediaEvalOpResult in
+    let result = node.getLoopedEvalResults(MediaEvalOpObserver.self,
+                                           inputsValuesList: [flattenedInputs]) { (values, mediaObserver, index) -> MediaEvalOpResult in
         assertInDebug(values.first != nil)
         
         // index of our loop

--- a/Stitch/Graph/Node/Patch/Type/Loop/LoopSelectNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Loop/LoopSelectNode.swift
@@ -94,7 +94,6 @@ struct LoopSelectNode: PatchNodeDefinition {
                                           outputLoopIndex: loopIndex,
                                           node: node)
         }
-                               .createPureEvalResult(node: node)
     }
     
     @MainActor

--- a/Stitch/Graph/Node/Patch/Type/Media/Base64StringToImagePatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Media/Base64StringToImagePatchNode.swift
@@ -52,7 +52,7 @@ struct Base64StringToImageNode: PatchNodeDefinition {
 
 @MainActor
 func base64StringToImageEval(node: PatchNode) -> EvalResult {
-    node.loopedEval(MediaEvalOpObserver.self) { values, mediaObserver, loopIndex in
+    node.loopedEval(MediaEvalOpObserver.self) { values, mediaObserver, loopIndex -> MediaEvalOpResult in
         let inputBase64String: String = values.first?.getString?.string ?? ""
         let prevOutputs = values.prevOutputs(node: node)
 

--- a/Stitch/Graph/Node/Patch/Type/Media/SoundImportNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Media/SoundImportNode.swift
@@ -132,7 +132,7 @@ func soundImportEval(node: PatchNode) -> EvalResult {
     let graphTime = node.graphDelegate?.graphStepState.graphTime ?? .zero
     let defaultOutputs = node.defaultOutputs
 
-    let results: [MediaEvalOpResult] = node.loopedEval(MediaEvalOpObserver.self) { values, mediaObserver, loopIndex in
+    let results: [MediaEvalOpResult] = node.getLoopedEvalResults(MediaEvalOpObserver.self) { values, mediaObserver, loopIndex in
         
         mediaObserver.mediaEvalOpCoordinator(inputPortIndex: 0,
                                              values: values,

--- a/Stitch/Graph/Node/Patch/Type/Media/VideoImportNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Media/VideoImportNode.swift
@@ -115,15 +115,14 @@ extension VideoImportNode {
 func videoImportEval(node: PatchNode) -> EvalResult {
     let defaultOutputs = node.defaultOutputs
     
-    return node.loopedEval(MediaEvalOpObserver.self) { values, asyncObserver, loopIndex in
+    return node.loopedEval(MediaEvalOpObserver.self) { values, asyncObserver, loopIndex -> MediaEvalOpResult in
         asyncObserver.mediaEvalOpCoordinator(inputPortIndex: 0,
                                              values: values,
                                              loopIndex: loopIndex,
-                                             defaultOutputs: defaultOutputs) { media in
+                                             defaultOutputs: defaultOutputs) { media -> PortValues in
             VideoImportNode.videoImportEvalOp(media: media,
                                               values: values,
                                               defaultOutputs: defaultOutputs)
         }
     }
-    .createPureEvalResult(node: node)
 }

--- a/Stitch/Graph/Node/Patch/Type/Pulse/PulseNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Pulse/PulseNode.swift
@@ -45,10 +45,10 @@ struct PulseNode: PatchNodeDefinition {
 @MainActor
 func pulseNodeEval(node: PatchNode,
                    // only needs graphTime
-                   state: GraphStepState) -> ImpureEvalResult {
+                   state: GraphStepState) -> EvalResult {
     let graphTime = state.graphTime
     
-    return node.loopedEval(ComputedNodeState.self) { values, computedState, _ in
+    return node.loopedEval(ComputedNodeState.self) { values, computedState, _ -> PortValues in
         let newVal = values.first?.getBool ?? false
         let computedStates = node.computedStates
         
@@ -63,33 +63,26 @@ func pulseNodeEval(node: PatchNode,
         
         if newVal && !prevVal {
             //            log("pulseNodeClosure: false -> true")
-            return .init(outputs:
-                [
-                    .pulse(graphTime),
-                    output2
-                ]
-            )
+            return [
+                .pulse(graphTime),
+                output2
+            ]
         }
         // ie turned off: was true, is now false
         else if !newVal && prevVal {
             //            log("pulseNodeClosure: true -> false")
-            return .init(outputs:
-                [
-                    output,
-                    .pulse(graphTime)
-                ]
-            )
+            return [
+                output,
+                .pulse(graphTime)
+            ]
         }
         // no change
         else {
             //            log("pulseNodeClosure: no change")
-            return .init(outputs:
-                [
-                    output,
-                    output2
-                ]
-            )
+            return [
+                output,
+                output2
+            ]
         }
     }
-    .toImpureEvalResult()//defaultOutputs: PulseNode.defaultOutputs)
 }

--- a/Stitch/Graph/Node/Patch/Type/Pulse/PulseOnChangeNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Pulse/PulseOnChangeNode.swift
@@ -78,5 +78,4 @@ func pulseOnChangeEval(node: PatchNode,
                                computedState: computedState,
                                graphTime: state.graphTime)
     }
-    .toImpureEvalResult() //defaultOutputs: [[numberDefaultFalse]])
 }

--- a/Stitch/Graph/Node/Patch/Type/Pulse/RepeatingPulsePatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Pulse/RepeatingPulsePatchNode.swift
@@ -61,5 +61,4 @@ func repeatingPulseEval(node: PatchNode,
             return ImpureEvalOpResult(outputs: [.pulse(pulseAt)])
         }
     }
-    .toImpureEvalResult()    
 }

--- a/Stitch/Graph/Node/Patch/Type/StopwatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/StopwatchNode.swift
@@ -119,5 +119,4 @@ func stopwatchEval(node: PatchNode,
                            graphTime: graphStep.graphTime,
                            computedState: computedState)
     } // ?? [numberDefaultFalse]
-    .createPureEvalResult()
 }

--- a/Stitch/Graph/Node/Patch/Type/Value/SplitterPatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Value/SplitterPatchNode.swift
@@ -43,7 +43,7 @@ func mediaAwareIdentityEvaluation(node: PatchNode) -> EvalResult {
     
     if node.userVisibleType == .media {
         // TODO: debug why this broke the Monthly Stays demo: https://github.com/StitchDesign/Stitch--Old/issues/7049
-        return node.loopedEval { (values, loopIndex) -> MediaEvalOpResult in
+        return node.getLoopedEvalResults { (values, loopIndex) -> MediaEvalOpResult in
             // splitter must have node-type
             guard let nodeType = node.userVisibleType else {
                 fatalErrorIfDebug()

--- a/Stitch/Graph/Node/Patch/Type/VelocityNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/VelocityNode.swift
@@ -48,7 +48,6 @@ func velocityEval(node: PatchNode) -> EvalResult {
         
         // Save next previous value
         computedState.previousValue = .number(valueAtCurrentFrame)
-        return [.number(newValue)]
+        return [PortValue.number(newValue)]
     } // ?? [[numberDefaultFalse]]
-    .createPureEvalResult()
 }

--- a/Stitch/Graph/Node/Port/Util/PortValue/PortValuesUtils.swift
+++ b/Stitch/Graph/Node/Port/Util/PortValue/PortValuesUtils.swift
@@ -132,7 +132,7 @@ extension PortValuesList {
 }
 
 
-extension PortValues: NodeEvalOpResult {
+extension PortValues: NodeEvalOpResultable {
     init(from values: PortValues) {
         self = values
     }

--- a/Stitch/Graph/Node/Util/NodeMediaUtils.swift
+++ b/Stitch/Graph/Node/Util/NodeMediaUtils.swift
@@ -41,7 +41,7 @@ struct MediaEvalOpResult: MediaEvalResultable {
     var media: GraphMediaValue?
 }
 
-extension MediaEvalOpResult: NodeEvalOpResult {
+extension MediaEvalOpResult: NodeEvalOpResultable {
     var valueResult: AsyncMediaOutputs { .byIndex(self.values) }
     
     @MainActor
@@ -73,7 +73,7 @@ extension MediaEvalOpResult: NodeEvalOpResult {
 }
 
 /// Used by Core ML Detection node.
-struct MediaEvalValuesListResult: NodeEvalOpResult, MediaEvalResultable {
+struct MediaEvalValuesListResult: NodeEvalOpResultable, MediaEvalResultable {
     var valuesList: PortValuesList
     var media: GraphMediaValue?
 }


### PR DESCRIPTION
Simplifies signatures a bit and adds a new basic `NodeEvalOp` result type. Preliminary work for spring/pop node type fixes.