### PR TITLE
Prefer port UI view model (rather than node row view model) when that's all we need

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -902,8 +902,8 @@
 		ECE585762DB6C84F00749ED3 /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = ECE585752DB6C84F00749ED3 /* StitchEngine */; };
 		ECE585792DB6CC8700749ED3 /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = ECE585782DB6CC8700749ED3 /* StitchEngine */; };
 		ECE5857C2DB6D39C00749ED3 /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = ECE5857B2DB6D39C00749ED3 /* StitchEngine */; };
-		ECE5857E2DB6EB5700749ED3 /* InputPortUIData.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECE5857D2DB6EB5600749ED3 /* InputPortUIData.swift */; };
-		ECE585802DB6EF2200749ED3 /* OutputPortUIData.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECE5857F2DB6EF2200749ED3 /* OutputPortUIData.swift */; };
+		ECE5857E2DB6EB5700749ED3 /* InputPortUIViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECE5857D2DB6EB5600749ED3 /* InputPortUIViewModel.swift */; };
+		ECE585802DB6EF2200749ED3 /* OutputPortUIViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECE5857F2DB6EF2200749ED3 /* OutputPortUIViewModel.swift */; };
 		ECE639202C489C4F00FB8D5F /* ShadowFlyoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECE6391F2C489C4F00FB8D5F /* ShadowFlyoutView.swift */; };
 		ECE639222C489C6900FB8D5F /* FlyoutUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECE639212C489C6900FB8D5F /* FlyoutUtils.swift */; };
 		ECE708642B8D492A009F4525 /* CurveToUnpackNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECE708632B8D492A009F4525 /* CurveToUnpackNode.swift */; };
@@ -1874,8 +1874,8 @@
 		ECE35EED27CEE93700CB8F5C /* PickerActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerActions.swift; sourceTree = "<group>"; };
 		ECE35EEF27CEE99300CB8F5C /* InputEditedActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputEditedActions.swift; sourceTree = "<group>"; };
 		ECE35EF127CEE9AE00CB8F5C /* InputCommittedActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputCommittedActions.swift; sourceTree = "<group>"; };
-		ECE5857D2DB6EB5600749ED3 /* InputPortUIData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputPortUIData.swift; sourceTree = "<group>"; };
-		ECE5857F2DB6EF2200749ED3 /* OutputPortUIData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputPortUIData.swift; sourceTree = "<group>"; };
+		ECE5857D2DB6EB5600749ED3 /* InputPortUIViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputPortUIViewModel.swift; sourceTree = "<group>"; };
+		ECE5857F2DB6EF2200749ED3 /* OutputPortUIViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputPortUIViewModel.swift; sourceTree = "<group>"; };
 		ECE6391F2C489C4F00FB8D5F /* ShadowFlyoutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowFlyoutView.swift; sourceTree = "<group>"; };
 		ECE639212C489C6900FB8D5F /* FlyoutUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlyoutUtils.swift; sourceTree = "<group>"; };
 		ECE708632B8D492A009F4525 /* CurveToUnpackNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurveToUnpackNode.swift; sourceTree = "<group>"; };
@@ -4448,9 +4448,9 @@
 			children = (
 				B5969F8B2C2CAAA60012F4BD /* NodeRowViewModel.swift */,
 				EC8C1AAA2D7799A90058D969 /* InputNodeRowViewModel.swift */,
-				ECE5857D2DB6EB5600749ED3 /* InputPortUIData.swift */,
+				ECE5857D2DB6EB5600749ED3 /* InputPortUIViewModel.swift */,
 				EC8C1AAC2D7799CA0058D969 /* OutputNodeRowViewModel.swift */,
-				ECE5857F2DB6EF2200749ED3 /* OutputPortUIData.swift */,
+				ECE5857F2DB6EF2200749ED3 /* OutputPortUIViewModel.swift */,
 				EC8C1AAE2D779A090058D969 /* GraphItemType.swift */,
 				EC8C1AB02D779A190058D969 /* NodeRowViewModelId.swift */,
 			);
@@ -5595,7 +5595,7 @@
 				EC8DD69C29A594930061FB67 /* PortValuesUtils.swift in Sources */,
 				ECE35EE427CEE7E100CB8F5C /* FieldCoercers.swift in Sources */,
 				EC252403269F5C71003ABF8F /* EditJSONEntry.swift in Sources */,
-				ECE585802DB6EF2200749ED3 /* OutputPortUIData.swift in Sources */,
+				ECE585802DB6EF2200749ED3 /* OutputPortUIViewModel.swift in Sources */,
 				B521489A2C837CA6009AD42C /* DelayOneNode.swift in Sources */,
 				ECEC7E0826CCBEAC008A39C1 /* ClassicAnimationCurve.swift in Sources */,
 				205E6DDE25AFCB23001C5C27 /* GraphState.swift in Sources */,
@@ -5695,7 +5695,7 @@
 				EC004DD92B46438900C5DB33 /* TextFieldLayerNode.swift in Sources */,
 				E4100F9E29B83E0C00656871 /* Resnet50.mlmodel in Sources */,
 				EC89F7DF27602BE700C4447A /* SelectionHelpers.swift in Sources */,
-				ECE5857E2DB6EB5700749ED3 /* InputPortUIData.swift in Sources */,
+				ECE5857E2DB6EB5700749ED3 /* InputPortUIViewModel.swift in Sources */,
 				B5EFD5BC2D63EC5D006A68FB /* OpenAIStructuredOutputs.swift in Sources */,
 				B555FB412D59CD3E00E1D349 /* StitchAISchema.swift in Sources */,
 				B59602152D56839C007C7AA9 /* StitchAITypeCasting.swift in Sources */,

--- a/Stitch/Graph/Edge/Model/ConnectedEdgeData.swift
+++ b/Stitch/Graph/Edge/Model/ConnectedEdgeData.swift
@@ -15,7 +15,7 @@ struct ConnectedEdgeData: Equatable, Identifiable {
         lhs.zIndex == rhs.zIndex
     }
     
-    // TODO: use a better type for identifier? Should only need `InputCoordinate` ?
+    // TODO: use a better type for identifier? Should only need `InputCoordinate` ? NodeRowViewModelId is actually just node-io-coordinate + "canvas vs inspector"
     let id: NodeRowViewModelId
     
     let upstreamOutput: OutputPortUIViewModel
@@ -25,60 +25,26 @@ struct ConnectedEdgeData: Equatable, Identifiable {
     let zIndex: Double
 
     // To create a "connected edge", we MUST have both an upstream canvas item and a downstream canvas item
-    // TODO: can these initializer *really* fail? It must be called with at least one upstream row view model and one downstream row view model
-//    @MainActor
-//    init?(upstreamCanvasItem: CanvasItemViewModel,
-//          upstreamOutputPortUIViewModel: OutputPortUIViewModel,
-//          downstreamInput: InputNodeRowViewModel) {
-//        
-//        guard let downstreamNode = downstreamInput.nodeDelegate,
-//              let inputData = EdgeAnchorDownstreamData(from: downstreamInput,
-//                                                       upstreamNodeId: upstreamCanvasItem.id),
-//              let outputData = EdgeAnchorUpstreamData(from: upstreamCanvasItem.outputPortUIViewModels,
-//                                                      upstreamNodeId: upstreamCanvasItem.id.nodeId,
-//                                                      inputRowViewModelsOnDownstreamNode: downstreamNode.allInputViewModels) else {
-//            return nil
-//        }
-//        
-//        self.id = downstreamInput.id
-//        self.upstreamOutput = upstreamOutputPortUIViewModel
-//        self.downstreamInput = downstreamInput.portUIViewModel
-//        self.inputData = inputData
-//        self.outputData = outputData
-//        self.zIndex = max(upstreamCanvasItem.zIndex, upstreamCanvasItem.zIndex)
-//    }
-    
+    // TODO: can this initializer *really* fail? It must be called with at least one upstream row view model and one downstream row view model
     @MainActor
-    static func create(upstreamCanvasItem: CanvasItemViewModel,
+    init?(upstreamCanvasItem: CanvasItemViewModel,
                        upstreamOutputPortUIViewModel: OutputPortUIViewModel,
-                       downstreamInput: InputNodeRowViewModel) -> Self? {
+                       downstreamInput: InputNodeRowViewModel) {
         
-//        guard let downstreamNode = downstreamInput.nodeDelegate,
-//              let inputData = EdgeAnchorDownstreamData(from: downstreamInput,
-//                                                       upstreamNodeId: upstreamCanvasItem.id),
-//              let outputData = EdgeAnchorUpstreamData(from: upstreamCanvasItem.outputPortUIViewModels,
-//                                                      upstreamNodeId: upstreamCanvasItem.id.nodeId,
-//                                                      inputRowViewModelsOnDownstreamNode: downstreamNode.allInputViewModels) else {
-//            fatalErrorIfDebug()
-//            return nil
-//        }
+        guard let downstreamNode = downstreamInput.nodeDelegate,
+              let inputData = EdgeAnchorDownstreamData(from: downstreamInput,
+                                                       upstreamNodeId: upstreamCanvasItem.id),
+              let outputData = EdgeAnchorUpstreamData(from: upstreamCanvasItem.outputPortUIViewModels,
+                                                      upstreamNodeId: upstreamCanvasItem.id.nodeId,
+                                                      inputRowViewModelsOnDownstreamNode: downstreamNode.allInputViewModels) else {
+            return nil
+        }
         
-        let downstreamNode = downstreamInput.nodeDelegate!
-        
-        let inputData = EdgeAnchorDownstreamData(from: downstreamInput,
-                                                 upstreamNodeId: upstreamCanvasItem.id)!
-        
-        let outputData = EdgeAnchorUpstreamData(from: upstreamCanvasItem.outputPortUIViewModels,
-                                                upstreamNodeId: upstreamCanvasItem.id.nodeId,
-                                                inputRowViewModelsOnDownstreamNode: downstreamNode.allInputViewModels)!
-        
-        
-        
-        return .init(id: downstreamInput.id,
-                     upstreamOutput: upstreamOutputPortUIViewModel,
-                     downstreamInput: downstreamInput.portUIViewModel,
-                     inputData: inputData,
-                     outputData: outputData,
-                     zIndex: max(upstreamCanvasItem.zIndex, upstreamCanvasItem.zIndex))
+        self.id = downstreamInput.id
+        self.upstreamOutput = upstreamOutputPortUIViewModel
+        self.downstreamInput = downstreamInput.portUIViewModel
+        self.inputData = inputData
+        self.outputData = outputData
+        self.zIndex = max(upstreamCanvasItem.zIndex, upstreamCanvasItem.zIndex)
     }
 }

--- a/Stitch/Graph/Edge/Util/PortDragActions.swift
+++ b/Stitch/Graph/Edge/Util/PortDragActions.swift
@@ -28,7 +28,7 @@ extension GraphState {
         guard var existingDrawingGesture = self.edgeDrawingObserver.drawingGesture else {
             log("InputDragged: started")
             
-            guard let upstreamObserver = inputRowObserver.upstreamOutputObserver?.nodeRowViewModel else {
+            guard let upstreamObserver = inputRowObserver.upstreamOutputObserver?.rowViewModelForCanvasItemAtThisTraversalLevel else {
                 return
             }
             

--- a/Stitch/Graph/Edge/View/EdgeDrawingView.swift
+++ b/Stitch/Graph/Edge/View/EdgeDrawingView.swift
@@ -66,8 +66,11 @@ struct EdgeFromDraggedOutputView: View {
     var body: some View {
         Group {
             if let downstreamNode = outputDrag.output.nodeDelegate,
-                let outputAnchorData = EdgeAnchorUpstreamData(from: outputRowViewModel,
-                                                              connectedDownstreamNode: downstreamNode),
+               let upstreamCanvasItem = outputRowViewModel.canvasItemDelegate,
+                let outputAnchorData = EdgeAnchorUpstreamData(
+                    from: upstreamCanvasItem.outputPortUIViewModels,
+                    upstreamNodeId: upstreamCanvasItem.id.nodeId,
+                    inputRowViewModelsOnDownstreamNode: downstreamNode.allInputViewModels),
                let outputPortViewData = outputRowViewModel.portAddress,
                let outputNodeId = outputRowViewModel.canvasItemDelegate?.id,
                let pointFrom = outputRowViewModel.anchorPoint {

--- a/Stitch/Graph/Edge/View/EdgeDrawingView.swift
+++ b/Stitch/Graph/Edge/View/EdgeDrawingView.swift
@@ -80,14 +80,14 @@ struct EdgeFromDraggedOutputView: View {
                          pointTo: pointTo,
                          color: self.color.color(theme),
                          isActivelyDragged: true, // always true for actively-dragged edge
-                         firstFrom: outputAnchorData.firstUpstreamRowViewModel.anchorPoint ?? .zero,
-                         firstTo: inputAnchorData?.firstInputRowViewModel.anchorPoint ?? .zero,
-                         lastFrom: outputAnchorData.lastUpstreamRowViewModel.anchorPoint ?? .zero,
-                         lastTo: inputAnchorData?.lastInputRowViewModel.anchorPoint ?? .zero,
-                         firstFromWithEdge: outputAnchorData.firstConnectedUpstreamRowViewModel?.anchorPoint?.y,
-                         lastFromWithEdge: outputAnchorData.lastConnectedUpstreamRowViewModel?.anchorPoint?.y,
-                         firstToWithEdge: inputAnchorData?.firstConnectedInputRowViewModel.anchorPoint?.y,
-                         lastToWithEdge: inputAnchorData?.lastConectedInputRowViewModel.anchorPoint?.y,
+                         firstFrom: outputAnchorData.firstUpstreamOutput.anchorPoint ?? .zero,
+                         firstTo: inputAnchorData?.firstInput.anchorPoint ?? .zero,
+                         lastFrom: outputAnchorData.lastUpstreamRowOutput.anchorPoint ?? .zero,
+                         lastTo: inputAnchorData?.lastInput.anchorPoint ?? .zero,
+                         firstFromWithEdge: outputAnchorData.firstConnectedUpstreamOutput?.anchorPoint?.y,
+                         lastFromWithEdge: outputAnchorData.lastConnectedUpstreamOutput?.anchorPoint?.y,
+                         firstToWithEdge: inputAnchorData?.firstConnectedInput.anchorPoint?.y,
+                         lastToWithEdge: inputAnchorData?.lastConectedInput.anchorPoint?.y,
                          totalOutputs: outputAnchorData.totalOutputs,
                          // we never animate the actively dragged edge
                          edgeAnimationEnabled: false)

--- a/Stitch/Graph/Edge/View/ExistingEdgesView.swift
+++ b/Stitch/Graph/Edge/View/ExistingEdgesView.swift
@@ -20,7 +20,7 @@ struct GraphConnectedEdgesView: View {
        let possibleEdge = graph.edgeEditingState?
             .possibleEdges
             .first(where: {
-                $0.edge.to == edgeData.downstreamRowObserver.portAddress
+                $0.edge.to == edgeData.downstreamInput.portAddress
                 && graph.edgeEditingState?.animationInProgressIds.contains($0.id) ?? false
             })
         
@@ -109,8 +109,8 @@ struct ConnectedEdgeView: View {
 
     @MainActor init(data: ConnectedEdgeData,
                     edgeAnimationEnabled: Bool) {
-        self.inputPortUIViewModel = data.downstreamRowObserver.portUIViewModel
-        self.upstreamOutputPortUIViewModel = data.upstreamRowObserver.portUIViewModel
+        self.inputPortUIViewModel = data.downstreamInput
+        self.upstreamOutputPortUIViewModel = data.upstreamOutput
         self.downstreamAnchor = data.inputData
         self.upstreamAnchor = data.outputData
         self.zIndex = data.zIndex

--- a/Stitch/Graph/Edge/View/ExistingEdgesView.swift
+++ b/Stitch/Graph/Edge/View/ExistingEdgesView.swift
@@ -105,56 +105,57 @@ struct CandidateEdgesView: View {
     }
 }
 
-extension ConnectedEdgeView {
+struct ConnectedEdgeView: View {
+
     @MainActor init(data: ConnectedEdgeData,
                     edgeAnimationEnabled: Bool) {
-        self.inputRowViewModel = data.downstreamRowObserver
-        self.upstreamOutputRowViewModel = data.upstreamRowObserver
-        self.inputData = data.inputData
-        self.outputData = data.outputData
+        self.inputPortUIViewModel = data.downstreamRowObserver.portUIViewModel
+        self.upstreamOutputPortUIViewModel = data.upstreamRowObserver.portUIViewModel
+        self.downstreamAnchor = data.inputData
+        self.upstreamAnchor = data.outputData
         self.zIndex = data.zIndex
         self.edgeAnimationEnabled = edgeAnimationEnabled
     }
-}
-
-struct ConnectedEdgeView: View {
-
+    
     @Environment(\.appTheme) private var theme
     
-    @Bindable var inputRowViewModel: InputNodeRowViewModel
-    @Bindable var upstreamOutputRowViewModel: OutputNodeRowViewModel
-    let inputData: EdgeAnchorDownstreamData
-    let outputData: EdgeAnchorUpstreamData
+    @Bindable var inputPortUIViewModel: InputPortUIViewModel
+    @Bindable var upstreamOutputPortUIViewModel: OutputPortUIViewModel
+    
+    let downstreamAnchor: EdgeAnchorDownstreamData
+    let upstreamAnchor: EdgeAnchorUpstreamData
+    
     let edgeAnimationEnabled: Bool
+    
     let zIndex: Double
         
     var body: some View {
-        let firstUpstreamObserver = inputData.firstInputRowViewModel
-        let firstInputObserver = inputData.firstInputRowViewModel
-        let lastInputObserver = inputData.lastInputRowViewModel
-        let firstConnectedInputObserver = inputData.firstConnectedInputRowViewModel
-        let lastConnectedInputObserver = inputData.lastConectedInputRowViewModel
-        let lastUpstreamObserver = outputData.lastUpstreamRowViewModel
-        let totalOutputs = outputData.totalOutputs
-        let lastConnectedUpstreamObserver = outputData.lastConnectedUpstreamRowViewModel
+        let firstConnectedInputObserver = downstreamAnchor.firstConnectedInput
         
-        if let inputPortViewData = inputRowViewModel.portAddress,
-           let outputPortViewData = upstreamOutputRowViewModel.portAddress,
-           let pointTo = inputRowViewModel.anchorPoint,
-           let pointFrom = upstreamOutputRowViewModel.anchorPoint,
-           let firstFrom = firstUpstreamObserver.anchorPoint,
-           let firstTo = firstInputObserver.anchorPoint,
-           let lastFrom = lastUpstreamObserver.anchorPoint,
-           let lastTo = lastInputObserver.anchorPoint,
-           let firstFromWithEdge = firstConnectedInputObserver.anchorPoint?.y,
-           let lastFromWithEdge = lastConnectedUpstreamObserver?.anchorPoint?.y,
-           let firstToWithEdge = firstConnectedInputObserver.anchorPoint?.y,
-           let lastToWithEdge = lastConnectedInputObserver.anchorPoint?.y {
+        if let inputPortViewData: InputPortIdAddress = inputPortUIViewModel.portAddress,
+           let outputPortViewData: OutputPortIdAddress = upstreamOutputPortUIViewModel.portAddress,
+           
+            let pointTo: CGPoint = inputPortUIViewModel.anchorPoint,
+           let pointFrom: CGPoint = upstreamOutputPortUIViewModel.anchorPoint,
+           
+            let firstFrom: CGPoint = upstreamAnchor.firstUpstreamOutput.anchorPoint,
+            let firstTo: CGPoint = downstreamAnchor.firstInput.anchorPoint,
+           
+            let lastFrom: CGPoint = upstreamAnchor.lastUpstreamRowOutput.anchorPoint,
+           let lastTo: CGPoint = downstreamAnchor.lastInput.anchorPoint,
+           
+            let firstFromWithEdge: CGFloat = firstConnectedInputObserver.anchorPoint?.y,
+           let lastFromWithEdge: CGFloat = upstreamAnchor.lastConnectedUpstreamOutput?.anchorPoint?.y,
+           
+            let firstToWithEdge: CGFloat = firstConnectedInputObserver.anchorPoint?.y,
+           let lastToWithEdge: CGFloat = downstreamAnchor.lastConectedInput.anchorPoint?.y {
+            
             let edge = PortEdgeUI(from: outputPortViewData,
                                   to: inputPortViewData)
-            let portColor: PortColor = inputRowViewModel.portColor
+            
+            let portColor: PortColor = inputPortUIViewModel.portColor
             let isSelectedEdge = (portColor == .highlightedEdge || portColor == .highlightedLoopEdge)
-           
+            
             let zIndexBoost = isSelectedEdge ? SELECTED_EDGE_Z_INDEX_BOOST : 0
             let newZIndex: ZIndex = self.zIndex + zIndexBoost
             
@@ -171,7 +172,7 @@ struct ConnectedEdgeView: View {
                      lastFromWithEdge: lastFromWithEdge,
                      firstToWithEdge: firstToWithEdge,
                      lastToWithEdge: lastToWithEdge,
-                     totalOutputs: totalOutputs,
+                     totalOutputs: upstreamAnchor.totalOutputs,
                      edgeAnimationEnabled: edgeAnimationEnabled)
             .zIndex(newZIndex)
             

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/GraphItemType.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/GraphItemType.swift
@@ -9,7 +9,7 @@ import Foundation
 
 
 enum GraphItemType: Hashable {
-    case node(CanvasItemId)
+    case node(CanvasItemId) // i.e. canvas
     
     // Passing in layer input type ensures uniqueness of IDs in inspector
     case layerInspector(NodeIOPortType) // portId (layer output) or layer-input-type (layer input)

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
@@ -54,7 +54,7 @@ extension InputNodeRowObserver {
     func findConnectedCanvasItems() -> CanvasItemIdSet {
         // Does this input row observer has an upstream connection (i.e. output observer)?
         // If so, return that observer's canvas item id
-        if let upstreamId = self.upstreamOutputObserver?.nodeRowViewModel?.canvasItemDelegate?.id {
+        if let upstreamId = self.upstreamOutputObserver?.rowViewModelForCanvasItemAtThisTraversalLevel?.canvasItemDelegate?.id {
             return .init([upstreamId])
         } else {
             return .init()

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputNodeRowViewModel.swift
@@ -23,7 +23,7 @@ final class InputNodeRowViewModel: NodeRowViewModel {
     @MainActor var cachedFieldValueGroups = FieldGroupList()
     
     // MARK: data specific to a draggable port on the canvas; not derived from underlying row observer and not applicable to row view models in the inspector
-    @MainActor var portData: InputPortUIData
+    @MainActor var portUIViewModel: InputPortUIViewModel
     
     // MARK: delegates, weak references to parents
     
@@ -38,7 +38,7 @@ final class InputNodeRowViewModel: NodeRowViewModel {
          initialValue: PortValue,
          rowDelegate: InputNodeRowObserver?,
          canvasItemDelegate: CanvasItemViewModel?) {
-        self.portData = .init(id: InputCoordinate(portId: id.portId,
+        self.portUIViewModel = .init(id: InputCoordinate(portId: id.portId,
                                                   nodeId: id.nodeId))
         self.id = id
         self.cachedActiveValue = initialValue

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputPortUIViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/InputPortUIViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  OutputPortUIData.swift
+//  InputPortUIData.swift
 //  Stitch
 //
 //  Created by Christian J Clampitt on 4/21/25.
@@ -9,22 +9,22 @@ import Foundation
 
 // May want a common protocol differentiated by `portAddress` type
 @Observable
-final class OutputPortUIData: Identifiable, AnyObject {
+final class InputPortUIViewModel: Identifiable, AnyObject {
     
-    let id: OutputCoordinate // which node id + port id this is for
+    let id: InputCoordinate // which node id + port id this is for
     
     // the portDragged and portDragEnded methods DO require specific input vs output row view model;
     // so instead you can pass down the nodeIO and the
     @MainActor var anchorPoint: CGPoint? = nil
     @MainActor var portColor: PortColor = .noEdge
-    @MainActor var portAddress: OutputPortIdAddress?
+    @MainActor var portAddress: InputPortIdAddress?
     @MainActor var connectedCanvasItems = CanvasItemIdSet()
     
     @MainActor
-    init(id: OutputCoordinate,
+    init(id: InputCoordinate,
          anchorPoint: CGPoint? = nil,
          portColor: PortColor = .noEdge,
-         portAddress: OutputPortIdAddress? = nil,
+         portAddress: InputPortIdAddress? = nil,
          connectedCanvasItems: CanvasItemIdSet = .init()) {
         self.id = id
         self.anchorPoint = anchorPoint
@@ -35,36 +35,36 @@ final class OutputPortUIData: Identifiable, AnyObject {
 }
 
 
-extension OutputNodeRowViewModel {
+extension InputNodeRowViewModel {
     @MainActor var anchorPoint: CGPoint? {
         get {
-            self.portData.anchorPoint
+            self.portUIViewModel.anchorPoint
         } set(newValue) {
-            self.portData.anchorPoint = newValue
+            self.portUIViewModel.anchorPoint = newValue
         }
     }
     
     @MainActor var portColor: PortColor {
         get {
-            self.portData.portColor
+            self.portUIViewModel.portColor
         } set(newValue) {
-            self.portData.portColor = newValue
+            self.portUIViewModel.portColor = newValue
         }
     }
     
     @MainActor var portAddress: PortAddressType? {
         get {
-            self.portData.portAddress
+            self.portUIViewModel.portAddress
         } set(newValue) {
-            self.portData.portAddress = newValue
+            self.portUIViewModel.portAddress = newValue
         }
     }
     
     @MainActor var connectedCanvasItems: CanvasItemIdSet {
         get {
-            self.portData.connectedCanvasItems
+            self.portUIViewModel.connectedCanvasItems
         } set(newValue) {
-            self.portData.connectedCanvasItems = newValue
+            self.portUIViewModel.connectedCanvasItems = newValue
         }
     }
 }

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputNodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputNodeRowViewModel.swift
@@ -22,7 +22,7 @@ final class OutputNodeRowViewModel: NodeRowViewModel {
     @MainActor var cachedFieldValueGroups = FieldGroupList()
         
     // MARK: data specific to a draggable port on the canvas; not derived from underlying row observer and not applicable to row view models in the inspector
-    @MainActor var portData: OutputPortUIData
+    @MainActor var portUIViewModel: OutputPortUIViewModel
     
     // MARK: delegates, weak references to parents
     
@@ -40,7 +40,7 @@ final class OutputNodeRowViewModel: NodeRowViewModel {
          rowDelegate: OutputNodeRowObserver?,
          canvasItemDelegate: CanvasItemViewModel?) {
         
-        self.portData = .init(id: OutputCoordinate(portId: id.portId,
+        self.portUIViewModel = .init(id: OutputCoordinate(portId: id.portId,
                                                    nodeId: id.nodeId))
         self.id = id
         self.cachedActiveValue = initialValue

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputPortUIViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputPortUIViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  InputPortUIData.swift
+//  OutputPortUIData.swift
 //  Stitch
 //
 //  Created by Christian J Clampitt on 4/21/25.
@@ -9,22 +9,22 @@ import Foundation
 
 // May want a common protocol differentiated by `portAddress` type
 @Observable
-final class InputPortUIData: Identifiable, AnyObject {
+final class OutputPortUIViewModel: Identifiable, AnyObject {
     
-    let id: InputCoordinate // which node id + port id this is for
+    let id: OutputCoordinate // which node id + port id this is for
     
     // the portDragged and portDragEnded methods DO require specific input vs output row view model;
     // so instead you can pass down the nodeIO and the
     @MainActor var anchorPoint: CGPoint? = nil
     @MainActor var portColor: PortColor = .noEdge
-    @MainActor var portAddress: InputPortIdAddress?
+    @MainActor var portAddress: OutputPortIdAddress?
     @MainActor var connectedCanvasItems = CanvasItemIdSet()
     
     @MainActor
-    init(id: InputCoordinate,
+    init(id: OutputCoordinate,
          anchorPoint: CGPoint? = nil,
          portColor: PortColor = .noEdge,
-         portAddress: InputPortIdAddress? = nil,
+         portAddress: OutputPortIdAddress? = nil,
          connectedCanvasItems: CanvasItemIdSet = .init()) {
         self.id = id
         self.anchorPoint = anchorPoint
@@ -35,36 +35,36 @@ final class InputPortUIData: Identifiable, AnyObject {
 }
 
 
-extension InputNodeRowViewModel {
+extension OutputNodeRowViewModel {
     @MainActor var anchorPoint: CGPoint? {
         get {
-            self.portData.anchorPoint
+            self.portUIViewModel.anchorPoint
         } set(newValue) {
-            self.portData.anchorPoint = newValue
+            self.portUIViewModel.anchorPoint = newValue
         }
     }
     
     @MainActor var portColor: PortColor {
         get {
-            self.portData.portColor
+            self.portUIViewModel.portColor
         } set(newValue) {
-            self.portData.portColor = newValue
+            self.portUIViewModel.portColor = newValue
         }
     }
     
     @MainActor var portAddress: PortAddressType? {
         get {
-            self.portData.portAddress
+            self.portUIViewModel.portAddress
         } set(newValue) {
-            self.portData.portAddress = newValue
+            self.portUIViewModel.portAddress = newValue
         }
     }
     
     @MainActor var connectedCanvasItems: CanvasItemIdSet {
         get {
-            self.portData.connectedCanvasItems
+            self.portUIViewModel.connectedCanvasItems
         } set(newValue) {
-            self.portData.connectedCanvasItems = newValue
+            self.portUIViewModel.connectedCanvasItems = newValue
         }
     }
 }

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputPortUIViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/OutputPortUIViewModel.swift
@@ -34,6 +34,12 @@ final class OutputPortUIViewModel: Identifiable, AnyObject {
     }
 }
 
+extension CanvasItemViewModel {
+    @MainActor
+    var outputPortUIViewModels: [OutputPortUIViewModel] {
+        self.outputViewModels.map(\.portUIViewModel)
+    }
+}
 
 extension OutputNodeRowViewModel {
     @MainActor var anchorPoint: CGPoint? {

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -422,31 +422,16 @@ extension GraphState {
         
         return connectedInputs.compactMap { (downstreamInput: InputNodeRowViewModel) in
             
-            guard let upstreamOutputObserver = downstreamInput.rowDelegate?.upstreamOutputObserver else {
-                log("no upstream observer for downstreamInput \(downstreamInput.id)")
-                return nil
-            }
-            
-            guard let upstreamOutputPortUIViewModel = upstreamOutputObserver.nodeRowViewModel?.portUIViewModel else {
-                log("no upstreamOutputPortUIViewModel for downstreamInput \(downstreamInput.id)")
-                return nil
-            }
-            
-            guard let upstreamCanvasItem = self.getCanvasItem(outputId: upstreamOutputObserver.id) else {
-                log("no upstream canvas item for downstreamInput \(downstreamInput.id)")
-                return nil
-            }
-            
-            guard let data = ConnectedEdgeData.create(
-                upstreamCanvasItem: upstreamCanvasItem,
-                upstreamOutputPortUIViewModel: upstreamOutputPortUIViewModel,
-                downstreamInput: downstreamInput) else {
-                
+            guard let upstreamOutputObserver = downstreamInput.rowDelegate?.upstreamOutputObserver,
+                  let upstreamOutputPortUIViewModel = upstreamOutputObserver.rowViewModelForCanvasItemAtThisTraversalLevel?.portUIViewModel,
+                  let upstreamCanvasItem: CanvasItemViewModel = upstreamOutputObserver.rowViewModelForCanvasItemAtThisTraversalLevel?.canvasItemDelegate else {
                 log("no connected edge data for downstreamInput \(downstreamInput.id)")
                 return nil
             }
             
-            return data
+            return ConnectedEdgeData(upstreamCanvasItem: upstreamCanvasItem,
+                                     upstreamOutputPortUIViewModel: upstreamOutputPortUIViewModel,
+                                     downstreamInput: downstreamInput)
         }
     }
 }

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -413,16 +413,40 @@ extension GraphState {
                 canvasItem.inputViewModels
             }
         
-        
-        let connectedInputs = newInputs.filter { input in
+        let connectedInputs: [InputNodeRowViewModel] = newInputs.filter { input in
             guard input.nodeDelegate?.patchNodeViewModel?.patch != .wirelessReceiver else {
                 return false
             }
             return input.rowDelegate?.containsUpstreamConnection ?? false
         }
         
-        return connectedInputs.compactMap { connection in
-            ConnectedEdgeData(downstreamRowObserver: connection)
+        return connectedInputs.compactMap { (downstreamInput: InputNodeRowViewModel) in
+            
+            guard let upstreamOutputObserver = downstreamInput.rowDelegate?.upstreamOutputObserver else {
+                log("no upstream observer for downstreamInput \(downstreamInput.id)")
+                return nil
+            }
+            
+            guard let upstreamOutputPortUIViewModel = upstreamOutputObserver.nodeRowViewModel?.portUIViewModel else {
+                log("no upstreamOutputPortUIViewModel for downstreamInput \(downstreamInput.id)")
+                return nil
+            }
+            
+            guard let upstreamCanvasItem = self.getCanvasItem(outputId: upstreamOutputObserver.id) else {
+                log("no upstream canvas item for downstreamInput \(downstreamInput.id)")
+                return nil
+            }
+            
+            guard let data = ConnectedEdgeData.create(
+                upstreamCanvasItem: upstreamCanvasItem,
+                upstreamOutputPortUIViewModel: upstreamOutputPortUIViewModel,
+                downstreamInput: downstreamInput) else {
+                
+                log("no connected edge data for downstreamInput \(downstreamInput.id)")
+                return nil
+            }
+            
+            return data
         }
     }
 }


### PR DESCRIPTION
Most of our edge-view logic only needs facts about the port UI, not the cached field UI etc. So, where possible, we pass just that port UI data, not the full row view model.

Follow up to https://github.com/StitchDesign/Stitch/pull/1112, showing how to use more specific data.

QA'd on Humane demo and small project with a group node in which I tested creating, updating and deleting edges.