### PR TITLE
Fixed new edge creation with pre-existing layer inputs

### DIFF
--- a/Stitch/Graph/LayerInspector/LayerPortAddedToCanvas.swift
+++ b/Stitch/Graph/LayerInspector/LayerPortAddedToCanvas.swift
@@ -287,9 +287,11 @@ extension StitchDocumentViewModel {
             return
         }
         
-        guard !unpackedPort.canvasObserver.isDefined else {
+        // Remove existing layer input
+        if let existingCanvasObserver = unpackedPort.canvasObserver {
             log("addLayerFieldToCanvas: Field \(fieldIndex) for input \(layerInput) already on canvas")
-            return
+            graph.deleteCanvasItem(existingCanvasObserver.id,
+                                   document: self)
         }
     
         // MARK: CREATING AND INITIALIZING THE CANVAS ITEM VIEW MODEL ITSELF

--- a/Stitch/Graph/LayerInspector/LayerPortAddedToCanvas.swift
+++ b/Stitch/Graph/LayerInspector/LayerPortAddedToCanvas.swift
@@ -169,11 +169,12 @@ extension StitchDocumentViewModel {
         
         let input: InputLayerNodeRowData = layerNode[keyPath: layerInput.packedLayerInputKeyPath]
         
-        // If already on this canvas, do nothing
+        // Remove existing layer input
         // (Can happen from dragging an edge onto the inspector)
-        guard !input.canvasObserver.isDefined else {
+        if let existingCanvasObserver = input.canvasObserver {
             log("Layer Input \(layerInput) already on canvas")
-            return
+            graph.deleteCanvasItem(existingCanvasObserver.id,
+                                   document: self)
         }
         
         let canvasPosition = self.getLayerInputOrFieldCanvasInsertionPosition(


### PR DESCRIPTION
Fixes and issue where the new edge dragging support for layer inspector inputs would invalidate new connections should existing canvas inputs exist on the graph. Same fix for both pack and unpacked fields.