### PR TITLE
Fixed Stitch AI issue where new nodes could overwrite existing ones

### DIFF
--- a/Stitch/Graph/StitchAI/DatasetRecording/LLMRecordingState.swift
+++ b/Stitch/Graph/StitchAI/DatasetRecording/LLMRecordingState.swift
@@ -79,6 +79,26 @@ extension Array where Element == any StepActionable {
     }
 }
 
+extension Array where Element == any StepActionable {
+    /// Ensures newly created nodes won't overwrite the graph.
+    func remapNodeIdsForNewNodes() -> Self {
+        // Old : New pairings
+        var idMap = [NodeId : NodeId]()
+        
+        self.forEach {
+            if let addNodeAction = $0 as? StepActionAddNode {
+                idMap.updateValue(.init(), forKey: addNodeAction.nodeId)
+            }
+        }
+        
+        let convertedIdSteps = self.map { step in
+            step.remapNodeIds(nodeIdMap: idMap)
+        }
+        
+        return convertedIdSteps
+    }
+}
+
 extension StitchDocumentViewModel {
     
     @MainActor
@@ -86,7 +106,10 @@ extension StitchDocumentViewModel {
         // Wipe old error reason
         self.llmRecording.actionsError = nil
         
-        let convertedActions = try actions.convertSteps()
+        let convertedActions = try actions
+            .convertSteps()
+        // Change Ids for newly created nodes
+            .remapNodeIdsForNewNodes()
         
         // Are these steps valid?
         // invalid = e.g. tried to create a connection for a node before we created that node

--- a/Stitch/Graph/StitchAI/DatasetRecording/LLMRecordingState.swift
+++ b/Stitch/Graph/StitchAI/DatasetRecording/LLMRecordingState.swift
@@ -101,6 +101,11 @@ extension StitchDocumentViewModel {
         }
         
         for action in convertedActions {
+            if let addAction = action as? StepActionAddNode {
+                // add-node actions cannot re-use IDs
+                assertInDebug(!self.visibleGraph.nodes.keys.contains(addAction.nodeId))
+            }
+            
             do {
                 try self.applyAction(action)
             } catch let error as StitchFileError {

--- a/Stitch/Graph/StitchAI/GraphPrompting/DataModel/Step.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/DataModel/Step.swift
@@ -42,6 +42,10 @@ struct Step: Hashable {
     }
 }
 
+extension Step: Identifiable {
+    var id: Int { self.hashValue }
+}
+
 extension Step: Codable {
     enum CodingKeys: String, CodingKey {
         case stepType = "step_type"

--- a/Stitch/Graph/StitchAI/GraphPrompting/UI/EditBeforeSubmitModalView.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/UI/EditBeforeSubmitModalView.swift
@@ -25,7 +25,7 @@ struct EditBeforeSubmitModalView: View {
                 .padding(.top)
             
             List {
-                ForEach(self.recordingState.actions, id: \.hashValue) { action in
+                ForEach(self.recordingState.actions) { action in
                     LLMActionCorrectionView(action: action,
                                             graph: graph)
                 }

--- a/Stitch/Graph/StitchAI/StitchAISystemPrompt.swift
+++ b/Stitch/Graph/StitchAI/StitchAISystemPrompt.swift
@@ -184,7 +184,7 @@ extension StitchAIManager {
     21. During the connect_nodes action, you MUST provide the fromNodeId and the toNodeId. Both are required. You can not create this action without BOTH of these values. If you are missing those values, try again until you have them. Do NOT use nodeId for this action; ONLY use fromNodeId and toNodeId.
 
     # Core Rules:
-    - Each node must have a unique UUID as its node_id.
+    - Each node must have a unique UUID as its node_id. Make sure a new UUID is randomly generated each time `add_node` is invoked to prevent conflicts with existing graphs.
     - Never use node names as port names.
     - Use integer port identifiers (0, 1, 2, ...) for patch nodes.
     - Use string port identifiers for layer nodes. Limit options to those listed in `LayerPorts` in structured outputs.


### PR DESCRIPTION
The main change in here is new logic that given each new node ID from Stitch AI, creates a new ID ensuring uniqueness. Steps have a new protocol function that will mutate properties given some node ID mapping.