### PR TITLE
Complete classic animation with duration < 0.1 when duration completes

### DIFF
--- a/Stitch/Graph/Node/Patch/Type/Animation/spring+and+pop+animations/SpringHelpers.swift
+++ b/Stitch/Graph/Node/Patch/Type/Animation/spring+and+pop+animations/SpringHelpers.swift
@@ -11,7 +11,6 @@ import SwiftUI
 
 struct SpringHelpers {
     
-    // TODO: don't create a native Spring everytime; instead, store it on the animation state
     static func progress(spring: Spring,
                          from: CGFloat, // current output
                          to: CGFloat, // toValue


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7160
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7095

Given some of our classic animation assumptions (e.g. frame rate, completion difference epsilon), some curves' animations can continue indefinitely at durations < 0.1. 

As a workaround, we'll treat duration < 0.1 animations are completing when we've run the expected duration rather than reached some epsilon.
