### PR TITLE
Proper z-indexing on HStack of a layer-input-on-canvas's fields

### DIFF
--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -300,10 +300,13 @@ struct PotentiallyBlockedFieldsView<ValueView>: View where ValueView: View {
     @ViewBuilder var valueEntryView: (InputFieldViewModel, Bool) -> ValueView
     
     var body: some View {
-        ForEach(fieldGroup.fieldObservers) { fieldViewModel in
+        let fields = fieldGroup.fieldObservers
+        ForEach(Array(zip(fields.indices, fields)), id: \.0) { index, fieldViewModel in
+//        ForEach(fieldGroup.fieldObservers) { fieldViewModel in
             let isBlocked = fieldViewModel.isBlocked(self.blockedFields)
             if !isBlocked {
                 self.valueEntryView(fieldViewModel, isMultifield)
+                    .zIndex(-CGFloat(index))
             }
         }
     }


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7200

<img width="525" alt="Screenshot 2025-04-30 at 2 59 38 PM" src="https://github.com/user-attachments/assets/3e0b21d8-6279-44e8-afbd-ebaeccd9930d" />
