### PR TITLE
Wipe outputs when graph reset; add test

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -793,6 +793,7 @@
 		ECBC95FB27613D9200508966 /* evalTests+2.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBC95FA27613D9200508966 /* evalTests+2.swift */; };
 		ECBD32FD2988A31E00C778BE /* ImpureEvaluation.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBD32FC2988A31E00C778BE /* ImpureEvaluation.swift */; };
 		ECBD32FF2988A36F00C778BE /* PureEvaluation.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBD32FE2988A36F00C778BE /* PureEvaluation.swift */; };
+		ECBFDB0B2DB98B4500C1D6D5 /* GraphTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBFDB0A2DB98B4500C1D6D5 /* GraphTests.swift */; };
 		ECC175872A43D6A30017815D /* StitchNodeNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC175862A43D6A30017815D /* StitchNodeNames.swift */; };
 		ECC1758A2A43D9440017815D /* LayerDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC175892A43D9440017815D /* LayerDescription.swift */; };
 		ECC2BCCB2B9B72A700D5F942 /* SidebarListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC2BCCA2B9B72A700D5F942 /* SidebarListView.swift */; };
@@ -1771,6 +1772,7 @@
 		ECBC95FA27613D9200508966 /* evalTests+2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "evalTests+2.swift"; sourceTree = "<group>"; };
 		ECBD32FC2988A31E00C778BE /* ImpureEvaluation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImpureEvaluation.swift; sourceTree = "<group>"; };
 		ECBD32FE2988A36F00C778BE /* PureEvaluation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PureEvaluation.swift; sourceTree = "<group>"; };
+		ECBFDB0A2DB98B4500C1D6D5 /* GraphTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphTests.swift; sourceTree = "<group>"; };
 		ECC175862A43D6A30017815D /* StitchNodeNames.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StitchNodeNames.swift; sourceTree = "<group>"; };
 		ECC175892A43D9440017815D /* LayerDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerDescription.swift; sourceTree = "<group>"; };
 		ECC2BCCA2B9B72A700D5F942 /* SidebarListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarListView.swift; sourceTree = "<group>"; };
@@ -2069,6 +2071,7 @@
 				B5305CE5285150D1008F11F4 /* SampleData */,
 				B54C37B9281BB8B400D81E43 /* SampleProjects */,
 				B54C37B62818FB4D00D81E43 /* Versioning */,
+				ECBFDB0A2DB98B4500C1D6D5 /* GraphTests.swift */,
 				EC10BA512629FBF800A9BE89 /* evalTests.swift */,
 				ECBC95FA27613D9200508966 /* evalTests+2.swift */,
 				ECFCF1822A395C6900A20C40 /* perfTests.swift */,
@@ -5825,6 +5828,7 @@
 				ECBC95FB27613D9200508966 /* evalTests+2.swift in Sources */,
 				E42C0D052D47F87A00AA2BB1 /* openAIRequestTests.swift in Sources */,
 				EC6DF0AB29FA050F0052545E /* jsonPerfTests.swift in Sources */,
+				ECBFDB0B2DB98B4500C1D6D5 /* GraphTests.swift in Sources */,
 				B5F9EB9E28D3927F00112799 /* MockFileManager.swift in Sources */,
 				ECF007A926A1D8D0001329B6 /* jsonTests.swift in Sources */,
 				B54C9BEC2762B01000FA2BC0 /* cameraTests.swift in Sources */,

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverSchemaObserverIdentifiable.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverSchemaObserverIdentifiable.swift
@@ -90,6 +90,6 @@ extension OutputNodeRowObserver {
     func onPrototypeRestart(document: StitchDocumentViewModel) {
         // Set outputs to be empty
         // MARK: no longer seems necessary, removing for fixing flashing media on restart
-//        self.allLoopedValues = []
+        self.allLoopedValues = []
     }
 }

--- a/StitchTests/GraphTests.swift
+++ b/StitchTests/GraphTests.swift
@@ -1,0 +1,51 @@
+//
+//  GraphTests.swift
+//  StitchTests
+//
+//  Created by Christian J Clampitt on 4/23/25.
+//
+
+import XCTest
+@testable import Stitch
+
+final class GraphTests: XCTestCase {
+    
+    @MainActor var store = StitchStore()
+    
+    // Cannot be async, so cannot be used to create a document
+    @MainActor
+    override func setUp() {
+        self.store = StitchStore() // wipe the store
+    }
+
+    /*
+     We treat graph open and graph reset the same: outputs are empty.
+     
+     Nodes' evals know how to provide themselves with default prevValues if the output is empty etc.
+     
+     Added as test due to regression where we stopped wiping outputs (which broke e.g. Counter node on graph reset) and did not catch it in QA.
+     */
+    @MainActor
+    func testOutputsWipedOnGraphReset() throws {
+        let document: StitchDocumentViewModel = .createTestFriendlyDocument(store)
+        
+        let counterNode = document.nodeInserted(choice: .patch(.counter))!
+        let loopOptionSwitchNode = document.nodeInserted(choice: .patch(.loopOptionSwitch))!
+                
+        // Provide some non-zero value
+        counterNode.outputsObservers.first!.updateOutputValues([.number(99)])
+        loopOptionSwitchNode.outputsObservers.first!.updateOutputValues([.number(99)])
+        
+        // Confirm the output is non-zero
+        XCTAssert(counterNode.outputs.first!.first!.getNumber == 99)
+        XCTAssert(loopOptionSwitchNode.outputs.first!.first!.getNumber == 99)
+        
+        // Restart the prototype
+        document.onPrototypeRestart(document: document)
+        
+        // Confirm the output is zero
+        XCTAssert(counterNode.outputs.first!.first!.getNumber == 0)
+        XCTAssert(loopOptionSwitchNode.outputs.first!.first!.getNumber == 0)
+    }
+
+}


### PR DESCRIPTION
Added test since we missed this during QA and the regression has been around ~2 weeks.


https://github.com/user-attachments/assets/d1682802-bbd3-4796-9196-2cc5e57f8b83

