### PR TITLE
Explicit min and max width for non-inspector media picker labels

### DIFF
--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaConstants.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaConstants.swift
@@ -30,7 +30,8 @@ let VIDEO_INPUT_INDEX_SCRUBTIME = 2
 
 let RESNET50_STRING = "Resnet50"
 
-let CORE_ML_NO_RESULTS = "No Results"
+//let CORE_ML_NO_RESULTS = "No Results"
+let CORE_ML_NO_RESULTS = ""
 
 enum DefaultMediaOption: CaseIterable {
     case model3dToyRobot

--- a/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerValueEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerValueEntry.swift
@@ -100,6 +100,32 @@ struct MediaPickerValueEntry: View {
             TruncatedTextView(isMultiselectInspectorInputWithHeterogenousValues ? .HETEROGENOUS_VALUES : label,
                               truncateAt: 30,
                               color: isSelectedInspectorRow ? theme.fontColor : STITCH_TITLE_FONT_COLOR)
+            
+            // Note: truncation logic does not quite seem correct; we were truncating at ~5-10 characters, not 30
+            // TODO: better to just set a single width for all media-labels, regardless of length or "None" etc.?
+            .modifier(MediaPickerValueEntryWidth(
+                label: label,
+                isFieldInsideLayerInspector: isFieldInsideLayerInspector))
         })
+    }
+}
+
+struct MediaPickerValueEntryWidth: ViewModifier {
+    let label: String
+    let isFieldInsideLayerInspector: Bool
+    
+    func body(content: Content) -> some View {
+        if isFieldInsideLayerInspector {
+            content
+        } else {
+            content
+            .frame(minWidth: self.minimumLabelWidth,
+                   maxWidth: NODE_INPUT_OR_OUTPUT_WIDTH * 2,
+                   alignment: .leading)
+        }
+    }
+    
+    var minimumLabelWidth: CGFloat? {
+        label == "None" ? NODE_INPUT_OR_OUTPUT_WIDTH : (NODE_INPUT_OR_OUTPUT_WIDTH * 1.5)
     }
 }

--- a/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
@@ -109,10 +109,8 @@ struct MediaFieldLabelView: View {
     @MainActor
     func updateMediaObserver() {
         self.mediaObserver = node.getMediaObserver(portType: inputType,
-                                                   
                                                    // TODO: loop support
                                                    loopIndex: 0,
-                                                   
                                                    // TODO: remove media ID check
                                                    mediaId: nil)
     }

--- a/Stitch/Graph/Node/Port/View/Field/InputView/ReadOnlyEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/ReadOnlyEntry.swift
@@ -42,6 +42,12 @@ struct ReadOnlyValueEntry: View {
             .monospacedDigit()
             .frame(width: fieldWidth,
                    alignment: alignment)
+        
+        // TODO: `NODE_INPUT_OR_OUTPUT_WIDTH * 1.5` is long enough for CoreML's "No Results" but too long for most other cases; but e.g. the DeviceInfo node's outputs properly need more space
+//            .frame(minWidth: NODE_INPUT_OR_OUTPUT_WIDTH * 1.5,
+//                   maxWidth: NODE_INPUT_OR_OUTPUT_WIDTH * 2,
+//                   alignment: alignment)
+//            .border(.blue)
     }
 }
 


### PR DESCRIPTION
<img width="1349" alt="Screenshot 2025-04-20 at 7 29 39 PM" src="https://github.com/user-attachments/assets/2938ac63-3efa-40f2-a5de-3ccd7ca1abcd" />
