### PR TITLE
Always update fields UI on user edit; catch next time fields-UI discrepancy happens in debug

### DIFF
--- a/Stitch/Graph/Menu/NumberAdjustmentBar/AdjustmentBarPopoverView.swift
+++ b/Stitch/Graph/Menu/NumberAdjustmentBar/AdjustmentBarPopoverView.swift
@@ -99,6 +99,7 @@ struct AdjustmentBarPopoverView: View {
                 graph.inputEditedFromUI(
                     fieldValue: .layerDimension(.auto),
                     fieldIndex: fieldCoordinate.fieldIndex,
+                    rowId: fieldCoordinate.rowId,
                     activeIndex: activeIndex,
                     rowObserver: rowObserver,
                     isFieldInsideLayerInspector: isFieldInsideLayerInspector,

--- a/Stitch/Graph/Menu/NumberAdjustmentBar/WideAdjustmentBarView.swift
+++ b/Stitch/Graph/Menu/NumberAdjustmentBar/WideAdjustmentBarView.swift
@@ -150,6 +150,7 @@ struct WideAdjustmentBarView: View {
                                 graph.inputEditedFromUI(
                                     fieldValue: fieldValueNumberType.createFieldValueForAdjustmentBar(from: n.number),
                                     fieldIndex: self.fieldCoordinate.fieldIndex,
+                                    rowId: self.fieldCoordinate.rowId,
                                     activeIndex: activeIndex,
                                     rowObserver: rowObserver,
                                     isFieldInsideLayerInspector: isFieldInsideLayerInspector,
@@ -375,6 +376,7 @@ struct WideAdjustmentBarView: View {
                     graph?.inputEditedFromUI(
                         fieldValue: fieldValue,
                         fieldIndex: pref.field.fieldIndex,
+                        rowId: pref.field.rowId,
                         activeIndex: activeIndex,
                         rowObserver: rowObserver,
                         isFieldInsideLayerInspector: isFieldInsideLayerInspector,

--- a/Stitch/Graph/Node/Port/Util/Field/FieldValueUtils.swift
+++ b/Stitch/Graph/Node/Port/Util/Field/FieldValueUtils.swift
@@ -11,17 +11,10 @@ import StitchSchemaKit
 
 extension PortValue {
     /// Coercion logic from port value to fields. Contains a 2D list of field values given a 1-many mapping between a field group type and its field values.
-//    @MainActor
-//    func createFieldValuesList<RowViewModel>(nodeIO: NodeIO,
-//                                             layerInputPort: LayerInputPort?,
-//                                             isLayerInspector: Bool) -> [FieldValues] where RowViewModel: NodeRowViewModel {
     @MainActor
     func createFieldValuesList(nodeIO: NodeIO,
                                layerInputPort: LayerInputPort?,
                                isLayerInspector: Bool) -> [FieldValues] {
-        
-//        let layerInputPort = rowViewModel.id.layerInputPort
-//        let isLayerInspector = rowViewModel.isLayerInspector
         
         switch self.getNodeRowType(nodeIO: nodeIO,
                                    layerInputPort: layerInputPort,

--- a/Stitch/Graph/Node/Port/Util/InputEdit/InputCommittedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/InputEdit/InputCommittedActions.swift
@@ -117,6 +117,10 @@ extension GraphState {
         
         guard valueChange else {
             log("GraphState.inputEditCommitted: value did not change, so returning early")
+            
+            // See note in `inputEdited`
+            input.immediatelyUpdateFieldObserversAfterInputEdit(value)
+            
             return
         }
         

--- a/Stitch/Graph/Node/Port/View/Field/InputView/CommonEditingView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/CommonEditingView.swift
@@ -378,6 +378,7 @@ struct CommonEditingView: View {
         self.graph.inputEditedFromUI(
             fieldValue: .string(.init(newEdit)),
             fieldIndex: fieldIndex,
+            rowId: rowViewModel.id,
             activeIndex: document.activeIndex,
             rowObserver: rowObserver,
             isFieldInsideLayerInspector: self.isFieldInsideLayerInspector,

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -111,7 +111,9 @@ extension NodeRowViewModel {
         
         let nodeIO = Self.RowObserver.nodeIOType
                 
-        let newFieldsByGroup = newValue.createFieldValuesList(
+        // TODO: what is perf cost of recreating the FieldValues every time? Can we separate (1) "simple updates, where underlying row observer's PortValue type did not change" from (2) "complex update, where observer's PortValue type may have changed"?
+        // TODO: check `oldValue.asNodeType == newValue.asNodeType` ? If the PortValue type did not change, then the field count etc. could not have changed.
+        let newFieldsByGroup: [FieldValues] = newValue.createFieldValuesList(
             nodeIO: nodeIO,
             layerInputPort: self.id.layerInputPort,
             isLayerInspector: self.isLayerInspector)
@@ -146,12 +148,12 @@ extension NodeRowViewModel {
             
             fieldObserverGroup.updateFieldValues(fieldValues: newFields)
         } // zip
-        
+
         
         // Whenever we update ui-fields' values, we need to potentially block or unblock the same/other fields.
         if let node = self.nodeDelegate,
-           let graph = node.graphDelegate,
            let layerNode = node.layerNodeReader,
+           let graph = node.graphDelegate,
            let activeIndex = graph.documentDelegate?.activeIndex {
             
             layerNode.refreshBlockedInputs(graph: graph, activeIndex: activeIndex)


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7137

This PR does two things:
1. Making the bug impossible by applying a true condition: user manual input edit/commit now always update the fields UI, whether value changed or not
2. Catches the bug next time it occurs: dev debug crash if user edit's value and input's existing value were 'same' but have differing fields UI (canvas only, since there's some trickiness with )


