### PR TITLE
Explicitly set width on DropDownChoiceView's label, guaranteeing  enough space for longer options if even we started with shorter option

### DIFF
--- a/Stitch/Graph/Node/Port/View/Field/InputView/DropDownChoiceView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/DropDownChoiceView.swift
@@ -40,6 +40,10 @@ struct DropDownChoiceView: View {
         } label: {
             StitchTextView(string: finalChoiceDisplay,
                            fontColor: isSelectedInspectorRow ? theme.fontColor : STITCH_FONT_GRAY_COLOR)
+            // Required to force picker's display to always be large enough to display full option
+            .frame(width: NODE_INPUT_OR_OUTPUT_WIDTH,
+                   height: NODE_ROW_HEIGHT,
+                   alignment: .leading)
         }
         #if targetEnvironment(macCatalyst)
         .menuIndicator(.hidden) // hide caret indicator


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7128

https://github.com/user-attachments/assets/d3f0fd47-2b37-4500-b4e7-2665f40212ea

