### PR TITLE
Standalone type for a row view model's port data

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -902,6 +902,8 @@
 		ECE585762DB6C84F00749ED3 /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = ECE585752DB6C84F00749ED3 /* StitchEngine */; };
 		ECE585792DB6CC8700749ED3 /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = ECE585782DB6CC8700749ED3 /* StitchEngine */; };
 		ECE5857C2DB6D39C00749ED3 /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = ECE5857B2DB6D39C00749ED3 /* StitchEngine */; };
+		ECE5857E2DB6EB5700749ED3 /* InputPortUIData.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECE5857D2DB6EB5600749ED3 /* InputPortUIData.swift */; };
+		ECE585802DB6EF2200749ED3 /* OutputPortUIData.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECE5857F2DB6EF2200749ED3 /* OutputPortUIData.swift */; };
 		ECE639202C489C4F00FB8D5F /* ShadowFlyoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECE6391F2C489C4F00FB8D5F /* ShadowFlyoutView.swift */; };
 		ECE639222C489C6900FB8D5F /* FlyoutUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECE639212C489C6900FB8D5F /* FlyoutUtils.swift */; };
 		ECE708642B8D492A009F4525 /* CurveToUnpackNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECE708632B8D492A009F4525 /* CurveToUnpackNode.swift */; };
@@ -1872,6 +1874,8 @@
 		ECE35EED27CEE93700CB8F5C /* PickerActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerActions.swift; sourceTree = "<group>"; };
 		ECE35EEF27CEE99300CB8F5C /* InputEditedActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputEditedActions.swift; sourceTree = "<group>"; };
 		ECE35EF127CEE9AE00CB8F5C /* InputCommittedActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputCommittedActions.swift; sourceTree = "<group>"; };
+		ECE5857D2DB6EB5600749ED3 /* InputPortUIData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputPortUIData.swift; sourceTree = "<group>"; };
+		ECE5857F2DB6EF2200749ED3 /* OutputPortUIData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputPortUIData.swift; sourceTree = "<group>"; };
 		ECE6391F2C489C4F00FB8D5F /* ShadowFlyoutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowFlyoutView.swift; sourceTree = "<group>"; };
 		ECE639212C489C6900FB8D5F /* FlyoutUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlyoutUtils.swift; sourceTree = "<group>"; };
 		ECE708632B8D492A009F4525 /* CurveToUnpackNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurveToUnpackNode.swift; sourceTree = "<group>"; };
@@ -4444,7 +4448,9 @@
 			children = (
 				B5969F8B2C2CAAA60012F4BD /* NodeRowViewModel.swift */,
 				EC8C1AAA2D7799A90058D969 /* InputNodeRowViewModel.swift */,
+				ECE5857D2DB6EB5600749ED3 /* InputPortUIData.swift */,
 				EC8C1AAC2D7799CA0058D969 /* OutputNodeRowViewModel.swift */,
+				ECE5857F2DB6EF2200749ED3 /* OutputPortUIData.swift */,
 				EC8C1AAE2D779A090058D969 /* GraphItemType.swift */,
 				EC8C1AB02D779A190058D969 /* NodeRowViewModelId.swift */,
 			);
@@ -5589,6 +5595,7 @@
 				EC8DD69C29A594930061FB67 /* PortValuesUtils.swift in Sources */,
 				ECE35EE427CEE7E100CB8F5C /* FieldCoercers.swift in Sources */,
 				EC252403269F5C71003ABF8F /* EditJSONEntry.swift in Sources */,
+				ECE585802DB6EF2200749ED3 /* OutputPortUIData.swift in Sources */,
 				B521489A2C837CA6009AD42C /* DelayOneNode.swift in Sources */,
 				ECEC7E0826CCBEAC008A39C1 /* ClassicAnimationCurve.swift in Sources */,
 				205E6DDE25AFCB23001C5C27 /* GraphState.swift in Sources */,
@@ -5688,6 +5695,7 @@
 				EC004DD92B46438900C5DB33 /* TextFieldLayerNode.swift in Sources */,
 				E4100F9E29B83E0C00656871 /* Resnet50.mlmodel in Sources */,
 				EC89F7DF27602BE700C4447A /* SelectionHelpers.swift in Sources */,
+				ECE5857E2DB6EB5700749ED3 /* InputPortUIData.swift in Sources */,
 				B5EFD5BC2D63EC5D006A68FB /* OpenAIStructuredOutputs.swift in Sources */,
 				B555FB412D59CD3E00E1D349 /* StitchAISchema.swift in Sources */,
 				B59602152D56839C007C7AA9 /* StitchAITypeCasting.swift in Sources */,

--- a/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
@@ -304,6 +304,7 @@ extension GraphState {
         
         unpackedPort.canvasObserver?.initializeDelegate(
             node,
+            activeIndex: document.activeIndex,
             unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
             unpackedPortIndex: fieldIndex)
         

--- a/Stitch/Graph/LayerInspector/LayerInspectorActions.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorActions.swift
@@ -139,6 +139,7 @@ extension StitchDocumentViewModel {
             outputRowObservers: [])
         
         input.canvasObserver?.initializeDelegate(node,
+                                                 activeIndex: self.activeIndex,
                                                  unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
                                                  unpackedPortIndex: unpackedPortIndex)
         
@@ -175,6 +176,7 @@ struct LayerOutputAddedToGraph: StitchDocumentEvent {
         
         graph.layerOutputAddedToGraph(node: node,
                                       output: outputPort,
+                                      activeIndex: state.activeIndex,
                                       portId: portId,
                                       groupNodeFocused: state.groupNodeFocused?.groupNodeId,
                                       insertionLocation: state.newCanvasItemInsertionLocation)
@@ -187,6 +189,7 @@ extension GraphState {
     @MainActor
     func layerOutputAddedToGraph(node: NodeViewModel,
                                  output: OutputLayerNodeRowData,
+                                 activeIndex: ActiveIndex,
                                  portId: Int,
                                  groupNodeFocused: NodeId?,
                                  insertionLocation: CGPoint) {
@@ -206,6 +209,7 @@ extension GraphState {
             outputRowObservers: [output.rowObserver])
         
         output.canvasObserver?.initializeDelegate(node,
+                                                  activeIndex: activeIndex,
                                                   unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
                                                   unpackedPortIndex: unpackedPortIndex)
         

--- a/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
+++ b/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
@@ -181,6 +181,7 @@ extension StitchComponentViewModel {
         
         self.componentDelegate = masterComponent
         self.canvas.initializeDelegate(node,
+                                       activeIndex: document.activeIndex,
                                        unpackedPortParentFieldGroupType: nil,
                                        unpackedPortIndex: nil)
         self.graph.initializeDelegate(document: document,

--- a/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
+++ b/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
@@ -140,7 +140,7 @@ final class OutputLayerNodeRowData: LayerNodeRowData, Identifiable {
     @MainActor
     func initializeDelegate(_ node: NodeViewModel,
                             graph: GraphState,
-                            document: StitchDocumentViewModel) {
+                            activeIndex: ActiveIndex) {
         self.rowObserver.initializeDelegate(node, graph: graph)
         let rowDelegate = self.rowObserver
         
@@ -151,7 +151,7 @@ final class OutputLayerNodeRowData: LayerNodeRowData, Identifiable {
                         
         self.inspectorRowViewModel.initializeDelegate(
             node, // for setting NodeViewModel on NodeRowViewModel
-            initialValue: rowDelegate.getActiveValue(activeIndex: document.activeIndex),
+            initialValue: rowDelegate.getActiveValue(activeIndex: activeIndex),
             // Not relevant for output
             unpackedPortParentFieldGroupType: nil,
             unpackedPortIndex: nil,

--- a/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
+++ b/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
@@ -145,6 +145,7 @@ final class OutputLayerNodeRowData: LayerNodeRowData, Identifiable {
         let rowDelegate = self.rowObserver
         
         self.canvasObserver?.initializeDelegate(node,
+                                                activeIndex: activeIndex,
                                                 // Not relevant for output
                                                 unpackedPortParentFieldGroupType: nil,
                                                 unpackedPortIndex: nil)
@@ -168,6 +169,7 @@ extension LayerNodeRowData {
                             graph: GraphState) {
         self.rowObserver.initializeDelegate(node, graph: graph)
         self.canvasObserver?.initializeDelegate(node,
+                                                activeIndex: activeIndex,
                                                 unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
                                                 unpackedPortIndex: unpackedPortIndex)
         

--- a/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
+++ b/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
@@ -405,8 +405,14 @@ extension LayerNodeViewModel: SchemaObserver {
                         nodeId: schema.id)
         }
         
+        guard let document = self.nodeDelegate?.graphDelegate?.documentDelegate else {
+            fatalErrorIfDebug()
+            return
+        }
+        
         // Process output canvases
-        self.updateOutputData(from: schema.outputCanvasPorts)
+        self.updateOutputData(from: schema.outputCanvasPorts,
+                              activeIndex: document.activeIndex)
         
         // Updates canvas item counts
         self.resetInputCanvasItemsCache()
@@ -421,7 +427,8 @@ extension LayerNodeViewModel: SchemaObserver {
     }
     
     @MainActor
-    func updateOutputData(from canvases: [CanvasNodeEntity?]) {
+    func updateOutputData(from canvases: [CanvasNodeEntity?],
+                          activeIndex: ActiveIndex) {
         canvases.enumerated().forEach { portIndex, canvasEntity in
             guard let outputData = self.outputPorts[safe: portIndex],
                   let node = self.nodeDelegate else {
@@ -444,6 +451,7 @@ extension LayerNodeViewModel: SchemaObserver {
                     
                     outputData.canvasObserver?.initializeDelegate(
                         node,
+                        activeIndex: activeIndex,
                         // Not relevant
                         unpackedPortParentFieldGroupType: nil,
                         unpackedPortIndex: nil)

--- a/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
+++ b/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
@@ -493,7 +493,7 @@ extension LayerNodeViewModel {
     @MainActor
     func initializeDelegate(_ node: NodeViewModel,
                             graph: GraphState,
-                            document: StitchDocumentViewModel) {
+                            activeIndex: ActiveIndex) {
         self.nodeDelegate = node
         
         // Reset known input canvas items
@@ -501,7 +501,8 @@ extension LayerNodeViewModel {
         
         // Set up outputs
         self.outputPorts.forEach {
-            $0.initializeDelegate(node, graph: graph, document: document)
+            $0.initializeDelegate(node, graph: graph,
+                                  activeIndex: activeIndex)
         }
         
         self.resetInputCanvasItemsCache()

--- a/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
+++ b/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
@@ -134,7 +134,9 @@ extension PatchNodeViewModel: SchemaObserver {
 
 extension PatchNodeViewModel {
     @MainActor
-    func initializeDelegate(_ node: NodeViewModel, graph: GraphState) {
+    func initializeDelegate(_ node: NodeViewModel,
+                            graph: GraphState,
+                            activeIndex: ActiveIndex) {
         self.delegate = node
         
         self.inputsObservers.forEach {
@@ -148,6 +150,7 @@ extension PatchNodeViewModel {
         // Assign weak for group canvas if group splitter node
         
         self.canvasObserver.initializeDelegate(node,
+                                               activeIndex: activeIndex,
                                                unpackedPortParentFieldGroupType: nil,
                                                unpackedPortIndex: nil)
     }
@@ -160,6 +163,7 @@ extension PatchNodeViewModel {
                                         userVisibleType: UserVisibleType? = nil,
                                         mathExpression: String?,
                                         splitterNode: SplitterNodeEntity?,
+                                        activeIndex: ActiveIndex,
                                         delegate: NodeViewModel,
                                         graph: GraphState) {
         let entity = PatchNodeEntity(id: id,
@@ -170,7 +174,7 @@ extension PatchNodeViewModel {
                                      splitterNode: splitterNode,
                                      mathExpression: mathExpression)
         self.init(from: entity)
-        self.initializeDelegate(delegate, graph: graph)
+        self.initializeDelegate(delegate, graph: graph, activeIndex: activeIndex)
         self.delegate = delegate
         self.splitterNode = splitterNode
     }
@@ -180,6 +184,7 @@ extension PatchNodeViewModel {
                                 inputs: [NodePortInputEntity],
                                 canvasEntity: CanvasNodeEntity,
                                 userVisibleType: UserVisibleType? = nil,
+                                activeIndex: ActiveIndex,
                                 delegate: NodeViewModel,
                                 graph: GraphState) {
         self.init(id: id,
@@ -189,6 +194,7 @@ extension PatchNodeViewModel {
                   userVisibleType: userVisibleType,
                   mathExpression: nil,
                   splitterNode: nil,
+                  activeIndex: activeIndex,
                   delegate: delegate,
                   graph: graph)
     }

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
@@ -7,9 +7,10 @@
 
 import Foundation
 
-// UI data
+
 @Observable
 final class InputNodeRowViewModel: NodeRowViewModel {
+    
     typealias PortAddressType = InputPortIdAddress
     
     static let nodeIO: NodeIO = .input
@@ -22,11 +23,7 @@ final class InputNodeRowViewModel: NodeRowViewModel {
     @MainActor var cachedFieldValueGroups = FieldGroupList()
     
     // MARK: data specific to a draggable port on the canvas; not derived from underlying row observer and not applicable to row view models in the inspector
-    @MainActor var anchorPoint: CGPoint?
-    @MainActor var portColor: PortColor = .noEdge
-    @MainActor var portAddress: PortAddressType?
-    @MainActor var connectedCanvasItems = CanvasItemIdSet()
-    
+    @MainActor var portData: InputPortUIData
     
     // MARK: delegates, weak references to parents
     
@@ -41,11 +38,14 @@ final class InputNodeRowViewModel: NodeRowViewModel {
          initialValue: PortValue,
          rowDelegate: InputNodeRowObserver?,
          canvasItemDelegate: CanvasItemViewModel?) {
+        self.portData = .init(id: InputCoordinate(portId: id.portId,
+                                                  nodeId: id.nodeId))
         self.id = id
         self.cachedActiveValue = initialValue
-        self.nodeDelegate = nodeDelegate
+        self.nodeDelegate = nodeDelegate // This is referencing the object itself, already !?
         self.rowDelegate = rowDelegate
         self.canvasItemDelegate = canvasItemDelegate
+      
     }
 }
 

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputPortUIData.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputPortUIData.swift
@@ -1,0 +1,70 @@
+//
+//  InputPortUIData.swift
+//  Stitch
+//
+//  Created by Christian J Clampitt on 4/21/25.
+//
+
+import Foundation
+
+// May want a common protocol differentiated by `portAddress` type
+@Observable
+final class InputPortUIData: Identifiable, AnyObject {
+    
+    let id: InputCoordinate // which node id + port id this is for
+    
+    // the portDragged and portDragEnded methods DO require specific input vs output row view model;
+    // so instead you can pass down the nodeIO and the
+    @MainActor var anchorPoint: CGPoint? = nil
+    @MainActor var portColor: PortColor = .noEdge
+    @MainActor var portAddress: InputPortIdAddress?
+    @MainActor var connectedCanvasItems = CanvasItemIdSet()
+    
+    @MainActor
+    init(id: InputCoordinate,
+         anchorPoint: CGPoint? = nil,
+         portColor: PortColor = .noEdge,
+         portAddress: InputPortIdAddress? = nil,
+         connectedCanvasItems: CanvasItemIdSet = .init()) {
+        self.id = id
+        self.anchorPoint = anchorPoint
+        self.portColor = portColor
+        self.portAddress = portAddress
+        self.connectedCanvasItems = connectedCanvasItems
+    }
+}
+
+
+extension InputNodeRowViewModel {
+    @MainActor var anchorPoint: CGPoint? {
+        get {
+            self.portData.anchorPoint
+        } set(newValue) {
+            self.portData.anchorPoint = newValue
+        }
+    }
+    
+    @MainActor var portColor: PortColor {
+        get {
+            self.portData.portColor
+        } set(newValue) {
+            self.portData.portColor = newValue
+        }
+    }
+    
+    @MainActor var portAddress: PortAddressType? {
+        get {
+            self.portData.portAddress
+        } set(newValue) {
+            self.portData.portAddress = newValue
+        }
+    }
+    
+    @MainActor var connectedCanvasItems: CanvasItemIdSet {
+        get {
+            self.portData.connectedCanvasItems
+        } set(newValue) {
+            self.portData.connectedCanvasItems = newValue
+        }
+    }
+}

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
@@ -109,28 +109,17 @@ extension NodeRowViewModel {
                 initialValue: initialValue,
                 rowObserverLayerInput: layerInput)
         }
-        
-        self.updatePortViewData()
-    }
-    
-    @MainActor func updatePortViewData() {
-        let newPortViewData = self.getPortViewData()
-        if self.portAddress != newPortViewData {
-            self.portAddress = newPortViewData
+                
+        /// Considerable perf cost from `ConnectedEdgeView`, so now a function.
+        if let canvasId = self.canvasItemDelegate?.id {
+            let newPortAddress: PortAddressType = .init(portId: self.id.portId,
+                                                        canvasId: canvasId)
+            if self.portAddress != newPortAddress {
+                self.portAddress = newPortAddress
+            }
         }
     }
-    
-    /// Considerable perf cost from `ConnectedEdgeView`, so now a function.
-    @MainActor
-    func getPortViewData() -> PortAddressType? {
-        guard let canvasId = self.canvasItemDelegate?.id else {
-            return nil
-        }
         
-        return .init(portId: self.id.portId,
-                     canvasId: canvasId)
-    }
-    
     @MainActor
     func initializeValues(unpackedPortParentFieldGroupType: FieldGroupType?,
                           unpackedPortIndex: Int?,
@@ -164,14 +153,9 @@ extension NodeRowViewModel {
         let oldViewValue = self.cachedActiveValue // the old cached value
         let newViewValue = PortValue.getActiveValue(allLoopedValues: values,
                                                     activeIndex: activeIndex)
+        
         let didViewValueChange = oldViewValue != newViewValue
         
-        /*
-         Conditions for forcing fields update:
-         1. Is at time of initialization--used for layers, or
-         2. Did values change AND visible in frame, or
-         3. Is this an input for a layer node that is focused in the property sidebar?
-         */
         let shouldUpdate = didViewValueChange || isLayerFocusedInPropertySidebar
 
         if shouldUpdate {

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputNodeRowViewModel.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-
 @Observable
 final class OutputNodeRowViewModel: NodeRowViewModel {
     typealias PortAddressType = OutputPortIdAddress
@@ -23,12 +22,7 @@ final class OutputNodeRowViewModel: NodeRowViewModel {
     @MainActor var cachedFieldValueGroups = FieldGroupList()
         
     // MARK: data specific to a draggable port on the canvas; not derived from underlying row observer and not applicable to row view models in the inspector
-    
-    @MainActor var anchorPoint: CGPoint?
-    @MainActor var portColor: PortColor = .noEdge
-    @MainActor var portAddress: PortAddressType?
-    @MainActor var connectedCanvasItems = CanvasItemIdSet()
-    
+    @MainActor var portData: OutputPortUIData
     
     // MARK: delegates, weak references to parents
     
@@ -45,6 +39,9 @@ final class OutputNodeRowViewModel: NodeRowViewModel {
          initialValue: PortValue,
          rowDelegate: OutputNodeRowObserver?,
          canvasItemDelegate: CanvasItemViewModel?) {
+        
+        self.portData = .init(id: OutputCoordinate(portId: id.portId,
+                                                   nodeId: id.nodeId))
         self.id = id
         self.cachedActiveValue = initialValue
         self.nodeDelegate = nodeDelegate

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputPortUIData.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputPortUIData.swift
@@ -1,0 +1,70 @@
+//
+//  OutputPortUIData.swift
+//  Stitch
+//
+//  Created by Christian J Clampitt on 4/21/25.
+//
+
+import Foundation
+
+// May want a common protocol differentiated by `portAddress` type
+@Observable
+final class OutputPortUIData: Identifiable, AnyObject {
+    
+    let id: OutputCoordinate // which node id + port id this is for
+    
+    // the portDragged and portDragEnded methods DO require specific input vs output row view model;
+    // so instead you can pass down the nodeIO and the
+    @MainActor var anchorPoint: CGPoint? = nil
+    @MainActor var portColor: PortColor = .noEdge
+    @MainActor var portAddress: OutputPortIdAddress?
+    @MainActor var connectedCanvasItems = CanvasItemIdSet()
+    
+    @MainActor
+    init(id: OutputCoordinate,
+         anchorPoint: CGPoint? = nil,
+         portColor: PortColor = .noEdge,
+         portAddress: OutputPortIdAddress? = nil,
+         connectedCanvasItems: CanvasItemIdSet = .init()) {
+        self.id = id
+        self.anchorPoint = anchorPoint
+        self.portColor = portColor
+        self.portAddress = portAddress
+        self.connectedCanvasItems = connectedCanvasItems
+    }
+}
+
+
+extension OutputNodeRowViewModel {
+    @MainActor var anchorPoint: CGPoint? {
+        get {
+            self.portData.anchorPoint
+        } set(newValue) {
+            self.portData.anchorPoint = newValue
+        }
+    }
+    
+    @MainActor var portColor: PortColor {
+        get {
+            self.portData.portColor
+        } set(newValue) {
+            self.portData.portColor = newValue
+        }
+    }
+    
+    @MainActor var portAddress: PortAddressType? {
+        get {
+            self.portData.portAddress
+        } set(newValue) {
+            self.portData.portAddress = newValue
+        }
+    }
+    
+    @MainActor var connectedCanvasItems: CanvasItemIdSet {
+        get {
+            self.portData.connectedCanvasItems
+        } set(newValue) {
+            self.portData.connectedCanvasItems = newValue
+        }
+    }
+}

--- a/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
@@ -209,15 +209,11 @@ extension CanvasItemViewModel {
     
     @MainActor
     func initializeDelegate(_ node: NodeViewModel,
+                            activeIndex: ActiveIndex,
                             unpackedPortParentFieldGroupType: FieldGroupType?,
                             unpackedPortIndex: Int?) {
         
         self.nodeDelegate = node
-
-        guard let activeIndex = node.graphDelegate?.documentDelegate?.activeIndex else {
-            fatalErrorIfDebug()
-            return
-        }
         
         self.inputViewModels.forEach {
             // Note: assumes the row view model as already have its underling row observer delegate assigned

--- a/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
@@ -80,16 +80,20 @@ extension NodeViewModelType {
                             document: StitchDocumentViewModel) {
         let graph = document.graph
         
+        let activeIndex = document.activeIndex
+        
         switch self {
         case .patch(let patchNodeViewModel):
             patchNodeViewModel.initializeDelegate(node,
-                                                  graph: graph)
+                                                  graph: graph,
+                                                  activeIndex: activeIndex)
         case .layer(let layerNodeViewModel):
             layerNodeViewModel.initializeDelegate(node,
                                                   graph: graph,
-                                                  activeIndex: document.activeIndex)
+                                                  activeIndex: activeIndex)
         case .group(let canvasItemViewModel):
             canvasItemViewModel.initializeDelegate(node,
+                                                   activeIndex: activeIndex,
                                                    // Not relevant
                                                    unpackedPortParentFieldGroupType: nil,
                                                    unpackedPortIndex: nil)

--- a/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
@@ -82,9 +82,12 @@ extension NodeViewModelType {
         
         switch self {
         case .patch(let patchNodeViewModel):
-            patchNodeViewModel.initializeDelegate(node, graph: graph)
+            patchNodeViewModel.initializeDelegate(node,
+                                                  graph: graph)
         case .layer(let layerNodeViewModel):
-            layerNodeViewModel.initializeDelegate(node, graph: graph, document: document)
+            layerNodeViewModel.initializeDelegate(node,
+                                                  graph: graph,
+                                                  activeIndex: document.activeIndex)
         case .group(let canvasItemViewModel):
             canvasItemViewModel.initializeDelegate(node,
                                                    // Not relevant

--- a/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
+++ b/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
@@ -173,6 +173,7 @@ extension VisibleNodesViewModel {
                 // Note: A Group Node's inputs and outputs are actually underlying input-splitters and output-splitters.
                 // TODO: shouldn't the row view models already have been initialized when we initialized patch nodes?
                 canvasGroup.initializeDelegate(node,
+                                               activeIndex: activeIndex,
                                                // Layer inputs can never be inputs for group nodes
                                                unpackedPortParentFieldGroupType: nil,
                                                unpackedPortIndex: nil)


### PR DESCRIPTION
Introduce standalone type for row view model port data.

Seems like row view model has two main uses:
1. cached field ui values (relevant for both canvas and inspector)
2. port ui data (canvas only)

In some contexts I'm noticing that I probably only need the port ui data (and maybe some fact about the row observer), not the whole row view model.