### PR TITLE
Improved identity and memory safety for layers

### DIFF
--- a/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/PreviewModel3DLayer.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/3DModelLayerNode/PreviewModel3DLayer.swift
@@ -64,7 +64,7 @@ struct Preview3DModelLayer: View {
 
     @MainActor
     var layerNode: LayerNodeViewModel? {
-        self.graph.getNodeViewModel(layerViewModel.id.layerNodeId.asNodeId)?
+        self.graph.getNodeViewModel(layerViewModel.previewCoordinate.layerNodeId.asNodeId)?
             .layerNode
     }
 

--- a/Stitch/Graph/Node/Layer/Type/Media/RealityView/PreviewRealityLayer.swift
+++ b/Stitch/Graph/Node/Layer/Type/Media/RealityView/PreviewRealityLayer.swift
@@ -30,7 +30,7 @@ struct PreviewRealityLayer: View {
         let scale = viewModel.scale.asCGFloat
         let cameraDirection = viewModel.cameraDirection.getCameraDirection ?? .back
         
-        if let node = document.visibleGraph.getNodeViewModel(viewModel.id.layerNodeId.asNodeId) {
+        if let node = document.visibleGraph.getNodeViewModel(viewModel.previewCoordinate.layerNodeId.asNodeId) {
             @Bindable var node = node
             
             RealityLayerView(document: document,

--- a/Stitch/Graph/Node/Layer/Type/SwitchLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/SwitchLayerNode.swift
@@ -55,7 +55,7 @@ struct SwitchLayerNode: LayerNodeDefinition {
             viewModel: viewModel,
             isPinnedViewRendering: isPinnedViewRendering,
             interactiveLayer: viewModel.interactiveLayer,
-            id: viewModel.id, 
+            id: viewModel.previewCoordinate, 
             isEnabled: viewModel.enabled.getBool ?? false,
             togglePulse: viewModel.isSwitchToggled.getPulse ?? .zero,
             position: viewModel.position.getPosition ?? .zero,

--- a/Stitch/Graph/PrototypePreview/Frame/View/NativeScrollGestureView.swift
+++ b/Stitch/Graph/PrototypePreview/Frame/View/NativeScrollGestureView.swift
@@ -175,7 +175,7 @@ struct NativeScrollGestureViewInner: ViewModifier {
                 y: (-newValue.y).asPositiveZero
             )
             
-            graph.scheduleForNextGraphStep(layerViewModel.id.layerNodeId.asNodeId)
+            graph.scheduleForNextGraphStep(layerViewModel.previewCoordinate.layerNodeId.asNodeId)
             
         } // .onScrollGeometryChange
         

--- a/Stitch/Graph/PrototypePreview/Layer/Model/LayerData.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/LayerData.swift
@@ -12,13 +12,11 @@ import OrderedCollections
 typealias LayerDataList = [LayerData]
 
 /// Data type used for getting sorted data in views.
-indirect enum LayerData {
-    case nongroup(layerNode: LayerNodeViewModel,
-                  layerViewModel: LayerViewModel,
+enum LayerData {
+    case nongroup(id: PreviewCoordinate,
                   isPinned: Bool)
 
-    case group(layerNode: LayerNodeViewModel,
-               layerViewModel: LayerViewModel,
+    case group(id: PreviewCoordinate,
                children: LayerDataList,
                isPinned: Bool)
 
@@ -29,58 +27,57 @@ indirect enum LayerData {
 
 extension LayerData: Identifiable {
     var id: PreviewCoordinate {
-        self.layer.id
+        switch self {
+        case .nongroup(let id, let isPinned):
+            return id
+        case .group(let id, let children, let isPinned):
+            return id
+        case .mask(let masked, let masker):
+            return masked.first!.id
+        }
     }
 
     var groupDataList: LayerDataList? {
         switch self {
         case .nongroup, .mask:
             return nil
-        case .group(_, _, let layerDataList, _):
+        case .group(_, let layerDataList, _):
             return layerDataList
         }
     }
 
     var isPinned: Bool {
         switch self {
-        case .nongroup(_, _, let isPinned):
+        case .nongroup(_, let isPinned):
             return isPinned
-        case .group(_, _, _, let isPinned):
+        case .group(_, _, let isPinned):
             return isPinned
         case .mask:
             return false
         }
     }
     
-    var layer: LayerViewModel {
-        switch self {
-        case .nongroup(_, let layer, _):
-            return layer
-        case .group(_, let layer, _, _):
-            return layer
-        case .mask(masked: let layerDataList, masker: _):
-            // TODO: `layerDataList` should be NonEmpty; there's no way to gracefully fail here
-            return layerDataList.first!.layer
-        }
+    @MainActor
+    func getLayer(graph: GraphState) -> LayerViewModel? {
+        let id = self.id
+        return graph.getNodeViewModel(id.layerNodeId.asNodeId)?.layerNode?.previewLayerViewModels[safe: id.loopIndex]
     }
     
     @MainActor
-    var zIndex: CGFloat {
-        switch self {
-        case .nongroup(_, let layer, _):
-            return layer.zIndex.getNumber ?? .zero
-        case .group(_, let layer, _, _):
-            return layer.zIndex.getNumber ?? .zero
-        case .mask(masked: let masked, masker: _):
-            // TODO: is z-index for a LayerData really the first
-            return masked.first?.layer.zIndex.getNumber ?? .zero
+    func getZIndex(graph: GraphState) -> CGFloat {
+        guard let layer = self.getLayer(graph: graph) else {
+            return .zero
         }
+        
+        return layer.zIndex.getNumber ?? .zero
     }
 }
 
 /// Provides equatable equivalent that supports main actor isolation.
 protocol MainActorEquatable {
-    @MainActor static func equals(_ lhs: Self, _ rhs: Self) -> Bool
+    @MainActor static func equals(_ lhs: Self,
+                                  _ rhs: Self,
+                                  graph: GraphState) -> Bool
 }
 
 // TODO: Can we separate "cached preview layers changed" from the data we need
@@ -88,13 +85,17 @@ protocol MainActorEquatable {
 // Note: we define a custom == on LayerData because
 extension LayerData: MainActorEquatable {
     @MainActor
-    static func equals(_ lhs: LayerData, _ rhs: LayerData) -> Bool {
+    static func equals(_ lhs: LayerData,
+                       _ rhs: LayerData,
+                       graph: GraphState) -> Bool {
         lhs.id == rhs.id &&
         lhs.isPinned == rhs.isPinned &&
-        lhs.zIndex == rhs.zIndex &&
+        lhs.getZIndex(graph: graph) == rhs.getZIndex(graph: graph) &&
 
         // Did the children change?
-        LayerDataList.equals(lhs.groupDataList ?? [], rhs.groupDataList ?? []) &&
+        LayerDataList.equals(lhs.groupDataList ?? [],
+                             rhs.groupDataList ?? [],
+                             graph: graph) &&
         
         // Important to check if the case changed
         // (e.g. we hid a masker layer, so a previously masked layer now became .nonGroup or .group instead of .mask)
@@ -138,13 +139,17 @@ extension LayerData {
 
 extension Array where Element: MainActorEquatable {
     @MainActor
-    static func equals(_ lhs: [Element], _ rhs: [Element]) -> Bool {
+    static func equals(_ lhs: [Element],
+                       _ rhs: [Element],
+                       graph: GraphState) -> Bool {
         guard lhs.count == rhs.count else {
             return false
         }
         
         return zip(lhs, rhs).allSatisfy { lhsElement, rhsElement in
-            Element.equals(lhsElement, rhsElement)
+            Element.equals(lhsElement,
+                           rhsElement,
+                           graph: graph)
         }
     }
 }

--- a/Stitch/Graph/PrototypePreview/Layer/Model/LayerType.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Model/LayerType.swift
@@ -24,14 +24,16 @@ indirect enum LayerType: Equatable, Hashable {
 }
 
 struct LayerTypeNonGroupData: Equatable, Hashable {
-    let id: PreviewCoordinate
+    let id: UUID
+    let previewCoordinate: PreviewCoordinate
     let zIndex: CGFloat
     let sidebarIndex: Int
     let layer: Layer // debug
 }
 
 struct LayerTypeGroupData: Equatable, Hashable {
-    let id: PreviewCoordinate
+    let id: UUID
+    let previewCoordinate: PreviewCoordinate
     let zIndex: CGFloat
     let sidebarIndex: Int
     let childrenSidebarLayers: SidebarLayerList
@@ -41,7 +43,7 @@ struct LayerTypeGroupData: Equatable, Hashable {
 extension LayerType {
     
     // Only used for pinning?
-    var id: PreviewCoordinate {
+    var id: UUID {
         switch self {
         case .nongroup(let data, _):
             return data.id
@@ -51,6 +53,19 @@ extension LayerType {
             // TODO: what is the the layer-node-id of a LayerType in a masking situation? Really, it's nil, there's no single LayerNode
             // return masked.id
             return masked.first!.id
+        }
+    }
+    
+    var previewCoordinate: PreviewCoordinate {
+        switch self {
+        case .nongroup(let data, _):
+            return data.previewCoordinate
+        case .group(let data, _):
+            return data.previewCoordinate
+        case .mask(masked: let masked, masker: _):
+            // TODO: what is the the layer-node-id of a LayerType in a masking situation? Really, it's nil, there's no single LayerNode
+            // return masked.id
+            return masked.first!.previewCoordinate
         }
     }
 

--- a/Stitch/Graph/PrototypePreview/Layer/Util/LayerNodesSorting.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Util/LayerNodesSorting.swift
@@ -174,16 +174,7 @@ func getLayerDataFromLayerType(_ layerType: LayerType,
         
         // we call `getLayerDataFromLayerType` recursively, and
     case .nongroup(let data, let isPinned): // LayerData
-        
-        guard let layerNode = layerNodes.get(data.id.layerNodeId.id),
-              let previewLayer: LayerViewModel = layerNode
-                // these layer view models are ALREADY CREATED on the layer node
-            .previewLayerViewModels[safe: data.id.loopIndex] else {
-            return nil
-        }
-        
-        return .nongroup(layerNode: layerNode,
-                         layerViewModel: previewLayer,
+        return .nongroup(id: data.id,
                          isPinned: isPinned)
         
     case .group(let layerGroupData, let isPinned): // LayerGroupData
@@ -208,8 +199,7 @@ func getLayerDataFromLayerType(_ layerType: LayerType,
             isInGroupOrientation: isInGroupOrientation,
             activeIndex: activeIndex)
         
-        return .group(layerNode: layerNode,
-                      layerViewModel: previewLayer,
+        return .group(id: layerGroupData.id,
                       children: childrenData,
                       isPinned: isPinned)
     }

--- a/Stitch/Graph/PrototypePreview/Layer/Util/LayerNodesSorting.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Util/LayerNodesSorting.swift
@@ -105,12 +105,12 @@ func layerSortingComparator(lhs: LayerType,
     let rhsSidebarIndex = rhs.sidebarIndex
     
     // If both layers are in same pinning linked list, prioritize the lower-level pin over a receiver
-    let isPinningScenario = pinMap.areLayersInSamePinFamily(idSet: .init([lhs.id.layerNodeId, rhs.id.layerNodeId]))
+    let isPinningScenario = pinMap.areLayersInSamePinFamily(idSet: .init([lhs.previewCoordinate.layerNodeId, rhs.previewCoordinate.layerNodeId]))
     
     // Determines if a view is pinned and if so, how nested that pin is (higher value = more nesting)
     if isPinningScenario {
-        let lhsPinNestedCount = pinMap.getPinnedNestedLayerCount(id: lhs.id.layerNodeId)
-        let rhsPinNestedCount = pinMap.getPinnedNestedLayerCount(id: rhs.id.layerNodeId)
+        let lhsPinNestedCount = pinMap.getPinnedNestedLayerCount(id: lhs.previewCoordinate.layerNodeId)
+        let rhsPinNestedCount = pinMap.getPinnedNestedLayerCount(id: rhs.previewCoordinate.layerNodeId)
         
         if lhsPinNestedCount != rhsPinNestedCount {
             return rhsPinNestedCount > lhsPinNestedCount
@@ -175,11 +175,12 @@ func getLayerDataFromLayerType(_ layerType: LayerType,
         // we call `getLayerDataFromLayerType` recursively, and
     case .nongroup(let data, let isPinned): // LayerData
         return .nongroup(id: data.id,
+                         previewCoordinate: data.previewCoordinate,
                          isPinned: isPinned)
         
     case .group(let layerGroupData, let isPinned): // LayerGroupData
-        guard let layerNode = layerNodes.get(layerGroupData.id.layerNodeId.asNodeId),
-              let previewLayer: LayerViewModel = layerNode.previewLayerViewModels[safe: layerGroupData.id.loopIndex] else {
+        guard let layerNode = layerNodes.get(layerGroupData.previewCoordinate.layerNodeId.asNodeId),
+              let previewLayer: LayerViewModel = layerNode.previewLayerViewModels[safe: layerGroupData.previewCoordinate.loopIndex] else {
             
             return nil
         }
@@ -200,6 +201,7 @@ func getLayerDataFromLayerType(_ layerType: LayerType,
             activeIndex: activeIndex)
         
         return .group(id: layerGroupData.id,
+                      previewCoordinate: layerGroupData.previewCoordinate,
                       children: childrenData,
                       isPinned: isPinned)
     }
@@ -223,6 +225,7 @@ func getLayerTypesFromSidebarLayerData(_ layerData: SidebarLayerData,
         let layerTypes: LayerTypeOrderedSet = layerNode.previewLayerViewModels
             .map { layerViewModel in
                     .group(data: .init(id: layerViewModel.id,
+                                       previewCoordinate: layerViewModel.previewCoordinate,
                                        zIndex: layerViewModel.zIndex.getNumber ?? .zero,
                                        sidebarIndex: sidebarIndex,
                                        childrenSidebarLayers: children,
@@ -240,6 +243,7 @@ func getLayerTypesFromSidebarLayerData(_ layerData: SidebarLayerData,
             .reversed() // Reverse loop's layer view models, for default "ZStack" case
             .map { layerViewModel in
                     .nongroup(data: .init(id: layerViewModel.id,
+                                          previewCoordinate: layerViewModel.previewCoordinate,
                                           zIndex: layerViewModel.zIndex.getNumber ?? .zero,
                                           sidebarIndex: sidebarIndex,
                                           layer: layerNode.layer),

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PinningUtils.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PinningUtils.swift
@@ -204,7 +204,7 @@ func getFlattenedPinMap(layerNodes: LayerNodesDict,
                 
                 // `PinToId.root` case does not have a corresponding layer node,
                 //
-                let pinReceivingLayer = pinToId.asLayerNodeId(viewModel.id.layerNodeId,
+                let pinReceivingLayer = pinToId.asLayerNodeId(viewModel.previewCoordinate.layerNodeId,
                                                               from: graph)
                 
                 if pinReceivingLayer == nil && pinToId != .root {
@@ -328,7 +328,7 @@ extension GraphState {
             // Note: PinTo = Parent is perhaps redundant vs layer's Anchoring, which is always relative to parent
             // Worst case we can just remove this enum case in the next migration; Root still represents a genuinely new scenario
         case .parent:
-            if let layerNode = self.getNode(pinnedLayerViewModel.id.layerNodeId.asNodeId)?.layerNode,
+            if let layerNode = self.getNode(pinnedLayerViewModel.previewCoordinate.layerNodeId.asNodeId)?.layerNode,
                let parent = layerNode.layerGroupId {
                 return self.getPinReceiverData(pinReceiverId: parent.asLayerNodeId,
                                                for: pinnedLayerViewModel)
@@ -357,7 +357,7 @@ extension GraphState {
         }
         
         // TODO: suppose View A (pinned) has a loop of 5, but View B (pin-receiver) has a loop of only 2; which pin-receiver view model should we return?
-        let pinReceiverAtSameLoopIndex = pinReceiver.layerNodeViewModel?.previewLayerViewModels[safe: pinnedLayerViewModel.id.loopIndex]
+        let pinReceiverAtSameLoopIndex = pinReceiver.layerNodeViewModel?.previewLayerViewModels[safe: pinnedLayerViewModel.previewCoordinate.loopIndex]
         
         let firstPinReceiver = pinReceiver.layerNodeViewModel?.previewLayerViewModels.first
         

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonMisc.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonMisc.swift
@@ -57,7 +57,7 @@ struct PreviewLayerRotationModifier: ViewModifier {
     
     @MainActor
     var receivesPin: Bool {
-        graph.pinMap.get(viewModel.id.layerNodeId).isDefined
+        graph.pinMap.get(viewModel.previewCoordinate.layerNodeId).isDefined
     }
     
     @MainActor

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewWindowCoordinateSpaceReader.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewWindowCoordinateSpaceReader.swift
@@ -21,7 +21,7 @@ struct PreviewWindowCoordinateSpaceReader: ViewModifier {
     }
     
     var key: PreviewCoordinate {
-        viewModel.id
+        viewModel.previewCoordinate
     }
     
     /// Important to only report pin data from ghost view.
@@ -45,7 +45,7 @@ struct PreviewWindowCoordinateSpaceReader: ViewModifier {
                         //viewModel.previewWindowRect = newValue
                         
                         // If this layer *receives* a pin, populate its pin-receiver data fields:
-                        if pinMap.get(viewModel.id.layerNodeId).isDefined,
+                        if pinMap.get(viewModel.previewCoordinate.layerNodeId).isDefined,
                            // TODO: how or why can newValue
                            (!newValue.width.isNaN && !newValue.height.isNaN) {
                             // log("PreviewWindowCoordinateSpaceReader: had pinMap entry for viewModel.id.layerNodeId \(viewModel.id.layerNodeId), newValue.origin: \(newValue.origin)")

--- a/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
@@ -228,8 +228,9 @@ struct PreviewLayersView: View {
             // So we use the largest width.
             // TODO: perf implications of iterating through e.g. 900 views?
             let longestReadWidth = presentedLayers.max { d1, d2 in
-                d1.layer.readSize.width < d2.layer.readSize.width
-            }?.layer.readSize.width ?? .zero
+                d1.getLayer(graph: graph)?.readSize.width ?? -1 <
+                    d2.getLayer(graph: graph)?.readSize.width ?? -1
+            }?.getLayer(graph: graph)?.readSize.width ?? .zero
             
             // logInView("gridView: longestReadWidth: \(longestReadWidth)")
             
@@ -406,28 +407,34 @@ struct LayerDataView: View {
                 }
             }
             
-        case .nongroup(let layerNode, let layerViewModel, _):
-            NonGroupPreviewLayersView(document: document,
-                                      graph: graph,
-                                      layerNode: layerNode,
-                                      layerViewModel: layerViewModel,
-                                      isPinnedViewRendering: !isGhostView,
-                                      parentSize: parentSize,
-                                      parentDisablesPosition: parentDisablesPosition,
-                                      parentIsScrollableGrid: parentIsScrollableGrid,
-                                      realityContent: realityContent)
+        case .nongroup(let id, _):
+            if let layerNode = graph.getNode(id.layerNodeId.asNodeId)?.layerNode,
+               let layerViewModel = layerNode.previewLayerViewModels[safe: id.loopIndex] {
+                NonGroupPreviewLayersView(document: document,
+                                          graph: graph,
+                                          layerNode: layerNode,
+                                          layerViewModel: layerViewModel,
+                                          isPinnedViewRendering: !isGhostView,
+                                          parentSize: parentSize,
+                                          parentDisablesPosition: parentDisablesPosition,
+                                          parentIsScrollableGrid: parentIsScrollableGrid,
+                                          realityContent: realityContent)
+            }
                         
-        case .group(let layerNode, let layerViewModel, let childrenData, _):
-            GroupPreviewLayersView(document: document,
-                                   graph: graph,
-                                   layerNode: layerNode,
-                                   layerViewModel: layerViewModel,
-                                   childrenData: childrenData,
-                                   isPinnedViewRendering: !isGhostView,
-                                   parentSize: parentSize,
-                                   parentDisablesPosition: parentDisablesPosition,
-                                   parentIsScrollableGrid: parentIsScrollableGrid,
-                                   realityContent: realityContent)
+        case .group(let id, let childrenData, _):
+            if let layerNode = graph.getNode(id.layerNodeId.asNodeId)?.layerNode,
+               let layerViewModel = layerNode.previewLayerViewModels[safe: id.loopIndex] {
+                GroupPreviewLayersView(document: document,
+                                       graph: graph,
+                                       layerNode: layerNode,
+                                       layerViewModel: layerViewModel,
+                                       childrenData: childrenData,
+                                       isPinnedViewRendering: !isGhostView,
+                                       parentSize: parentSize,
+                                       parentDisablesPosition: parentDisablesPosition,
+                                       parentIsScrollableGrid: parentIsScrollableGrid,
+                                       realityContent: realityContent)
+            }
         } // switch
     }
 }

--- a/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
@@ -373,9 +373,9 @@ struct LayerDataView: View {
       
             ForEach(maskedLayerDataList) { (maskedLayerData: LayerData) in
                 
-                if let maskedIndex = maskedLayerDataList.firstIndex(where: { $0.id == maskedLayerData.id }),
+                if let maskedIndex = maskedLayerDataList.firstIndex(where: { $0.previewCoordinate == maskedLayerData.previewCoordinate }),
                     maskedIndex < maskerLayerDataList.endIndex, // Is this check necessary?
-                    let maskerLayerData: LayerData = maskerLayerDataList.first(where: { $0.id.loopIndex == maskedLayerData.id.loopIndex }) {
+                    let maskerLayerData: LayerData = maskerLayerDataList.first(where: { $0.previewCoordinate.loopIndex == maskedLayerData.previewCoordinate.loopIndex }) {
                     
                     // Turn masked LayerData into a single view
                     let masked: some View = LayerDataView(
@@ -407,7 +407,7 @@ struct LayerDataView: View {
                 }
             }
             
-        case .nongroup(let id, _):
+        case .nongroup(_, let id, _):
             if let layerNode = graph.getNode(id.layerNodeId.asNodeId)?.layerNode,
                let layerViewModel = layerNode.previewLayerViewModels[safe: id.loopIndex] {
                 NonGroupPreviewLayersView(document: document,
@@ -421,7 +421,7 @@ struct LayerDataView: View {
                                           realityContent: realityContent)
             }
                         
-        case .group(let id, let childrenData, _):
+        case .group(_, let id, let childrenData, _):
             if let layerNode = graph.getNode(id.layerNodeId.asNodeId)?.layerNode,
                let layerViewModel = layerNode.previewLayerViewModels[safe: id.loopIndex] {
                 GroupPreviewLayersView(document: document,

--- a/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
@@ -503,7 +503,11 @@ struct NonGroupPreviewLayersView: View {
                     return
                 }
                 
-                Task(priority: .high) { [weak layerViewModel] in
+                Task(priority: .high) { [weak layerViewModel, weak document] in
+                    guard let document = document else {
+                        return
+                    }
+                    
                     await layerViewModel?.loadMedia(mediaValue: mediaValue,
                                                     document: document,
                                                     mediaRowObserver: layerViewModel?.mediaRowObserver)

--- a/Stitch/Graph/PrototypePreview/Layer/View/PreviewLayerView.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/PreviewLayerView.swift
@@ -21,7 +21,7 @@ struct PreviewLayerView: View {
     let realityContent: LayerRealityCameraContent?
 
     var id: PreviewCoordinate {
-        self.layerViewModel.id
+        self.layerViewModel.previewCoordinate
     }
     
     var body: some View {

--- a/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/ViewModel/LayerViewModel.swift
@@ -15,7 +15,9 @@ import StitchEngine
 final class LayerViewModel: Sendable {
     private let mediaImportCoordinator = MediaLayerImportCoordinator()
     
-    let id: PreviewCoordinate
+    // Make unique ID for each layer view model so that a new creation can't use the same preview coordinate and confuse the view that nothing changed
+    let id = UUID()
+    let previewCoordinate: PreviewCoordinate
     let layer: Layer
     let interactiveLayer: InteractiveLayer
     
@@ -39,7 +41,7 @@ final class LayerViewModel: Sendable {
     @MainActor
     var readFrame: CGRect = .zero {
         didSet {
-            dispatch(AssignedLayerUpdated(changedLayerNode: self.id.layerNodeId))
+            dispatch(AssignedLayerUpdated(changedLayerNode: self.previewCoordinate.layerNodeId))
         }
     }
     
@@ -252,7 +254,7 @@ final class LayerViewModel: Sendable {
          position: PortValue = .position(.zero),
          nodeDelegate: NodeViewModel?) {
         
-        self.id = id
+        self.previewCoordinate = id
         self.layer = layer
         self.zIndex = zIndex
         self.position = position
@@ -413,7 +415,7 @@ extension LayerViewModel: InteractiveLayerDelegate {
 extension LayerViewModel {
     @MainActor var mediaRowObserver: InputNodeRowObserver? {
         guard let layerNode = self.nodeDelegate?.graphDelegate?
-            .getNodeViewModel(self.id.layerNodeId.asNodeId)?.layerNode else {
+            .getNodeViewModel(self.previewCoordinate.layerNodeId.asNodeId)?.layerNode else {
             return nil
         }
                 
@@ -533,7 +535,7 @@ extension LayerViewModel {
                                     portId: Int,
                                     inputType: LayerInputPort,
                                     graph: GraphSetter) {
-        let loopIndex = self.id.loopIndex
+        let loopIndex = self.previewCoordinate.loopIndex
         let inputSupportsLoopedValues = inputType.supportsLoopedTypes
         
         if !inputSupportsLoopedValues {

--- a/Stitch/Graph/ViewModel/GraphCalculatable.swift
+++ b/Stitch/Graph/ViewModel/GraphCalculatable.swift
@@ -88,7 +88,9 @@ extension GraphState {
             pinMap: rootPinMap,
             activeIndex: activeIndex)
                 
-        if !LayerDataList.equals(self.cachedOrderedPreviewLayers, previewLayers) {
+        if !LayerDataList.equals(self.cachedOrderedPreviewLayers,
+                                 previewLayers,
+                                 graph: self) {
             self.cachedOrderedPreviewLayers = previewLayers
         }
         if self.flattenedPinMap != flattenedPinMap {


### PR DESCRIPTION
Tagging https://github.com/StitchDesign/Stitch--Old/issues/7165.

These changes are the result of a memory leak investigation. Findings will be included in the tagged issue.

Changes here include:
* An improved ID property for layer view models, which previously used preview coordinate. The issue here is that it's theoretically possible for a new layer view model to be created using the same ID as one that was destroyed. Now we use a UUID to ensure unique identity between objects.
* Removal of references from the `LayerData` struct. This was an effort to reduce the likelihood of a retain cycle on layer view models, should some process choose to strongly retain a reference. In all likelihood this was never happening in the code so this change is more preventative than anything.

Overall these changes should have no net effect on memory usage or performance but should hopefully prevent future harm.