### PR TITLE
Preserve input's value when pasting into project where connected upstream is absent

### DIFF
--- a/Stitch/App/Util/TypeExtension/CollectionExtensionUtils.swift
+++ b/Stitch/App/Util/TypeExtension/CollectionExtensionUtils.swift
@@ -64,6 +64,16 @@ extension Dictionary where Key == NodeId {
     }
 }
 
+extension Dictionary {
+    func get(_ id: Self.Key?) -> Self.Value? {
+        guard let id = id else {
+            return nil
+        }
+
+        return self.get(id)
+    }
+}
+
 // Works for sorting GroupNodeId, which conforms to
 extension Dictionary where Key: Identifiable {
     func merge(with secondDict: Self) -> Self {

--- a/Stitch/Graph/Node/Model/StitchClipboardContent.swift
+++ b/Stitch/Graph/Node/Model/StitchClipboardContent.swift
@@ -19,6 +19,7 @@ struct StitchClipboardContent: StitchComponentable, StitchDocumentEncodable {
     static let subfolders: [StitchEncodableSubfolder] = StitchEncodableSubfolder.allCases
     
     var graphEntity: GraphEntity
+    let originGraphOutputValuesMap: OriginGraphOutputValueMap
 }
 
 extension StitchClipboardContent {
@@ -29,7 +30,8 @@ extension StitchClipboardContent {
     }
     
     init() {
-        self.init(graphEntity: .createEmpty())
+        self.init(graphEntity: .createEmpty(),
+                  originGraphOutputValuesMap: .init())
     }
     var rootUrl: URL {
         Self.rootUrl

--- a/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
+++ b/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
@@ -109,17 +109,18 @@ extension GraphState {
             groupNodeFocused: document.groupNodeFocused,
             selectedNodeIds: state.selectedCanvasItems.compactMap(\.nodeCase).toSet)
                 
-        let (destinationGraphEntity, newNodes, nodeIdMap) = Self.insertNodesAndSidebarLayersIntoDestinationGraph(
+        let (destinationGraphEntity, pastedNodes, nodeIdMap) = Self.insertNodesAndSidebarLayersIntoDestinationGraph(
             destinationGraph: self.createSchema(),
             graphToInsert: copyResult.component.graphEntity,
             focusedGroupNode: document.groupNodeFocused?.groupNodeId,
             destinationGraphInfo: nil,
+            originGraphOutputValuesMap: .init(), // irrelevant for duplication cases
             originalOptionDraggedLayer: nil)
         
         // TODO: should we provide an explicit `rootUrl` here too? See `sidebarSelectedItemsDuplicated`
         self.update(from: destinationGraphEntity)
         
-        self.updateGraphAfterPaste(newNodes: newNodes,
+        self.updateGraphAfterPaste(pastedNodes: pastedNodes,
                                    document: document,
                                    nodeIdMap: nodeIdMap,
                                    isOptionDragInSidebar: false)

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarSelectedItemsDuplicated.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarSelectedItemsDuplicated.swift
@@ -33,16 +33,17 @@ extension GraphState {
         let copyResult = self.createCopiedComponent(groupNodeFocused: groupNodeFocused,
                                                     selectedNodeIds: selectedNodeIds)
         
-        let (destinationGraphEntity, newNodes, nodeIdMap) = Self.insertNodesAndSidebarLayersIntoDestinationGraph(
+        let (destinationGraphEntity, pastedNodes, nodeIdMap) = Self.insertNodesAndSidebarLayersIntoDestinationGraph(
             destinationGraph: self.createSchema(),
             graphToInsert: copyResult.component.graphEntity,
             focusedGroupNode: groupNodeFocused?.groupNodeId,
             destinationGraphInfo: nil,
+            originGraphOutputValuesMap: copyResult.originGraphOutputValuesMap,
             originalOptionDraggedLayer: originalOptionDraggedLayer)
             
         self.update(from: destinationGraphEntity, rootUrl: rootUrl)
 
-        self.updateGraphAfterPaste(newNodes: newNodes,
+        self.updateGraphAfterPaste(pastedNodes: pastedNodes,
                                    document: document,
                                    nodeIdMap: nodeIdMap,
                                    isOptionDragInSidebar: originalOptionDraggedLayer.isDefined)

--- a/Stitch/Graph/Util/NodeSelection/CopyAndPasteNodesActions.swift
+++ b/Stitch/Graph/Util/NodeSelection/CopyAndPasteNodesActions.swift
@@ -71,8 +71,7 @@ struct SelectedGraphItemsCopied: StitchDocumentEvent {
     }
 }
 
-// "Paste" = past shortcut, which pastes BOTH nodes AND comments
-// struct SelectedGraphNodesPasted: AppEnvironmentEvent {
+// "Paste" = paste shortcut, which pastes BOTH nodes AND comments
 struct SelectedGraphItemsPasted: StitchDocumentEvent {
 
     func handle(state: StitchDocumentViewModel) {
@@ -85,16 +84,17 @@ struct SelectedGraphItemsPasted: StitchDocumentEvent {
         let pasteboardUrl = StitchClipboardContent.rootUrl
 
         do {
-            let componentData = try Data(contentsOf: pasteboardUrl.appendingVersionedSchemaPath())
-            let newComponent = try getStitchDecoder().decode(StitchClipboardContent.self, from: componentData)
+            let componentData: Data = try Data(contentsOf: pasteboardUrl.appendingVersionedSchemaPath())
+            let newComponent: StitchClipboardContent = try getStitchDecoder().decode(StitchClipboardContent.self, from: componentData)
             let importedFiles = try ComponentEncoder.readAllImportedFiles(rootUrl: pasteboardUrl)
 
             let graph = state.visibleGraph
-
+            
             graph.insertNewComponent(component: newComponent,
                                      encoder: graph.documentEncoderDelegate,
                                      copiedFiles: importedFiles,
                                      isCopyPaste: true,
+                                     originGraphOutputValuesMap: newComponent.originGraphOutputValuesMap,
                                      document: state)
             state.encodeProjectInBackground()
         } catch {


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7140

QA video: copy-pasting, into a separate project, both patch and layer packed/unpacked inputs/input-fields where upstream output node is / is not pasted as well.

https://github.com/user-attachments/assets/5b842ddf-edd8-4d42-965c-762f6b96957c

