### PR TITLE
Reverting side effect positioning of LLM-generated nodes

### DIFF
--- a/Stitch/Graph/StitchAI/DatasetRecording/LLMRecordingState.swift
+++ b/Stitch/Graph/StitchAI/DatasetRecording/LLMRecordingState.swift
@@ -112,16 +112,6 @@ extension StitchDocumentViewModel {
         }
         
         // Only adjust node positions if actions were valid and successfully applied
-        // Note: position AI-generated nodes after a short delay, so that view has time to read canvas items' sizes
-//        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-//            let (depthMap, _) = convertedActions.calculateAINodesAdjacency()
-//            let createdNodes = convertedActions.nodesCreatedByLLMActions()
-//            if let depthMap = depthMap {
-//                dispatch(UpdateAIGeneratedNodesPositions(depthMap: depthMap, createdNodes: createdNodes))
-//            }
-//        }
-        
-        // Only adjust node positions if actions were valid and successfully applied
         positionAIGeneratedNodes(convertedActions: convertedActions,
                                  nodes: self.visibleGraph.visibleNodesViewModel,
                                  viewPortCenter: self.newCanvasItemInsertionLocation)
@@ -367,90 +357,6 @@ func positionAIGeneratedNodes(convertedActions: [any StepActionable],
         }
     }
 }
-
-
-//struct UpdateAIGeneratedNodesPositions: StitchDocumentEvent {
-//    
-//    let depthMap: DepthMap
-//    let createdNodes: NodeIdSet
-//    
-//    func handle(state: StitchDocumentViewModel) {
-//        
-//        let graph = state.visibleGraph
-//        
-//        graph.visibleNodesViewModel.setAllCanvasItemsVisible()
-//        
-//        positionAIGeneratedNodes(
-//            depthMap: depthMap,
-//            createdNodes: createdNodes,
-//            graph: graph,
-//            viewPortCenter: state.newCanvasItemInsertionLocation)
-//        
-//        state.updateVisibleCanvasItems()
-//        
-//        state.encodeProjectInBackground()
-//    }
-//}
-//
-//@MainActor
-//func positionAIGeneratedNodes(depthMap: DepthMap,
-//                              createdNodes: NodeIdSet,
-//                              graph: GraphReader,
-//                              viewPortCenter: CGPoint) {
-//    
-//    guard !depthMap.isEmpty else {
-//        log("Depth-map was empty")
-//        return
-//    }
-//                    
-//    let depthLevels = depthMap.values.sorted().toOrderedSet
-//        
-//    // Iterate by depth-level, so that nodes at same depth (e.g. 0) can be y-offset from each other
-//    depthLevels.forEach { depthLevel in
-//
-//        // TODO: just rewrite the adjacency logic to be a mapping of [Int: [UUID]] instead of [UUID: Int]
-//        // Find all the created-nodes at this depth-level,
-//        // and adjust their positions
-//        let createdNodesAtThisLevel = createdNodes.compactMap {
-//            if depthMap.get($0) == depthLevel {
-//                return graph.getNode($0)
-//            }
-//            log("positionAIGeneratedNodes: Could not get depth level for \($0.debugFriendlyId)")
-//            return nil
-//        }
-//        
-//        createdNodesAtThisLevel.enumerated().forEach { x in
-//            let createdNode = x.element
-//            let createdNodeIndexAtThisDepthLevel = x.offset
-//            // log("positionAIGeneratedNodes: createdNode.id: \(createdNode.id)")
-//            // log("positionAIGeneratedNodes: createdNodeIndexAtThisDepthLevel: \(createdNodeIndexAtThisDepthLevel)")
-//            createdNode.getAllCanvasObservers().enumerated().forEach { canvasItemAndIndex in
-//                
-//                // default stagger size
-//                var staggerSize = CGSize(width: CANVAS_ITEM_ADDED_VIA_LLM_STEP_WIDTH_STAGGER,
-//                                         height: CANVAS_ITEM_ADDED_VIA_LLM_STEP_HEIGHT_STAGGER)
-//                
-//                log("staggerSize: \(staggerSize)")
-//                
-//                if let canvasSize = canvasItemAndIndex.element.sizeByLocalBounds {
-//                    log("canvasSize: \(canvasSize)")
-//                    staggerSize = canvasSize
-//                }
-//                
-//                let staggerPadding: CGFloat = 60
-//                
-//                let newPosition = CGPoint(
-//                    x: viewPortCenter.x + (CGFloat(depthLevel) * staggerSize.width + staggerPadding),
-//                    y: viewPortCenter.y + (CGFloat(canvasItemAndIndex.offset) * staggerSize.height + staggerPadding) + (CGFloat(createdNodeIndexAtThisDepthLevel) * staggerSize.height)
-//                )
-//                // log("positionAIGeneratedNodes: canvasItemAndIndex.element.id: \(canvasItemAndIndex.element.id)")
-//                // log("positionAIGeneratedNodes: newPosition: \(newPosition)")
-//                canvasItemAndIndex.element.position = newPosition
-//                canvasItemAndIndex.element.previousPosition = newPosition
-//            }
-//        }
-//    }
-//}
 
 // Might not need this anymore ?
 // Also overlaps with `StitchAIPromptState` ?

--- a/Stitch/Graph/StitchAI/DatasetRecording/LLMRecordingState.swift
+++ b/Stitch/Graph/StitchAI/DatasetRecording/LLMRecordingState.swift
@@ -113,14 +113,19 @@ extension StitchDocumentViewModel {
         
         // Only adjust node positions if actions were valid and successfully applied
         // Note: position AI-generated nodes after a short delay, so that view has time to read canvas items' sizes
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-            let (depthMap, _) = convertedActions.calculateAINodesAdjacency()
-            let createdNodes = convertedActions.nodesCreatedByLLMActions()
-            if let depthMap = depthMap {
-                dispatch(UpdateAIGeneratedNodesPositions(depthMap: depthMap, createdNodes: createdNodes))
-            }
-        }
-                
+//        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+//            let (depthMap, _) = convertedActions.calculateAINodesAdjacency()
+//            let createdNodes = convertedActions.nodesCreatedByLLMActions()
+//            if let depthMap = depthMap {
+//                dispatch(UpdateAIGeneratedNodesPositions(depthMap: depthMap, createdNodes: createdNodes))
+//            }
+//        }
+        
+        // Only adjust node positions if actions were valid and successfully applied
+        positionAIGeneratedNodes(convertedActions: convertedActions,
+                                 nodes: self.visibleGraph.visibleNodesViewModel,
+                                 viewPortCenter: self.newCanvasItemInsertionLocation)
+           
         // Write to disk ONLY IF WE WERE SUCCESSFUL
         self.encodeProjectInBackground()
         
@@ -307,41 +312,28 @@ extension StitchDocumentViewModel {
     }
 }
 
-struct UpdateAIGeneratedNodesPositions: StitchDocumentEvent {
-    
-    let depthMap: DepthMap
-    let createdNodes: NodeIdSet
-    
-    func handle(state: StitchDocumentViewModel) {
-        
-        let graph = state.visibleGraph
-        
-        graph.visibleNodesViewModel.setAllCanvasItemsVisible()
-        
-        positionAIGeneratedNodes(
-            depthMap: depthMap,
-            createdNodes: createdNodes,
-            graph: graph,
-            viewPortCenter: state.newCanvasItemInsertionLocation)
-        
-        state.updateVisibleCanvasItems()
-        
-        state.encodeProjectInBackground()
-    }
-}
-
 @MainActor
-func positionAIGeneratedNodes(depthMap: DepthMap,
-                              createdNodes: NodeIdSet,
-                              graph: GraphReader,
+func positionAIGeneratedNodes(convertedActions: [any StepActionable],
+                              nodes: VisibleNodesViewModel,
                               viewPortCenter: CGPoint) {
     
+    let (depthMap, hasCycle) = convertedActions.calculateAINodesAdjacency()
+    
+    guard let depthMap = depthMap,
+          !hasCycle else {
+        fatalErrorIfDebug("Did not have a cycle but was not able create depth-map")
+        return
+    }
+    
     guard !depthMap.isEmpty else {
-        log("Depth-map was empty")
+//        fatalErrorIfDebug("Depth-map should never be empty")
+        log("Depth-map should never be empty")
         return
     }
                     
     let depthLevels = depthMap.values.sorted().toOrderedSet
+
+    let createdNodes = convertedActions.nodesCreatedByLLMActions()
         
     // Iterate by depth-level, so that nodes at same depth (e.g. 0) can be y-offset from each other
     depthLevels.forEach { depthLevel in
@@ -351,7 +343,7 @@ func positionAIGeneratedNodes(depthMap: DepthMap,
         // and adjust their positions
         let createdNodesAtThisLevel = createdNodes.compactMap {
             if depthMap.get($0) == depthLevel {
-                return graph.getNode($0)
+                return nodes.getViewModel($0)
             }
             log("positionAIGeneratedNodes: Could not get depth level for \($0.debugFriendlyId)")
             return nil
@@ -363,23 +355,9 @@ func positionAIGeneratedNodes(depthMap: DepthMap,
             // log("positionAIGeneratedNodes: createdNode.id: \(createdNode.id)")
             // log("positionAIGeneratedNodes: createdNodeIndexAtThisDepthLevel: \(createdNodeIndexAtThisDepthLevel)")
             createdNode.getAllCanvasObservers().enumerated().forEach { canvasItemAndIndex in
-                
-                // default stagger size
-                var staggerSize = CGSize(width: CANVAS_ITEM_ADDED_VIA_LLM_STEP_WIDTH_STAGGER,
-                                         height: CANVAS_ITEM_ADDED_VIA_LLM_STEP_HEIGHT_STAGGER)
-                
-                log("staggerSize: \(staggerSize)")
-                
-                if let canvasSize = canvasItemAndIndex.element.sizeByLocalBounds {
-                    log("canvasSize: \(canvasSize)")
-                    staggerSize = canvasSize
-                }
-                
-                let staggerPadding: CGFloat = 60
-                
-                let newPosition = CGPoint(
-                    x: viewPortCenter.x + (CGFloat(depthLevel) * staggerSize.width + staggerPadding),
-                    y: viewPortCenter.y + (CGFloat(canvasItemAndIndex.offset) * staggerSize.height + staggerPadding) + (CGFloat(createdNodeIndexAtThisDepthLevel) * staggerSize.height)
+                let newPosition =  CGPoint(
+                    x: viewPortCenter.x + (CGFloat(depthLevel) * CANVAS_ITEM_ADDED_VIA_LLM_STEP_WIDTH_STAGGER),
+                    y: viewPortCenter.y + (CGFloat(canvasItemAndIndex.offset) * CANVAS_ITEM_ADDED_VIA_LLM_STEP_HEIGHT_STAGGER) + (CGFloat(createdNodeIndexAtThisDepthLevel) * CANVAS_ITEM_ADDED_VIA_LLM_STEP_HEIGHT_STAGGER)
                 )
                 // log("positionAIGeneratedNodes: canvasItemAndIndex.element.id: \(canvasItemAndIndex.element.id)")
                 // log("positionAIGeneratedNodes: newPosition: \(newPosition)")
@@ -389,6 +367,90 @@ func positionAIGeneratedNodes(depthMap: DepthMap,
         }
     }
 }
+
+
+//struct UpdateAIGeneratedNodesPositions: StitchDocumentEvent {
+//    
+//    let depthMap: DepthMap
+//    let createdNodes: NodeIdSet
+//    
+//    func handle(state: StitchDocumentViewModel) {
+//        
+//        let graph = state.visibleGraph
+//        
+//        graph.visibleNodesViewModel.setAllCanvasItemsVisible()
+//        
+//        positionAIGeneratedNodes(
+//            depthMap: depthMap,
+//            createdNodes: createdNodes,
+//            graph: graph,
+//            viewPortCenter: state.newCanvasItemInsertionLocation)
+//        
+//        state.updateVisibleCanvasItems()
+//        
+//        state.encodeProjectInBackground()
+//    }
+//}
+//
+//@MainActor
+//func positionAIGeneratedNodes(depthMap: DepthMap,
+//                              createdNodes: NodeIdSet,
+//                              graph: GraphReader,
+//                              viewPortCenter: CGPoint) {
+//    
+//    guard !depthMap.isEmpty else {
+//        log("Depth-map was empty")
+//        return
+//    }
+//                    
+//    let depthLevels = depthMap.values.sorted().toOrderedSet
+//        
+//    // Iterate by depth-level, so that nodes at same depth (e.g. 0) can be y-offset from each other
+//    depthLevels.forEach { depthLevel in
+//
+//        // TODO: just rewrite the adjacency logic to be a mapping of [Int: [UUID]] instead of [UUID: Int]
+//        // Find all the created-nodes at this depth-level,
+//        // and adjust their positions
+//        let createdNodesAtThisLevel = createdNodes.compactMap {
+//            if depthMap.get($0) == depthLevel {
+//                return graph.getNode($0)
+//            }
+//            log("positionAIGeneratedNodes: Could not get depth level for \($0.debugFriendlyId)")
+//            return nil
+//        }
+//        
+//        createdNodesAtThisLevel.enumerated().forEach { x in
+//            let createdNode = x.element
+//            let createdNodeIndexAtThisDepthLevel = x.offset
+//            // log("positionAIGeneratedNodes: createdNode.id: \(createdNode.id)")
+//            // log("positionAIGeneratedNodes: createdNodeIndexAtThisDepthLevel: \(createdNodeIndexAtThisDepthLevel)")
+//            createdNode.getAllCanvasObservers().enumerated().forEach { canvasItemAndIndex in
+//                
+//                // default stagger size
+//                var staggerSize = CGSize(width: CANVAS_ITEM_ADDED_VIA_LLM_STEP_WIDTH_STAGGER,
+//                                         height: CANVAS_ITEM_ADDED_VIA_LLM_STEP_HEIGHT_STAGGER)
+//                
+//                log("staggerSize: \(staggerSize)")
+//                
+//                if let canvasSize = canvasItemAndIndex.element.sizeByLocalBounds {
+//                    log("canvasSize: \(canvasSize)")
+//                    staggerSize = canvasSize
+//                }
+//                
+//                let staggerPadding: CGFloat = 60
+//                
+//                let newPosition = CGPoint(
+//                    x: viewPortCenter.x + (CGFloat(depthLevel) * staggerSize.width + staggerPadding),
+//                    y: viewPortCenter.y + (CGFloat(canvasItemAndIndex.offset) * staggerSize.height + staggerPadding) + (CGFloat(createdNodeIndexAtThisDepthLevel) * staggerSize.height)
+//                )
+//                // log("positionAIGeneratedNodes: canvasItemAndIndex.element.id: \(canvasItemAndIndex.element.id)")
+//                // log("positionAIGeneratedNodes: newPosition: \(newPosition)")
+//                canvasItemAndIndex.element.position = newPosition
+//                canvasItemAndIndex.element.previousPosition = newPosition
+//            }
+//        }
+//    }
+//}
 
 // Might not need this anymore ?
 // Also overlaps with `StitchAIPromptState` ?


### PR DESCRIPTION
Addresses two problems:
1.  issues with generating LLM training data (edges and positions inaccurate, can't create new edge etc.; super jumpy)
2. sizes were also not very correct and relying on a 0.2 sec delay was silly


For (1), we still have 'flashes' when e.g. add or remove an edge while creating LLM training data.

For (2), we can probably get away with a manual static printing of `patch -> node type -> size (but especially width)` (@narner's idea, sounds good imo)