### PR TITLE
Remove unused `var connectedNodes` from input and output observers; renamed `PortViewData` to `PortIdAddress`

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -121,7 +121,7 @@
 		B55500C42C1B9E300081C3F1 /* FieldViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55500C32C1B9E300081C3F1 /* FieldViewModel.swift */; };
 		B55500C62C1B9F9D0081C3F1 /* FieldValueMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55500C52C1B9F9D0081C3F1 /* FieldValueMedia.swift */; };
 		B55500C82C1B9FCF0081C3F1 /* LayerDimensionField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55500C72C1B9FCF0081C3F1 /* LayerDimensionField.swift */; };
-		B55500CA2C1BA37D0081C3F1 /* PortViewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55500C92C1BA37D0081C3F1 /* PortViewData.swift */; };
+		B55500CA2C1BA37D0081C3F1 /* PortIdAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55500C92C1BA37D0081C3F1 /* PortIdAddress.swift */; };
 		B55500CC2C1BA3F60081C3F1 /* PortEdgeUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55500CB2C1BA3F60081C3F1 /* PortEdgeUI.swift */; };
 		B55500D32C1BA6810081C3F1 /* PreviewWindowSizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55500D22C1BA6810081C3F1 /* PreviewWindowSizing.swift */; };
 		B55500D92C1BA9470081C3F1 /* PreviewShapeLayerKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55500D82C1BA9470081C3F1 /* PreviewShapeLayerKind.swift */; };
@@ -1110,7 +1110,7 @@
 		B55500C32C1B9E300081C3F1 /* FieldViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldViewModel.swift; sourceTree = "<group>"; };
 		B55500C52C1B9F9D0081C3F1 /* FieldValueMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldValueMedia.swift; sourceTree = "<group>"; };
 		B55500C72C1B9FCF0081C3F1 /* LayerDimensionField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerDimensionField.swift; sourceTree = "<group>"; };
-		B55500C92C1BA37D0081C3F1 /* PortViewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortViewData.swift; sourceTree = "<group>"; };
+		B55500C92C1BA37D0081C3F1 /* PortIdAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortIdAddress.swift; sourceTree = "<group>"; };
 		B55500CB2C1BA3F60081C3F1 /* PortEdgeUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortEdgeUI.swift; sourceTree = "<group>"; };
 		B55500D22C1BA6810081C3F1 /* PreviewWindowSizing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewWindowSizing.swift; sourceTree = "<group>"; };
 		B55500D82C1BA9470081C3F1 /* PreviewShapeLayerKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewShapeLayerKind.swift; sourceTree = "<group>"; };
@@ -3333,7 +3333,7 @@
 				EC16587C2B6AF03F00FE4AE6 /* EdgeEditingState.swift */,
 				EC1658812B6AFDDA00FE4AE6 /* EdgeEditingModeInputLabel.swift */,
 				ECFA5D47287DEE510037CD59 /* PortColor.swift */,
-				B55500C92C1BA37D0081C3F1 /* PortViewData.swift */,
+				B55500C92C1BA37D0081C3F1 /* PortIdAddress.swift */,
 				203D56B925B0DA7C00EF7AC2 /* PortEdgeData.swift */,
 				B55500CB2C1BA3F60081C3F1 /* PortEdgeUI.swift */,
 				EC8967012B4E1D3B0066879B /* EdgeStyle.swift */,
@@ -5414,7 +5414,7 @@
 				EC9C6F9B298C45EE00E05523 /* NodeTagMenuButtonsView.swift in Sources */,
 				ECCFB3662C35E09400E94D60 /* LengthDimension.swift in Sources */,
 				ECDE943428089FCE00005401 /* NodesView.swift in Sources */,
-				B55500CA2C1BA37D0081C3F1 /* PortViewData.swift in Sources */,
+				B55500CA2C1BA37D0081C3F1 /* PortIdAddress.swift in Sources */,
 				ECC2BCEB2B9B867E00D5F942 /* SidebarListActionHelpers.swift in Sources */,
 				ECA92A58260A6C1D00281B52 /* Coordinate.swift in Sources */,
 				B5CF644A294B8B6200EF83DB /* NodeTitleTextField.swift in Sources */,

--- a/Stitch/Graph/Edge/Model/EdgeEditingState.swift
+++ b/Stitch/Graph/Edge/Model/EdgeEditingState.swift
@@ -9,7 +9,7 @@ import StitchSchemaKit
 import SwiftUI
 import NonEmpty
 
-typealias PossibleEdgeId = InputPortViewData
+typealias PossibleEdgeId = InputPortIdAddress
 
 struct PossibleEdge: Hashable {
     var edge: PortEdgeUI
@@ -23,7 +23,7 @@ struct PossibleEdge: Hashable {
 }
 
 extension PossibleEdge: Identifiable {
-    var id: InputPortViewData {
+    var id: InputPortIdAddress {
         edge.id
     }
 }
@@ -37,7 +37,7 @@ struct EdgeEditingState {
     static let defaultNearbyCanvasItemIndex = 0
     
     // currently hovered-over output
-    var originOutput: OutputPortViewData
+    var originOutput: OutputPortIdAddress
     
     // the node that is east of, and the shortest distance from, the origin node
     //    var nearbyCanvasItem: CanvasItemId
@@ -69,7 +69,7 @@ struct EdgeEditingState {
      Not the same thing as the edge's isCommitted, since e.g. de-committing an edge sets is isCommitted = false
      but we still need to show the edge until the withdrawal animation completes.
      */
-    var shownIds: Set<InputPortViewData> = .init()
+    var shownIds: Set<InputPortIdAddress> = .init()
 
     /*
      Possible edge id found in set = edge is currently animating (extending or withdrawing).

--- a/Stitch/Graph/Edge/Model/PortEdgeUI.swift
+++ b/Stitch/Graph/Edge/Model/PortEdgeUI.swift
@@ -11,13 +11,13 @@ typealias VisibleEdges = [PortEdgeUI]
 
 // Better: `GraphEdge`
 struct PortEdgeUI: Equatable, Hashable {
-    let from: OutputPortViewData // ie nodeId, portId
-    let to: InputPortViewData
+    let from: OutputPortIdAddress // ie nodeId, portId
+    let to: InputPortIdAddress
 }
 
 extension PortEdgeUI: Identifiable {
     // Inputs can only have one edge so we use that as our identifiable
-    var id: InputPortViewData {
+    var id: InputPortIdAddress {
         self.to
     }
     

--- a/Stitch/Graph/Edge/Model/PortIdAddress.swift
+++ b/Stitch/Graph/Edge/Model/PortIdAddress.swift
@@ -8,22 +8,22 @@
 import Foundation
 import StitchSchemaKit
 
-// TODO: rename to `PortIdAddress`, since this is really a port-id-based way of representing an input's or output's address
-protocol PortViewData: Hashable {
+// fka `PortViewData`
+/// A port-id-based way of representing an input's or output's address
+protocol PortIdAddress: Hashable {
     var portId: Int { get set }
     var canvasId: CanvasItemId { get set }
     
     init(portId: Int, canvasId: CanvasItemId)
 }
 
-// TODO: rename to `InputPortIdAddress`
-struct InputPortViewData: PortViewData {
+struct InputPortIdAddress: PortIdAddress {
     var portId: Int
     var canvasId: CanvasItemId
 }
 
 // TODO: rename to `OutputPortIdAddress`
-struct OutputPortViewData: PortViewData {
+struct OutputPortIdAddress: PortIdAddress {
     var portId: Int
     var canvasId: CanvasItemId
 }

--- a/Stitch/Graph/Edge/Util/EdgeEditingActions.swift
+++ b/Stitch/Graph/Edge/Util/EdgeEditingActions.swift
@@ -19,7 +19,7 @@ struct OutputHoveredLongEnough: GraphEvent {
 extension GraphState {
 
     @MainActor
-    func outputHovered(outputCoordinate: OutputPortViewData,
+    func outputHovered(outputCoordinate: OutputPortIdAddress,
                        groupNodeFocused: NodeId?) {
         // log("outputHovered fired")
         
@@ -82,7 +82,7 @@ extension GraphState {
     
     @MainActor
     func getShownAndPossibleEdges(nearbyNode: CanvasItemViewModel,
-                                  outputCoordinate: OutputPortViewData,
+                                  outputCoordinate: OutputPortIdAddress,
                                   groupNodeFocused: NodeId?) -> (shownEdges: Set<PossibleEdgeId>,
                                             possibleEdges: PossibleEdgeSet) {
         var alreadyShownEdges = Set<PossibleEdgeId>()
@@ -138,12 +138,12 @@ extension CanvasItemViewModel {
     // or the input-splitter coords for a group node.
     @MainActor
     func edgeFriendlyInputCoordinates(from nodes: VisibleNodesViewModel,
-                                      focusedGroupId: NodeId?) -> [InputPortViewData] {
+                                      focusedGroupId: NodeId?) -> [InputPortIdAddress] {
         
         // this looks at ALL nodes' inputs -- need to look only at
         
         nodes.getCanvasItemsAtTraversalLevel(at: focusedGroupId)
-            .flatMap { canvasItem -> [InputPortViewData] in
+            .flatMap { canvasItem -> [InputPortIdAddress] in
                 
                 guard let nodeId = self.nodeDelegate?.id,
                       let canvasItemNodeId = canvasItem.nodeDelegate?.id,
@@ -154,7 +154,7 @@ extension CanvasItemViewModel {
                 
                 let inputsCount = canvasItem.inputViewModels.count
                 return (0..<inputsCount).map {
-                    InputPortViewData(portId: $0, canvasId: canvasItem.id)
+                    InputPortIdAddress(portId: $0, canvasId: canvasItem.id)
                 }
             }
     }
@@ -323,7 +323,7 @@ extension StitchDocumentViewModel {
         let labelAsPortId = labelPresssed.toPortId // i.e. port index
         // log("keyCharPressedDuringEdgeEditingMode: labelAsPortId: \(labelAsPortId)")
         
-        let destinationInput = InputPortViewData(portId: labelAsPortId, canvasId: nearbyNode.id)
+        let destinationInput = InputPortIdAddress(portId: labelAsPortId, canvasId: nearbyNode.id)
         
         //    let destinationInput = nearbyNode.groupNode?.splitterInputs[safe: labelAsPortId]?.rowObserver?.id ?? .init(portId: labelAsPortId, nodeId: nearbyNode.id)
         

--- a/Stitch/Graph/Edge/Util/PortActions.swift
+++ b/Stitch/Graph/Edge/Util/PortActions.swift
@@ -87,7 +87,7 @@ extension GraphState {
     // Note: this removes ANY incoming edge to the `edge.to` input; whereas in some use-cases e.g. group node creation, we had expected only to remove the specific passed-in edge if it existed.
     // Hence the rename from `edgeRemoved` to `removesEdgeAt`
     @MainActor
-    func removeEdgeAt(input: InputPortViewData) {
+    func removeEdgeAt(input: InputPortIdAddress) {
         guard let inputCoordinate = self.getInputCoordinate(from: input) else {
             log("GraphState: removeEdgeAt: could not find input \(input.portId), \(input.canvasId)")
             return

--- a/Stitch/Graph/Edge/Util/PortDragActions.swift
+++ b/Stitch/Graph/Edge/Util/PortDragActions.swift
@@ -249,8 +249,8 @@ struct EligibleInputReset: ProjectEnvironmentEvent {
 
 extension GraphState {
     @MainActor
-    func createEdgeFromEligibleInput(from: OutputPortViewData?,
-                                     to: InputPortViewData?,
+    func createEdgeFromEligibleInput(from: OutputPortIdAddress?,
+                                     to: InputPortIdAddress?,
                                      sourceNodeId: NodeId) {
         // Create visual edge if connecting two nodes
         if let from = from,

--- a/Stitch/Graph/Edge/View/EditMode/EdgeEditModeOutputHoverView.swift
+++ b/Stitch/Graph/Edge/View/EditMode/EdgeEditModeOutputHoverView.swift
@@ -16,7 +16,7 @@ struct EdgeEditModeOutputHoverViewModifier: ViewModifier {
 
     @Bindable var graph: GraphState
     let document: StitchDocumentViewModel
-    let outputCoordinate: OutputPortViewData
+    let outputCoordinate: OutputPortIdAddress
     
     var isDraggingOutput: Bool {
         graph.edgeDrawingObserver.drawingGesture.isDefined

--- a/Stitch/Graph/Edge/View/PossibleEdgesView.swift
+++ b/Stitch/Graph/Edge/View/PossibleEdgesView.swift
@@ -97,7 +97,7 @@ extension Shape {
 // `Curve` and `Straight` edge styles are simpler than `Circuit`
 struct PossibleEdgeSimpleView: View {
     let possibleEdge: PossibleEdge
-    let shownPossibleEdgeIds: Set<InputPortViewData>
+    let shownPossibleEdgeIds: Set<InputPortIdAddress>
     let from: CGPoint
     let to: CGPoint
     let color: Color

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -47,9 +47,11 @@ protocol NodeRowObserver: AnyObject, Observable, Identifiable, Sendable, NodeRow
             
     @MainActor var nodeDelegate: NodeViewModel? { get set }
     
+    // Just for updating port color; cached
     @MainActor
     var hasLoopedValues: Bool { get set }
-        
+    
+    // Just for updating port color; derived from input's or output's connection
     @MainActor
     var hasEdge: Bool { get }
     

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverCachedViewDataExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverCachedViewDataExtensions.swift
@@ -13,7 +13,7 @@ import StitchSchemaKit
 /*
  Iterates through this row observer's row view models, updating each row view model's:
  - cache of connectedCanvasItems
- -
+ - port color
  */
 extension InputNodeRowObserver {
     

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 // UI data
 @Observable
 final class InputNodeRowViewModel: NodeRowViewModel {
-    typealias PortViewType = InputPortIdAddress
+    typealias PortAddressType = InputPortIdAddress
     
     static let nodeIO: NodeIO = .input
     
@@ -30,7 +30,7 @@ final class InputNodeRowViewModel: NodeRowViewModel {
     @MainActor var anchorPoint: CGPoint?
     @MainActor var portColor: PortColor = .noEdge
     @MainActor var isDragging = false
-    @MainActor var portViewData: PortViewType?
+    @MainActor var portViewData: PortAddressType?
     
     
     // MARK: delegates, weak references to parents
@@ -57,7 +57,9 @@ final class InputNodeRowViewModel: NodeRowViewModel {
 extension InputNodeRowViewModel {
     @MainActor
     func findConnectedCanvasItems(rowObserver: InputNodeRowObserver) -> CanvasItemIdSet {
+        // Does this input row observer has an upstream connection?
         guard let upstreamOutputObserver = rowObserver.upstreamOutputObserver,
+              // If so, find that row view model
               let upstreamNodeRowViewModel = upstreamOutputObserver.nodeRowViewModel,
               let upstreamId = upstreamNodeRowViewModel.canvasItemDelegate?.id else {
             return .init()

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
@@ -7,11 +7,10 @@
 
 import Foundation
 
-
 // UI data
 @Observable
 final class InputNodeRowViewModel: NodeRowViewModel {
-    typealias PortViewType = InputPortViewData
+    typealias PortViewType = InputPortIdAddress
     
     static let nodeIO: NodeIO = .input
     

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
@@ -9,10 +9,9 @@ import Foundation
 import SwiftUI
 import StitchSchemaKit
 
-
 protocol NodeRowViewModel: StitchLayoutCachable, Observable, Identifiable {
     associatedtype RowObserver: NodeRowObserver
-    associatedtype PortViewType: PortViewData
+    associatedtype PortViewType: PortIdAddress
     
     var id: NodeRowViewModelId { get }
     

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
@@ -11,7 +11,8 @@ import StitchSchemaKit
 
 protocol NodeRowViewModel: StitchLayoutCachable, Observable, Identifiable {
     associatedtype RowObserver: NodeRowObserver
-    associatedtype PortViewType: PortIdAddress
+    // fka `PortViewType`
+    associatedtype PortAddressType: PortIdAddress
     
     var id: NodeRowViewModelId { get }
     
@@ -28,7 +29,7 @@ protocol NodeRowViewModel: StitchLayoutCachable, Observable, Identifiable {
     
     @MainActor var anchorPoint: CGPoint? { get set }
     @MainActor var portColor: PortColor { get set }
-    @MainActor var portViewData: PortViewType? { get set }
+    @MainActor var portViewData: PortAddressType? { get set }
     @MainActor var isDragging: Bool { get set }
     @MainActor func portDragged(gesture: DragGesture.Value, graphState: GraphState)
     @MainActor func portDragEnded(graphState: GraphState)
@@ -112,7 +113,7 @@ extension NodeRowViewModel {
     
     /// Considerable perf cost from `ConnectedEdgeView`, so now a function.
     @MainActor
-    func getPortViewData() -> PortViewType? {
+    func getPortViewData() -> PortAddressType? {
         guard let canvasId = self.canvasItemDelegate?.id else {
             return nil
         }

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputNodeRowViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 
 @Observable
 final class OutputNodeRowViewModel: NodeRowViewModel {
-    typealias PortViewType = OutputPortViewData
+    typealias PortViewType = OutputPortIdAddress
     
     static let nodeIO: NodeIO = .output
 

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputNodeRowViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 
 @Observable
 final class OutputNodeRowViewModel: NodeRowViewModel {
-    typealias PortViewType = OutputPortIdAddress
+    typealias PortAddressType = OutputPortIdAddress
     
     static let nodeIO: NodeIO = .output
 
@@ -31,13 +31,20 @@ final class OutputNodeRowViewModel: NodeRowViewModel {
     @MainActor var anchorPoint: CGPoint?
     @MainActor var portColor: PortColor = .noEdge
     @MainActor var isDragging = false
-    @MainActor var portViewData: PortViewType?
+    @MainActor var portViewData: PortAddressType?
     
     
     // MARK: delegates, weak references to parents
     
     @MainActor weak var nodeDelegate: NodeViewModel?
     @MainActor weak var rowDelegate: OutputNodeRowObserver?
+    
+    /*
+     // Can an inspector output-row ever have a canvas item delegate ? Or would a "layer output on the graph" be represented as a non-nil canvas item reference on the `OutputLayerNodeRowData` ?
+     // i.e. is this `canvasItemDelegate` only for
+     
+     
+     */
     @MainActor weak var canvasItemDelegate: CanvasItemViewModel?
     
     init(id: NodeRowViewModelId,

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -697,7 +697,7 @@ extension GraphState {
             .getInputRowObserver(for: coordinate.portType)
     }
         
-    @MainActor func getOutputObserver(coordinate: OutputPortViewData) -> OutputNodeRowObserver? {
+    @MainActor func getOutputObserver(coordinate: OutputPortIdAddress) -> OutputNodeRowObserver? {
         self.getCanvasItem(coordinate.canvasId)?
             .outputViewModels[safe: coordinate.portId]?
             .rowDelegate
@@ -871,7 +871,7 @@ extension GraphState {
     
    
     @MainActor
-    func getInputCoordinate(from viewData: InputPortViewData) -> NodeIOCoordinate? {
+    func getInputCoordinate(from viewData: InputPortIdAddress) -> NodeIOCoordinate? {
         guard let node = self.getCanvasItem(viewData.canvasId),
               let inputRow = node.inputViewModels[safe: viewData.portId]?.rowDelegate else {
             return nil
@@ -881,7 +881,7 @@ extension GraphState {
     }
     
     @MainActor
-    func getOutputCoordinate(from viewData: OutputPortViewData) -> NodeIOCoordinate? {
+    func getOutputCoordinate(from viewData: OutputPortIdAddress) -> NodeIOCoordinate? {
         guard let node = self.getCanvasItem(viewData.canvasId),
               let outputRow = node.outputViewModels[safe: viewData.portId]?.rowDelegate else {
             return nil


### PR DESCRIPTION
QA'd on Humane, Obscured-Squares demos.