### PR TITLE
Support extended view on outputs

### DIFF
--- a/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "92e39f467ba47c05414125446780d391ffc34330a566ca1bb65ad078f0b3610c",
+  "originHash" : "9e165734ead499e7e0eeef385a8613539873df54cf2db7c5dbd5b819fd5dbee3",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",

--- a/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorPortView.swift
@@ -384,7 +384,7 @@ struct LayerInspectorOutputPortView: View {
                                  isSelectedInspectorRow: propertyRowIsSelected)
                 Spacer()
                 
-                LayerOutputFieldsView(fieldValueTypes: rowViewModel.cachedFieldValueGroups,
+                LayerOutputFieldsView(fieldGroups: rowViewModel.cachedFieldValueGroups,
                                       valueEntryView: valueEntryView)
             } // HStack
         }
@@ -400,14 +400,14 @@ struct LayerInspectorOutputPortView: View {
 struct LayerOutputFieldsView<ValueEntry>: View where ValueEntry: View {
     typealias ValueEntryViewBuilder = (OutputFieldViewModel, Bool) -> ValueEntry
     
-    let fieldValueTypes: [FieldGroup]
+    let fieldGroups: [FieldGroup]
     @ViewBuilder var valueEntryView: ValueEntryViewBuilder
 
     var body: some View {
-        ForEach(fieldValueTypes) { (fieldGroupViewModel: FieldGroup) in
-            let isMultifield = fieldGroupViewModel.fieldObservers.count > 1
+        ForEach(fieldGroups) { (fieldGroup: FieldGroup) in
+            let isMultifield = fieldGroup.fieldObservers.count > 1
             
-            if let fieldGroupLabel = fieldGroupViewModel.groupLabel {
+            if let fieldGroupLabel = fieldGroup.groupLabel {
                 HStack {
                     LabelDisplayView(label: fieldGroupLabel,
                                      isLeftAligned: false,
@@ -418,7 +418,7 @@ struct LayerOutputFieldsView<ValueEntry>: View where ValueEntry: View {
             }
             
             HStack {
-                ForEach(fieldGroupViewModel.fieldObservers) { fieldViewModel in
+                ForEach(fieldGroup.fieldObservers) { fieldViewModel in
                     self.valueEntryView(fieldViewModel,
                                         isMultifield)
                 }

--- a/Stitch/Graph/Node/Port/View/Field/InputView/CanvasCommonEditingView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/CanvasCommonEditingView.swift
@@ -8,6 +8,14 @@
 import SwiftUI
 
 
+extension Color {
+    static let EXTENDED_FIELD_BACKGROUND_COLOR: Self = .WHITE_IN_LIGHT_MODE_BLACK_IN_DARK_MODE
+}
+
+extension CGFloat {
+    static let EXTENDED_FIELD_LENGTH: Self = 52
+}
+
 struct CanvasCommonEditingView: View {
     
     @Bindable var document: StitchDocumentViewModel
@@ -22,10 +30,8 @@ struct CanvasCommonEditingView: View {
         
     let fieldWidth: CGFloat
     
-    static let HOVER_EXTRA_LENGTH: CGFloat = 52
-    
     var hoveringAdjustment: CGFloat {
-        shouldShowExtendedField ? Self.HOVER_EXTRA_LENGTH : 0
+        shouldShowExtendedField ? .EXTENDED_FIELD_LENGTH : 0
     }
     
     func onTap() {

--- a/Stitch/Graph/Node/Port/View/Field/InputView/CanvasCommonEditingView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/CanvasCommonEditingView.swift
@@ -28,13 +28,6 @@ struct CanvasCommonEditingView: View {
         shouldShowExtendedField ? Self.HOVER_EXTRA_LENGTH : 0
     }
     
-    
-//    func onFingerTap() {
-//        if !self.isHovering {
-//            dispatch(ReduxFieldFocused(focusedField: .textInput(self.inputField.id)))
-//        }
-//    }
-    
     func onTap() {
         dispatch(ReduxFieldFocused(focusedField: .textInput(self.inputField.id)))
     }

--- a/Stitch/Graph/Node/Port/View/Field/InputView/InputFieldBackgroundView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/InputFieldBackgroundView.swift
@@ -57,11 +57,11 @@ struct InputFieldBackgroundColorView: ViewModifier {
 //            if isForLayerInspector {
 //                return .INSPECTOR_FIELD_BACKGROUND_COLOR
 //            } else {
-                return .WHITE_IN_LIGHT_MODE_BLACK_IN_DARK_MODE
+                return .EXTENDED_FIELD_BACKGROUND_COLOR
 //            }
             
         } else if isHovering {
-            return .WHITE_IN_LIGHT_MODE_BLACK_IN_DARK_MODE
+            return .EXTENDED_FIELD_BACKGROUND_COLOR
         }
         
         // "At rest" i.e. no user interaction

--- a/Stitch/Graph/Node/Port/View/Field/InputView/ReadOnlyEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/ReadOnlyEntry.swift
@@ -36,13 +36,13 @@ struct ReadOnlyValueEntry: View {
     }
 
     // TODO: implement "extended view on hover" for individual output fields
-//    @State var isHovering: Bool = false
-//    
-//    static let HOVER_EXTRA_LENGTH: CGFloat = 52
-//    
-//    var hoveringAdjustment: CGFloat {
-//        isHovering ? Self.HOVER_EXTRA_LENGTH : 0
-//    }
+    @State var isHovering: Bool = false
+    
+    static let HOVER_EXTRA_LENGTH: CGFloat = 52
+    
+    var hoveringAdjustment: CGFloat {
+        isHovering ? Self.HOVER_EXTRA_LENGTH : 0
+    }
     
     var body: some View {
         StitchTextView(string: value,
@@ -51,29 +51,7 @@ struct ReadOnlyValueEntry: View {
             .monospacedDigit()
             .frame(width: fieldWidth,
                    alignment: alignment)
-        
-        //            .overlay(content: {
-        //                if isHovering {
-        //                    StitchTextView(string: value,
-        //                                   fontColor: fontColor)
-        //                        .frame(width: fieldWidth + hoveringAdjustment,
-        //                               alignment: alignment)
-        //                        .padding([.leading, .top, .bottom], 2)
-        //
-        //                        .background {
-        //                            // Why is `RoundedRectangle.fill` so much lighter than `RoundedRectangle.background` ?
-        //                            let color = isHovering ? Color.green : Color.clear
-        //                            RoundedRectangle(cornerRadius: 4)
-        //                                .fill(color)
-        //                        }
-        //                        // .offset(x: hoveringAdjustment / 2)
-        //                }
-        //            })
-        //            .onHover { isHovering in
-        //                self.isHovering = isHovering
-        //            }
-        
-        
+                
         // TODO: `NODE_INPUT_OR_OUTPUT_WIDTH * 1.5` is long enough for CoreML's "No Results" but too long for most other cases; but e.g. the DeviceInfo node's outputs properly need more space
         //            .frame(minWidth: NODE_INPUT_OR_OUTPUT_WIDTH * 1.5,
         //                   maxWidth: NODE_INPUT_OR_OUTPUT_WIDTH * 2,

--- a/Stitch/Graph/Node/Port/View/Field/InputView/ReadOnlyEntry.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/ReadOnlyEntry.swift
@@ -51,6 +51,7 @@ struct ReadOnlyValueEntry: View {
             .monospacedDigit()
             .frame(width: fieldWidth,
                    alignment: alignment)
+            .padding([.leading, .top, .bottom], 2) // padding to mat
                 
         // TODO: `NODE_INPUT_OR_OUTPUT_WIDTH * 1.5` is long enough for CoreML's "No Results" but too long for most other cases; but e.g. the DeviceInfo node's outputs properly need more space
         //            .frame(minWidth: NODE_INPUT_OR_OUTPUT_WIDTH * 1.5,

--- a/Stitch/Graph/Node/Port/View/Field/InputView/TapToEditTextView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/InputView/TapToEditTextView.swift
@@ -27,13 +27,7 @@ struct TapToEditTextView: View {
     @Bindable var document: StitchDocumentViewModel
     
     @Bindable var inputField: InputFieldViewModel
-    
-    // TODO: isn't this always just `inputField.fieldValue.stringValue` ?
-//    let inputString: String
-    var inputString: String {
-        inputField.fieldValue.stringValue
-    }
-    
+        
     let fieldWidth: CGFloat
                 
     // Only for field-types that use a "TextField + Dropdown" view,
@@ -59,6 +53,10 @@ struct TapToEditTextView: View {
     
     var onReadOnlyTap: () -> Void
         
+    var inputString: String {
+        inputField.fieldValue.stringValue
+    }
+    
     var rowId: NodeRowViewModelId {
         inputField.id.rowId
     }

--- a/Stitch/Graph/Node/Port/View/Field/OutputFieldValueView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/OutputFieldValueView.swift
@@ -145,14 +145,12 @@ struct OutputFieldValueView: View {
     
     // TODO: implement "extended view on hover" for individual output fields
     @State var isHovering: Bool = false
-    
-    static let HOVER_EXTRA_LENGTH: CGFloat = 52
-    
+        
     var hoveringAdjustment: CGFloat {
-        isHovering ? Self.HOVER_EXTRA_LENGTH : 0
+        isHovering ? .EXTENDED_FIELD_LENGTH : 0
     }
 
-    var isCanvasOutputField: Bool {
+    var isCanvas: Bool {
         self.rowViewModel.id.graphItemType.isCanvas
     }
     
@@ -170,20 +168,19 @@ struct OutputFieldValueView: View {
                 StitchTextView(string: displayName,
                                fontColor: STITCH_FONT_GRAY_COLOR)
                     .frame(width: NODE_INPUT_OR_OUTPUT_WIDTH + hoveringAdjustment,
-                           alignment: outputAlignment)
+                           alignment: .leading) // Always leading
                     .padding([.leading, .top, .bottom], 2)
 
                     .background {
                         // Why is `RoundedRectangle.fill` so much lighter than `RoundedRectangle.background` ?
-                        let color = isHovering ? Color.green : Color.clear
                         RoundedRectangle(cornerRadius: 4)
-                            .fill(color)
+                            .fill(isHovering ? Color.EXTENDED_FIELD_BACKGROUND_COLOR : Color.clear)
                     }
                      .offset(x: hoveringAdjustment / 2)
             }
         })
         .onHover { isHovering in
-            if isCanvasOutputField {
+            if isCanvas {
                 self.isHovering = isHovering
             }
             

--- a/Stitch/Graph/Node/Port/View/Field/OutputFieldValueView.swift
+++ b/Stitch/Graph/Node/Port/View/Field/OutputFieldValueView.swift
@@ -142,7 +142,20 @@ struct OutputFieldValueView: View {
             readOnlyView(self.fieldValue.stringValue)
         }
     }
+    
+    // TODO: implement "extended view on hover" for individual output fields
+    @State var isHovering: Bool = false
+    
+    static let HOVER_EXTRA_LENGTH: CGFloat = 52
+    
+    var hoveringAdjustment: CGFloat {
+        isHovering ? Self.HOVER_EXTRA_LENGTH : 0
+    }
 
+    var isCanvasOutputField: Bool {
+        self.rowViewModel.id.graphItemType.isCanvas
+    }
+    
     @ViewBuilder func readOnlyView(_ displayName: String) -> some View {
         ReadOnlyValueEntry(value: displayName,
                            alignment: outputAlignment,
@@ -150,5 +163,30 @@ struct OutputFieldValueView: View {
                            isSelectedInspectorRow: isSelectedInspectorRow,
                            isForLayerInspector: isForLayerInspector,
                            isFieldInMultifieldInput: isFieldInMultifieldInput)
+        
+        .overlay(content: {
+            
+            if isHovering {
+                StitchTextView(string: displayName,
+                               fontColor: STITCH_FONT_GRAY_COLOR)
+                    .frame(width: NODE_INPUT_OR_OUTPUT_WIDTH + hoveringAdjustment,
+                           alignment: outputAlignment)
+                    .padding([.leading, .top, .bottom], 2)
+
+                    .background {
+                        // Why is `RoundedRectangle.fill` so much lighter than `RoundedRectangle.background` ?
+                        let color = isHovering ? Color.green : Color.clear
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(color)
+                    }
+                     .offset(x: hoveringAdjustment / 2)
+            }
+        })
+        .onHover { isHovering in
+            if isCanvasOutputField {
+                self.isHovering = isHovering
+            }
+            
+        }
     }
 }

--- a/Stitch/Graph/Node/View/CanvasItemSelectedViewModifier.swift
+++ b/Stitch/Graph/Node/View/CanvasItemSelectedViewModifier.swift
@@ -24,11 +24,14 @@ struct CanvasItemSelectedViewModifier: ViewModifier {
 //            .padding(3)
 //            .padding(7)
             .padding(6)
-            .overlay {
+//            .overlay {
+            .background {
                 if isSelected {
                     // needs to be slightly larger than
                     RoundedRectangle(cornerRadius: CANVAS_ITEM_SELECTED_CORNER_RADIUS)
                         .strokeBorder(theme.themeData.highlightedEdgeColor, lineWidth: 3)
+                        
+                        .zIndex(-9999)
                 }
             }
     }

--- a/Stitch/Graph/Node/View/NodeView.swift
+++ b/Stitch/Graph/Node/View/NodeView.swift
@@ -66,21 +66,19 @@ struct NodeView: View {
             // Catalyst right-click to open canvas item menu
                 .contextMenu {
                     CanvasItemMenuButtonsView(graph: graph,
-                                           document: document,
-                                           node: stitch,
-                                           canvasItemId: node.id,
-                                           activeGroupId: activeGroupId,
-                                           canAddInput: canAddInput,
-                                           canRemoveInput: canRemoveInput,
-                                           atleastOneCommentBoxSelected: atleastOneCommentBoxSelected)
+                                              document: document,
+                                              node: stitch,
+                                              canvasItemId: node.id,
+                                              activeGroupId: activeGroupId,
+                                              canAddInput: canAddInput,
+                                              canRemoveInput: canRemoveInput,
+                                              atleastOneCommentBoxSelected: atleastOneCommentBoxSelected)
                 }
 #endif
-                .modifier(
-                    NodeViewTapGestureModifier(graph: graph,
-                                               document: document,
-                                               stitch: stitch,
-                                               node: node)
-                )
+                .modifier(NodeViewTapGestureModifier(graph: graph,
+                                                     document: document,
+                                                     stitch: stitch,
+                                                     node: node))
             
             /*
              Note: every touch on a part of a node is an interaction (e.g. the title, an input field etc.) with a single node --- except for touching the node tag menu.

--- a/Stitch/Graph/Node/View/NodeViewType.swift
+++ b/Stitch/Graph/Node/View/NodeViewType.swift
@@ -230,6 +230,14 @@ struct DefaultNodeOutputsView: View {
                                     node: node,
                                     rowObserver: rowObserver,
                                     rowViewModel: rowViewModel)
+
+                    // TODO: how to handle "hover to show more of output" vs "hover to enter edge edit mode" ?
+//                    .modifier(EdgeEditModeOutputHoverViewModifier(
+//                        graph: graph,
+//                        document: document,
+//                        outputCoordinate: .init(portId: rowViewModel.id.portId,
+//                                                canvasId: canvas.id)))
+                    
                     .zIndex(-99)
                 }
                 .modifier(EdgeEditModeOutputHoverViewModifier(

--- a/Stitch/Graph/Node/View/NodeViewType.swift
+++ b/Stitch/Graph/Node/View/NodeViewType.swift
@@ -201,7 +201,8 @@ struct DefaultNodeOutputsView: View {
                 HStack {
                     if showOutputFields {
                         ForEach(rowViewModel.cachedFieldValueGroups) { fieldGroup in
-                            ForEach(fieldGroup.fieldObservers) { outputViewModel in
+                            let fields = fieldGroup.fieldObservers
+                            ForEach(Array(zip(fields.indices, fields)), id: \.0) { index, outputViewModel in
                                 OutputFieldView(graph: graph,
                                                 document: document,
                                                 outputField: outputViewModel,
@@ -211,6 +212,7 @@ struct DefaultNodeOutputsView: View {
                                                 isForLayerInspector: false,
                                                 isFieldInMultifieldInput: isMultiField,
                                                 isSelectedInspectorRow: false)
+                                .zIndex(-CGFloat(index))
                             }
                         }
                     } // if showOutputFields
@@ -222,11 +224,13 @@ struct DefaultNodeOutputsView: View {
                                      isLeftAligned: false,
                                      fontColor: STITCH_FONT_GRAY_COLOR,
                                      isSelectedInspectorRow: false)
+                    .zIndex(-98)
                     
                     NodeRowPortView(graph: graph,
                                     node: node,
                                     rowObserver: rowObserver,
                                     rowViewModel: rowViewModel)
+                    .zIndex(-99)
                 }
                 .modifier(EdgeEditModeOutputHoverViewModifier(
                     graph: graph,


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7198

Still needs some love for:
1. when last field extends past end of node and goes against similar-color background
2. differentiating output field hover to see more value vs hovering output for edge edit mode