### PR TITLE
Use `KeyPath` instead of `ReferenceWritableKeyPath`  for layerNodeKeyPath

### DIFF
--- a/Stitch/Graph/Node/Model/RowData/LayerInputType.swift
+++ b/Stitch/Graph/Node/Model/RowData/LayerInputType.swift
@@ -1426,7 +1426,8 @@ extension PortValue {
 
 extension LayerInputType {
     /// Key paths for parent layer view model
-    var layerNodeKeyPath: ReferenceWritableKeyPath<LayerNodeViewModel, InputLayerNodeRowData> {
+//    var layerNodeKeyPath: ReferenceWritableKeyPath<LayerNodeViewModel, InputLayerNodeRowData> {
+    var layerNodeKeyPath: KeyPath<LayerNodeViewModel, InputLayerNodeRowData> {
         let portKeyPath = self.layerInput.layerNodeKeyPath
         
         switch self.portType {


### PR DESCRIPTION
Apparently we did not need `ReferenceWritableKeyPath`  for layerNodeKeyPath ?

No compiler complaints.

QA'd on Humane demo, Circular Text demo.