### PR TITLE
Reduce usage of _packed; keep NodeId on LayerInputObserver

### DIFF
--- a/Stitch/Graph/GraphStep/GraphStepIncrementer.swift
+++ b/Stitch/Graph/GraphStep/GraphStepIncrementer.swift
@@ -268,20 +268,8 @@ extension NodeViewModel {
             let newValues = layerNode.previewLayerViewModels
                 .map { $0.transform3D }
             layerNode.transform3DPort.updatePortValues(newValues)
-            layerNode.transform3DPort.updateAllRowObserversPortViewModels(graph)
-        }
-    }
-}
-
-extension LayerInputObserver {
-    @MainActor
-    func updateAllRowObserversPortViewModels(_ graph: GraphState) {
-        switch self.mode {
-        case .packed:
-            self._packedData.rowObserver.updatePortViewModels(graph)
-        case .unpacked:
-            self._unpackedData.allPorts.forEach {
-                $0.rowObserver.updatePortViewModels(graph)
+            layerNode.transform3DPort.allRowObservers.forEach {
+                $0.updatePortViewModels(graph)
             }
         }
     }

--- a/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
@@ -356,7 +356,7 @@ struct LayerInputFieldAddedToGraph: StitchDocumentEvent {
            let layerMultiselectInput = multiselectInputs.first(where: { $0 == layerInput}) {
             
             layerMultiselectInput.multiselectObservers(graph).forEach { observer in
-                addLayerField(observer.packedRowObserver.id.nodeId)
+                addLayerField(observer.nodeId)
             }
         } else {
             addLayerField(nodeId)

--- a/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
@@ -157,14 +157,17 @@ struct GenericFlyoutRowView: View {
         graph.propertySidebar.selectedProperty == layerInspectorRowId
     }
     
-    var rowObserver: InputNodeRowObserver {
+    var rowObserver: InputNodeRowObserver? {
         switch self.layerInputObserver.observerMode {
+        
         case .packed(let inputLayerNodeRowData):
             return inputLayerNodeRowData.rowObserver
+        
         case .unpacked(let layerInputUnpackedPortObserver):
+            
             guard let unpackedObserver = layerInputUnpackedPortObserver.allPorts[safe: fieldIndex] else {
                 fatalErrorIfDebug()
-                return self.layerInputObserver._packedData.rowObserver
+                return nil
             }
             
             return unpackedObserver.rowObserver
@@ -190,23 +193,26 @@ struct GenericFlyoutRowView: View {
                                         fieldIndex: fieldIndex)
             }
                                     
-            InputValueEntry(graph: graph,
-                            document: document,
-                            viewModel: viewModel,
-                            node: node,
-                            rowViewModel: rowViewModel,
-                            canvasItem: nil,
-                            // For input editing, however, we need the proper packed vs unpacked state
-                            rowObserver: rowObserver,
-                            isCanvasItemSelected: false, // Always false
-                            hasIncomingEdge: false,
-                            isForLayerInspector: true,
-                            isPackedLayerInputAlreadyOnCanvas: canvasItemId.isDefined,
-                            isFieldInMultifieldInput: isMultifield,
-                            isForFlyout: true,
-                            // Always false for flyout row
-                            isSelectedInspectorRow: isPropertyRowSelected,
-                            useIndividualFieldLabel: layerInputObserver.useIndividualFieldLabel(activeIndex: document.activeIndex))
+            if let rowObserver = self.rowObserver {
+                InputValueEntry(graph: graph,
+                                document: document,
+                                viewModel: viewModel,
+                                node: node,
+                                rowViewModel: rowViewModel,
+                                canvasItem: nil,
+                                // For input editing, however, we need the proper packed vs unpacked state
+                                rowObserver: rowObserver,
+                                isCanvasItemSelected: false, // Always false
+                                hasIncomingEdge: false,
+                                isForLayerInspector: true,
+                                isPackedLayerInputAlreadyOnCanvas: canvasItemId.isDefined,
+                                isFieldInMultifieldInput: isMultifield,
+                                isForFlyout: true,
+                                // Always false for flyout row
+                                isSelectedInspectorRow: isPropertyRowSelected,
+                                useIndividualFieldLabel: layerInputObserver.useIndividualFieldLabel(activeIndex:  document.activeIndex))
+            }
+            
         } // HStack
         .contentShape(Rectangle())
         .onHover(perform: { hovering in

--- a/Stitch/Graph/LayerInspector/LayerInspectorActions.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorActions.swift
@@ -62,8 +62,8 @@ extension StitchDocumentViewModel {
            let layerMultiselectInput = multiselectInputs.first(where: { $0 == layerInput}) {
             layerMultiselectInput.multiselectObservers(self.visibleGraph).forEach { observer in
                 // Note: we cannot add "whole input" to canvas if one field is already on canvas
-                if observer.mode == .packed {
-                    addLayerInput(observer.packedRowObserver.id.nodeId)
+                if let packedRow = observer.packedRowObserverOnlyIfPacked {
+                    addLayerInput(packedRow.id.nodeId)
                 }
             }
         } else {
@@ -110,6 +110,11 @@ extension StitchDocumentViewModel {
         
         guard let layerNode = self.visibleGraph.getLayerNode(nodeId) else {
             fatalErrorIfDebug()
+            return
+        }
+        
+        guard layerNode[keyPath: layerInput.layerNodeKeyPath].mode == .packed else {
+            log("Tried to add whole layer input to canvas when layer input was in unpack mode")
             return
         }
         

--- a/Stitch/Graph/LayerInspector/LayerInspectorGridInputView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorGridInputView.swift
@@ -24,9 +24,7 @@ struct LayerInspectorGridInputView: View {
         HStack(alignment: .firstTextBaseline) {
             
             // Label
-            LabelDisplayView(label: layerInputObserver.overallPortLabel(usesShortLabel: true,
-                                                                        node: node,
-                                                                        graph: graph),
+            LabelDisplayView(label: layerInputObserver.overallPortLabel(usesShortLabel: true),
                              isLeftAligned: false,
                              fontColor: STITCH_FONT_GRAY_COLOR,
                              isSelectedInspectorRow: false)

--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -105,10 +105,7 @@ struct InspectorLayerInputView: View {
     let forFlyout: Bool
     
     var label: String {
-        layerInputObserver
-            .overallPortLabel(usesShortLabel: true,
-                              node: node,
-                              graph: graph)
+        layerInputObserver.overallPortLabel(usesShortLabel: true)
     }
         
     var layerInput: LayerInputPort {

--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -40,6 +40,7 @@ struct LayerInspectorInputPortView: View {
             nodeId: node.id)
         
         // Does this inspector-row (the entire input) have a canvas item?
+        //
         let canvasItemId: CanvasItemId? = observerMode.isPacked ? layerInputObserver._packedData.canvasObserver?.id : nil
         
         LayerInspectorPortView(layerInputObserver: layerInputObserver,
@@ -148,6 +149,7 @@ struct InspectorLayerInputView: View {
                                  document: document,
                                  graph: graph,
                                  node: node,
+                                 // TODO: we always want to show all input fields in the inspector, but cannot assume data is in a packed state
                                  rowObserver: layerInputObserver.packedRowObserver,
                                  rowViewModel: layerInputObserver._packedData.inspectorRowViewModel,
                                  fieldValueTypes: fieldValueTypes,

--- a/Stitch/Graph/LayerInspector/OpenFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/OpenFlyoutView.swift
@@ -75,14 +75,15 @@ struct OpenFlyoutView: View, KeyboardReadable {
                                         layerNode: layerNode,
                                         graph: graph,
                                         document: document)
-                    } else if flyoutInput.usesColor {
+                    } else if flyoutInput.usesColor,
+                              let packedRow =  portObserver.packedRowObserverOnlyIfPacked {
                         ColorFlyoutView(graph: graph,
-                                        rowObserver: portObserver.packedRowObserver,
+                                        rowObserver: packedRow,
                                         layerInputObserver: portObserver,
                                         activeIndex: document.activeIndex)
                     }
                     // One multifield input presented in separate rows in the flyout
-                    else {                        
+                    else {
                         // The Flyout takes the whole input,
                         // and displays each field
                         GenericFlyoutView(graph: graph,

--- a/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
+++ b/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
@@ -155,8 +155,7 @@ final class OutputLayerNodeRowData: LayerNodeRowData, Identifiable {
             initialValue: rowDelegate.getActiveValue(activeIndex: activeIndex),
             // Not relevant for output
             unpackedPortParentFieldGroupType: nil,
-            unpackedPortIndex: nil,
-            layerInput: nil)
+            unpackedPortIndex: nil)
     }
 }
 
@@ -179,8 +178,7 @@ extension LayerNodeRowData {
             node,
             initialValue: rowDelegate.getActiveValue(activeIndex: activeIndex),
             unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-            unpackedPortIndex: unpackedPortIndex,
-            layerInput: rowDelegate.id.layerInput?.layerInput)
+            unpackedPortIndex: unpackedPortIndex)
     }
     
     @MainActor

--- a/Stitch/Graph/Node/Port/Model/Field/FieldValueMedia.swift
+++ b/Stitch/Graph/Node/Port/Model/Field/FieldValueMedia.swift
@@ -78,7 +78,7 @@ extension FieldValueMedia {
             
                 destinationInputs = multiselectInput.multiselectObservers(graph).map({ (observer: LayerInputObserver) in
                     InputCoordinate(portType: .keyPath(layerInput),
-                                    nodeId: observer.packedRowObserver.id.nodeId)
+                                    nodeId: observer.nodeId)
                 })
             }
             

--- a/Stitch/Graph/Node/Port/Util/Field/FieldValueUtils.swift
+++ b/Stitch/Graph/Node/Port/Util/Field/FieldValueUtils.swift
@@ -11,12 +11,17 @@ import StitchSchemaKit
 
 extension PortValue {
     /// Coercion logic from port value to fields. Contains a 2D list of field values given a 1-many mapping between a field group type and its field values.
+//    @MainActor
+//    func createFieldValuesList<RowViewModel>(nodeIO: NodeIO,
+//                                             layerInputPort: LayerInputPort?,
+//                                             isLayerInspector: Bool) -> [FieldValues] where RowViewModel: NodeRowViewModel {
     @MainActor
-    func createFieldValuesList<RowViewModel>(nodeIO: NodeIO,
-                                             rowViewModel: RowViewModel) -> [FieldValues] where RowViewModel: NodeRowViewModel {
+    func createFieldValuesList(nodeIO: NodeIO,
+                               layerInputPort: LayerInputPort?,
+                               isLayerInspector: Bool) -> [FieldValues] {
         
-        let layerInputPort = rowViewModel.id.layerInputPort
-        let isLayerInspector = rowViewModel.isLayerInspector
+//        let layerInputPort = rowViewModel.id.layerInputPort
+//        let isLayerInspector = rowViewModel.isLayerInspector
         
         switch self.getNodeRowType(nodeIO: nodeIO,
                                    layerInputPort: layerInputPort,

--- a/Stitch/Graph/Node/Port/Util/InputEdit/InputEditedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/InputEdit/InputEditedActions.swift
@@ -38,11 +38,6 @@ extension GraphState {
 extension LayerInputObserver {
     
     @MainActor
-    var nodeId: NodeId {
-        self.packedRowObserver.id.nodeId
-    }
-    
-    @MainActor
     func getInputNodeRowObserver(for fieldIndex: Int, _ graph: GraphState) -> InputNodeRowObserver? {
         
         guard let layerNode = graph.getNode(self.nodeId)?.layerNode else {

--- a/Stitch/Graph/Node/Port/View/PortValuesPreview/PortValuesPreviewView.swift
+++ b/Stitch/Graph/Node/Port/View/PortValuesPreview/PortValuesPreviewView.swift
@@ -50,7 +50,8 @@ struct PortValuesPreviewView<NodeRowObserverType: NodeRowObserver>: View {
             // TODO: handle ShapeCommand port-preview ?
             guard let fieldValues = value.createFieldValuesList(
                 nodeIO: nodeIO,
-                rowViewModel: rowViewModel).first else {
+                layerInputPort: rowViewModel.id.layerInputPort,
+                isLayerInspector: false).first else {
                 
                 fatalErrorIfDebug()
                 return nil

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
@@ -148,21 +148,13 @@ extension LayerInputObserver {
     // Currently, spacing
     @MainActor
     func usesGridMultifieldArrangement() -> Bool {
-        self._packedData.inspectorRowViewModel.cachedActiveValue.getPadding.isDefined
+        self.port.getDefaultValue(for: self.layer).getPadding.isDefined
     }
     
     // The overall-label for the port, e.g. "Size" (not "W" or "H") for the size property
     @MainActor
-    func overallPortLabel(usesShortLabel: Bool,
-                          node: NodeViewModel,
-                          graph: GraphState) -> String {
-        let rowObserver = self._packedData.rowObserver
-        
-        return rowObserver
-            .label(useShortLabel: usesShortLabel,
-                   node: node,
-                   coordinate: .input(rowObserver.id),
-                   graph: graph)
+    func overallPortLabel(usesShortLabel: Bool) -> String {
+        self.port.label(useShortLabel: usesShortLabel)
     }
     
     // Returns all fields, regardless of packed vs unpacked
@@ -175,6 +167,7 @@ extension LayerInputObserver {
         switch self.mode {
         case .packed:
             return allFields
+            
         case .unpacked:
             guard let groupings = self.port.labelGroupings else {
                 return allFields
@@ -182,6 +175,11 @@ extension LayerInputObserver {
             
             // Groupings are gone in unpacked mode so we just need the fields
             let flattenedFields = allFields.flatMap { $0.fieldObservers }
+            
+            // TODO: APRIL 25: what is this?
+//            
+//            let _fieldGroup: FieldGroup = createFieldValueTypes(initialValue: <#T##PortValue#>, nodeIO: <#T##NodeIO#>, unpackedPortParentFieldGroupType: <#T##FieldGroupType?#>, unpackedPortIndex: <#T##Int?#>, layerInput: <#T##LayerInputPort?#>)
+            
             let fieldGroupsFromPacked = self._packedData.inspectorRowViewModel.cachedFieldValueGroups
             
             // Create nested array for label groupings (used for 3D model)

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -98,8 +98,7 @@ extension NodeRowViewModel {
                 nodeIO: nodeIO,
                 // Node Row Type change is only when a patch node changes its node type; can't happen for layer nodes
                 unpackedPortParentFieldGroupType: nil,
-                unpackedPortIndex: nil,
-                layerInput: nil)
+                unpackedPortIndex: nil)
             return
         }
         
@@ -112,7 +111,10 @@ extension NodeRowViewModel {
         
         let nodeIO = Self.RowObserver.nodeIOType
                 
-        let newFieldsByGroup = newValue.createFieldValuesList(nodeIO: nodeIO, rowViewModel: self)
+        let newFieldsByGroup = newValue.createFieldValuesList(
+            nodeIO: nodeIO,
+            layerInputPort: self.id.layerInputPort,
+            isLayerInspector: self.isLayerInspector)
         
         // Assert equal array counts
         guard newFieldsByGroup.count == self.cachedFieldValueGroups.count else {
@@ -138,8 +140,7 @@ extension NodeRowViewModel {
                     // Note: this is only for a patch node whose node-type has changed (?); does not happen with layer nodes, a layer input being packed or unpacked is irrelevant here etc.
                     // Not relevant?
                     unpackedPortParentFieldGroupType: nil,
-                    unpackedPortIndex:  nil,
-                    layerInput: nil)
+                    unpackedPortIndex:  nil)
                 return
             }
             

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
@@ -75,8 +75,7 @@ extension NodeRowViewModel {
     func initializeDelegate(_ node: NodeViewModel,
                             initialValue: PortValue,
                             unpackedPortParentFieldGroupType: FieldGroupType?,
-                            unpackedPortIndex: Int?,
-                            layerInput: LayerInputPort?) {
+                            unpackedPortIndex: Int?) {
         
         // Why must we set the delegate
         self.nodeDelegate = node
@@ -85,8 +84,7 @@ extension NodeRowViewModel {
             self.initializeValues(
                 unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
                 unpackedPortIndex: unpackedPortIndex,
-                initialValue: initialValue,
-                rowObserverLayerInput: layerInput)
+                initialValue: initialValue)
         }
                 
         /// Considerable perf cost from `ConnectedEdgeView`, so now a function.
@@ -102,8 +100,7 @@ extension NodeRowViewModel {
     @MainActor
     func initializeValues(unpackedPortParentFieldGroupType: FieldGroupType?,
                           unpackedPortIndex: Int?,
-                          initialValue: PortValue,
-                          rowObserverLayerInput: LayerInputPort?) {
+                          initialValue: PortValue) {
         if initialValue != self.cachedActiveValue {
             self.cachedActiveValue = initialValue
         }
@@ -112,8 +109,7 @@ extension NodeRowViewModel {
             initialValue: initialValue,
             nodeIO: Self.nodeIO,
             unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-            unpackedPortIndex: unpackedPortIndex,
-            layerInput: rowObserverLayerInput)
+            unpackedPortIndex: unpackedPortIndex)
         
         let didFieldsChange = !zip(self.cachedFieldValueGroups, fields).allSatisfy { $0.id == $1.id }
         

--- a/Stitch/Graph/Node/View/CanvasLayerInputView.swift
+++ b/Stitch/Graph/Node/View/CanvasLayerInputView.swift
@@ -20,9 +20,7 @@ struct CanvasLayerInputView: View {
     
     var body: some View {
         HStack {
-            LabelDisplayView(label: layerInputObserver.overallPortLabel(usesShortLabel: false,
-                                                                        node: node,
-                                                                        graph: graph),
+            LabelDisplayView(label: layerInputObserver.overallPortLabel(usesShortLabel: false),
                              isLeftAligned: false,
                              fontColor: STITCH_FONT_GRAY_COLOR,
                              isSelectedInspectorRow: false)

--- a/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
@@ -223,8 +223,7 @@ extension CanvasItemViewModel {
                     node,
                     initialValue: rowObserver.getActiveValue(activeIndex: activeIndex),
                     unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                    unpackedPortIndex: unpackedPortIndex,
-                    layerInput: rowObserver.id.layerInput?.layerInput)
+                    unpackedPortIndex: unpackedPortIndex)
             }
         }
         
@@ -235,8 +234,7 @@ extension CanvasItemViewModel {
                     initialValue: rowObserver.getActiveValue(activeIndex: activeIndex),
                     // Not relevant for output row view models
                     unpackedPortParentFieldGroupType: nil,
-                    unpackedPortIndex: nil,
-                    layerInput: nil)
+                    unpackedPortIndex: nil)
             }
         }
         

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModel.swift
@@ -662,8 +662,7 @@ extension NodeViewModel {
             initialValue: newInputObserver.getActiveValue(activeIndex: document.activeIndex),
             // Only relevant for layer nodes, which cannot have an input added or removed
             unpackedPortParentFieldGroupType: nil,
-            unpackedPortIndex: nil,
-            layerInput: nil)
+            unpackedPortIndex: nil)
     }
 
     @MainActor


### PR DESCRIPTION
more cleanup and simplifications

QA'd on Humane demo.