### PR TITLE
Fixed media input looping regressions

### DIFF
--- a/Stitch/Graph/Node/Patch/Type/Value/SplitterPatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Value/SplitterPatchNode.swift
@@ -59,7 +59,8 @@ func mediaAwareIdentityEvaluation(node: PatchNode) -> EvalResult {
                                          media: .init(computedMedia: media))
             }
             
-            return MediaEvalOpResult(values: [value])
+            return MediaEvalOpResult(values: [value],
+                                     media: nil)
         }
         .createPureEvalResult(node: node)
         


### PR DESCRIPTION
Logic was missing for extending/removing ephemeral observers specifically for looped inputs. Fixes issues surrounding loop builder media or any other occasion where media can be created into a loop.