### PR TITLE
Fixed Repeating Pulse node after prototype restart

### DIFF
--- a/Stitch/Graph/Node/Eval/LoopedEval.swift
+++ b/Stitch/Graph/Node/Eval/LoopedEval.swift
@@ -263,10 +263,9 @@ extension NodeViewModel {
     /// Saves previous values in `ComputedNodeState`.
     @MainActor
     func loopedEvalOutputsPersistence(graphTime: TimeInterval,
-                                      callback: @escaping (PortValues, TimeInterval, ComputedNodeState) -> PortValue) -> EvalResult {
+                                      callback: @escaping (PortValues, ComputedNodeState) -> PortValue) -> EvalResult {
         self.loopedEval(ComputedNodeState.self) { values, computedState, _ in
             let newValue = callback(values,
-                                    graphTime,
                                     computedState)
             computedState.previousValue = newValue
             

--- a/Stitch/Graph/Node/Patch/Type/Pulse/CounterNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Pulse/CounterNode.swift
@@ -56,8 +56,11 @@ func counterEval(node: PatchNode,
     
     let graphTime: TimeInterval = graphStep.graphTime
     
-    return node.loopedEvalOutputsPersistence(graphTime: graphTime,
-                                             callback: counterOpClosure)
+    return node.loopedEvalOutputsPersistence(graphTime: graphTime) { values, computedState in
+        counterOpClosure(values: values,
+                         graphTime: graphTime,
+                         computedState: computedState)
+    }
 }
 
 func counterOpClosure(values: PortValues,

--- a/Stitch/Graph/Node/Patch/Type/Pulse/RepeatingPulsePatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Pulse/RepeatingPulsePatchNode.swift
@@ -41,14 +41,14 @@ func repeatingPulseEval(node: PatchNode,
                         graphState: GraphState) -> ImpureEvalResult {
     let graphTime = graphState.graphStepState.graphTime
             
-    return node.loopedEval { values, loopIndex in
+    return node.loopedEvalOutputsPersistence(graphTime: graphTime) { values, computedState in
         // to determine whether it's time to pulse or not,
         // will have to look at the existing outputs' indices' .pulse(lastAt)
         let frequency: Double = values.first?.getNumber ?? 0.0
 
         // Look at the *output's* index's `pulsedAt`;
         // we need to know if it's been long enough since last pulse.
-        let pulseAt: TimeInterval = values[safe: 1]?.getPulse ?? .zero
+        let pulseAt: TimeInterval = computedState.previousValue?.getPulse ?? .zero
 
         let _shouldPulse = shouldPulse(currentTime: graphTime,
                                        lastTimePulsed: pulseAt,
@@ -56,9 +56,9 @@ func repeatingPulseEval(node: PatchNode,
 
         if frequency > 0 && _shouldPulse {
             // We pulsed, so update pulse-time
-            return ImpureEvalOpResult(outputs: [.pulse(graphTime)])
+            return .pulse(graphTime)
         } else {
-            return ImpureEvalOpResult(outputs: [.pulse(pulseAt)])
+            return .pulse(pulseAt)
         }
     }
 }

--- a/Stitch/Graph/Node/Patch/Type/Pulse/SwitchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Pulse/SwitchNode.swift
@@ -45,8 +45,11 @@ struct SwitchNode: PatchNodeDefinition {
 @MainActor
 func switchEval(node: PatchNode,
                 graphStep: GraphStepState) -> ImpureEvalResult {
-    node.loopedEvalOutputsPersistence(graphTime: graphStep.graphTime,
-                                      callback: switchOpClosure)
+    node.loopedEvalOutputsPersistence(graphTime: graphStep.graphTime) { values, computedState in
+        switchOpClosure(values: values,
+                        graphTime: graphStep.graphTime,
+                        computedState: computedState)
+    }
 }
 
 func switchOpClosure(values: PortValues,


### PR DESCRIPTION
Issue was caused by reliance on actual outputs, which weren't getting reset on prototype restart. Instead, computed node state gets reset. We now read from computed node state.

Resolves https://github.com/StitchDesign/Stitch--Old/issues/7208.