### PR TITLE
LayerInputObserver: prefer `packedRowObserver` API to accessing `_packedData` directly

### DIFF
--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -199,7 +199,9 @@ struct LayerInputFieldsView: View {
     @ViewBuilder
     func valueEntryView(_ portViewModel: InputFieldViewModel,
                         _ isMultifield: Bool) -> some View {
+        
         switch layerInputFieldType {
+        
         case .inspector:
             let layerInputType = LayerInputType(layerInput: layerInputObserver.port,
                                                 portType: .packed)
@@ -214,7 +216,7 @@ struct LayerInputFieldsView: View {
                             node: node,
                             rowViewModel: layerInputData.inspectorRowViewModel,
                             canvasItem: nil,
-                            rowObserver: layerInputData.rowObserver,
+                            rowObserver: layerInputObserver.packedRowObserver,
                             isCanvasItemSelected: false,
                             hasIncomingEdge: false,
                             isForLayerInspector: true,

--- a/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
+++ b/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
@@ -262,8 +262,6 @@ extension LayerInputObserver {
                 nodeId: NodeId) {        
         let portObserver = layerNode[keyPath: layerInputType.layerNodeKeyPath]
         let unpackedObservers = portObserver._unpackedData.allPorts
-
-        self.port = layerInputType
         
         // Updated packed data
         portObserver._packedData.updateCanvasObserver(from: schema.packedData,

--- a/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
@@ -416,14 +416,17 @@ extension LayerViewModel {
             .getNodeViewModel(self.id.layerNodeId.asNodeId)?.layerNode else {
             return nil
         }
-        
+                
         switch layerNode.layer {
         case .image:
-            return layerNode.imagePort._packedData.rowObserver
+            assertInDebug(layerNode.imagePort.mode == .packed)
+            return layerNode.imagePort.packedRowObserverOnlyIfPacked
         case .video:
-            return layerNode.videoPort._packedData.rowObserver
+            assertInDebug(layerNode.videoPort.mode == .packed)
+            return layerNode.videoPort.packedRowObserverOnlyIfPacked
         case .model3D:
-            return layerNode.model3DPort._packedData.rowObserver
+            assertInDebug(layerNode.model3DPort.mode == .packed)
+            return layerNode.model3DPort.packedRowObserverOnlyIfPacked
         default:
             fatalErrorIfDebug()
             return nil


### PR DESCRIPTION
Remaining direct accesses of _packedData are for updates (delegates, schema-syncing).