### PR TITLE
U/ellbosch/2504/prev value fix

### DIFF
--- a/Stitch/Graph/Node/Eval/LoopedEval.swift
+++ b/Stitch/Graph/Node/Eval/LoopedEval.swift
@@ -259,6 +259,20 @@ extension NodeViewModel {
             
         return results
     }
+    
+    /// Saves previous values in `ComputedNodeState`.
+    @MainActor
+    func loopedEvalOutputsPersistence(graphTime: TimeInterval,
+                                      callback: @escaping (PortValues, TimeInterval, ComputedNodeState) -> PortValue) -> EvalResult {
+        self.loopedEval(ComputedNodeState.self) { values, computedState, _ in
+            let newValue = callback(values,
+                                    graphTime,
+                                    computedState)
+            computedState.previousValue = newValue
+            
+            return [newValue]
+        }
+    }
 }
 
 @MainActor

--- a/Stitch/Graph/Node/Model/Definition/PatchNodeDefinitionKinds.swift
+++ b/Stitch/Graph/Node/Model/Definition/PatchNodeDefinitionKinds.swift
@@ -258,7 +258,7 @@ extension Patch {
         case .loopFilter:
             return nil
         case .loopOptionSwitch:
-            return nil
+            return LoopOptionSwitchNode.self
         case .loopRemove:
             return LoopRemoveNode.self
         case .loopReverse:

--- a/Stitch/Graph/Node/Patch/Type/Loop/LoopInsert.swift
+++ b/Stitch/Graph/Node/Patch/Type/Loop/LoopInsert.swift
@@ -61,7 +61,9 @@ final class LoopingEphemeralObserver: NodeEphemeralObservable {
 }
 
 extension LoopingEphemeralObserver {
-    func onPrototypeRestart(document: StitchDocumentViewModel) { }
+    func onPrototypeRestart(document: StitchDocumentViewModel) {
+        self.previousValues = []
+    }
 }
 
 extension PortValues {

--- a/Stitch/Graph/Node/Patch/Type/Pulse/CounterNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Pulse/CounterNode.swift
@@ -73,9 +73,6 @@ func counterOpClosure(values: PortValues,
     // old output
     let prevValue: Double = computedState.previousValue?.getNumber ?? .zero
     
-    // update new previous value, default to 0 if there wasn't a previous value
-    //        computedState.previousValue = isNewState ? .number(0) : values[safe: 5]
-    
     //        log("counterOpClosure: graphTime: \(graphTime)")
     //        log("counterOpClosure: incPulse: \(incPulse)")
     //        log("counterOpClosure: values[0].getPulse: \(values[0].getPulse!)")

--- a/Stitch/Graph/Node/Patch/Type/Pulse/CounterNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Pulse/CounterNode.swift
@@ -53,61 +53,60 @@ struct CounterPatchNode: PatchNodeDefinition {
 @MainActor
 func counterEval(node: PatchNode,
                  graphStep: GraphStepState) -> ImpureEvalResult {
-
-    let inputsValues = node.inputs
-    let outputsValues = node.outputs
+    
     let graphTime: TimeInterval = graphStep.graphTime
-
-    let previousOutput: PortValues = outputsValues.first ?? [.number(.zero)]
-
-    let op = counterOpClosure(graphTime: graphTime)
-
-    return pulseEvalUpdate(
-        inputsValues,
-        [previousOutput],
-        op)
+    
+    return node.loopedEval(ComputedNodeState.self) { values, computedState, _ in
+        let newValue = counterOpClosure(values: values,
+                                        graphTime: graphTime,
+                                        computedState: computedState)
+        computedState.previousValue = newValue
+        
+        return [newValue]
+    }
 }
 
-func counterOpClosure(graphTime: TimeInterval) -> PulseOperationT {
-
-    return { (values: PortValues) -> PulseOpResultT in
-
-        let incPulsed = values[0].getPulse?.shouldPulse(graphTime) ?? false
-        let decPulsed = values[1].getPulse?.shouldPulse(graphTime) ?? false
-        let jumpPulsed = values[2].getPulse?.shouldPulse(graphTime) ?? false
-
-        let jumpNumber = values[3].getNumber ?? .zero
-        let maxNumber = values[4].getNumber ?? .zero
-
-        // old output
-        let prevValue: Double = values[safe: 5]?.getNumber ?? .zero
-
-        //        log("counterOpClosure: graphTime: \(graphTime)")
-        //        log("counterOpClosure: incPulse: \(incPulse)")
-        //        log("counterOpClosure: values[0].getPulse: \(values[0].getPulse!)")
-        //        log("counterOpClosure: values[5].getNumber: \(values[5].getNumber!)")
-
-        // Jump has priority if we received multiple pulses
-        if jumpPulsed {
-            return PulseOpResultT(.number(jumpNumber))
+func counterOpClosure(values: PortValues,
+                      graphTime: TimeInterval,
+                      computedState: ComputedNodeState) -> PortValue {
+    let incPulsed = values[0].getPulse?.shouldPulse(graphTime) ?? false
+    let decPulsed = values[1].getPulse?.shouldPulse(graphTime) ?? false
+    let jumpPulsed = values[2].getPulse?.shouldPulse(graphTime) ?? false
+    
+    let jumpNumber = values[3].getNumber ?? .zero
+    let maxNumber = values[4].getNumber ?? .zero
+    
+    // old output
+    let prevValue: Double = computedState.previousValue?.getNumber ?? .zero
+    
+    // update new previous value, default to 0 if there wasn't a previous value
+    //        computedState.previousValue = isNewState ? .number(0) : values[safe: 5]
+    
+    //        log("counterOpClosure: graphTime: \(graphTime)")
+    //        log("counterOpClosure: incPulse: \(incPulse)")
+    //        log("counterOpClosure: values[0].getPulse: \(values[0].getPulse!)")
+    //        log("counterOpClosure: values[5].getNumber: \(values[5].getNumber!)")
+    
+    // Jump has priority if we received multiple pulses
+    if jumpPulsed {
+        return .number(jumpNumber)
+    }
+    // Inc and Dec cancel each other out.
+    else if incPulsed && decPulsed {
+        //            log("counterOpClosure: no change")
+        return .number(prevValue)
+    } else if incPulsed {
+        //            log("counterOpClosure: incPulsed")
+        var n = prevValue + 1
+        if (maxNumber > 0) && n >= maxNumber {
+            n = 0
         }
-        // Inc and Dec cancel each other out.
-        else if incPulsed && decPulsed {
-            //            log("counterOpClosure: no change")
-            return PulseOpResultT(.number(prevValue))
-        } else if incPulsed {
-            //            log("counterOpClosure: incPulsed")
-            var n = prevValue + 1
-            if (maxNumber > 0) && n >= maxNumber {
-                n = 0
-            }
-            return PulseOpResultT(.number(n))
-        } else if decPulsed {
-            //            log("counterOpClosure: decPulsed")
-            return PulseOpResultT(.number(prevValue - 1))
-        } else {
-            //            log("counterOpClosure: no change")
-            return PulseOpResultT(.number(prevValue))
-        }
+        return .number(n)
+    } else if decPulsed {
+        //            log("counterOpClosure: decPulsed")
+        return .number(prevValue - 1)
+    } else {
+        //            log("counterOpClosure: no change")
+        return .number(prevValue)
     }
 }

--- a/Stitch/Graph/Node/Patch/Type/Pulse/CounterNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Pulse/CounterNode.swift
@@ -56,14 +56,8 @@ func counterEval(node: PatchNode,
     
     let graphTime: TimeInterval = graphStep.graphTime
     
-    return node.loopedEval(ComputedNodeState.self) { values, computedState, _ in
-        let newValue = counterOpClosure(values: values,
-                                        graphTime: graphTime,
-                                        computedState: computedState)
-        computedState.previousValue = newValue
-        
-        return [newValue]
-    }
+    return node.loopedEvalOutputsPersistence(graphTime: graphTime,
+                                             callback: counterOpClosure)
 }
 
 func counterOpClosure(values: PortValues,

--- a/Stitch/Graph/Node/Patch/Type/Pulse/SwitchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Pulse/SwitchNode.swift
@@ -45,56 +45,46 @@ struct SwitchNode: PatchNodeDefinition {
 @MainActor
 func switchEval(node: PatchNode,
                 graphStep: GraphStepState) -> ImpureEvalResult {
-
-    let inputsValues = node.inputs
-    let outputsValues = node.outputs
-    let graphTime: TimeInterval = graphStep.graphTime
-
-    let op = switchOpClosure(graphTime: graphTime)
-
-    return pulseEvalUpdate(
-        inputsValues,
-        [outputsValues.first ?? [.bool(false)]],
-        op)
+    node.loopedEvalOutputsPersistence(graphTime: graphStep.graphTime,
+                                      callback: switchOpClosure)
 }
 
-func switchOpClosure(graphTime: TimeInterval) -> PulseOperationT {
+func switchOpClosure(values: PortValues,
+                     graphTime: TimeInterval,
+                     computedState: ComputedNodeState) -> PortValue {
 
-    return { (values: PortValues) -> PulseOpResultT in
-
-        // values are all the inputs' values at that given index slot
-        let flipPulsed: Bool = (values.first?.getPulse ?? .zero).shouldPulse(graphTime)
-
-        let onPulsed: Bool = (values[safe: 1]?.getPulse ?? .zero).shouldPulse(graphTime)
-
-        let offPulsed: Bool = (values[safe: 2]?.getPulse ?? .zero).shouldPulse(graphTime)
-
-        //        log("switchEval op: flipPulsed: \(flipPulsed)")
-        //        log("switchEval op: onPulsed: \(onPulsed)")
-        //        log("switchEval op: flipPulsed: \(flipPulsed)")
-
-        // previous outputs were added to end of inputs
-        let prevValue: PortValue = values[safe: 3] ?? .bool(false)
-
-        if prevValue.getBool == nil {
-            fatalError("switchEval")
-        }
-
-        // NEEDS TESTS; only confirmed in-app.
-
-        // ie turn on + turn off at same time => noop
-        // and shouldFlip overpowers should turn on vs off
-        if flipPulsed {
-            let x = toggleBool(prevValue.getBool!)
-            //            log("switchEval op: flip: x: \(x)")
-            return PulseOpResultT(.bool(x))
-        } else if onPulsed && !offPulsed {
-            return PulseOpResultT(.bool(true))
-        } else if !onPulsed && offPulsed {
-            return PulseOpResultT(.bool(false))
-        } else {
-            //            log("switchEval op: default: prevValue: \(prevValue)")
-            return PulseOpResultT(prevValue)
-        }
+    // values are all the inputs' values at that given index slot
+    let flipPulsed: Bool = (values.first?.getPulse ?? .zero).shouldPulse(graphTime)
+    
+    let onPulsed: Bool = (values[safe: 1]?.getPulse ?? .zero).shouldPulse(graphTime)
+    
+    let offPulsed: Bool = (values[safe: 2]?.getPulse ?? .zero).shouldPulse(graphTime)
+    
+    //        log("switchEval op: flipPulsed: \(flipPulsed)")
+    //        log("switchEval op: onPulsed: \(onPulsed)")
+    //        log("switchEval op: flipPulsed: \(flipPulsed)")
+    
+    // previous outputs were added to end of inputs
+    let prevValue: PortValue = computedState.previousValue ?? .bool(false)
+    
+    if prevValue.getBool == nil {
+        fatalError("switchEval")
+    }
+    
+    // NEEDS TESTS; only confirmed in-app.
+    
+    // ie turn on + turn off at same time => noop
+    // and shouldFlip overpowers should turn on vs off
+    if flipPulsed {
+        let x = toggleBool(prevValue.getBool!)
+        //            log("switchEval op: flip: x: \(x)")
+        return .bool(x)
+    } else if onPulsed && !offPulsed {
+        return .bool(true)
+    } else if !onPulsed && offPulsed {
+        return .bool(false)
+    } else {
+        //            log("switchEval op: default: prevValue: \(prevValue)")
+        return prevValue
     }
 }

--- a/Stitch/Graph/Node/Patch/Util/PatchDefaultNodeExtensions.swift
+++ b/Stitch/Graph/Node/Patch/Util/PatchDefaultNodeExtensions.swift
@@ -182,8 +182,6 @@ extension Patch {
             node = loopCountNode(id: id, position: position, zIndex: zIndex)
         case .loopDedupe:
             node = loopDedupeNode(id: id, position: position, zIndex: zIndex)
-        case .loopOptionSwitch:
-            node = loopOptionSwitchNode(id: id, position: position, zIndex: zIndex)
         case .loopReverse:
             node = loopReverseNode(id: id, position: position, zIndex: zIndex)
         case .loopSum:

--- a/Stitch/Graph/Node/Patch/Util/PatchUtils.swift
+++ b/Stitch/Graph/Node/Patch/Util/PatchUtils.swift
@@ -424,7 +424,7 @@ extension Patch {
             } else {
                 return .single(.coreML)
             }
-        case .loopBuilder, .splitter:
+        case .loopBuilder, .splitter, .loopInsert, .loopRemove:
             return .all
         default:
             return nil

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverSchemaObserverIdentifiable.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserverSchemaObserverIdentifiable.swift
@@ -90,6 +90,6 @@ extension OutputNodeRowObserver {
     func onPrototypeRestart(document: StitchDocumentViewModel) {
         // Set outputs to be empty
         // MARK: no longer seems necessary, removing for fixing flashing media on restart
-        self.allLoopedValues = []
+//        self.allLoopedValues = []
     }
 }


### PR DESCRIPTION
Tagging #1126, which reverted media flashing fixes in favor of prototype restart fixes. This PR aims to accomplish fixes for both.

Nodes which rely on previous values now use ephemeral state to hold those previous values, which get reset by prototype restart. A few nodes weren't doing that, now they mostly are after this change.