### PR TITLE
New prototype focus state for disabling graph shortcuts

### DIFF
--- a/Stitch/Graph/Node/Port/Model/Field/FocusedUserEditField.swift
+++ b/Stitch/Graph/Node/Port/Model/Field/FocusedUserEditField.swift
@@ -35,7 +35,8 @@ enum FocusedUserEditField: Equatable, Hashable {
          stitchAIPromptModal,
          sidebarLayerTitle(String),
          previewWindowSettingsWidth,
-         previewWindowSettingsHeight
+         previewWindowSettingsHeight,
+         prototypeWindow
 
     var getTextFieldLayerInputEdit: PreviewCoordinate? {
         switch self {

--- a/Stitch/Graph/Node/Port/Model/Field/FocusedUserEditField.swift
+++ b/Stitch/Graph/Node/Port/Model/Field/FocusedUserEditField.swift
@@ -36,7 +36,8 @@ enum FocusedUserEditField: Equatable, Hashable {
          sidebarLayerTitle(String),
          previewWindowSettingsWidth,
          previewWindowSettingsHeight,
-         prototypeWindow
+         prototypeWindow,
+         prototypeTextField(PreviewCoordinate)
 
     var getTextFieldLayerInputEdit: PreviewCoordinate? {
         switch self {

--- a/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/GeneratePreview.swift
@@ -55,9 +55,18 @@ struct GeneratePreview: View {
                               realityContent: nil)
             .hidden()
             .disabled(true)
-        }        
+        }
         .modifier(HoverGestureModifier(document: document,
                                        previewWindowSize: document.previewWindowSize))
+        // Tracks focus state on prototype window to disable some graph shortcuts (i.e. node creation shortcuts)
+        .simultaneousGesture(
+            TapGesture()
+                .onEnded {
+                    if document.reduxFocusedField != .prototypeWindow {
+                        document.reduxFocusedField = .prototypeWindow
+                    }
+                }
+        )
     }
 }
 

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/TextField/PreviewTextFieldLayer.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/TextField/PreviewTextFieldLayer.swift
@@ -10,7 +10,9 @@ import SwiftUI
 import StitchSchemaKit
 
 struct PreviewTextFieldLayer: View {
-
+    @FocusedValue(\.focusedField) private var focusedField
+    @FocusState private var isFocused: Bool
+    
     @Bindable var document: StitchDocumentViewModel
     @Bindable var graph: GraphState
     @Bindable var viewModel: LayerViewModel
@@ -51,9 +53,6 @@ struct PreviewTextFieldLayer: View {
     let parentIsScrollableGrid: Bool
 
     let focusedTextFieldLayer: PreviewCoordinate?
-
-    // Don't need to explicitly handle
-    @FocusState private var isFocused: Bool
     
     var id: PreviewCoordinate {
         interactiveLayer.id
@@ -86,6 +85,16 @@ struct PreviewTextFieldLayer: View {
         
         TextField(placeholder,
                   text: $viewModel.textFieldInput)
+            .focusedValue(\.focusedField, .prototypeTextField(self.id))
+            .onChange(of: self.document.reduxFocusedField) { _, focusedField in
+                // Disables focus state here with other graph taps
+                switch focusedField {
+                case .prototypeTextField:
+                    return
+                default:
+                    self.isFocused = false
+                }
+            }
             .autocorrectionDisabled()
             .autocapitalization(.none)
             .multilineTextAlignment(textAlignment.asMultilineAlignment ?? .leading)

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/TextField/PreviewTextFieldLayerUtils.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/TextField/PreviewTextFieldLayerUtils.swift
@@ -48,7 +48,7 @@ extension FocusedUserEditField {
         case .commentBox(let commentBoxId):
             return nil
             
-        case .projectTitle, .jsonPopoverOutput, .insertNodeMenu, .textFieldLayer, .any, .llmRecordingModal, .stitchAIPromptModal, .sidebarLayerTitle, .previewWindowSettingsWidth, .previewWindowSettingsHeight:
+        case .projectTitle, .jsonPopoverOutput, .insertNodeMenu, .textFieldLayer, .any, .llmRecordingModal, .stitchAIPromptModal, .sidebarLayerTitle, .previewWindowSettingsWidth, .previewWindowSettingsHeight, .prototypeWindow:
             return nil
         }
     }

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/TextField/PreviewTextFieldLayerUtils.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/TextField/PreviewTextFieldLayerUtils.swift
@@ -48,7 +48,7 @@ extension FocusedUserEditField {
         case .commentBox(let commentBoxId):
             return nil
             
-        case .projectTitle, .jsonPopoverOutput, .insertNodeMenu, .textFieldLayer, .any, .llmRecordingModal, .stitchAIPromptModal, .sidebarLayerTitle, .previewWindowSettingsWidth, .previewWindowSettingsHeight, .prototypeWindow:
+        case .projectTitle, .jsonPopoverOutput, .insertNodeMenu, .textFieldLayer, .any, .llmRecordingModal, .stitchAIPromptModal, .sidebarLayerTitle, .previewWindowSettingsWidth, .previewWindowSettingsHeight, .prototypeWindow, .prototypeTextField:
             return nil
         }
     }


### PR DESCRIPTION
Fixes an issue where keypresses intended for the prototype would be picked up by graph shortcuts used for graph editing (like node shortcuts).

Adds two new focus states:
1. General prototype window focus
2. Prototype field layers

Tracking the latter enables us to de-focus text fields in the prototype, which would previously remain in focus with other selections in the app.