### PR TITLE
`GenericFlyoutView` no longer relies on `_packedData`

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -749,6 +749,7 @@
 		ECAB9FF82A588E800036EBEA /* AnchorPopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAB9FF72A588E800036EBEA /* AnchorPopoverView.swift */; };
 		ECABB55F269C9E5A00AC9931 /* NetworkRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECABB55E269C9E5A00AC9931 /* NetworkRequest.swift */; };
 		ECABB561269CE23100AC9931 /* NetworkRequestNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECABB560269CE23100AC9931 /* NetworkRequestNode.swift */; };
+		ECAC6EF72DBC5FE0003D34C4 /* FlyoutHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAC6EF62DBC5FE0003D34C4 /* FlyoutHeader.swift */; };
 		ECAD8930292EAF9A005A87A2 /* OptionEqualsNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD892F292EAF9A005A87A2 /* OptionEqualsNode.swift */; };
 		ECADA8B428FB5B5D0007748F /* UIImageExtensionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECADA8B328FB5B5D0007748F /* UIImageExtensionUtils.swift */; };
 		ECAFD08E2D4878CC00101226 /* LLMActionHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAFD08D2D4878CC00101226 /* LLMActionHelpers.swift */; };
@@ -1730,6 +1731,7 @@
 		ECAB9FF72A588E800036EBEA /* AnchorPopoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnchorPopoverView.swift; sourceTree = "<group>"; };
 		ECABB55E269C9E5A00AC9931 /* NetworkRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRequest.swift; sourceTree = "<group>"; };
 		ECABB560269CE23100AC9931 /* NetworkRequestNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRequestNode.swift; sourceTree = "<group>"; };
+		ECAC6EF62DBC5FE0003D34C4 /* FlyoutHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlyoutHeader.swift; sourceTree = "<group>"; };
 		ECAD892F292EAF9A005A87A2 /* OptionEqualsNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionEqualsNode.swift; sourceTree = "<group>"; };
 		ECADA8B328FB5B5D0007748F /* UIImageExtensionUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImageExtensionUtils.swift; sourceTree = "<group>"; };
 		ECAFD08D2D4878CC00101226 /* LLMActionHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMActionHelpers.swift; sourceTree = "<group>"; };
@@ -2130,6 +2132,7 @@
 				EC1A35792C25CE8100E5A6D8 /* LayerInspectorActions.swift */,
 				B50F41702C1F52C00082262F /* LayerInspectorView.swift */,
 				ECEA12FB2C45B67D0058CD6A /* GenericFlyoutView.swift */,
+				ECAC6EF62DBC5FE0003D34C4 /* FlyoutHeader.swift */,
 				EC2C8C982C654D5300D067B8 /* OpenFlyoutView.swift */,
 				EC49069E2CCACF0100165554 /* ColorFlyoutView.swift */,
 				ECE639212C489C6900FB8D5F /* FlyoutUtils.swift */,
@@ -5065,6 +5068,7 @@
 				E40B2F552CB86F2B005F5479 /* OpenAIResponseStructs.swift in Sources */,
 				EC46AC0B26CEE3B80062CB26 /* AppState.swift in Sources */,
 				ECA92A24260A6A2300281B52 /* LoopNode.swift in Sources */,
+				ECAC6EF72DBC5FE0003D34C4 /* FlyoutHeader.swift in Sources */,
 				B5E5FFAE2749804500C5FE92 /* GroupNodeUtils.swift in Sources */,
 				EC08D5552898873C00FEE846 /* MathUtils.swift in Sources */,
 				EC0093E026D6F648000EAE08 /* ProgressNode.swift in Sources */,

--- a/Stitch/Graph/LayerInspector/ColorFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/ColorFlyoutView.swift
@@ -37,7 +37,7 @@ struct ColorFlyoutView: View {
     }
     
     var body: some View {
-        if let fieldObserver = layerInputObserver.fieldValueTypes.first?.fieldObservers.first {
+        if let fieldObserver = layerInputObserver.fieldGroups.first?.fieldObservers.first {
             
             StitchCustomColorPickerView(
                 rowObserver: rowObserver,

--- a/Stitch/Graph/LayerInspector/FlyoutHeader.swift
+++ b/Stitch/Graph/LayerInspector/FlyoutHeader.swift
@@ -1,0 +1,26 @@
+//
+//  FlyoutHeader.swift
+//  Stitch
+//
+//  Created by Christian J Clampitt on 4/25/25.
+//
+
+import SwiftUI
+
+struct FlyoutHeader: View {
+    
+    let flyoutTitle: String
+    
+    var body: some View {
+        HStack {
+            StitchTextView(string: flyoutTitle).font(.title3)
+            Spacer()
+            Image(systemName: "xmark.circle.fill")
+                .onTapGesture {
+                    withAnimation {
+                        dispatch(FlyoutClosed())
+                    }
+                }
+        }
+    }
+}

--- a/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
@@ -54,6 +54,9 @@ struct GenericFlyoutView: View {
     var flyoutRows: some View {
         // Assumes: all flyouts (besides shadow-flyout) have a single row which contains multiple fields
         ForEach(fieldGroups) { (fieldGroup: FieldGroup) in
+            
+            FieldGroupLabelView(fieldGroup: fieldGroup)
+            
             VStack { // flyout fields always stacked vertically
                 PotentiallyBlockedFieldsView(
                     fieldGroupViewModel: fieldGroup,
@@ -69,7 +72,23 @@ struct GenericFlyoutView: View {
                             isMultifield: isMultifield)
                     }
             }
-            
+        }
+    }
+}
+
+// Only actually for packed 3D Transform layer inputs?
+struct FieldGroupLabelView: View {
+    let fieldGroup: FieldGroup
+    
+    var body: some View {
+        if let fieldGroupLabel = fieldGroup.groupLabel {
+            HStack {
+                LabelDisplayView(label: fieldGroupLabel,
+                                 isLeftAligned: false,
+                                 fontColor: STITCH_FONT_GRAY_COLOR,
+                                 isSelectedInspectorRow: false)
+                Spacer()
+            }
         }
     }
 }

--- a/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/GenericFlyoutView.swift
@@ -180,7 +180,7 @@ struct GenericFlyoutRowView: View {
                                         // For layer inspector row button, provide a NodeIOCoordinate that assumes unpacked + field index
                                         coordinate: InputCoordinate(portType: .keyPath(layerInputType),
                                                                     nodeId: node.id),
-                                        canvasItemId: canvasItemId,
+                                         packedInputCanvasItemId: canvasItemId,
                                         isHovered: isHovered,
                                         fieldIndex: fieldIndex)
             }

--- a/Stitch/Graph/LayerInspector/LayerInspector3DTransformInputView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspector3DTransformInputView.swift
@@ -18,7 +18,7 @@ struct LayerInspector3DTransformInputView: View {
     
     var body: some View {
         VStack {
-            ForEach(layerInputObserver.fieldValueTypes) { fieldGrouping in
+            ForEach(layerInputObserver.fieldGroups) { fieldGrouping in
                 VStack {
                     if let fieldGroupLabel = fieldGrouping.groupLabel {
                         HStack {

--- a/Stitch/Graph/LayerInspector/LayerInspectorGridInputView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorGridInputView.swift
@@ -15,7 +15,7 @@ struct LayerInspectorGridInputView: View {
     let isPropertyRowSelected: Bool
     
     var allFieldObservers: [FieldViewModel] {
-        layerInputObserver.fieldValueTypes.flatMap(\.fieldObservers)
+        layerInputObserver.fieldGroups.flatMap(\.fieldObservers)
     }
     
     var body: some View {

--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -308,6 +308,7 @@ struct LayerInspectorOutputsSectionView: View {
                             rowObserver: output.rowObserver,
                             graph: graph,
                             document: document,
+                            // Outputs can never be "packed vs unpacked"
                             canvasItem: output.canvasObserver,
                             forFlyout: false)
                     } else {

--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -183,7 +183,7 @@ struct LayerInspectorInputView: View {
         let blockedFields = portObserver.blockedFields
         
         let allFieldsBlockedOut = portObserver
-            .fieldValueTypes.first?
+            .fieldGroups.first?
             .fieldObservers.allSatisfy({ $0.isBlocked(blockedFields)})
         ?? false
                 

--- a/Stitch/Graph/LayerInspector/ShadowFlyoutView.swift
+++ b/Stitch/Graph/LayerInspector/ShadowFlyoutView.swift
@@ -98,7 +98,7 @@ struct ShadowFlyoutRowView: View {
                                     layerInputObserver: layerInputObserver,
                                     layerInspectorRowId: layerInspectorRowId,
                                     coordinate: coordinate,
-                                    canvasItemId: canvasItemId,
+                                    packedInputCanvasItemId: canvasItemId,
                                     isHovered: isHovered)
             .offset(y: isShadowOffsetRow ? INSPECTOR_LIST_ROW_TOP_AND_BOTTOM_INSET : 0)
             

--- a/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputValueEntry.swift
@@ -441,7 +441,6 @@ struct InputFieldValueView: View {
                         nodeKind: nodeKind,
                         isInput: true,
                         fieldIndex: fieldIndex,
-                        isNodeSelected: isCanvasItemSelected,
                         isFieldInsideLayerInspector: isFieldInsideLayerInspector,
                         isSelectedInspectorRow: isSelectedInspectorRow,
                         isMultiselectInspectorInputWithHeterogenousValues: hasHeterogenousValues,

--- a/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/MediaPickerView.swift
@@ -39,7 +39,6 @@ struct MediaInputFieldValueView: View {
     let nodeKind: NodeKind
     let isInput: Bool
     let fieldIndex: Int
-    let isNodeSelected: Bool
     let isFieldInsideLayerInspector: Bool
     let isSelectedInspectorRow: Bool
     let isMultiselectInspectorInputWithHeterogenousValues: Bool
@@ -86,7 +85,6 @@ struct MediaInputFieldValueView: View {
                                 coordinate: rowObserver.id,
                                 isInput: isInput,
                                 fieldIndex: fieldIndex,
-                                isNodeSelected: isNodeSelected,
                                 isMultiselectInspectorInputWithHeterogenousValues: isMultiselectInspectorInputWithHeterogenousValues)
         }
     }
@@ -104,7 +102,6 @@ struct MediaFieldLabelView: View {
     let coordinate: InputCoordinate
     let isInput: Bool
     let fieldIndex: Int
-    let isNodeSelected: Bool
     let isMultiselectInspectorInputWithHeterogenousValues: Bool
     
     @MainActor

--- a/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/OutputValueView.swift
@@ -19,7 +19,6 @@ struct OutputValueEntry: View {
     let node: NodeViewModel
     let canvasItem: CanvasItemViewModel?
     let isMultiField: Bool
-    let isCanvasItemSelected: Bool
     let forPropertySidebar: Bool
     let propertyIsAlreadyOnGraph: Bool
     let isFieldInMultifieldInput: Bool
@@ -49,7 +48,6 @@ struct OutputValueEntry: View {
                         node: node,
                         canvasItem: canvasItem,
                         isMultiField: isMultiField,
-                        isCanvasItemSelected: isCanvasItemSelected,
                         forPropertySidebar: forPropertySidebar,
                         propertyIsAlreadyOnGraph: propertyIsAlreadyOnGraph,
                         isFieldInMultifieldInput: isFieldInMultifieldInput,
@@ -82,7 +80,6 @@ struct OutputValueView: View {
     let node: NodeViewModel
     let canvasItem: CanvasItemViewModel?
     let isMultiField: Bool
-    let isCanvasItemSelected: Bool
     let forPropertySidebar: Bool
     let propertyIsAlreadyOnGraph: Bool
     let isFieldInMultifieldInput: Bool
@@ -150,7 +147,6 @@ struct OutputValueView: View {
                                 coordinate: rowObserver.id,
                                 isInput: false,
                                 fieldIndex: fieldIndex,
-                                isNodeSelected: isCanvasItemSelected,
                                 isMultiselectInspectorInputWithHeterogenousValues: false)
             
         case .color(let color):

--- a/Stitch/Graph/Node/Port/View/LayerInspectorRowButton.swift
+++ b/Stitch/Graph/Node/Port/View/LayerInspectorRowButton.swift
@@ -16,7 +16,7 @@ struct LayerInspectorRowButton: View {
     let layerInputObserver: LayerInputObserver?
     let layerInspectorRowId: LayerInspectorRowId
     let coordinate: NodeIOCoordinate
-    let canvasItemId: CanvasItemId?
+    let packedInputCanvasItemId: CanvasItemId?
     let isHovered: Bool
     
     // non-nil = this inspector row button is for a field, not a
@@ -59,7 +59,7 @@ struct LayerInspectorRowButton: View {
     
     @MainActor
     var showButton: Bool {
-        if canvasItemId.isDefined || isWholeInputWithAtleastOneFieldAlreadyOnCanvas ||  isHovered || (canBeAddedToCanvas && isPortSelected) {
+        if packedInputCanvasItemId.isDefined || isWholeInputWithAtleastOneFieldAlreadyOnCanvas ||  isHovered || (canBeAddedToCanvas && isPortSelected) {
             return true
         } else {
             return false
@@ -68,7 +68,7 @@ struct LayerInspectorRowButton: View {
     
     @MainActor
     var imageString: String {
-        if canvasItemId.isDefined {
+        if packedInputCanvasItemId.isDefined {
             return "scope"
         } else if isWholeInputWithAtleastOneFieldAlreadyOnCanvas {
             return "circle.fill"
@@ -84,7 +84,7 @@ struct LayerInspectorRowButton: View {
             let nodeId = coordinate.nodeId
             
             // If we're already on the canvas, jump to that canvas item
-            if let canvasItemId = canvasItemId {
+            if let canvasItemId = packedInputCanvasItemId {
                 dispatch(JumpToCanvasItem(id: canvasItemId))
             }
             

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
@@ -407,6 +407,11 @@ extension LayerInputObserver {
         self.mode == .packed ? self._packedData.rowObserver : nil
     }
     
+    @MainActor
+    var packedCanvasObserverOnlyIfPacked: CanvasItemViewModel? {
+        self.mode == .packed ? self._packedData.canvasObserver : nil
+    }
+    
     // All row observers for this input; for working with row observer(s) regardless of pack vs unpack
     @MainActor
     var allRowObservers: [InputNodeRowObserver] {

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
@@ -142,9 +142,9 @@ extension LayerInputObserver {
     var usesMultifields: Bool {
         switch self.mode {
         case .packed:
-            return (self.fieldValueTypes.first?.fieldObservers.count ?? 0) > 1
+            return (self.fieldGroups.first?.fieldObservers.count ?? 0) > 1
         case .unpacked:
-            return self.fieldValueTypes.count > 1
+            return self.fieldGroups.count > 1
         }
     }
     
@@ -162,7 +162,7 @@ extension LayerInputObserver {
     
     // Returns all fields, regardless of packed vs unpacked
     @MainActor
-    var fieldValueTypes: [FieldGroup] {
+    var fieldGroups: [FieldGroup] {
         let allFields = self.allInputData.flatMap { (portData: InputLayerNodeRowData) in
             portData.inspectorRowViewModel.cachedFieldValueGroups
         }

--- a/Stitch/Graph/Node/View/NodeView.swift
+++ b/Stitch/Graph/Node/View/NodeView.swift
@@ -181,9 +181,8 @@ struct NodeView: View {
         VStack(alignment: .leading,
                spacing: SPACING_BETWEEN_NODE_ROWS) {
             if self.stitch.patch == .wirelessReceiver {
-                WirelessPortView(isOutput: false,
-                                 id: stitch.id)
-                .padding(.trailing, NODE_BODY_SPACING)
+                WirelessPortView(isOutput: false, id: stitch.id)
+                    .padding(.trailing, NODE_BODY_SPACING)
             } else if let layerNode: LayerNodeViewModel = self.stitch.layerNode,
                       let layerInputCoordinate: LayerInputCoordinate = self.node.id.layerInputCase {
                 // Layer input or field
@@ -218,8 +217,7 @@ struct NodeView: View {
                 DefaultNodeOutputsView(graph: graph,
                                        document: document,
                                        node: stitch,
-                                       canvas: node,
-                                       isNodeSelected: isSelected)
+                                       canvas: node)
             }
         }
     }

--- a/Stitch/Graph/Node/View/NodeViewType.swift
+++ b/Stitch/Graph/Node/View/NodeViewType.swift
@@ -134,7 +134,6 @@ struct DefaultNodeOutputsView: View {
     @Bindable var document: StitchDocumentViewModel
     @Bindable var node: NodeViewModel
     @Bindable var canvas: CanvasItemViewModel
-    let isNodeSelected: Bool
 
     @MainActor
     var showOutputFields: Bool {
@@ -180,7 +179,6 @@ struct DefaultNodeOutputsView: View {
                                                  node: node,
                                                  canvasItem: canvas,
                                                  isMultiField: isMultiField,
-                                                 isCanvasItemSelected: isNodeSelected,
                                                  forPropertySidebar: false,
                                                  propertyIsAlreadyOnGraph: false,
                                                  isFieldInMultifieldInput: isMultiField,


### PR DESCRIPTION
GenericFlyoutView no longer relies on _packedData, just field observers etc.

QA video, especially for the tricky case of inspector row and fly-out for packed 3D transform input: 


https://github.com/user-attachments/assets/8d0fa669-bf01-4db1-b54e-d675e00642a1

