### PR TITLE
Right-align dropdown labels in inspector; use nil-image background to better show translucent colors in color picker

### DIFF
--- a/Stitch/Graph/Node/Port/View/Field/InputView/DropDownChoiceView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/DropDownChoiceView.swift
@@ -43,7 +43,7 @@ struct DropDownChoiceView: View {
             // Required to force picker's display to always be large enough to display full option
             .frame(width: NODE_INPUT_OR_OUTPUT_WIDTH,
                    height: NODE_ROW_HEIGHT,
-                   alignment: .leading)
+                   alignment: isFieldInsideLayerInspector ? .trailing : .leading)
         }
         #if targetEnvironment(macCatalyst)
         .menuIndicator(.hidden) // hide caret indicator

--- a/Stitch/Graph/Node/Port/View/Field/ValueButton/StitchColorPicker/StitchColorPickerView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/ValueButton/StitchColorPicker/StitchColorPickerView.swift
@@ -14,10 +14,15 @@ struct ColorOrbWrapperModifier: ViewModifier {
     
     func body(content: Content) -> some View {
         content
-            .padding(2)
             .background {
-//                Circle().fill(.white) // original
-                Circle().fill(COLOR_ORB_WRAPPING_COLOR)
+                Image(uiImage: IMAGE_EMPTY)
+                    .resizable()
+                    .clipShape(Circle())
+            }
+            .padding(2)
+            .overlay {
+                Circle()
+                    .strokeBorder(COLOR_ORB_WRAPPING_COLOR, lineWidth: 2)
             }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7157


https://github.com/user-attachments/assets/368fe219-0891-45a6-9260-d15714a33307

