### PR TITLE
Padding on bottom of inspector

### DIFF
--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -120,7 +120,8 @@ struct LayerInspectorView: View {
                 #if targetEnvironment(macCatalyst)
                 .padding(.trailing, LAYER_INSPECTOR_ROW_SPACING + LAYER_INSPECTOR_ROW_ICON_LENGTH)
                 #endif
-                .padding(.bottom)
+                
+                bottomPadding
                 
             } // List
             .listSectionSpacing(.compact) // reduce spacing between sections
@@ -130,6 +131,15 @@ struct LayerInspectorView: View {
             // And using .plain requires manually adding trailing and leading padding
             .listStyle(.plain)
         } // VStack
+    }
+    
+    // Lists are a little strange with their bottom padding
+    var bottomPadding: some View {
+        Rectangle()
+            .fill(.clear)
+            .frame(height: 24)
+            .listRowBackground(Color.WHITE_IN_LIGHT_MODE_BLACK_IN_DARK_MODE.ignoresSafeArea())
+            .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0,  trailing: 0))
     }
 }
 


### PR DESCRIPTION
last input row is no longer so close to the bottom, gives us a little more room to breathe

<img width="1440" alt="Screenshot 2025-04-24 at 7 28 28 PM" src="https://github.com/user-attachments/assets/6033514d-266e-4be8-a932-e052c2ce5a08" />
