### PR TITLE
Fix all non-edge-edit-mode edge animation issues

### DIFF
--- a/Stitch/Graph/Edge/Util/PortDragActions.swift
+++ b/Stitch/Graph/Edge/Util/PortDragActions.swift
@@ -148,18 +148,8 @@ extension GraphState {
         // Starting port drag
         if !self.edgeDrawingObserver.drawingGesture.isDefined {
             
-            self.outputDragStartedCount += 1
-
             let diffFromCenter = OutputNodeRowViewModel.calculateDiffFromCenter(from: gesture)
-
-            // 3 still allows flashing;
-            // 10 creates a noticeable lag;
-            // 5 is perfect?
-            guard self.outputDragStartedCount > 5 else {
-                // log("OutputDragged: exiting early: state.outputDragStartedCount was: \(state.outputDragStartedCount)")
-                return
-            }
-
+            
             let drag = OutputDragGesture(output: outputRowViewModel,
                                          dragLocation: gesture.location,
                                          startingDiffFromCenter: diffFromCenter)
@@ -169,9 +159,19 @@ extension GraphState {
             // Wipe selected edges, canvas items. etc.
             self.resetAlertAndSelectionState(document: document)
             
+            if let outputRowObserver = self.getOutputRowObserver(outputRowViewModel.nodeIOCoordinate),
+               let canvasItemId = outputRowViewModel.canvasItemDelegate?.id {
+                
+                outputRowViewModel.portUIViewModel.updatePortColor(
+                    canvasItemId: canvasItemId,
+                    hasEdge: outputRowObserver.hasEdge,
+                    hasLoop: outputRowObserver.hasLoopedValues,
+                    selectedEdges: selectedEdges,
+                    selectedCanvasItems: self.selectedCanvasItems,
+                    drawingObserver: self.edgeDrawingObserver)
+            }
+            
         } else {
-            self.outputDragStartedCount = 0
-
             guard let existingDrag = self.edgeDrawingObserver.drawingGesture else {
                 // log("OutputDragged: output drag not yet initialized by SwiftUI handler; exiting early")
                 return
@@ -187,7 +187,6 @@ extension GraphState {
     
     @MainActor
     func outputDragEnded() {
-        self.outputDragStartedCount = 0
         
         guard let from = self.edgeDrawingObserver.drawingGesture?.output,
               let to = self.edgeDrawingObserver.nearestEligibleInput,
@@ -218,13 +217,6 @@ extension GraphState {
     }
 }
 
-struct EligibleInputReset: ProjectEnvironmentEvent {
-    func handle(graphState: GraphState,
-                environment: StitchEnvironment) -> GraphResponse {
-        graphState.edgeDrawingObserver.nearestEligibleInput = nil
-        return .noChange
-    }
-}
 
 extension GraphState {
     @MainActor
@@ -240,9 +232,7 @@ extension GraphState {
             DispatchQueue.main.async { [weak self] in
                 self?.edgeDrawingObserver.reset()
             }
-//            let resetRecentlyDrawnEdgeEffect: Effect = createDelayedEffect(
-//                delayInNanoseconds: TimeHelpers.ThreeTenthsOfASecondInNanoseconds,
-//                action: ResetRecentlyDrawnEdge())
+
             self.edgeAdded(edge: newEdge)
         }
 
@@ -257,12 +247,6 @@ struct ResetRecentlyDrawnEdge: GraphEvent {
         state.edgeDrawingObserver.reset()
     }
 }
-
-//struct DisableEdgeAnimation: GraphEvent {
-//    func handle(state: GraphState) {
-//        state.edgeAnimationEnabled = false
-//    }
-//}
 
 struct TimeHelpers {
     static let ThreeTenthsOfASecondInSeconds: Double = 0.3

--- a/Stitch/Graph/Edge/Util/PortDragActions.swift
+++ b/Stitch/Graph/Edge/Util/PortDragActions.swift
@@ -135,7 +135,7 @@ extension GraphState {
                        rowId: NodeRowViewModelId) {
                 
         guard let outputRowViewModel = self.getOutputRowViewModel(for: rowId),
-                let document = self.documentDelegate else {
+              let document = self.documentDelegate else {
             fatalErrorIfDebug()
             return
         }

--- a/Stitch/Graph/Edge/View/DrawnEdge.swift
+++ b/Stitch/Graph/Edge/View/DrawnEdge.swift
@@ -11,7 +11,7 @@ import StitchSchemaKit
 
 // TODO: `curve` and `line` edges require less information than circuit edges; we could rework some of the edge-related views to not have to do as many calculations
 struct DrawnEdge: View {
-    static let animationDuration = TimeHelpers.ThreeTenthsOfASecondInSeconds
+    static let ANIMATION_DURATION = TimeHelpers.ThreeTenthsOfASecondInSeconds
 
     @Environment(\.edgeStyle) var edgeStyle
 
@@ -125,7 +125,7 @@ struct DrawnEdge: View {
     }
     
     var animationTime: Double {
-        edgeAnimationEnabled ? Self.animationDuration : .zero
+        edgeAnimationEnabled ? Self.ANIMATION_DURATION : .zero
     }
 
     var body: some View {

--- a/Stitch/Graph/Edge/View/EdgeDrawingView.swift
+++ b/Stitch/Graph/Edge/View/EdgeDrawingView.swift
@@ -93,7 +93,8 @@ struct EdgeFromDraggedOutputView: View {
                          totalOutputs: outputAnchorData.totalOutputs,
                          // we never animate the actively dragged edge
                          edgeAnimationEnabled: false)
-                .animation(.default, value: color)
+                .animation(.linear(duration: DrawnEdge.ANIMATION_DURATION),
+                           value: color)
             }
         }
         .onChange(of: pointTo) {

--- a/Stitch/Graph/Edge/View/EdgeDrawingView.swift
+++ b/Stitch/Graph/Edge/View/EdgeDrawingView.swift
@@ -11,7 +11,6 @@ import StitchSchemaKit
 struct EdgeDrawingView: View {
     let graph: GraphState
     @Bindable var edgeDrawingObserver: EdgeDrawingObserver
-//    let inputsAtThisTraversalLevel: [InputNodeRowViewModel]
     
     var body: some View {
         if let outputDrag = edgeDrawingObserver.drawingGesture {

--- a/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
+++ b/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
@@ -22,17 +22,14 @@ struct NodeRowPortView<NodeRowObserverType: NodeRowObserver>: View {
     
     @State private var showPopover: Bool = false
     
-    var coordinate: NodeIOPortType {
-        self.rowObserver.id.portType
-    }
-    
     var nodeIO: NodeIO {
         NodeRowObserverType.nodeIOType
     }
         
     var body: some View {
-        PortEntryView(rowViewModel: rowViewModel,
+        PortEntryView(portUIViewModel: rowViewModel.portUIViewModel,
                       graph: graph,
+                      rowId: rowViewModel.id,
                       nodeIO: nodeIO)
         .onTapGesture {
             // Can only tap canvas ports, not layer inspector ports

--- a/Stitch/Graph/Node/Port/View/PortView.swift
+++ b/Stitch/Graph/Node/Port/View/PortView.swift
@@ -19,25 +19,20 @@ let PORT_ENTRY_NON_EXTENDED_HITBOX_SIZE = CGSize(
 
 let NODE_PORT_HEIGHT: CGFloat = 8
 
-struct PortEntryView<NodeRowViewModelType: NodeRowViewModel>: View {
+struct PortEntryView<PortUIViewModelType: PortUIViewModel>: View {
     @Environment(\.appTheme) private var theme
     
-    @Bindable var rowViewModel: NodeRowViewModelType
+    @Bindable var portUIViewModel: PortUIViewModelType
     @Bindable var graph: GraphState
     
+    let rowId: NodeRowViewModelId
     let nodeIO: NodeIO
 
     @MainActor
     var portColor: Color {
-        rowViewModel.portUIViewModel.portColor.color(theme)
+        portUIViewModel.portColor.color(theme)
     }
-    
-    @State private var portIsBeingDragged = false
-    
-    var rowId: NodeRowViewModelId {
-        self.rowViewModel.id
-    }
-    
+        
     var body: some View {
         Rectangle().fill(self.portColor)
         //            Rectangle().fill(portBodyColor)
@@ -59,18 +54,22 @@ struct PortEntryView<NodeRowViewModelType: NodeRowViewModel>: View {
                     .offset(x: nodeIO == .input ? -4 : 4)
             }
             .overlay(PortEntryExtendedHitBox(graph: self.graph,
-                                             portIsBeingDragged: self.$portIsBeingDragged,
                                              nodeIO: nodeIO,
                                              rowId: rowId))
+        // Just for when user has tapped an edge?
             .onChange(of: graph.selectedEdges) {
-                dispatch(MaybeUpdatePortColor(rowId: rowId, nodeIO: nodeIO))
+                self.graph.maybeUpdatePortColor(rowId: rowId, nodeIO: nodeIO)
             }
+        
+        // TODO: better?: update the portColor of the specific port for the output drag, when/where we actually modify `drawingGesture`
             .onChange(of: self.graph.edgeDrawingObserver.drawingGesture.isDefined) { _, _ in
-                dispatch(MaybeUpdatePortColor(rowId: rowId, nodeIO: nodeIO))
+                self.graph.maybeUpdatePortColor(rowId: rowId, nodeIO: nodeIO)
             }
-            .onChange(of: self.graph.edgeDrawingObserver.nearestEligibleInput.isDefined) { _, _ in
-                dispatch(MaybeUpdatePortColor(rowId: rowId, nodeIO: nodeIO))
-            }
+        
+        // Now handled in `findEligibleInput` instead
+        //            .onChange(of: self.graph.edgeDrawingObserver.nearestEligibleInput.isDefined) { _, _ in
+        //                dispatch(MaybeUpdatePortColor(rowId: rowId, nodeIO: nodeIO))
+        //            }
     }
 }
 
@@ -80,27 +79,25 @@ struct PortEntryView<NodeRowViewModelType: NodeRowViewModel>: View {
 
  When updating that color, we will still need to know whether we have an edge and/or a loop, facts which are provided by the row observer.
  Previously we were accessing this via row view model's row observer delegate, which in any case caused an additional render cycle.
- 
- Note: trying an action because:
- - we can look up the row observer in state, to avoid a delegate-access which triggers a render-cycle
- - passing the node row observer to the PortEntryView was giving me complaints about generics
  */
-struct MaybeUpdatePortColor: GraphEvent {
-    let rowId: NodeRowViewModelId
-    let nodeIO: NodeIO
-    
-    func handle(state: GraphState) {
+extension GraphState {
+    @MainActor
+    func maybeUpdatePortColor(rowId: NodeRowViewModelId, nodeIO: NodeIO) {
         switch nodeIO {
+            
         case .input:
-            state.getInputRowObserver(rowId.asNodeIOCoordinate)?
-                .updatePortColorAndUpstreamOutputPortColor(selectedEdges: state.selectedEdges,
-                                                           selectedCanvasItems: state.selection.selectedCanvasItems,
-                                                           drawingObserver: state.edgeDrawingObserver)
+            self.getInputRowObserver(rowId.asNodeIOCoordinate)?
+                .updatePortColorAndUpstreamOutputPortColor(
+                    selectedEdges: self.selectedEdges,
+                    selectedCanvasItems: self.selectedCanvasItems,
+                    drawingObserver: self.edgeDrawingObserver)
+        
         case .output:
-            state.getOutputRowObserver(rowId.asNodeIOCoordinate)?
-                .updatePortColorAndDownstreamInputsPortColors(selectedEdges: state.selectedEdges,
-                                                              selectedCanvasItems: state.selection.selectedCanvasItems,
-                                                              drawingObserver: state.edgeDrawingObserver)
+            self.getOutputRowObserver(rowId.asNodeIOCoordinate)?
+                .updatePortColorAndDownstreamInputsPortColors(
+                    selectedEdges: self.selectedEdges,
+                    selectedCanvasItems: self.selectedCanvasItems,
+                    drawingObserver: self.edgeDrawingObserver)
         }
     }
 }
@@ -112,9 +109,7 @@ extension Color {
 
 struct PortEntryExtendedHitBox: View {
     @Bindable var graph: GraphState
-    
-    @Binding var portIsBeingDragged: Bool
-    
+        
     let nodeIO: NodeIO // input vs output
     let rowId: NodeRowViewModelId // how to retrieve the
     
@@ -123,7 +118,6 @@ struct PortEntryExtendedHitBox: View {
         Color.HITBOX_COLOR
             .frame(width: EXTENDED_HITBOX_WIDTH,
                    height: EXTENDED_HITBOX_HEIGHT)
-//            .zIndex(nodeIO == .output ? -9999 : 0)
             /*
              Used for obtaining the starting diff adjustment for a port drag;
              PortGestureRecognizerView handles the heavy lifting,
@@ -136,7 +130,6 @@ struct PortEntryExtendedHitBox: View {
                                  // .local = relative to this view
                                  coordinateSpace: .named(NodesView.coordinateNameSpace))
                         .onChanged { gesture in
-                            self.portIsBeingDragged = true
                             
                             switch nodeIO {
                             case .input:
@@ -147,7 +140,6 @@ struct PortEntryExtendedHitBox: View {
                         } // .onChanged
                         .onEnded { _ in
                             //                    log("PortEntry: onEnded")
-                            self.portIsBeingDragged = false
                             switch nodeIO {
                             case .input:
                                 graph.inputDragEnded()

--- a/Stitch/Graph/Node/Port/View/PortView.swift
+++ b/Stitch/Graph/Node/Port/View/PortView.swift
@@ -62,12 +62,6 @@ struct PortEntryView<NodeRowViewModelType: NodeRowViewModel>: View {
                                              portIsBeingDragged: self.$portIsBeingDragged,
                                              nodeIO: nodeIO,
                                              rowId: rowId))
-            .animation(.linear(duration: self.animationTime),
-                       value: self.portColor)
-        
-        // TODO: perf implications updating every port's color when selectedEdges or edgeDrawingObserver changes?
-        
-        // Update port color on selected edges change
             .onChange(of: graph.selectedEdges) {
                 dispatch(MaybeUpdatePortColor(rowId: rowId, nodeIO: nodeIO))
             }
@@ -77,12 +71,6 @@ struct PortEntryView<NodeRowViewModelType: NodeRowViewModel>: View {
             .onChange(of: self.graph.edgeDrawingObserver.nearestEligibleInput.isDefined) { _, _ in
                 dispatch(MaybeUpdatePortColor(rowId: rowId, nodeIO: nodeIO))
             }
-    }
-        
-    // Only animate port colors if we're dragging from this output
-//    @MainActor
-    var animationTime: Double {
-        self.portIsBeingDragged ? DrawnEdge.animationDuration : .zero
     }
 }
 

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/PortUIViewModel/OutputPortUIViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/PortUIViewModel/OutputPortUIViewModel.swift
@@ -60,7 +60,9 @@ extension OutputPortUIViewModel {
                             drawingObserver: EdgeDrawingObserver) -> PortColor {
                 
         if let drawnEdge = drawingObserver.drawingGesture,
-           drawnEdge.output.id == self.id {
+           // TODO: we had been comparing `drawnEdge.output.id == self.id`, but how were we able to compare `drawnEdge.output.id: NodeRowViewModelId` against `PortUIViewModel.id: NodeIOCoordinate` ?!
+            drawnEdge.output.nodeIOCoordinate == self.id {
+            
             let hasEligibleInput = drawingObserver.nearestEligibleInput.isDefined
             return PortColor(isSelected: hasEligibleInput,
                              hasEdge: hasEligibleInput,

--- a/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
+++ b/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
@@ -193,7 +193,6 @@ extension GraphState {
         // end any edge-drawing
         self.edgeDrawingObserver.reset()
         self.nodeIsMoving = true
-        self.outputDragStartedCount = 0
     }
 }
 
@@ -265,7 +264,6 @@ extension StitchDocumentViewModel {
             .forEach { _update($0) }
         
         graph.nodeIsMoving = false
-        graph.outputDragStartedCount = 0
         
         // Rebuild comment boxes
         graph.rebuildCommentBoxes(currentTraversalLevel: groupNodeFocused)

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -44,7 +44,6 @@ final class GraphState: Sendable {
     // Hackiness for handling edge case in our UI where somehow
     // UIKit node drag and SwiftUI port drag can happen at sometime.
     @MainActor var nodeIsMoving = false
-    @MainActor var outputDragStartedCount = 0
     
     // Keeps track of interaction nodes and their selected layer
     @MainActor var dragInteractionNodes = [LayerNodeId: NodeIdSet]()


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7197
Resolves https://github.com/StitchDesign/Stitch--Old/issues/5974

This PR resolves all our existing port/edge (non-edge-edit mode) animation issues. No more slivers/cuticles lagging behind during an output drag, etc.

Note: in `calculatePortColor`, how did the compiler allow a `NodeIOCoordinate == NodeRowViewModelId` check? Are we implementing a weird `Identifiable` or `Equatable` somewhere on one or both of those  ?


https://github.com/user-attachments/assets/cad64fab-8a9e-4a9c-a02b-8692d6d79e7c

