### PR TITLE
only parse a layer input if we are on a layer node

### DIFF
--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StepTypeAction.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/StepTypeAction.swift
@@ -277,19 +277,20 @@ struct StepActionConnectionAdded: StepActionable {
         
         // Create canvas node if destination is layer
         if let fromNodeLocation = document.visibleGraph.getNodeViewModel(self.fromNodeId)?.patchCanvasItem?.position,
-           let destinationNode = document.visibleGraph.getNodeViewModel(self.toNodeId) {
-            guard let layerInput = self.port.keyPath?.layerInput else {
-                // fatalErrorIfDebug()
-                throw StitchAIManagerError.actionValidationError("expected layer node keypath but got: \(self.port)")
+           let destinationNode = document.visibleGraph.getNodeViewModel(self.toNodeId),
+            destinationNode.kind.isLayer {
+                guard let layerInput = self.port.keyPath?.layerInput else {
+                    // fatalErrorIfDebug()
+                    throw StitchAIManagerError.actionValidationError("expected layer node keypath but got: \(self.port)")
+                }
+                
+                var position = fromNodeLocation
+                position.x += 200
+                
+                document.layerInputAddedToGraph(node: destinationNode,
+                                                layerInput: layerInput,
+                                                position: position)
             }
-            
-            var position = fromNodeLocation
-            position.x += 200
-            
-            document.layerInputAddedToGraph(node: destinationNode,
-                                            layerInput: layerInput,
-                                            position: position)
-        }
     }
     
     func removeAction(graph: GraphState, document: StitchDocumentViewModel) {


### PR DESCRIPTION
we were hitting setting layer input logic when we were on a node that is a layer input, which lead to errors like this:

![IMG_9302](https://github.com/user-attachments/assets/2fbdb171-884d-4ad5-851f-18e30a8fef3f)
