### PR TITLE
Fixed prototype restart for sound import node

### DIFF
--- a/Stitch/Graph/Node/Eval/AnimationEvaluationHelpers.swift
+++ b/Stitch/Graph/Node/Eval/AnimationEvaluationHelpers.swift
@@ -18,6 +18,10 @@ struct ImpureEvalOpResult {
 }
 
 extension ImpureEvalOpResult: NodeEvalOpResultable {
+    var values: PortValues {
+        outputs
+    }
+    
     init(from values: PortValues) {
         self.outputs = values
     }

--- a/Stitch/Graph/Node/Eval/AsyncMediaImpureEvalResult.swift
+++ b/Stitch/Graph/Node/Eval/AsyncMediaImpureEvalResult.swift
@@ -18,6 +18,17 @@ enum AsyncMediaOutputs {
 }
 
 extension AsyncMediaOutputs: NodeEvalOpResultable {
+    var values: PortValues {
+        switch self {
+        case .byIndex(let portValues):
+            return portValues
+        case .all(let portValuesList):
+            // Don't think this should happen but let Elliot know if it does
+            fatalErrorIfDebug()
+            return portValuesList.first ?? []
+        }
+    }
+    
     static func createEvalResult(from results: [AsyncMediaOutputs],
                                  node: NodeViewModel) -> EvalResult {
         results.toImpureEvalResult()

--- a/Stitch/Graph/Node/Eval/EphemeralObserver/NodeEphemeralObservable.swift
+++ b/Stitch/Graph/Node/Eval/EphemeralObserver/NodeEphemeralObservable.swift
@@ -31,7 +31,9 @@ extension NodeEphemeralObservable {
                          kind: NodeKind) { }
 }
 
-final class ComputedNodeState: NodeEphemeralObservable {
+final class ComputedNodeState: NodeEphemeralObservable, NodeEphemeralOutputPersistence {
+    static let outputIndexToSave = 0
+    
     // starts out empty when node has not yet been run;
     // filled every time we coerce- or parse-update
     var previousValue: PortValue?
@@ -56,7 +58,15 @@ final class ComputedNodeState: NodeEphemeralObservable {
     var sampleRangeState: SampleRangeComputedState?
 }
 
+protocol NodeEphemeralOutputPersistence: NodeEphemeralObservable {
+    
+    @MainActor var previousValue: PortValue? { get set }
+    
+    static var outputIndexToSave: Int { get }
+}
+
 extension ComputedNodeState {
+    @MainActor
     func onPrototypeRestart(document: StitchDocumentViewModel) {
         self.previousValue = nil
         self.preservedValues = .init()

--- a/Stitch/Graph/Node/Eval/MediaEvalOpObservable.swift
+++ b/Stitch/Graph/Node/Eval/MediaEvalOpObservable.swift
@@ -162,7 +162,7 @@ extension MediaEvalOpObservable {
                                                             values: [MediaEvalResult.ValueType],
                                                             loopIndex: Int,
                                                             defaultOutputs: [MediaEvalResult.ValueType],
-                                                            evalOp: @escaping @MainActor (GraphMediaValue) -> [MediaEvalResult.ValueType]) -> MediaEvalResult where MediaEvalResult: MediaEvalResultable {
+                                                            evalOp: @escaping @Sendable @MainActor (GraphMediaValue) -> [MediaEvalResult.ValueType]) -> MediaEvalResult where MediaEvalResult: MediaEvalResultable {
         guard let node = self.nodeDelegate else {
             return .init(from: defaultOutputs)
         }

--- a/Stitch/Graph/Node/Patch/Type/Pulse/CounterNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Pulse/CounterNode.swift
@@ -63,6 +63,7 @@ func counterEval(node: PatchNode,
     }
 }
 
+@MainActor
 func counterOpClosure(values: PortValues,
                       graphTime: TimeInterval,
                       computedState: ComputedNodeState) -> PortValue {

--- a/Stitch/Graph/Node/Patch/Type/Pulse/PulseOnChangeNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Pulse/PulseOnChangeNode.swift
@@ -39,6 +39,7 @@ struct PulseOnChangeNode: PatchNodeDefinition {
 }
 
 // outPulse is for an Output; can never be manually pulsed.
+@MainActor
 func pulseOnChangeOpClosure(values: PortValues,
                             computedState: ComputedNodeState,
                             graphTime: TimeInterval) -> ImpureEvalOpResult {

--- a/Stitch/Graph/Node/Patch/Type/Pulse/SwitchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Pulse/SwitchNode.swift
@@ -52,6 +52,7 @@ func switchEval(node: PatchNode,
     }
 }
 
+@MainActor
 func switchOpClosure(values: PortValues,
                      graphTime: TimeInterval,
                      computedState: ComputedNodeState) -> PortValue {

--- a/Stitch/Graph/Node/Port/Util/PortValue/PortValuesUtils.swift
+++ b/Stitch/Graph/Node/Port/Util/PortValue/PortValuesUtils.swift
@@ -133,6 +133,8 @@ extension PortValuesList {
 
 
 extension PortValues: NodeEvalOpResultable {
+    var values: PortValues { self }
+    
     init(from values: PortValues) {
         self = values
     }

--- a/Stitch/Graph/Node/Util/NodeMediaUtils.swift
+++ b/Stitch/Graph/Node/Util/NodeMediaUtils.swift
@@ -79,6 +79,11 @@ struct MediaEvalValuesListResult: NodeEvalOpResultable, MediaEvalResultable {
 }
 
 extension MediaEvalValuesListResult {
+    var values: PortValues {
+        fatalErrorIfDebug("Don't use this here")
+        return valuesList.first ?? []
+    }
+    
     init(from values: PortValuesList) {
         self.valuesList = values
     }


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7220

Issue here being the eval needs to rely on ephemeral state rather than outputs, which don't get directly reset on prototype restart.

Some extra work is done here to start support generic usage of node's which rely on previous values so that we can reuse implementation for other nodes.