### PR TITLE
Do not add whole input to canvas if one field already on canvas

### DIFF
--- a/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
@@ -56,34 +56,31 @@ struct GenericFlyoutView: View {
     }
         
     var body: some View {
-        // TODO: APRIL 25
-        Text("FIX ME")
-        
-//        VStack(alignment: .leading) {
-//            FlyoutHeader(flyoutTitle: layerInput.label(useShortLabel: true))
-//            flyoutRows
-//        }
-//        .modifier(FlyoutBackgroundColorModifier(
-//            width: Self.DEFAULT_FLYOUT_WIDTH,
-//            height: self.$height))
+        VStack(alignment: .leading) {
+            FlyoutHeader(flyoutTitle: layerInput.label(useShortLabel: true))
+            flyoutRows
+        }
+        .modifier(FlyoutBackgroundColorModifier(
+            width: Self.DEFAULT_FLYOUT_WIDTH,
+            height: self.$height))
     }
     
     @State var selectedFlyoutRow: Int? = nil
-//        
-//    // TODO: just use `NodeInputView` here ? Or keep this view separate and compose views ?
-//    @ViewBuilder @MainActor
-//    var flyoutRows: some View {
-//        // Assumes: all flyouts (besides shadow-flyout) have a single row which contains multiple fields
-//        LayerInputFieldsView(layerInputFieldType: .flyout,
-//                             document: document,
-//                             graph: graph,
-//                             node: node,
-//                             rowObserver: layerInputObserver.packedRowObserver,
-//                             rowViewModel: rowViewModel,
-//                             fieldValueTypes: fieldValueTypes,
-//                             layerInputObserver: layerInputObserver,
-//                             isNodeSelected: false)
-//    }
+    
+    // TODO: just use `NodeInputView` here ? Or keep this view separate and compose views ?
+    @ViewBuilder @MainActor
+    var flyoutRows: some View {
+        // Assumes: all flyouts (besides shadow-flyout) have a single row which contains multiple fields
+        LayerInputFieldsView(layerInputFieldType: .flyout,
+                             document: document,
+                             graph: graph,
+                             node: node,
+                             rowObserver: layerInputObserver.packedRowObserver,
+                             rowViewModel: rowViewModel,
+                             fieldValueTypes: fieldValueTypes,
+                             layerInputObserver: layerInputObserver,
+                             isNodeSelected: false)
+    }
 }
 
 extension Int {
@@ -258,16 +255,19 @@ struct FlyoutBackgroundColorModifier: ViewModifier {
 }
 
 
-extension GraphState {
+//extension GraphState {
+extension StitchDocumentViewModel {
     @MainActor
     func addLayerFieldToGraph(layerInput: LayerInputPort,
                               nodeId: NodeId,
                               fieldIndex: Int,
                               groupNodeFocused: NodeId?) {
         
-        guard let node = self.getNode(nodeId),
-              let layerNode = node.layerNode,
-              let document = self.documentDelegate else {
+        let document = self
+        let graph = document.visibleGraph
+        
+        guard let node = graph.getNode(nodeId),
+              let layerNode = node.layerNode else {
             log("LayerInputFieldAddedToGraph: no node, layer node and/or document")
             fatalErrorIfDebug()
             return
@@ -281,42 +281,50 @@ extension GraphState {
             fatalErrorIfDebug("LayerInputFieldAddedToGraph: no unpacked port for fieldIndex \(fieldIndex)")
             return
         }
-                
-        var unpackSchema = unpackedPort.createSchema()
-        unpackSchema.canvasItem = .init(position: document.newCanvasItemInsertionLocation,
-                                        zIndex: self.highestZIndex + 1,
-                                        parentGroupNodeId: groupNodeFocused)
         
-        // MARK: first group type grabbed since layers don't have differing groups within one input
+        
+        // MARK: CREATING AND INITIALIZING THE CANVAS ITEM VIEW MODEL ITSELF
+        
+        // First field-group grabbed since layers don't have differing groups within one input
         guard let unpackedPortParentFieldGroupType: FieldGroupType = layerInput
             .getDefaultValue(for: layerNode.layer)
-            .getNodeRowType(nodeIO: .input,
-                            layerInputPort: layerInput,
-                            isLayerInspector: true)
-                .fieldGroupTypes
+            .getNodeRowType(nodeIO: .input, layerInputPort: layerInput, isLayerInspector: true)
+            .fieldGroupTypes
             .first else {
-            
             fatalErrorIfDebug()
             return
         }
         
-        unpackedPort.update(from: unpackSchema,
-                            layerInputType: unpackedPort.id,
-                            layerNode: layerNode,
-                            nodeId: nodeId)
+        let canvasObserver = CanvasItemViewModel(
+            id: CanvasItemId.layerInput(LayerInputCoordinate(node: nodeId,
+                                                             keyPath: unpackedPort.id)),
+            position: document.newCanvasItemInsertionLocation,
+            zIndex: graph.highestZIndex + 1,
+            parentGroupNodeId: groupNodeFocused,
+            inputRowObservers: [unpackedPort.rowObserver],
+            outputRowObservers: [])
         
-        unpackedPort.canvasObserver?.initializeDelegate(
+        canvasObserver.initializeDelegate(
             node,
             activeIndex: document.activeIndex,
             unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
             unpackedPortIndex: fieldIndex)
+        
+        unpackedPort.canvasObserver = canvasObserver
+        
+        
+
+        // MARK: Change the pack mode
         
         let newPackMode = portObserver.mode
         if previousPackMode != newPackMode {
             portObserver.wasPackModeToggled(document: document)
         }
         
-        self.resetLayerInputsCache(layerNode: layerNode)
+        
+        // MARK: RESET CACHE
+        
+        graph.resetLayerInputsCache(layerNode: layerNode) // Why?
     }
 }
 
@@ -328,15 +336,11 @@ struct LayerInputFieldAddedToGraph: StitchDocumentEvent {
     
     @MainActor
     func handle(state: StitchDocumentViewModel) {
-        
-        //        log("LayerInputFieldAddedToGraph: layerInput: \(layerInput)")
-        //        log("LayerInputFieldAddedToGraph: nodeId: \(nodeId)")
-        //        log("LayerInputFieldAddedToGraph: fieldIndex: \(fieldIndex)")
-        
+                
         let graph = state.visibleGraph
         
         let addLayerField = { (nodeId: NodeId) in
-            graph.addLayerFieldToGraph(layerInput: layerInput,
+            state.addLayerFieldToGraph(layerInput: layerInput,
                                        nodeId: nodeId,
                                        fieldIndex: fieldIndex,
                                        groupNodeFocused: state.groupNodeFocused?.groupNodeId)

--- a/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
@@ -56,31 +56,34 @@ struct GenericFlyoutView: View {
     }
         
     var body: some View {
-        VStack(alignment: .leading) {
-            FlyoutHeader(flyoutTitle: layerInput.label(useShortLabel: true))
-            flyoutRows
-        }
-        .modifier(FlyoutBackgroundColorModifier(
-            width: Self.DEFAULT_FLYOUT_WIDTH,
-            height: self.$height))
+        // TODO: APRIL 25
+        Text("FIX ME")
+        
+//        VStack(alignment: .leading) {
+//            FlyoutHeader(flyoutTitle: layerInput.label(useShortLabel: true))
+//            flyoutRows
+//        }
+//        .modifier(FlyoutBackgroundColorModifier(
+//            width: Self.DEFAULT_FLYOUT_WIDTH,
+//            height: self.$height))
     }
     
     @State var selectedFlyoutRow: Int? = nil
-        
-    // TODO: just use `NodeInputView` here ? Or keep this view separate and compose views ?
-    @ViewBuilder @MainActor
-    var flyoutRows: some View {
-        // Assumes: all flyouts (besides shadow-flyout) have a single row which contains multiple fields
-        LayerInputFieldsView(layerInputFieldType: .flyout,
-                             document: document,
-                             graph: graph,
-                             node: node,
-                             rowObserver: layerInputObserver.packedRowObserver,
-                             rowViewModel: rowViewModel,
-                             fieldValueTypes: fieldValueTypes,
-                             layerInputObserver: layerInputObserver,
-                             isNodeSelected: false)
-    }
+//        
+//    // TODO: just use `NodeInputView` here ? Or keep this view separate and compose views ?
+//    @ViewBuilder @MainActor
+//    var flyoutRows: some View {
+//        // Assumes: all flyouts (besides shadow-flyout) have a single row which contains multiple fields
+//        LayerInputFieldsView(layerInputFieldType: .flyout,
+//                             document: document,
+//                             graph: graph,
+//                             node: node,
+//                             rowObserver: layerInputObserver.packedRowObserver,
+//                             rowViewModel: rowViewModel,
+//                             fieldValueTypes: fieldValueTypes,
+//                             layerInputObserver: layerInputObserver,
+//                             isNodeSelected: false)
+//    }
 }
 
 extension Int {

--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -20,67 +20,69 @@ struct LayerInspectorInputPortView: View {
     }
     
     var body: some View {
+        // TODO: APRIL 25
+        Text("Fix me")
         
-        let observerMode = layerInputObserver.observerMode
-        
-        // TODO: is this really correct, to always treat the layer's input as packed ?
-        let layerInputType = LayerInputType(layerInput: layerInputObserver.port,
-                                            // Always `.packed` at the inspector-row level
-                                            portType: .packed)
-        
-        let layerInspectorRowId: LayerInspectorRowId = .layerInput(layerInputType)
-        
-        // We pass down coordinate because that can be either for an input (added whole input to the graph) or output (added whole output to the graph, i.e. a port id)
-        // But now, what `AddLayerPropertyToGraphButton` needs is more like `RowCoordinate = LayerPortCoordinate || OutputCoordinate`
-        
-        // but canvas item view model needs to know "packed vs unpacked" for its id;
-        // so we do need to pass the packed-vs-unpacked information
-        
-        let coordinate: NodeIOCoordinate = .init(
-            portType: .keyPath(layerInputType),
-            nodeId: node.id)
-        
-        // Does this inspector-row (the entire input) have a canvas item?
-        let canvasItemId: CanvasItemId? = observerMode.isPacked ? layerInputObserver._packedData.canvasObserver?.id : nil
-        
-        LayerInspectorPortView(layerInputObserver: layerInputObserver,
-                               layerInspectorRowId: layerInspectorRowId,
-                               coordinate: coordinate,
-                               graph: graph,
-                               document: document,
-                               canvasItemId: canvasItemId) { isPropertyRowSelected in
-                    HStack {
-                        if isShadowLayerInputRow {
-                            ShadowInputInspectorRow(nodeId: node.id,
-                                                    isPropertyRowSelected: isPropertyRowSelected)
-                        }
-                        
-                        // Note: 3D Transform and PortValue.padding are arranged in a "grid" in the inspector ONLY.
-                        // So we handle them here, rather than in `fields` views used in flyouts and on canvas.
-                        else if layerInputObserver.port == .transform3D {
-                            LayerInspector3DTransformInputView(document: document,
-                                                               graph: graph,
-                                                               nodeId: node.id,
-                                                               layerInputObserver: layerInputObserver,
-                                                               isPropertyRowSelected: isPropertyRowSelected)
-                        } else if layerInputObserver.usesGridMultifieldArrangement() {
-                            // Multifields in the inspector are always "read-only" and "tap to open flyout"
-                            LayerInspectorGridInputView(document: document,
-                                                        graph: graph,
-                                                        node: node,
-                                                        layerInputObserver: layerInputObserver,
-                                                        isPropertyRowSelected: isPropertyRowSelected)
-                        } else {
-                            // Handles both single- and multifield-inputs (arranges an input's multiple-fields in an HStack)
-                            InspectorLayerInputView(
-                                document: document,
-                                graph: graph,
-                                node: node,
-                                layerInputObserver: layerInputObserver,
-                                forFlyout: false)
-                        }
-                    }
-            }
+//        let observerMode = layerInputObserver.observerMode
+//        
+//        // TODO: is this really correct, to always treat the layer's input as packed ?
+//        let layerInputType = LayerInputType(layerInput: layerInputObserver.port,
+//                                            // Always `.packed` at the inspector-row level
+//                                            portType: .packed)
+//        
+//        let layerInspectorRowId: LayerInspectorRowId = .layerInput(layerInputType)
+//        
+//        // We pass down coordinate because that can be either for an input (added whole input to the graph) or output (added whole output to the graph, i.e. a port id)
+//        // But now, what `AddLayerPropertyToGraphButton` needs is more like `RowCoordinate = LayerPortCoordinate || OutputCoordinate`
+//        
+//        // but canvas item view model needs to know "packed vs unpacked" for its id;
+//        // so we do need to pass the packed-vs-unpacked information
+//        
+//        let coordinate: NodeIOCoordinate = .init(
+//            portType: .keyPath(layerInputType),
+//            nodeId: node.id)
+//        
+//        // Does this inspector-row (the entire input) have a canvas item?
+//        let canvasItemId: CanvasItemId? = observerMode.isPacked ? layerInputObserver._packedData.canvasObserver?.id : nil
+//        
+//        LayerInspectorPortView(layerInputObserver: layerInputObserver,
+//                               layerInspectorRowId: layerInspectorRowId,
+//                               coordinate: coordinate,
+//                               graph: graph,
+//                               document: document,
+//                               canvasItemId: canvasItemId) { isPropertyRowSelected in
+//                    HStack {
+//                        if isShadowLayerInputRow {
+//                            ShadowInputInspectorRow(nodeId: node.id,
+//                                                    isPropertyRowSelected: isPropertyRowSelected)
+//                        }
+//                        
+//                        // Note: 3D Transform and PortValue.padding are arranged in a "grid" in the inspector ONLY.
+//                        // So we handle them here, rather than in `fields` views used in flyouts and on canvas.
+//                        else if layerInputObserver.port == .transform3D {
+//                            LayerInspector3DTransformInputView(document: document,
+//                                                               graph: graph,
+//                                                               nodeId: node.id,
+//                                                               layerInputObserver: layerInputObserver,
+//                                                               isPropertyRowSelected: isPropertyRowSelected)
+//                        } else if layerInputObserver.usesGridMultifieldArrangement() {
+//                            // Multifields in the inspector are always "read-only" and "tap to open flyout"
+//                            LayerInspectorGridInputView(document: document,
+//                                                        graph: graph,
+//                                                        node: node,
+//                                                        layerInputObserver: layerInputObserver,
+//                                                        isPropertyRowSelected: isPropertyRowSelected)
+//                        } else {
+//                            // Handles both single- and multifield-inputs (arranges an input's multiple-fields in an HStack)
+//                            InspectorLayerInputView(
+//                                document: document,
+//                                graph: graph,
+//                                node: node,
+//                                layerInputObserver: layerInputObserver,
+//                                forFlyout: false)
+//                        }
+//                    }
+//            }
         
         // NOTE: this fires unexpectedly, so we rely on canvas item deletion and `layer input field added to canvas` to handle changes in pack vs unpacked mode.
 //            .onChange(of: layerInputObserver.mode) { oldValue, newValue in

--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -20,69 +20,66 @@ struct LayerInspectorInputPortView: View {
     }
     
     var body: some View {
-        // TODO: APRIL 25
-        Text("Fix me")
+        let observerMode = layerInputObserver.observerMode
         
-//        let observerMode = layerInputObserver.observerMode
-//        
-//        // TODO: is this really correct, to always treat the layer's input as packed ?
-//        let layerInputType = LayerInputType(layerInput: layerInputObserver.port,
-//                                            // Always `.packed` at the inspector-row level
-//                                            portType: .packed)
-//        
-//        let layerInspectorRowId: LayerInspectorRowId = .layerInput(layerInputType)
-//        
-//        // We pass down coordinate because that can be either for an input (added whole input to the graph) or output (added whole output to the graph, i.e. a port id)
-//        // But now, what `AddLayerPropertyToGraphButton` needs is more like `RowCoordinate = LayerPortCoordinate || OutputCoordinate`
-//        
-//        // but canvas item view model needs to know "packed vs unpacked" for its id;
-//        // so we do need to pass the packed-vs-unpacked information
-//        
-//        let coordinate: NodeIOCoordinate = .init(
-//            portType: .keyPath(layerInputType),
-//            nodeId: node.id)
-//        
-//        // Does this inspector-row (the entire input) have a canvas item?
-//        let canvasItemId: CanvasItemId? = observerMode.isPacked ? layerInputObserver._packedData.canvasObserver?.id : nil
-//        
-//        LayerInspectorPortView(layerInputObserver: layerInputObserver,
-//                               layerInspectorRowId: layerInspectorRowId,
-//                               coordinate: coordinate,
-//                               graph: graph,
-//                               document: document,
-//                               canvasItemId: canvasItemId) { isPropertyRowSelected in
-//                    HStack {
-//                        if isShadowLayerInputRow {
-//                            ShadowInputInspectorRow(nodeId: node.id,
-//                                                    isPropertyRowSelected: isPropertyRowSelected)
-//                        }
-//                        
-//                        // Note: 3D Transform and PortValue.padding are arranged in a "grid" in the inspector ONLY.
-//                        // So we handle them here, rather than in `fields` views used in flyouts and on canvas.
-//                        else if layerInputObserver.port == .transform3D {
-//                            LayerInspector3DTransformInputView(document: document,
-//                                                               graph: graph,
-//                                                               nodeId: node.id,
-//                                                               layerInputObserver: layerInputObserver,
-//                                                               isPropertyRowSelected: isPropertyRowSelected)
-//                        } else if layerInputObserver.usesGridMultifieldArrangement() {
-//                            // Multifields in the inspector are always "read-only" and "tap to open flyout"
-//                            LayerInspectorGridInputView(document: document,
-//                                                        graph: graph,
-//                                                        node: node,
-//                                                        layerInputObserver: layerInputObserver,
-//                                                        isPropertyRowSelected: isPropertyRowSelected)
-//                        } else {
-//                            // Handles both single- and multifield-inputs (arranges an input's multiple-fields in an HStack)
-//                            InspectorLayerInputView(
-//                                document: document,
-//                                graph: graph,
-//                                node: node,
-//                                layerInputObserver: layerInputObserver,
-//                                forFlyout: false)
-//                        }
-//                    }
-//            }
+        // TODO: is this really correct, to always treat the layer's input as packed ?
+        let layerInputType = LayerInputType(layerInput: layerInputObserver.port,
+                                            // Always `.packed` at the inspector-row level
+                                            portType: .packed)
+        
+        let layerInspectorRowId: LayerInspectorRowId = .layerInput(layerInputType)
+        
+        // We pass down coordinate because that can be either for an input (added whole input to the graph) or output (added whole output to the graph, i.e. a port id)
+        // But now, what `AddLayerPropertyToGraphButton` needs is more like `RowCoordinate = LayerPortCoordinate || OutputCoordinate`
+        
+        // but canvas item view model needs to know "packed vs unpacked" for its id;
+        // so we do need to pass the packed-vs-unpacked information
+        
+        let coordinate: NodeIOCoordinate = .init(
+            portType: .keyPath(layerInputType),
+            nodeId: node.id)
+        
+        // Does this inspector-row (the entire input) have a canvas item?
+        let canvasItemId: CanvasItemId? = observerMode.isPacked ? layerInputObserver._packedData.canvasObserver?.id : nil
+        
+        LayerInspectorPortView(layerInputObserver: layerInputObserver,
+                               layerInspectorRowId: layerInspectorRowId,
+                               coordinate: coordinate,
+                               graph: graph,
+                               document: document,
+                               canvasItemId: canvasItemId) { isPropertyRowSelected in
+                    HStack {
+                        if isShadowLayerInputRow {
+                            ShadowInputInspectorRow(nodeId: node.id,
+                                                    isPropertyRowSelected: isPropertyRowSelected)
+                        }
+                        
+                        // Note: 3D Transform and PortValue.padding are arranged in a "grid" in the inspector ONLY.
+                        // So we handle them here, rather than in `fields` views used in flyouts and on canvas.
+                        else if layerInputObserver.port == .transform3D {
+                            LayerInspector3DTransformInputView(document: document,
+                                                               graph: graph,
+                                                               nodeId: node.id,
+                                                               layerInputObserver: layerInputObserver,
+                                                               isPropertyRowSelected: isPropertyRowSelected)
+                        } else if layerInputObserver.usesGridMultifieldArrangement() {
+                            // Multifields in the inspector are always "read-only" and "tap to open flyout"
+                            LayerInspectorGridInputView(document: document,
+                                                        graph: graph,
+                                                        node: node,
+                                                        layerInputObserver: layerInputObserver,
+                                                        isPropertyRowSelected: isPropertyRowSelected)
+                        } else {
+                            // Handles both single- and multifield-inputs (arranges an input's multiple-fields in an HStack)
+                            InspectorLayerInputView(
+                                document: document,
+                                graph: graph,
+                                node: node,
+                                layerInputObserver: layerInputObserver,
+                                forFlyout: false)
+                        }
+                    }
+            }
         
         // NOTE: this fires unexpectedly, so we rely on canvas item deletion and `layer input field added to canvas` to handle changes in pack vs unpacked mode.
 //            .onChange(of: layerInputObserver.mode) { oldValue, newValue in

--- a/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
+++ b/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
@@ -199,8 +199,10 @@ extension LayerNodeViewModel {
     @MainActor
     func preinitializeSupportedPort(layerInputPort: LayerInputPort,
                                     portType: LayerInputKeyPathType) {
+        
         let layerId = LayerInputType(layerInput: layerInputPort,
                                      portType: portType)
+        
         let coordinateId = NodeIOCoordinate(portType: .keyPath(layerId), nodeId: self.id)
         
         let layerData: InputLayerNodeRowData = self[keyPath: layerId.layerNodeKeyPath]
@@ -223,32 +225,32 @@ extension LayerNodeViewModel {
 }
 
 extension InputLayerNodeRowData {
+    // This is more like `InputLayerNodeRowData`'s canvas obsever
+    // If this InputLayerNodeRowData's associated schema has no canvas entity, then we remove the canvas observer; else we update the canvas observer; else we create a new canvas observer
     @MainActor
-    func update(from schema: LayerInputDataEntity,
-                layerInputType: LayerInputType,
-                layerNode: LayerNodeViewModel,
-                nodeId: NodeId) {
+    func updateCanvasObserver(from schema: LayerInputDataEntity,
+                              layerInputType: LayerInputType, // Can't we just use `self.id` ?
+                              nodeId: NodeId) {
         assertInDebug(self.rowObserver.id.nodeId == nodeId)
-                    
-        if let canvas = schema.canvasItem {
-            if let canvasObserver = self.canvasObserver {
-                canvasObserver.update(from: canvas)
-                
-            } else {
-                // Make new canvas observer since none yet created
-                let canvasId = CanvasItemId.layerInput(.init(node: nodeId,
-                                                             keyPath: layerInputType))
-                
-                self.canvasObserver = .init(from: canvas,
-                                            id: canvasId,
-                                            inputRowObservers: [self.rowObserver],
-                                            outputRowObservers: [])
-
-                // NOTE: DO NOT SET A CANVAS ITEM DELEGATE ON AN INSPECTOR ROW VIEW MODEL
-//                self.inspectorRowViewModel.canvasItemDelegate = self.canvasObserver
-            }
-        } else {
+        
+        guard let canvasEntity: CanvasNodeEntity = schema.canvasItem else {
             self.canvasObserver = nil
+            return
+        }
+
+        if let canvasObserver = self.canvasObserver {
+            canvasObserver.update(from: canvasEntity)
+        } else {
+            // Make new canvas observer since none yet created
+            self.canvasObserver = CanvasItemViewModel(
+                from: canvasEntity,
+                id: CanvasItemId.layerInput(LayerInputCoordinate(node: nodeId,
+                                                                 keyPath: layerInputType)),
+                inputRowObservers: [self.rowObserver],
+                outputRowObservers: [])
+     
+            // NOTE: DO NOT SET A CANVAS ITEM DELEGATE ON AN INSPECTOR ROW VIEW MODEL
+            //                self.inspectorRowViewModel.canvasItemDelegate = self.canvasObserver
         }
     }
 }
@@ -266,10 +268,9 @@ extension LayerInputObserver {
         self.port = layerInputType
         
         // Updated packed data
-        portObserver._packedData.update(from: schema.packedData,
+        portObserver._packedData.updateCanvasObserver(from: schema.packedData,
                                         layerInputType: .init(layerInput: layerInputType,
                                                               portType: .packed),
-                                        layerNode: layerNode,
                                         nodeId: nodeId)
         
         
@@ -291,10 +292,9 @@ extension LayerInputObserver {
                 .fieldGroupTypes
             
             unpackedPortParentFieldGroupTypes.forEach { unpackedPortParentFieldGroupType in
-                unpackedObserver.update(from: unpackedSchema,
+                unpackedObserver.updateCanvasObserver(from: unpackedSchema,
                                         layerInputType: .init(layerInput: layerInputType,
                                                               portType: .unpacked(unpackedPortType)),
-                                        layerNode: layerNode,
                                         nodeId: nodeId)
             }
         }

--- a/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
+++ b/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
@@ -254,27 +254,6 @@ extension InputLayerNodeRowData {
 }
 
 extension LayerInputObserver {
-    @MainActor
-    var packedObserver: InputLayerNodeRowData? {
-        switch self.mode {
-        case .packed:
-            // TODO: infinite loop? What was this method supposed to be?
-//            return self.packedObserver
-            return self._packedData
-        case .unpacked:
-            return nil
-        }
-    }
-    
-    @MainActor
-    var unpackedObserver: LayerInputUnpackedPortObserver? {
-        switch self.mode {
-        case .unpacked:
-            return self._unpackedData
-        default:
-            return nil
-        }
-    }
     
     @MainActor
     func update(from schema: LayerInputEntity,

--- a/Stitch/Graph/Node/Model/RowData/LayerInputType.swift
+++ b/Stitch/Graph/Node/Model/RowData/LayerInputType.swift
@@ -1067,7 +1067,8 @@ extension LayerViewModel {
 }
 
 extension LayerInputPort {
-    var layerNodeKeyPath: ReferenceWritableKeyPath<LayerNodeViewModel, LayerInputObserver> {
+//    var layerNodeKeyPath: ReferenceWritableKeyPath<LayerNodeViewModel, LayerInputObserver> {
+    var layerNodeKeyPath: KeyPath<LayerNodeViewModel, LayerInputObserver> {
         switch self {
         case .position:
             return \.positionPort
@@ -1424,48 +1425,23 @@ extension PortValue {
     }
 }
 
+extension LayerInputPort {
+    // For contexts where we MUST be accessing the packed data (e.g. input, not field, added to the graph)
+    var packedLayerInputKeyPath: KeyPath<LayerNodeViewModel, InputLayerNodeRowData> {
+        self.layerNodeKeyPath.appending(path: \._packedData)
+    }
+}
+
 extension LayerInputType {
+    
     /// Key paths for parent layer view model
-//    var layerNodeKeyPath: ReferenceWritableKeyPath<LayerNodeViewModel, InputLayerNodeRowData> {
+    //    var layerNodeKeyPath: ReferenceWritableKeyPath<LayerNodeViewModel, InputLayerNodeRowData> {
     var layerNodeKeyPath: KeyPath<LayerNodeViewModel, InputLayerNodeRowData> {
         let portKeyPath = self.layerInput.layerNodeKeyPath
         
         switch self.portType {
         case .packed:
-            return portKeyPath.appending(path: \._packedData)
-        case .unpacked(let unpackedType):
-            switch unpackedType {
-            case .port0:
-                return portKeyPath.appending(path: \._unpackedData.port0)
-            case .port1:
-                return portKeyPath.appending(path: \._unpackedData.port1)
-            case .port2:
-                return portKeyPath.appending(path: \._unpackedData.port2)
-            case .port3:
-                return portKeyPath.appending(path: \._unpackedData.port3)
-            case .port4:
-                return portKeyPath.appending(path: \._unpackedData.port4)
-            case .port5:
-                return portKeyPath.appending(path: \._unpackedData.port5)
-            case .port6:
-                return portKeyPath.appending(path: \._unpackedData.port6)
-            case .port7:
-                return portKeyPath.appending(path: \._unpackedData.port7)
-            case .port8:
-                return portKeyPath.appending(path: \._unpackedData.port8)
-            }
-        }
-    }
-    
-    
-    /// Key paths for parent layer view model
-    var _layerNodeKeyPath: ReferenceWritableKeyPath<LayerNodeViewModel, InputLayerNodeRowData> {
-        
-        let portKeyPath = self.layerInput.layerNodeKeyPath
-        
-        switch self.portType {
-        case .packed:
-            return portKeyPath.appending(path: \._packedData)
+            return self.layerInput.packedLayerInputKeyPath
         case .unpacked(let unpackedType):
             switch unpackedType {
             case .port0:

--- a/Stitch/Graph/Node/Model/RowData/LayerInputType.swift
+++ b/Stitch/Graph/Node/Model/RowData/LayerInputType.swift
@@ -1460,6 +1460,7 @@ extension LayerInputType {
     
     /// Key paths for parent layer view model
     var _layerNodeKeyPath: ReferenceWritableKeyPath<LayerNodeViewModel, InputLayerNodeRowData> {
+        
         let portKeyPath = self.layerInput.layerNodeKeyPath
         
         switch self.portType {

--- a/Stitch/Graph/Node/Model/RowData/LayerInputType.swift
+++ b/Stitch/Graph/Node/Model/RowData/LayerInputType.swift
@@ -1426,7 +1426,40 @@ extension PortValue {
 
 extension LayerInputType {
     /// Key paths for parent layer view model
-    var layerNodeKeyPath: ReferenceWritableKeyPath<LayerNodeViewModel, InputLayerNodeRowData> {
+//    var layerNodeKeyPath: ReferenceWritableKeyPath<LayerNodeViewModel, InputLayerNodeRowData> {
+    var layerNodeKeyPath: KeyPath<LayerNodeViewModel, InputLayerNodeRowData> {
+        let portKeyPath = self.layerInput.layerNodeKeyPath
+        
+        switch self.portType {
+        case .packed:
+            return portKeyPath.appending(path: \._packedData)
+        case .unpacked(let unpackedType):
+            switch unpackedType {
+            case .port0:
+                return portKeyPath.appending(path: \._unpackedData.port0)
+            case .port1:
+                return portKeyPath.appending(path: \._unpackedData.port1)
+            case .port2:
+                return portKeyPath.appending(path: \._unpackedData.port2)
+            case .port3:
+                return portKeyPath.appending(path: \._unpackedData.port3)
+            case .port4:
+                return portKeyPath.appending(path: \._unpackedData.port4)
+            case .port5:
+                return portKeyPath.appending(path: \._unpackedData.port5)
+            case .port6:
+                return portKeyPath.appending(path: \._unpackedData.port6)
+            case .port7:
+                return portKeyPath.appending(path: \._unpackedData.port7)
+            case .port8:
+                return portKeyPath.appending(path: \._unpackedData.port8)
+            }
+        }
+    }
+    
+    
+    /// Key paths for parent layer view model
+    var _layerNodeKeyPath: ReferenceWritableKeyPath<LayerNodeViewModel, InputLayerNodeRowData> {
         let portKeyPath = self.layerInput.layerNodeKeyPath
         
         switch self.portType {

--- a/Stitch/Graph/Node/Port/View/LayerInspectorRowButton.swift
+++ b/Stitch/Graph/Node/Port/View/LayerInspectorRowButton.swift
@@ -91,14 +91,18 @@ struct LayerInspectorRowButton: View {
             // Else we're adding an input (whole or field) or an output to the canvas
             else if let layerInput = coordinate.keyPath {
                 
-                if let fieldIndex = fieldIndex {
+                if let fieldIndex = fieldIndex,
+                   // Only for unpacked
+                   layerInput.portType != .packed {
                     dispatch(LayerInputFieldAddedToGraph(layerInput: layerInput.layerInput,
                                                          nodeId: nodeId,
                                                          fieldIndex: fieldIndex))
-                } else {
+                    
+                } else if layerInput.portType == .packed {
+                    // Only for packed
                     dispatch(LayerInputAddedToGraph(
                         nodeId: nodeId,
-                        coordinate: layerInput))
+                        layerInput: layerInput.layerInput))
                 }
                 
             } else if let portId = coordinate.portId {

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
@@ -279,12 +279,6 @@ extension LayerInputObserver {
     }
     
     @MainActor
-    var graphDelegate: GraphState? {
-        // Hacky solution, just get row observer delegate from packed data
-        self._packedData.rowObserver.nodeDelegate?.graphDelegate
-    }
-    
-    @MainActor
     func getActiveValue(activeIndex: ActiveIndex) -> PortValue {
         let values = self.values
         

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StepTypeAction.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StepTypeAction.swift
@@ -277,9 +277,8 @@ struct StepActionConnectionAdded: StepActionable {
         
         // Create canvas node if destination is layer
         if let fromNodeLocation = document.visibleGraph.getNodeViewModel(self.fromNodeId)?.patchCanvasItem?.position,
-           let destinationNode = document.visibleGraph.getNodeViewModel(self.toNodeId),
-           let layerNode = destinationNode.layerNode {
-            guard let keyPath = self.port.keyPath else {
+           let destinationNode = document.visibleGraph.getNodeViewModel(self.toNodeId) {
+            guard let layerInput = self.port.keyPath?.layerInput else {
                 // fatalErrorIfDebug()
                 throw StitchAIManagerError.actionValidationError("expected layer node keypath but got: \(self.port)")
             }
@@ -287,10 +286,8 @@ struct StepActionConnectionAdded: StepActionable {
             var position = fromNodeLocation
             position.x += 200
             
-            let inputData = layerNode[keyPath: keyPath.layerNodeKeyPath]
             document.layerInputAddedToGraph(node: destinationNode,
-                                            input: inputData,
-                                            coordinate: keyPath,
+                                            layerInput: layerInput,
                                             position: position)
         }
     }


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7187

Also cleans up some code:
- make explicit that AddLayerInput assumes packed mode
- when adding a field to the canvas, do not create a CanvasNodeEntity but rather create the CanvasItemViewModel directly

https://github.com/user-attachments/assets/b10a265f-fd2d-4eb2-90b2-882547e53b49

