### PR TITLE
When active index changes, only update port views of on-screen nodes at current traversal level

### DIFF
--- a/Stitch/Graph/Node/View/NodesOnlyView.swift
+++ b/Stitch/Graph/Node/View/NodesOnlyView.swift
@@ -75,10 +75,15 @@ struct NodesOnlyView: View {
                 }
             }
         }
+        // TODO: why can't we do this logic from `ActiveIndexChangedAction` ?
         .onChange(of: self.activeIndex) {
+            
             // Update values when active index changes
-            graph.nodes.values.forEach { node in
-                node.activeIndexChanged(activeIndex: self.activeIndex)
+            // Perf optimization: only update nodes that are on-screen and at this traversal level
+            graph.getNodesAtThisTraversalLevel(groupNodeFocused: self.focusedGroup?.groupNodeId).forEach { node in
+                if node.isVisibleInFrame(graph.visibleCanvasIds, graph.selectedSidebarLayers) {
+                    node.activeIndexChanged(activeIndex: self.activeIndex)
+                }
             }
         }
         // Also do this on `initial: true` ?

--- a/Stitch/Graph/Util/GraphUIActions.swift
+++ b/Stitch/Graph/Util/GraphUIActions.swift
@@ -340,12 +340,14 @@ struct ActiveIndexChangedAction: StitchDocumentEvent {
         
         state.activeIndex = index
         
-        // Note: previously this logic was handled in the view (`NodeInputOutputView`);
-        // the advantage was that only actively-rendered
-        graph.getNodesAtThisTraversalLevel(groupNodeFocused: state.groupNodeFocused?.groupNodeId)
-            .forEach { node in
-            node.updatePortViewModels(graph)
-        }
+        // TODO: See `NodesOnlyView`'s `.onChange`
+        // TODO: why does this not trigger updates of the input and output views ?
+        //        graph.getNodesAtThisTraversalLevel(groupNodeFocused: state.groupNodeFocused?.groupNodeId)
+        //            .forEach { node in
+        //                if node.isVisibleInFrame(graph.selectedCanvasItems, graph.selectedSidebarLayers) {
+        //                    node.activeIndexChanged(activeIndex: state.activeIndex)
+        //                }
+        //        }
     }
 }
 


### PR DESCRIPTION
Improves: https://github.com/StitchDesign/Stitch--Old/issues/7179


https://github.com/user-attachments/assets/c22d0a64-834a-405d-ba90-e3c2971ff680



