### PR TITLE
Improved edge drag performance

### DIFF
--- a/Stitch/Graph/Edge/Util/EdgeUtils.swift
+++ b/Stitch/Graph/Edge/Util/EdgeUtils.swift
@@ -101,9 +101,10 @@ extension GraphState {
             guard let inputCenter = inputViewModel.portUIViewModel.anchorPoint else {
                 continue
             }
-            
-            log("findEligibleCanvasInput: inputCenter: \(inputCenter)")
-            log("findEligibleCanvasInput: cursorLocation: \(cursorLocation)")
+  
+            // Awful for perf
+//            log("findEligibleCanvasInput: inputCenter: \(inputCenter)")
+//            log("findEligibleCanvasInput: cursorLocation: \(cursorLocation)")
             
             if areNear(inputCenter,
                        cursorLocation,

--- a/Stitch/Graph/Edge/Util/EdgeUtils.swift
+++ b/Stitch/Graph/Edge/Util/EdgeUtils.swift
@@ -134,9 +134,10 @@ extension GraphState {
         // *animate* the port color change:
         withAnimation(.linear(duration: DrawnEdge.ANIMATION_DURATION)) {
             if let drawingGesture = self.edgeDrawingObserver.drawingGesture,
-               let outputObserver = self.getOutputRowObserver(drawingGesture.output.nodeIOCoordinate),
-               let canvasItemId = drawingGesture.output.canvasItemDelegate?.id {
-                drawingGesture.output.portUIViewModel.updatePortColor(
+               let outputObserver = self.getOutputRowObserver(drawingGesture.outputId.asNodeIOCoordinate),
+               let canvasItemId = drawingGesture.outputId.graphItemType.getCanvasItemId,
+               let outputRowViewModel = self.getOutputRowViewModel(for: drawingGesture.outputId) {
+                outputRowViewModel.portUIViewModel.updatePortColor(
                     canvasItemId: canvasItemId,
                     hasEdge: outputObserver.hasEdge,
                     hasLoop: outputObserver.hasLoopedValues,

--- a/Stitch/Graph/Edge/Util/PortDragActions.swift
+++ b/Stitch/Graph/Edge/Util/PortDragActions.swift
@@ -30,7 +30,7 @@ extension GraphState {
         self.edgeAnimationEnabled = true
         
         // If we already have an active input-drag:
-        if var existingDrawingGesture = self.edgeDrawingObserver.drawingGesture {
+        if let existingDrawingGesture = self.edgeDrawingObserver.drawingGesture {
             // Called when drag has already started
             existingDrawingGesture.cursorLocationInGlobalCoordinateSpace = dragLocation
             self.edgeDrawingObserver.drawingGesture = existingDrawingGesture
@@ -52,7 +52,7 @@ extension GraphState {
             self.edgeDrawingObserver.nearestEligibleEdgeDestination = .canvasInput(inputRowViewModel)
 
             self.edgeDrawingObserver.drawingGesture = OutputDragGesture(
-                output: upstreamObserver,
+                outputId: upstreamObserver.id,
                 cursorLocationInGlobalCoordinateSpace: dragLocation,
                 startingDiffFromCenter: .zero)
 
@@ -69,13 +69,14 @@ extension GraphState {
         }
         
         if let drawingGesture = self.edgeDrawingObserver.drawingGesture,
-           let fromRowObserver = self.getOutputRowObserver(drawingGesture.output.nodeIOCoordinate),
-           let nearestEligible = self.edgeDrawingObserver.nearestEligibleEdgeDestination {
+           let fromRowObserver = self.getOutputRowObserver(drawingGesture.outputId.asNodeIOCoordinate),
+           let nearestEligible = self.edgeDrawingObserver.nearestEligibleEdgeDestination,
+           let dragOriginOutput = self.getOutputRowViewModel(for: drawingGesture.outputId) {
             
             self.createEdgeAfterPortDragEnded(
                 nearestEligibleDestination: nearestEligible,
                 sourceNodeId: fromRowObserver.id.nodeId,
-                dragOriginOutput: drawingGesture.output,
+                dragOriginOutput: dragOriginOutput,
                 document: document)
 
             self.edgeDrawingObserver.reset()
@@ -196,7 +197,7 @@ extension GraphState {
             // TODO: MAY 12: resolve this, but with the updated gesture.location
             //            let diffFromCenter = OutputNodeRowViewModel.calculateDiffFromCenter(from: gesture)
             
-            let drag = OutputDragGesture(output: outputRowViewModel,
+            let drag = OutputDragGesture(outputId: rowId,
                                          // dragLocation: gesture.location,
                                          cursorLocationInGlobalCoordinateSpace: cursorLocationInGlobalCoordinateSpace,
                                          // startingDiffFromCenter: diffFromCenter)
@@ -228,11 +229,14 @@ extension GraphState {
             return
         }
         
+        let graph = document.visibleGraph
+        
         // We could have had an eligible canvas input and/or inspector input/input-field.
         // If we had both, prefer that inspector ?
         
         // We ought to have these if we were dragging an output
-        guard let dragOriginOutput = self.edgeDrawingObserver.drawingGesture?.output,
+        guard let dragGesture = self.edgeDrawingObserver.drawingGesture,
+              let dragOriginOutput = graph.getOutputRowViewModel(for: dragGesture.outputId),
               let draggedOutputObserver: OutputNodeRowObserver = self.getOutputRowObserver(dragOriginOutput.nodeIOCoordinate) else {
             
             fatalErrorIfDebug("Output drag ended but we did not have an edge drawing observer and/or could not retrieve the output row observer")

--- a/Stitch/Graph/Edge/Util/PortDragActions.swift
+++ b/Stitch/Graph/Edge/Util/PortDragActions.swift
@@ -33,7 +33,6 @@ extension GraphState {
         if let existingDrawingGesture = self.edgeDrawingObserver.drawingGesture {
             // Called when drag has already started
             existingDrawingGesture.cursorLocationInGlobalCoordinateSpace = dragLocation
-            self.edgeDrawingObserver.drawingGesture = existingDrawingGesture
                         
 //            if let outputNodeId = existingDrawingGesture.output.canvasItemDelegate?.id,
 //               let dragLocationInNodesViewCoordinateSpace = self.dragLocationInNodesViewCoordinateSpace {
@@ -181,7 +180,6 @@ extension GraphState {
             drag = existingDrawingGesture
 //            drag.dragLocation = gesture.location
             drag.cursorLocationInGlobalCoordinateSpace = cursorLocationInGlobalCoordinateSpace
-            self.edgeDrawingObserver.drawingGesture = drag
 //
 //            if let outputNodeId = existingDrawingGesture.output.canvasItemDelegate?.id,
 //               let dragLocationInNodesViewCoordinateSpace = self.dragLocationInNodesViewCoordinateSpace {
@@ -256,10 +254,10 @@ extension GraphState {
                 sourceNodeId: draggedOutputObserver.id.nodeId,
                 dragOriginOutput: dragOriginOutput,
                 document: document)
+            self.encodeProjectInBackground()
         }
         
         self.edgeDrawingObserver.reset()
-        self.encodeProjectInBackground()
     }
     
     @MainActor

--- a/Stitch/Graph/Edge/View/EdgeDrawingView.swift
+++ b/Stitch/Graph/Edge/View/EdgeDrawingView.swift
@@ -15,11 +15,16 @@ struct EdgeDrawingView: View {
     var body: some View {
         // TODO: MAY 14: fix this
         if let outputDrag = edgeDrawingObserver.drawingGesture,
-           let elgibleCanvasInput = edgeDrawingObserver.nearestEligibleEdgeDestination?.getCanvasInput {
+           let elgibleCanvasInput = edgeDrawingObserver.nearestEligibleEdgeDestination?.getCanvasInput,
+           let outputRowViewModel = graph.getOutputRowViewModel(for: outputDrag.outputId),
+           let canvasId = outputDrag.outputId.graphItemType.getCanvasItemId,
+           let canvasItem = graph.getCanvasItem(canvasId) {
             EdgeFromDraggedOutputView(
                 graph: graph,
                 outputDrag: outputDrag,
-                nearestEligibleInput: elgibleCanvasInput)
+                nearestEligibleInput: elgibleCanvasInput,
+                outputRowViewModel: outputRowViewModel,
+                canvasItem: canvasItem)
         } else {
             EmptyView()
         }
@@ -37,9 +42,8 @@ struct EdgeFromDraggedOutputView: View {
     
     let nearestEligibleInput: InputNodeRowViewModel?
 
-    var outputRowViewModel: OutputNodeRowViewModel {
-        outputDrag.output
-    }
+    let outputRowViewModel: OutputNodeRowViewModel
+    let canvasItem: CanvasItemViewModel
     
     // Note: the rules for the color of an actively dragged edge are simple:
     // gray if no eligible input, else highlighted-loop if a loop, else highlighted.
@@ -68,7 +72,7 @@ struct EdgeFromDraggedOutputView: View {
     
     var body: some View {
         Group {
-            if let downstreamNode = graph.getNode(outputDrag.output.id.nodeId),
+            if let downstreamNode = graph.getNode(outputDrag.outputId.nodeId),
                let upstreamCanvasItem = outputRowViewModel.canvasItemDelegate,
                 let outputAnchorData = EdgeAnchorUpstreamData(
                     from: upstreamCanvasItem.outputPortUIViewModels,

--- a/Stitch/Graph/Edge/ViewModel/EdgeDrawingObserver.swift
+++ b/Stitch/Graph/Edge/ViewModel/EdgeDrawingObserver.swift
@@ -59,10 +59,10 @@ extension EdgeDrawingObserver {
     }
 }
 
-// TODO: technically this could also be a dragged input that we detached?
-struct OutputDragGesture {
+@Observable
+final class OutputDragGesture {
     // the output we started dragging from
-    let output: OutputNodeRowViewModel
+    var outputId: NodeRowViewModelId
     
     // fka `dragLocation`
     var cursorLocationInGlobalCoordinateSpace: CGPoint
@@ -72,4 +72,12 @@ struct OutputDragGesture {
     // since UIKit pan gesture gesture.location is inaccurate
     // for high velocities.
     var startingDiffFromCenter: CGSize
+    
+    init(outputId: NodeRowViewModelId,
+         cursorLocationInGlobalCoordinateSpace: CGPoint,
+         startingDiffFromCenter: CGSize) {
+        self.outputId = outputId
+        self.cursorLocationInGlobalCoordinateSpace = cursorLocationInGlobalCoordinateSpace
+        self.startingDiffFromCenter = startingDiffFromCenter
+    }
 }

--- a/Stitch/Graph/LayerInspector/EdgeDraggedToInspector.swift
+++ b/Stitch/Graph/LayerInspector/EdgeDraggedToInspector.swift
@@ -42,11 +42,17 @@ extension View {
 
 // Only used in
 struct TrackDraggedOutput: ViewModifier {
-    let id: OutputCoordinate? // nil = was for input
-    let isActivelyDraggedOutput: Bool
+    let graph: GraphState
+    let id: NodeIOCoordinate
+    let nodeIO: NodeIO
+    
+    var isActivelyDraggedOutput: Bool {
+        let activeDrag = graph.edgeDrawingObserver.drawingGesture?.outputId.asNodeIOCoordinate
+        return self.id == activeDrag
+    }
     
     func body(content: Content) -> some View {
-        if let id = id {
+        if nodeIO == .output {
             content.trackEdgeDraggedToInspectorAnchorPreference(id: .draggedOutput(id),
                                                                 shouldTrack: isActivelyDraggedOutput)
         } else {

--- a/Stitch/Graph/Node/Port/View/PortView.swift
+++ b/Stitch/Graph/Node/Port/View/PortView.swift
@@ -44,7 +44,7 @@ struct PortEntryView<PortUIViewModelType: PortUIViewModel>: View {
     }
     
     var activelyDraggedOutputCoordinate: OutputCoordinate? {
-        graph.edgeDrawingObserver.drawingGesture?.output.nodeIOCoordinate
+        graph.edgeDrawingObserver.drawingGesture?.outputId.asNodeIOCoordinate
     }
     
     var body: some View {

--- a/Stitch/Graph/Node/Port/View/PortView.swift
+++ b/Stitch/Graph/Node/Port/View/PortView.swift
@@ -43,10 +43,6 @@ struct PortEntryView<PortUIViewModelType: PortUIViewModel>: View {
         self.rowId.asNodeIOCoordinate
     }
     
-    var activelyDraggedOutputCoordinate: OutputCoordinate? {
-        graph.edgeDrawingObserver.drawingGesture?.outputId.asNodeIOCoordinate
-    }
-    
     var body: some View {
         Rectangle().fill(self.portColor)
         //            Rectangle().fill(portBodyColor)
@@ -61,9 +57,9 @@ struct PortEntryView<PortUIViewModelType: PortUIViewModel>: View {
         
         // For perf reasons, we only populate `EdgeDraggedToInspectorPreferenceKey` if we're actively dragging an edge
             .modifier(TrackDraggedOutput(
-                id: nodeIO == .output ? nodeIOCoordinate : nil,
-                isActivelyDraggedOutput: nodeIOCoordinate == activelyDraggedOutputCoordinate
-            ))
+                graph: graph,
+                id: nodeIOCoordinate,
+                nodeIO: nodeIO))
         
             .frame(PORT_ENTRY_NON_EXTENDED_HITBOX_SIZE)
            

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/PortUIViewModel/OutputPortUIViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/PortUIViewModel/OutputPortUIViewModel.swift
@@ -61,7 +61,7 @@ extension OutputPortUIViewModel {
                 
         if let drawnEdge = drawingObserver.drawingGesture,
            // TODO: we had been comparing `drawnEdge.output.id == self.id`, but how were we able to compare `drawnEdge.output.id: NodeRowViewModelId` against `PortUIViewModel.id: NodeIOCoordinate` ?!
-            drawnEdge.output.nodeIOCoordinate == self.id {
+            drawnEdge.outputId.asNodeIOCoordinate == self.id {
             
             let hasEligibleInput = drawingObserver.nearestEligibleEdgeDestination.isDefined
             

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/TextField/PreviewTextFieldLayerUtils.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/TextField/PreviewTextFieldLayerUtils.swift
@@ -71,7 +71,9 @@ extension StitchDocumentViewModel {
         }
         
         // Selected input gets reset when we focus a text field
-        self.selectedInput = nil
+        if self.selectedInput != nil {
+            self.selectedInput = nil            
+        }
     }
     
     @MainActor

--- a/Stitch/Graph/View/GraphBaseView.swift
+++ b/Stitch/Graph/View/GraphBaseView.swift
@@ -190,7 +190,7 @@ struct ActivelyDrawnEdgeThatCanEnterInspector: ViewModifier {
                 return
             }
             
-            if let outputNodeId = drawingGesture.output.canvasItemDelegate?.id,
+            if let outputNodeId = drawingGesture.outputId.graphItemType.getCanvasItemId,
                let dragLocationInNodesViewCoordinateSpace = graph.dragLocationInNodesViewCoordinateSpace {
                 graph.findEligibleCanvasInput(
                     cursorLocation: dragLocationInNodesViewCoordinateSpace,
@@ -212,7 +212,7 @@ struct ActivelyDrawnEdgeThatCanEnterInspector: ViewModifier {
             // *animate* the port color change:
             withAnimation(.linear(duration: DrawnEdge.ANIMATION_DURATION)) {
                 graph
-                    .getOutputRowObserver(drawingGesture.output.id.asNodeIOCoordinate)?
+                    .getOutputRowObserver(drawingGesture.outputId.asNodeIOCoordinate)?
                     .updateRowViewModelsPortColor(selectedEdges: graph.selectedEdges,
                                                   selectedCanvasItems: graph.selectedCanvasItems,
                                                   drawingObserver: drawingObserver)
@@ -273,18 +273,17 @@ struct ActivelyDrawnEdgeThatCanEnterInspector: ViewModifier {
                 GeometryReader { geometry in
                     if let drawingGesture = graph.edgeDrawingObserver.drawingGesture,
                        // The output from which the currently-dragged edge originates
-                        let draggedOutputPref = preferences[.draggedOutput(drawingGesture.output.nodeIOCoordinate)] {
+                       let draggedOutputPref = preferences[.draggedOutput(drawingGesture.outputId.asNodeIOCoordinate)],
+                       let outputRowViewModel = self.graph.getOutputRowViewModel(for: drawingGesture.outputId) {
                         
                         // Location of dragged edge's end, i.e. user's cursor position
                         let draggedOutputRect: CGRect = geometry[draggedOutputPref]
-                        
-                        let outputRowViewModel = drawingGesture.output
                         
                         // Always draw the
                         let pointTo = drawingGesture.cursorLocationInGlobalCoordinateSpace
                         
                         
-                        if let downstreamNode = graph.getNode(drawingGesture.output.id.nodeId),
+                        if let downstreamNode = graph.getNode(drawingGesture.outputId.nodeId),
                            let upstreamCanvasItem = outputRowViewModel.canvasItemDelegate,
                             let outputAnchorData = EdgeAnchorUpstreamData(
                                 from: upstreamCanvasItem.outputPortUIViewModels,


### PR DESCRIPTION
The perf issue here is largely on main but merging for Chris's branch to ease rebase conflicts.

The main fix is extra render cycles on port views caused by drag gesture state changes. Drag gestures used immutable data and are frequently updated on drag. The fix here is using a view model approach.

Before:
https://github.com/user-attachments/assets/5e008eb0-90bc-4b0e-8fc2-ccdd1ccf0d68

After:
https://github.com/user-attachments/assets/41b72dc1-027e-41ff-a27d-46452288827a

