### PR TITLE
Fixed Mac top bar color tint regression; revert icon hover removal

### DIFF
--- a/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
+++ b/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
@@ -296,7 +296,7 @@ struct GoUpOneTraversalLevel: StitchDocumentEvent {
 }
 
 // TODO: 'toggle preview window' icon needs to change between hide vs show
-// Hacky view to get hover effect on Catalyst topbar buttons
+// Hacky view to get hover effect on Catalyst topbar buttons and to enforce gray tint
 struct CatalystNavBarButton: View, Identifiable {
 
     // let systemName: String  for `Image(systemName:)`

--- a/Stitch/Home/View/ProjectsHomeViewWrapper.swift
+++ b/Stitch/Home/View/ProjectsHomeViewWrapper.swift
@@ -43,17 +43,17 @@ struct ProjectsHomeViewWrapper: View {
                             iconName: APP_SETTINGS_ICON_NAME)
                     } else {
 #if targetEnvironment(macCatalyst)
-                        CatalystHomescreenNavBarButton(action: { [weak store] in
-                               store?.createNewProjectSideEffect(isProjectImport: false)
+                        CatalystNavBarButton(action: { [weak store] in
+                            store?.createNewProjectSideEffect(isProjectImport: false)
                         },
-                                                       iconName: .sfSymbol(.NEW_PROJECT_SF_SYMBOL_NAME))
+                                             iconName: .sfSymbol(.NEW_PROJECT_SF_SYMBOL_NAME))
                         // Resolves issue where hover was still active after entering newly created project and then exiting
                         .id(UUID())
                         
-                        CatalystHomescreenNavBarButton(action: { [weak store] in
+                        CatalystNavBarButton(action: { [weak store] in
                             store?.conditionallToggleSampleProjectsModal()
                         },
-                                                       iconName: .sfSymbol(.OPEN_SAMPLE_PROJECTS_MODAL))
+                                             iconName: .sfSymbol(.OPEN_SAMPLE_PROJECTS_MODAL))
                         // Resolves issue where hover was still active after entering newly created project and then exiting
                         .id(UUID())
                         
@@ -63,8 +63,8 @@ struct ProjectsHomeViewWrapper: View {
                             .buttonStyle(.borderless)
                             .id(UUID())
                         
-                        CatalystHomescreenNavBarButton(action: SHOW_APP_SETTINGS_ACTION,
-                                                       iconName: .sfSymbol(.SETTINGS_SF_SYMBOL_NAME))
+                        CatalystNavBarButton(action: SHOW_APP_SETTINGS_ACTION,
+                                             iconName: .sfSymbol(.SETTINGS_SF_SYMBOL_NAME))
                         .id(UUID())
                         
 #else
@@ -89,20 +89,6 @@ struct ProjectsHomeViewWrapper: View {
                     }
                 }
             }
-    }
-}
-
-// Note: the UIKitTap modifier messes up ONLY the homescreen catalyst buttons ?
-struct CatalystHomescreenNavBarButton: View {
-    let action: () -> Void
-    let iconName: IconName
-
-    var body: some View {
-        Button(action: action ) {
-            iconName.image
-        }
-        .buttonStyle(.borderless)
-        // .hoverEffect() // ignored on Catalyst?
     }
 }
 


### PR DESCRIPTION
Also reverts changes that were exploring possible fixes for Mac toolbar icons disappearing.