### PR TITLE
Fixed various media looping regressions

### DIFF
--- a/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/Model3DLayerUtil.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/Model3DLayerUtil.swift
@@ -60,7 +60,8 @@ struct Model3DViewModifier: ViewModifier {
                 
                 // Set state for media object
                 let entity = self.createEntity()
-                viewModel.mediaViewModel.inputMedia = .init(computedMedia: .model3D(entity))
+                viewModel.mediaViewModel.inputMedia = .init(computedMedia: .model3D(entity),
+                                                            id: .init())
             }
             .onChange(of: viewModel.size3D) {
                 self.updateEntity()

--- a/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/PreviewModel3DLayer.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/PreviewModel3DLayer.swift
@@ -281,7 +281,8 @@ struct ModelEntityLayerViewModifier: ViewModifier {
                      
                         await MainActor.run { [weak entityCopy] in
                             guard let entityCopy = entityCopy else { return }
-                            previewLayer.mediaViewModel.inputMedia = .init(computedMedia: .model3D(entityCopy))
+                            previewLayer.mediaViewModel.inputMedia = .init(computedMedia: .model3D(entityCopy),
+                                                                           id: .init())
                             self.anchorEntity.addChild(entityCopy.containerEntity)
                             
                             self.assignGestures(entity: entityCopy)

--- a/Stitch/Graph/Node/Model/RowData/GraphMediaValue.swift
+++ b/Stitch/Graph/Node/Model/RowData/GraphMediaValue.swift
@@ -23,8 +23,9 @@ extension GraphMediaValue {
         self.mediaObject = mediaObject
     }
     
-    init(computedMedia: StitchMediaObject) {
-        self.id = .init()
+    init(computedMedia: StitchMediaObject,
+         id: UUID) {
+        self.id = id
         self.dataType = .computed
         self.mediaObject = computedMedia
     }

--- a/Stitch/Graph/Node/Patch/Type/Media/Base64StringToImagePatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Media/Base64StringToImagePatchNode.swift
@@ -61,9 +61,10 @@ func base64StringToImageEval(node: PatchNode) -> EvalResult {
                                               node: node) {
             switch await convertBase64StringToImage(inputBase64String) {
             case .success(let image):
-                let mediaValue = GraphMediaValue(computedMedia: .image(image))
+                let mediaValue = GraphMediaValue(computedMedia: .image(image),
+                                                 id: .init())
                 
-                return .init(values: [.asyncMedia(AsyncMediaValue(id: .init(),
+                return .init(values: [.asyncMedia(AsyncMediaValue(id: mediaValue.id,
                                                     dataType: .computed,
                                                     label: "Image"))],
                              media: mediaValue)

--- a/Stitch/Graph/Node/Patch/Type/Media/CameraFeedNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Media/CameraFeedNode.swift
@@ -180,7 +180,8 @@ func cameraFeedEval(node: PatchNode,
                                             label: "Camera")),
                 .size(currentCameraImage.layerSize)
             ],
-            media: .init(computedMedia: .image(currentCameraImage))
+            media: .init(computedMedia: .image(currentCameraImage),
+                         id: newId)
         )
     }
 }

--- a/Stitch/Graph/Node/Patch/Type/Media/MicrophoneFeedNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Media/MicrophoneFeedNode.swift
@@ -64,7 +64,8 @@ func microphoneEval(node: PatchNode) -> EvalResult {
             let newMic = StitchMic(isEnabled: isEnabled)
             let newSoundPlayer = StitchSoundPlayer(delegate: newMic, willPlay: true)
             
-            mediaObserver.computedMedia = .init(computedMedia: .mic(newSoundPlayer))
+            mediaObserver.computedMedia = .init(computedMedia: .mic(newSoundPlayer),
+                                                id: .init())
             
             return MediaEvalOpResult(values: node.defaultOutputs,
                                      media: mediaObserver.computedMedia)

--- a/Stitch/Graph/Node/Patch/Type/Value/SplitterPatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Value/SplitterPatchNode.swift
@@ -56,7 +56,8 @@ func mediaAwareIdentityEvaluation(node: PatchNode) -> EvalResult {
                                               loopIndex: loopIndex,
                                               mediaId: nil) {
                 return MediaEvalOpResult(values: [value],
-                                         media: .init(computedMedia: media))
+                                         media: .init(computedMedia: media,
+                                                      id: value.asyncMedia?.id ?? .init()))
             }
             
             return MediaEvalOpResult(values: [value],

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Media/Utils/MediaActions.swift
@@ -265,7 +265,8 @@ extension GraphState {
         }
         
         guard let mediaObserver = node.ephemeralObservers?[safe: loopIndex] as? MediaEvalOpObservable else {
-            fatalErrorIfDebug()
+            // Valid failure if loop builder removes input
+//            fatalErrorIfDebug()
             return
         }
         

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/NetworkRequest/NetworkRequestHandleResponse.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/NetworkRequest/NetworkRequestHandleResponse.swift
@@ -175,7 +175,8 @@ extension NetworkRequestNode {
             value = .asyncMedia(AsyncMediaValue(id: id,
                                                 dataType: .computed,
                                                 label: "Network Request Image"))
-            media = .init(computedMedia: mediaObjectLoaded)
+            media = .init(computedMedia: mediaObjectLoaded,
+                          id: id)
             
         case (RequestedResource.json(let x)):
             value = .init(x)

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -946,13 +946,16 @@ extension GraphState {
             
             outputsToUpdate[portId] = outputToUpdate
             
-            let mediaList: [GraphMediaValue?]? = media == nil ? nil : [media]
+            var outputMediaList = node.getAllMediaObservers()?.map(\.computedMedia) ?? []
+            if outputMediaList.count > loopIndex {
+                outputMediaList[loopIndex] = media
+            }
             
             // Update downstream node's inputs
             let changedInputIds = self.updateDownstreamInputs(
                 sourceNode: node,
                 upstreamOutputValues: outputToUpdate,
-                mediaList: mediaList,
+                mediaList: outputMediaList,
                 upstreamOutputChanged: outputsChanged,
                 outputCoordinate: outputCoordinate)
             let changedNodeIds = Set(changedInputIds.map(\.nodeId)).toSet


### PR DESCRIPTION
Fixes issues caused by media IDs incorrectly instantiating when we needed to use an already existing ID. Causing mismatches down the road that broke some media looping into loop builder, and perhaps other places.

Specifically enables camera feed input into loop builder.