### PR TITLE
When inside a project, CMD+N creates new project instead opening node menu

### DIFF
--- a/Stitch/App/Shortcut/ProjectsHomeCommands.swift
+++ b/Stitch/App/Shortcut/ProjectsHomeCommands.swift
@@ -296,13 +296,9 @@ struct ProjectsHomeCommands: Commands {
         } // CommandMenu
 
         CommandGroup(replacing: .newItem) {
-            SwiftUIShortcutView(title: activeProject ? "New Node" : "New Project",
+            SwiftUIShortcutView(title: "New Project",
                                 key: NEW_PROJECT_SHORTCUT) {
-                if activeProject {
-                    INSERT_NODE_ACTION()
-                } else {
-                    store.createNewProjectSideEffect(isProjectImport: false)
-                }
+                store.createNewProjectSideEffect(isProjectImport: false)
             }
 
             // NOTE: we already get CMD + W in Catalyst


### PR DESCRIPTION

https://github.com/user-attachments/assets/df557005-c1aa-4576-af74-ac6cb0ec9349

