### PR TITLE
Clarity NodeRowViewModel API

### DIFF
--- a/Stitch/Graph/Node/Port/Model/Field/FocusedUserEditField.swift
+++ b/Stitch/Graph/Node/Port/Model/Field/FocusedUserEditField.swift
@@ -64,9 +64,8 @@ enum FocusedUserEditField: Equatable, Hashable {
         // Determine whether the focused-field has a number (numeric or percentage);
         // if not, then up and down arrow keys should be passed down like normal.
         let rowId = focusedField.rowId
-        let nodeId = rowId.nodeId
         
-        if let rowViewModel = graph.getInputRowViewModel(for: rowId, nodeId: nodeId),
+        if let rowViewModel = graph.getInputRowViewModel(for: rowId),
            let fieldObserver = rowViewModel.cachedFieldValueGroups.first?.fieldObservers[safeIndex: focusedField.fieldIndex] {
             return fieldObserver.fieldValue.isNumberForArrowKeyIncrementAndDecrement
         }

--- a/Stitch/Graph/Node/Port/Util/NodeRowObserverUtil.swift
+++ b/Stitch/Graph/Node/Port/Util/NodeRowObserverUtil.swift
@@ -49,4 +49,3 @@ extension NodeRowViewModel {
         }
     }
 }
-

--- a/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
+++ b/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
@@ -39,7 +39,8 @@ struct NodeRowPortView<NodeRowObserverType: NodeRowObserver>: View {
     var body: some View {
         PortEntryView(rowViewModel: rowViewModel,
                       graph: graph,
-                      coordinate: coordinate)
+                      coordinate: coordinate,
+                      nodeIO: nodeIO)
         .onTapGesture {
             // Can only tap canvas ports, not layer inspector ports
             guard let canvasItemId = rowViewModel.canvasItemDelegate?.id else {

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -187,11 +187,14 @@ extension NodeRowObserver {
                     
         // Update visual color data
         self.allRowViewModels.forEach {
-            $0.updatePortColor(hasEdge: self.hasEdge,
-                               hasLoop: self.hasLoopedValues,
-                               selectedEdges: graph.selectedEdges,
-                               selectedCanvasItems: graph.selection.selectedCanvasItems,
-                               drawingObserver: graph.edgeDrawingObserver)
+            if let canvasItemId = $0.id.graphItemType.getCanvasItemId {
+                $0.updatePortColor(canvasItemId: canvasItemId,
+                                   hasEdge: self.hasEdge,
+                                   hasLoop: self.hasLoopedValues,
+                                   selectedEdges: graph.selectedEdges,
+                                   selectedCanvasItems: graph.selection.selectedCanvasItems,
+                                   drawingObserver: graph.edgeDrawingObserver)
+            }
         }
     }
     

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverCachedViewDataExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverCachedViewDataExtensions.swift
@@ -20,7 +20,7 @@ extension InputNodeRowObserver {
     @MainActor
     func refreshConnectedCanvasItemsCache() {
         self.allRowViewModels.forEach {
-            $0.connectedCanvasItems = $0.findConnectedCanvasItems(rowObserver: self)
+            $0.connectedCanvasItems = self.findConnectedCanvasItems()
         }
     }
     
@@ -29,12 +29,18 @@ extension InputNodeRowObserver {
                                                    selectedCanvasItems: CanvasItemIdSet,
                                                    drawingObserver: EdgeDrawingObserver) {
         self.allRowViewModels.forEach {
-            $0.updatePortColor(hasEdge: self.hasEdge,
-                               hasLoop: self.hasLoopedValues,
-                               selectedEdges: selectedEdges,
-                               selectedCanvasItems: selectedCanvasItems,
-                               // Not really applicable for input port color
-                               drawingObserver: drawingObserver)
+            
+            if let canvasItemId = $0.id.graphItemType.getCanvasItemId {
+                $0.updatePortColor(canvasItemId: canvasItemId,
+                                   hasEdge: self.hasEdge,
+                                   hasLoop: self.hasLoopedValues,
+                                   selectedEdges: selectedEdges,
+                                   selectedCanvasItems: selectedCanvasItems,
+                                   // Not really applicable for input port color
+                                   drawingObserver: drawingObserver)
+            }
+            
+            
         }
         
         // Note: previously this was only done when node-tapped
@@ -52,11 +58,14 @@ extension NodeRowObserver {
                                       selectedCanvasItems: CanvasItemIdSet,
                                       drawingObserver: EdgeDrawingObserver) {
         self.allRowViewModels.forEach {
-            $0.updatePortColor(hasEdge: self.hasEdge,
-                               hasLoop: self.hasLoopedValues,
-                               selectedEdges: selectedEdges,
-                               selectedCanvasItems: selectedCanvasItems,
-                               drawingObserver: drawingObserver)
+            if let canvasItemId = $0.id.graphItemType.getCanvasItemId {
+                $0.updatePortColor(canvasItemId: canvasItemId,
+                                   hasEdge: self.hasEdge,
+                                   hasLoop: self.hasLoopedValues,
+                                   selectedEdges: selectedEdges,
+                                   selectedCanvasItems: selectedCanvasItems,
+                                   drawingObserver: drawingObserver)
+            }
         }
     }
 }
@@ -66,7 +75,7 @@ extension OutputNodeRowObserver {
     @MainActor
     func refreshConnectedCanvasItemsCache() {
         self.allRowViewModels.forEach {
-            $0.connectedCanvasItems = $0.findConnectedCanvasItems(rowObserver: self)
+            $0.connectedCanvasItems = self.findConnectedCanvasItems()
         }
     }
     

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverExtensions.swift
@@ -30,11 +30,14 @@ extension NodeRowObserver {
         }
         
         self.allRowViewModels.forEach {
-            $0.updatePortColor(hasEdge: self.hasEdge,
-                               hasLoop: self.hasLoopedValues,
-                               selectedEdges: selectedEdges,
-                               selectedCanvasItems: selectedCanvasItems,
-                               drawingObserver: drawingObserver)
+            if let canvasItemId = $0.id.graphItemType.getCanvasItemId {
+                $0.updatePortColor(canvasItemId: canvasItemId,
+                                   hasEdge: self.hasEdge,
+                                   hasLoop: self.hasLoopedValues,
+                                   selectedEdges: selectedEdges,
+                                   selectedCanvasItems: selectedCanvasItems,
+                                   drawingObserver: drawingObserver)
+            }
         }
     }
     

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
@@ -7,6 +7,15 @@
 
 import Foundation
 
+
+@Observable
+final class InputPortUIData: Sendable {
+    
+    // the portDragged and portDragEnded methods DO require specific input vs output row view model;
+    // so instead you can pass down the nodeIO and the
+    
+}
+
 // UI data
 @Observable
 final class InputNodeRowViewModel: NodeRowViewModel {
@@ -29,7 +38,6 @@ final class InputNodeRowViewModel: NodeRowViewModel {
     
     @MainActor var anchorPoint: CGPoint?
     @MainActor var portColor: PortColor = .noEdge
-    @MainActor var isDragging = false
     @MainActor var portViewData: PortAddressType?
     
     
@@ -54,36 +62,38 @@ final class InputNodeRowViewModel: NodeRowViewModel {
     }
 }
 
-extension InputNodeRowViewModel {
+extension InputNodeRowObserver {
     @MainActor
-    func findConnectedCanvasItems(rowObserver: InputNodeRowObserver) -> CanvasItemIdSet {
-        // Does this input row observer has an upstream connection?
-        guard let upstreamOutputObserver = rowObserver.upstreamOutputObserver,
-              // If so, find that row view model
-              let upstreamNodeRowViewModel = upstreamOutputObserver.nodeRowViewModel,
-              let upstreamId = upstreamNodeRowViewModel.canvasItemDelegate?.id else {
+    func findConnectedCanvasItems() -> CanvasItemIdSet {
+        // Does this input row observer has an upstream connection (i.e. output observer)?
+        // If so, return that observer's canvas item id
+        if let upstreamId = self.upstreamOutputObserver?.nodeRowViewModel?.canvasItemDelegate?.id {
+            return .init([upstreamId])
+        } else {
             return .init()
         }
-        
-        return Set([upstreamId])
     }
+}
+
+extension InputNodeRowViewModel {
     
     @MainActor
-    func calculatePortColor(hasEdge: Bool,
+    func calculatePortColor(canvasItemId: CanvasItemId,
+                            hasEdge: Bool,
                             hasLoop: Bool,
                             selectedEdges: Set<PortEdgeUI>,
                             selectedCanvasItems: CanvasItemIdSet,
                             drawingObserver: EdgeDrawingObserver) -> PortColor {
-        
-        guard let canvasItemId = self.id.graphItemType.getCanvasItemId else {
-//            let selectedCanvasItems = self.graphDelegate?.selection.selectedCanvasItems else {
-            fatalErrorIfDebug() // called incorrectly
-            return .noEdge
-        }
-        
+                
         // Note: inputs always ignore actively-drawn or animated (edge-edit-mode) edges etc.
         let canvasItemIsSelected = selectedCanvasItems.contains(canvasItemId)
-        let isSelected = canvasItemIsSelected || self.isConnectedToASelectedCanvasItem(selectedCanvasItems) || self.hasSelectedEdge(selectedEdges: selectedEdges)
+        let isSelected = canvasItemIsSelected ||
+        
+        // Relies on self.connectedCanvasItems
+        self.isConnectedToASelectedCanvasItem(selectedCanvasItems)
+        
+        // Relies on self.portViewData
+        || self.hasSelectedEdge(selectedEdges: selectedEdges)
         
         return PortColor(isSelected: isSelected,
                          hasEdge: hasEdge,

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
@@ -31,11 +31,9 @@ final class InputNodeRowViewModel: NodeRowViewModel {
     
     @MainActor var cachedActiveValue: PortValue
     @MainActor var cachedFieldValueGroups = FieldGroupList()
-    @MainActor var connectedCanvasItems: Set<CanvasItemId> = .init()
-    
     
     // MARK: data specific to a draggable port on the canvas; not derived from underlying row observer and not applicable to row view models in the inspector
-    
+    @MainActor var connectedCanvasItems: Set<CanvasItemId> = .init()
     @MainActor var anchorPoint: CGPoint?
     @MainActor var portColor: PortColor = .noEdge
     @MainActor var portViewData: PortAddressType?

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
@@ -22,7 +22,6 @@ protocol NodeRowViewModel: StitchLayoutCachable, Observable, Identifiable {
     
     @MainActor var cachedActiveValue: PortValue { get set }
     @MainActor var cachedFieldValueGroups: [FieldGroup] { get set } // fields
-    @MainActor var connectedCanvasItems: Set<CanvasItemId> { get set }
     
     
     // MARK: data specific to a draggable port on the canvas; not derived from underlying row observer and not applicable to row view models in the inspector
@@ -30,12 +29,12 @@ protocol NodeRowViewModel: StitchLayoutCachable, Observable, Identifiable {
     @MainActor var anchorPoint: CGPoint? { get set }
     @MainActor var portColor: PortColor { get set }
     @MainActor var portViewData: PortAddressType? { get set }
-    
-    @MainActor func portDragged(gesture: DragGesture.Value, graphState: GraphState)
-    @MainActor func portDragEnded(graphState: GraphState)
-    
-    @MainActor func findConnectedCanvasItems(rowObserver: Self.RowObserver) -> CanvasItemIdSet
-    @MainActor func calculatePortColor(hasEdge: Bool,
+    @MainActor var connectedCanvasItems: Set<CanvasItemId> { get set }
+        
+    // Entrypoint for updating an input or output port's color, often when we don't know whether we specifically have an input or an output.
+    // Relies on row VM's non-nil canvas id, portViewData, connectedCanvasItems
+    @MainActor func calculatePortColor(canvasItemId: CanvasItemId,
+                                       hasEdge: Bool,
                                        hasLoop: Bool,
                                        selectedEdges: Set<PortEdgeUI>,
                                        selectedCanvasItems: CanvasItemIdSet,
@@ -175,18 +174,15 @@ extension NodeRowViewModel {
     }
     
     @MainActor
-    func updatePortColor(hasEdge: Bool,
+    func updatePortColor(canvasItemId: CanvasItemId,
+                         hasEdge: Bool,
                          hasLoop: Bool,
                          selectedEdges: Set<PortEdgeUI>,
                          selectedCanvasItems: CanvasItemIdSet,
                          drawingObserver: EdgeDrawingObserver) {
-        
-        // We can only update the port color on a row view model on the canvas, never the inspector
-        guard self.id.graphItemType.getCanvasItemId.isDefined else {
-            return
-        }
-        
-        let newColor = self.calculatePortColor(hasEdge: hasEdge,
+                
+        let newColor = self.calculatePortColor(canvasItemId: canvasItemId,
+                                               hasEdge: hasEdge,
                                                hasLoop: hasLoop,
                                                selectedEdges: selectedEdges,
                                                selectedCanvasItems: selectedCanvasItems,

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
@@ -33,13 +33,20 @@ protocol NodeRowViewModel: StitchLayoutCachable, Observable, Identifiable {
         
     // Entrypoint for updating an input or output port's color, often when we don't know whether we specifically have an input or an output.
     // Relies on row VM's non-nil canvas id, portViewData, connectedCanvasItems
-    @MainActor func calculatePortColor(canvasItemId: CanvasItemId,
-                                       hasEdge: Bool,
-                                       hasLoop: Bool,
-                                       selectedEdges: Set<PortEdgeUI>,
-                                       selectedCanvasItems: CanvasItemIdSet,
-                                       // output only
-                                       drawingObserver: EdgeDrawingObserver) -> PortColor
+    @MainActor func calculatePortColor(
+        // Restriction on type of row view model (canvas only, never inspector)
+        canvasItemId: CanvasItemId,
+        
+        // Facts from the underlying row observer
+        hasEdge: Bool,
+        hasLoop: Bool,
+        
+        // Facts from the graph
+        selectedEdges: Set<PortEdgeUI>,
+        selectedCanvasItems: CanvasItemIdSet,
+        // output only
+        drawingObserver: EdgeDrawingObserver
+    ) -> PortColor
 
     
     // MARK: delegates, weak references to parents

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputNodeRowViewModel.swift
@@ -23,11 +23,10 @@ final class OutputNodeRowViewModel: NodeRowViewModel {
     
     @MainActor var cachedActiveValue: PortValue
     @MainActor var cachedFieldValueGroups = FieldGroupList()
-    @MainActor var connectedCanvasItems: Set<CanvasItemId> = .init()
-    
-    
+        
     // MARK: data specific to a draggable port on the canvas; not derived from underlying row observer and not applicable to row view models in the inspector
     
+    @MainActor var connectedCanvasItems: Set<CanvasItemId> = .init()
     @MainActor var anchorPoint: CGPoint?
     @MainActor var portColor: PortColor = .noEdge
     @MainActor var portViewData: PortAddressType?
@@ -56,29 +55,27 @@ final class OutputNodeRowViewModel: NodeRowViewModel {
     }
 }
 
-extension OutputNodeRowViewModel {
+extension OutputNodeRowObserver {
     @MainActor
-    func findConnectedCanvasItems(rowObserver: OutputNodeRowObserver) -> CanvasItemIdSet {
-        rowObserver.getDownstreamCanvasItemsIds()
+    func findConnectedCanvasItems() -> CanvasItemIdSet {
+        self.getDownstreamCanvasItemsIds()
     }
-    
+}
+
+extension OutputNodeRowViewModel {
+
     /// Note: an actively-drawn edge SITS ON TOP OF existing edges. So there is no distinction between port color vs edge color.
     /// An actively-drawn edge's color is determined only by:
     /// 1. "Do we have a loop?" (blue vs theme-color) and
     /// 2. "Do we have an eligible input?" (highlight vs non-highlighted)
     @MainActor
-    func calculatePortColor(hasEdge: Bool,
+    func calculatePortColor(canvasItemId: CanvasItemId,
+                            hasEdge: Bool,
                             hasLoop: Bool,
                             selectedEdges: Set<PortEdgeUI>,
                             selectedCanvasItems: CanvasItemIdSet,
                             drawingObserver: EdgeDrawingObserver) -> PortColor {
-        
-        guard let canvasItemId = self.id.graphItemType.getCanvasItemId else {
-//            let selectedCanvasItems = self.graphDelegate?.selection.selectedCanvasItems else {
-            fatalErrorIfDebug() // called incorrectly
-            return .noEdge
-        }
-        
+                
         if let drawnEdge = drawingObserver.drawingGesture,
            drawnEdge.output.id == self.id {
             let hasEligibleInput = drawingObserver.nearestEligibleInput.isDefined

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -704,18 +704,16 @@ extension GraphState {
             .rowDelegate
     }
     
-    @MainActor func getInputRowViewModel(for rowId: NodeRowViewModelId,
-                                         nodeId: NodeId) -> InputNodeRowViewModel? {
-        guard let node = self.getNodeViewModel(nodeId) else {
+    @MainActor func getInputRowViewModel(for rowId: NodeRowViewModelId) -> InputNodeRowViewModel? {
+        guard let node = self.getNodeViewModel(rowId.nodeId) else {
             return nil
         }
         
         return node.getInputRowViewModel(for: rowId)
     }
     
-    @MainActor func getOutputRowViewModel(for rowId: NodeRowViewModelId,
-                                          nodeId: NodeId) -> OutputNodeRowViewModel? {
-        guard let node = self.getNodeViewModel(nodeId) else {
+    @MainActor func getOutputRowViewModel(for rowId: NodeRowViewModelId) -> OutputNodeRowViewModel? {
+        guard let node = self.getNodeViewModel(rowId.nodeId) else {
             return nil
         }
         
@@ -784,8 +782,7 @@ extension GraphState {
         
         return self.getInputRowViewModel(for: .init(graphItemType: .node(canvasItem.id),
                                                     nodeId: id.node,
-                                                    portId: 0),
-                                         nodeId: id.node)
+                                                    portId: 0))
     }
     
     @MainActor
@@ -796,8 +793,7 @@ extension GraphState {
         
         return self.getOutputRowViewModel(for: .init(graphItemType: .node(canvasItem.id),
                                                      nodeId: id.node,
-                                                     portId: 0),
-                                          nodeId: id.node)
+                                                     portId: 0))
     }
     
     @MainActor


### PR DESCRIPTION
Some methods defined on the generic were more like individual helpers in a larger function flow that actually relied on the row observer, not the row view model. 

Also, changed `calculatePortColor`'s API to clearly indicate that it is only for when we have a row view model for canvas item, never for the inspector. 