### PR TITLE
Update `layerDropdownChoiceCache` in `GraphState.updateGraphData` where we update other caches

### DIFF
--- a/Stitch/Graph/Sidebar/ViewModel/SidebarItemGestureViewModel.swift
+++ b/Stitch/Graph/Sidebar/ViewModel/SidebarItemGestureViewModel.swift
@@ -130,7 +130,7 @@ extension SidebarItemGestureViewModel {
                              isCommitting: isCommitting,
                              graph: graph)
         
-        // Recreate the layer drop down choices
+        // Recreate the layer drop down choices, since labels have changed
         graph.updateLayerDropdownChoiceCache()
     }
     

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -141,8 +141,7 @@ final class GraphState: Sendable {
         self.commentBoxesDict.sync(from: schema.commentBoxes)
         self.components = components
         
-        // Sync nodes and cached data
-        self.syncNodes(nodesDict: nodes)
+        self.visibleNodesViewModel.nodes = nodesDict
         
         if let stringWarning = schema.migrationWarning {
             self.migrationWarning = .init(rawValue: stringWarning)
@@ -211,11 +210,11 @@ extension GraphState {
         let activeIndex = document.activeIndex
         
         // TODO: this is not *just* ui-cache; what should we call `NodesPagingDict` etc. ?
-        self.refreshUICache(activeIndex: activeIndex,
-                            focusedGroupNode: document.groupNodeFocused?.groupNodeId,
-                            documentZoom: document.graphMovement.zoomData,
-                            documentFrame: document.frame,
-                            llmRecordingMode: document.llmRecording.mode)
+        self.refreshUICaches(activeIndex: activeIndex,
+                             focusedGroupNode: document.groupNodeFocused?.groupNodeId,
+                             documentZoom: document.graphMovement.zoomData,
+                             documentFrame: document.frame,
+                             llmRecordingMode: document.llmRecording.mode)
         
         
         // MARK: evaluate the graph
@@ -256,7 +255,7 @@ extension GraphState {
     
     
     @MainActor
-    func refreshUICache(activeIndex: ActiveIndex,
+    func refreshUICaches(activeIndex: ActiveIndex,
                         focusedGroupNode: NodeId?,
                         documentZoom: CGFloat,
                         documentFrame: CGRect,
@@ -267,6 +266,8 @@ extension GraphState {
         self.visibleNodesViewModel.updateNodesPagingDict(
             documentZoomData: documentZoom,
             documentFrame: documentFrame)
+        
+        self.updateLayerDropdownChoiceCache()
         
         self.visibleNodesViewModel.updateNodeRowObserversUpstreamAndDownstreamReferences()
                 
@@ -536,15 +537,9 @@ extension GraphState {
                                  nodeType: nodeType)
         }
         
-        self.syncNodes(nodesDict: newDictionary)
-    }
-    
-    @MainActor
-    func syncNodes(nodesDict: NodesViewModelDict) {
         self.visibleNodesViewModel.nodes = nodesDict
-        self.updateLayerDropdownChoiceCache()
     }
-    
+        
     @MainActor
     func updateLayerDropdownChoiceCache() {
         // Cache layer node info for perf


### PR DESCRIPTION
Goal: consolidate more of our "update our UI cache" logic in a single place. `updateGraphData` seems the place.

QA video 

https://github.com/user-attachments/assets/ac03d3d2-5155-4873-98bf-3382a8d4f69a

