### PR TITLE
Remove some unused `isVisible` parameter for removing connections; portIsDragging is now local view state

### DIFF
--- a/Stitch/Graph/Edge/Util/EdgeUtils.swift
+++ b/Stitch/Graph/Edge/Util/EdgeUtils.swift
@@ -101,15 +101,17 @@ extension GraphState {
         
         if nearestInputs.isEmpty {
             dispatch(EligibleInputReset())
-        } else {
-            nearestInputs.last?.eligibleInputDetected(graphState: self)
+        } else if let nearestInput = nearestInputs.last {
+            // While dragging cursor from an output/input,
+            // we've detected that we're over an eligible input
+            // to which we could create a connection.
+            self.edgeDrawingObserver.nearestEligibleInput = nearestInput
         }
     }
     
     /// Removes edges which root from some output coordinate.
     @MainActor
-    func removeConnections(from outputCoordinate: NodeIOCoordinate,
-                           isNodeVisible: Bool) {
+    func removeConnections(from outputCoordinate: NodeIOCoordinate) {
         guard let connectedInputs = self.connections.get(outputCoordinate) else {
             return
         }
@@ -120,14 +122,7 @@ extension GraphState {
                 return
             }
             
-            inputObserver.removeUpstreamConnection(isVisible: isNodeVisible,
-                                                   node: inputObserverNode)
+            inputObserver.removeUpstreamConnection(node: inputObserverNode)
         }
     }
 }
-
-// struct EdgeDrawingView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        EdgeDrawingView()
-//    }
-// }

--- a/Stitch/Graph/Edge/Util/PortActions.swift
+++ b/Stitch/Graph/Edge/Util/PortActions.swift
@@ -24,8 +24,7 @@ extension InputNodeRowObserver {
     /// 2. Flattens values.
     /// 3. Returns side effects for media which needs to be cleared.
     @MainActor
-    func removeUpstreamConnection(isVisible: Bool? = nil,
-                                  node: NodeViewModel) {
+    func removeUpstreamConnection(node: NodeViewModel) {
         
         guard let upstreamOutputObserver = self.upstreamOutputObserver else {
             log("InputNodeRowObserver: removeUpstreamConnection: could not find upstream output observer")
@@ -180,10 +179,7 @@ extension NodeViewModel {
             return
         }
         
-        inputObserver.removeUpstreamConnection(
-            isVisible: self.isVisibleInFrame(graph.visibleCanvasIds,
-                                             graph.selectedSidebarLayers),
-            node: node)
+        inputObserver.removeUpstreamConnection(node: node)
     }
 }
 

--- a/Stitch/Graph/Node/Patch/Type/Value/SplitterTypeActions.swift
+++ b/Stitch/Graph/Node/Patch/Type/Value/SplitterTypeActions.swift
@@ -65,13 +65,10 @@ extension GraphState {
             // If we switched away from being an output- or input-splitter,
             // we need to remove some edges.
             if currentType == .output {
-                self.removeConnections(from: outputPort,
-                                       isNodeVisible: splitterNode.isVisibleInFrame(self.visibleCanvasIds, self.selectedSidebarLayers))
+                self.removeConnections(from: outputPort)
             } else if currentType == .input {
                 if let inputObserver = splitterNode.getInputRowObserver(for: .portIndex(0)) {
-                    inputObserver
-                        .removeUpstreamConnection(isVisible: splitterNode.isVisibleInFrame(self.visibleCanvasIds, self.selectedSidebarLayers),
-                                                  node: splitterNode)
+                    inputObserver.removeUpstreamConnection(node: splitterNode)
                 }
             }
 
@@ -79,8 +76,7 @@ extension GraphState {
             // If we switched away from being an output-splitter,
             // then need to remove outgoing edges.
             if currentType == .output {
-                self.removeConnections(from: outputPort,
-                                       isNodeVisible: splitterNode.isVisibleInFrame(self.visibleCanvasIds, self.selectedSidebarLayers))
+                self.removeConnections(from: outputPort)
             }
 
         case .output:
@@ -88,9 +84,7 @@ extension GraphState {
             // then need to remove the incoming edge.
             if currentType == .input {
                 if let inputObserver = splitterNode.getInputRowObserver(for: .portIndex(0)) {
-                    inputObserver
-                        .removeUpstreamConnection(isVisible: splitterNode.isVisibleInFrame(self.visibleCanvasIds, self.selectedSidebarLayers),
-                                                  node: splitterNode)
+                    inputObserver.removeUpstreamConnection(node: splitterNode)
                 }
             }
         }

--- a/Stitch/Graph/Node/Port/Util/PortValue/UnpackedValueCoercer.swift
+++ b/Stitch/Graph/Node/Port/Util/PortValue/UnpackedValueCoercer.swift
@@ -74,7 +74,7 @@ extension PortValues {
             
             
         default:
-            log("LayerInputPort: pack")
+            // log("LayerInputPort: pack")
             return nil
         }
     }

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
@@ -30,9 +30,10 @@ protocol NodeRowViewModel: StitchLayoutCachable, Observable, Identifiable {
     @MainActor var anchorPoint: CGPoint? { get set }
     @MainActor var portColor: PortColor { get set }
     @MainActor var portViewData: PortAddressType? { get set }
-    @MainActor var isDragging: Bool { get set }
+    
     @MainActor func portDragged(gesture: DragGesture.Value, graphState: GraphState)
     @MainActor func portDragEnded(graphState: GraphState)
+    
     @MainActor func findConnectedCanvasItems(rowObserver: Self.RowObserver) -> CanvasItemIdSet
     @MainActor func calculatePortColor(hasEdge: Bool,
                                        hasLoop: Bool,

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputNodeRowViewModel.swift
@@ -30,7 +30,6 @@ final class OutputNodeRowViewModel: NodeRowViewModel {
     
     @MainActor var anchorPoint: CGPoint?
     @MainActor var portColor: PortColor = .noEdge
-    @MainActor var isDragging = false
     @MainActor var portViewData: PortAddressType?
     
     
@@ -42,8 +41,6 @@ final class OutputNodeRowViewModel: NodeRowViewModel {
     /*
      // Can an inspector output-row ever have a canvas item delegate ? Or would a "layer output on the graph" be represented as a non-nil canvas item reference on the `OutputLayerNodeRowData` ?
      // i.e. is this `canvasItemDelegate` only for
-     
-     
      */
     @MainActor weak var canvasItemDelegate: CanvasItemViewModel?
     

--- a/Stitch/Graph/ViewModel/GraphReaders.swift
+++ b/Stitch/Graph/ViewModel/GraphReaders.swift
@@ -59,6 +59,10 @@ extension GraphState: GraphReader {
     }
 }
 
+
+
+
+// TODO: remove
 extension GraphReader {
     @MainActor
     func updateCanvasItemFields(canvasItemId: CanvasItemId,


### PR DESCRIPTION
Also made it a little clearer what data input and output port drags rely on. Really, we're just using the protocol methods on row view model so we can have the specific input vs output port drag while keeping the UI input vs output agnostic.