### PR TITLE
Focus state fixes for port and sidebar selection

### DIFF
--- a/Stitch/App/Shortcut/InsertNodeCommands.swift
+++ b/Stitch/App/Shortcut/InsertNodeCommands.swift
@@ -21,7 +21,7 @@ struct InsertNodeCommands: View {
     }
     
     var hasSelectedInput: Bool {
-        self.store.currentDocument?.selectedInput.isDefined ?? false
+        self.store.currentDocument?.reduxFocusedField?.isInputPortSelected ?? false
     }
     
     var selectionLabel: String {

--- a/Stitch/App/Shortcut/ProjectsHomeCommands.swift
+++ b/Stitch/App/Shortcut/ProjectsHomeCommands.swift
@@ -41,10 +41,6 @@ struct ProjectsHomeCommands: Commands {
         activeReduxFocusedField.isDefined || focusedField.isDefined
     }
     
-    var hasSelectedInput: Bool {
-        self.store.currentDocument?.selectedInput.isDefined ?? false
-    }
-
     var body: some Commands {
 
         CommandMenu("Graph") {

--- a/Stitch/App/Shortcut/ProjectsHomeCommands.swift
+++ b/Stitch/App/Shortcut/ProjectsHomeCommands.swift
@@ -22,7 +22,7 @@ struct ProjectsHomeCommands: Commands {
     }
         
     var isSidebarFocused: Bool {
-        store.currentDocument?.visibleGraph.layersSidebarViewModel.isSidebarFocused ?? false
+        store.currentDocument?.isSidebarFocused ?? false
     }
     
     var graph: GraphState? {

--- a/Stitch/Graph/Gesture/Util/GraphUICursorSelectionActions.swift
+++ b/Stitch/Graph/Gesture/Util/GraphUICursorSelectionActions.swift
@@ -236,8 +236,6 @@ extension GraphState {
 
         self.selectedEdges = .init()
         
-        self.documentDelegate?.selectedInput = nil
-        
         // log("handleTrackpadDragStarted: self.selection.isFingerOnScreenSelection is now: \(self.selection.isFingerOnScreenSelection)")
     }
 

--- a/Stitch/Graph/LayerInspector/FlyoutUtils.swift
+++ b/Stitch/Graph/LayerInspector/FlyoutUtils.swift
@@ -89,9 +89,6 @@ struct FlyoutToggled: StitchDocumentEvent {
             if let fieldToFocus = fieldToFocus {
                 state.reduxFieldFocused(focusedField: fieldToFocus)
             }
-            
-            // Reset selected input when flyout opens
-            state.selectedInput = nil
         }
     }
 }

--- a/Stitch/Graph/Node/Patch/Type/Interaction/Keyboard/KeyPressActions.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/Keyboard/KeyPressActions.swift
@@ -157,7 +157,7 @@ extension StitchStore {
         if graph.edgeEditingState.isDefined {
             graph.keyCharPressedDuringEdgeEditingMode(char: char,
                                                       activeIndex: document.activeIndex)
-        } else if document.selectedInput.isDefined,
+        } else if document.reduxFocusedField?.isInputPortSelected ?? false,
                 let patch = char.patchFromShortcutKey() {
             document.nodeCreatedWhileInputSelected(choice: .patch(patch))
         } else {

--- a/Stitch/Graph/Node/Port/Model/Field/FocusedUserEditField.swift
+++ b/Stitch/Graph/Node/Port/Model/Field/FocusedUserEditField.swift
@@ -21,6 +21,7 @@ import StitchSchemaKit
 enum FocusedUserEditField: Equatable, Hashable {
     case textInput(FieldCoordinate), // focused text input
          nodeTitle(StitchTitleEdit), // focused stitch's title text
+         nodeInputPortSelection(NodeRowViewModelId),
          mathExpression(NodeId), // editing a math expression
          projectTitle, // i.e. for Catalyst
          // when a JSON Popover output is open,

--- a/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
+++ b/Stitch/Graph/Node/Port/View/NodeInputOutputView.swift
@@ -40,7 +40,7 @@ struct NodeRowPortView<NodeRowObserverType: NodeRowObserver>: View {
             }
 
             if nodeIO == .input {
-                dispatch(InputSelected(tappedInput: rowObserver.id))
+                document.reduxFocusedField = .nodeInputPortSelection(rowViewModel.id)
             }
             
             // Do nothing when input/output doesn't contain a loop
@@ -51,13 +51,5 @@ struct NodeRowPortView<NodeRowObserverType: NodeRowObserver>: View {
                 
             }
         }
-    }
-}
-
-struct InputSelected: StitchDocumentEvent {
-    let tappedInput: InputCoordinate
-    
-    func handle(state: StitchDocumentViewModel) {
-        state.selectedInput = tappedInput
     }
 }

--- a/Stitch/Graph/Node/Port/View/PortView.swift
+++ b/Stitch/Graph/Node/Port/View/PortView.swift
@@ -73,7 +73,7 @@ struct PortEntryView<PortUIViewModelType: PortUIViewModel>: View {
             }
             .background {
                 if nodeIO == .input,
-                   document.selectedInput == rowId.asNodeIOCoordinate {
+                   document.reduxFocusedField?.inputPortSelected == rowId {
                     UnevenRoundedRectangle(cornerRadii: .init(topLeading: 0,
                                                               bottomLeading: 0,
                                                               // a circle on the right side

--- a/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
+++ b/Stitch/Graph/Node/Util/Movement/NodeMovedAction.swift
@@ -187,6 +187,11 @@ extension GraphState {
         // end any edge-drawing
         self.edgeDrawingObserver.reset()
         self.nodeIsMoving = true
+        
+        // reset any focus state
+        if document.reduxFocusedField != nil {
+            document.reduxFocusedField = nil            
+        }
     }
 }
 

--- a/Stitch/Graph/Node/Util/NodeCreatedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeCreatedAction.swift
@@ -29,10 +29,11 @@ extension StitchDocumentViewModel {
         let graph = state.visibleGraph
         
         // Find the input
-        guard let selectedInput = state.selectedInput,
-              var selectedInputLocation = graph.getCanvasItem(inputId: selectedInput)?
+        guard let selectedInput = state.reduxFocusedField?.inputPortSelected,
+              let canvasId = selectedInput.graphItemType.getCanvasItemId,
+              var selectedInputLocation = graph.getCanvasItem(canvasId)?
             .locationOfInputs,
-              let selectedInputObserver = state.visibleGraph.getInputRowObserver(selectedInput),
+              let selectedInputObserver = state.visibleGraph.getInputRowViewModel(for: selectedInput)?.rowDelegate,
               let selectedInputType: UserVisibleType = selectedInputObserver.values.first?.toNodeType else {
             fatalErrorIfDebug()
             return
@@ -86,7 +87,7 @@ extension StitchDocumentViewModel {
         
         // Create an edge from the node's output to the selected input
         graph.addEdgeWithoutGraphRecalc(from: firstOutput.id,
-                                        to: selectedInput)
+                                        to: selectedInputObserver.id)
         
         // TODO: calculate a smaller portion of the graph?
         graph.calculateFullGraph()

--- a/Stitch/Graph/Node/Util/NodeDeletedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeDeletedAction.swift
@@ -16,7 +16,7 @@ struct DeleteShortcutKeyPressed: StitchDocumentEvent {
         let graph = state.visibleGraph
         
         // Check which we have focused: layers or canvas items
-        if state.visibleGraph.layersSidebarViewModel.isSidebarFocused {
+        if state.isSidebarFocused {
             graph.layersSidebarViewModel.deleteSelectedItems()
             graph.updateInspectorFocusedLayers()
         }

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/TextField/PreviewTextFieldLayerUtils.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/TextField/PreviewTextFieldLayerUtils.swift
@@ -17,6 +17,19 @@ struct ReduxFieldFocused: StitchDocumentEvent {
 }
 
 extension FocusedUserEditField {
+    var inputPortSelected: NodeRowViewModelId? {
+        switch self {
+        case .nodeInputPortSelection(let id):
+            return id
+            
+        default:
+            return nil
+        }
+    }
+    
+    var isInputPortSelected: Bool {
+        self.inputPortSelected != nil
+    }
     
     // Find the parent canvas item for this focused-field (whether a patch node, a layer input or layer output), and select that canvas item.
     var canvasFieldId: CanvasItemId? {
@@ -48,7 +61,7 @@ extension FocusedUserEditField {
         case .commentBox:
             return nil
             
-        case .projectTitle, .jsonPopoverOutput, .insertNodeMenu, .textFieldLayer, .any, .llmRecordingModal, .stitchAIPromptModal, .sidebarLayerTitle, .previewWindowSettingsWidth, .previewWindowSettingsHeight, .prototypeWindow, .prototypeTextField, .sidebar:
+        case .projectTitle, .jsonPopoverOutput, .insertNodeMenu, .textFieldLayer, .any, .llmRecordingModal, .stitchAIPromptModal, .sidebarLayerTitle, .previewWindowSettingsWidth, .previewWindowSettingsHeight, .prototypeWindow, .prototypeTextField, .sidebar, .nodeInputPortSelection:
             return nil
         }
     }
@@ -68,11 +81,6 @@ extension StitchDocumentViewModel {
         // if we selected a canvas item, we also thereby selected it:
         if let canvasItemId = focusedField.canvasFieldId {
             graph.selectSingleCanvasItem(canvasItemId)
-        }
-        
-        // Selected input gets reset when we focus a text field
-        if self.selectedInput != nil {
-            self.selectedInput = nil            
         }
     }
     

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/TextField/PreviewTextFieldLayerUtils.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/TextField/PreviewTextFieldLayerUtils.swift
@@ -16,6 +16,19 @@ struct ReduxFieldFocused: StitchDocumentEvent {
     }
 }
 
+extension StitchDocumentViewModel {
+    @MainActor
+    var isSidebarFocused: Bool {
+        switch self.reduxFocusedField {
+        case .sidebar, .sidebarLayerTitle:
+            return true
+            
+        default:
+            return false
+        }
+    }
+}
+
 extension FocusedUserEditField {
     var inputPortSelected: NodeRowViewModelId? {
         switch self {

--- a/Stitch/Graph/Sidebar/Util/Gesture/LegacySidebarActions.swift
+++ b/Stitch/Graph/Sidebar/Util/Gesture/LegacySidebarActions.swift
@@ -18,8 +18,9 @@ extension ProjectSidebarObservable {
             self.currentItemDragged = itemId
         }
         
-        if !self.isSidebarFocused {
-            self.isSidebarFocused = true
+        if let document = self.graphDelegate?.documentDelegate,
+           !document.isSidebarFocused {
+            document.reduxFocusedField = .sidebar
         }
     }
 
@@ -90,8 +91,8 @@ extension ProjectSidebarObservable {
         var draggedItem = item
         
         // Focus sidebar
-        if !self.isSidebarFocused {
-            self.isSidebarFocused = true
+        if !document.isSidebarFocused {
+            document.reduxFocusedField = .sidebar
         }
               
         // We have an in-progress option dupe-drag and have already duplicated the layers

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
@@ -26,9 +26,7 @@ extension ProjectSidebarObservable {
         if !self.isSidebarFocused {
             self.isSidebarFocused = true            
         }
-        
-        document.selectedInput = nil
-        
+                
         // Wipe redux field
         document.reduxFocusedField = nil
         

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarItemSelectionActions.swift
@@ -23,12 +23,7 @@ extension ProjectSidebarObservable {
         let originalSelections = self.selectionState.primary
         
         // Set sidebar to be focused:
-        if !self.isSidebarFocused {
-            self.isSidebarFocused = true            
-        }
-                
-        // Wipe redux field
-        document.reduxFocusedField = nil
+        document.reduxFocusedField = .sidebar
         
         // log("sidebarItemTapped: originalSelections: \(originalSelections)")
         

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeView.swift
@@ -19,7 +19,7 @@ struct SidebarListItemSwipeView<SidebarViewModel>: View where SidebarViewModel: 
     @Bindable var gestureViewModel: ItemViewModel
     
     var isSidebarFocused: Bool {
-        self.sidebarViewModel.isSidebarFocused
+        self.document.isSidebarFocused
     }
     
     var isSelected: Bool {

--- a/Stitch/Graph/Sidebar/ViewModel/LayersSidebarViewModel.swift
+++ b/Stitch/Graph/Sidebar/ViewModel/LayersSidebarViewModel.swift
@@ -24,9 +24,6 @@ final class LayersSidebarViewModel: ProjectSidebarObservable, Sendable {
     @MainActor var primary = Set<ItemID>()     // items selected because directly clicked
     @MainActor var lastFocused: ItemID?
     
-    // TODO: remove sidebar focus from here!!!!!
-    @MainActor var isSidebarFocused: Bool = false
-    
     // Option-drag duplication of layers
     @MainActor var haveDuplicated: Bool = false
     @MainActor var optionDragInProgress: Bool = false

--- a/Stitch/Graph/Sidebar/ViewModel/LayersSidebarViewModel.swift
+++ b/Stitch/Graph/Sidebar/ViewModel/LayersSidebarViewModel.swift
@@ -23,6 +23,8 @@ final class LayersSidebarViewModel: ProjectSidebarObservable, Sendable {
     // Selection state
     @MainActor var primary = Set<ItemID>()     // items selected because directly clicked
     @MainActor var lastFocused: ItemID?
+    
+    // TODO: remove sidebar focus from here!!!!!
     @MainActor var isSidebarFocused: Bool = false
     
     // Option-drag duplication of layers

--- a/Stitch/Graph/Sidebar/ViewModel/ProjectSidebarObservable.swift
+++ b/Stitch/Graph/Sidebar/ViewModel/ProjectSidebarObservable.swift
@@ -40,9 +40,6 @@ protocol ProjectSidebarObservable: AnyObject, Observable where ItemViewModel.ID 
     // e.g. user is hovering over or has selected a layer in the sidebar, which we then highlight in the preview window itself
     @MainActor var highlightedSidebarLayers: Set<Self.ItemID> { get set }
     
-    // tracks if sidebar is focused
-    @MainActor var isSidebarFocused: Bool { get set }
-    
     @MainActor var graphDelegate: GraphState? { get set }
 
     @MainActor func sidebarGroupCreated()

--- a/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
+++ b/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
@@ -189,7 +189,7 @@ extension StitchDocumentViewModel {
             return
         }
         
-        let activelySelectedLayers = self.visibleGraph.layersSidebarViewModel.isSidebarFocused
+        let activelySelectedLayers = self.isSidebarFocused
         
         if activelySelectedLayers {
             self.visibleGraph.sidebarSelectedItemsDuplicated(document: self)

--- a/Stitch/Graph/Util/NodeSelection/NodeSelectionUtil.swift
+++ b/Stitch/Graph/Util/NodeSelection/NodeSelectionUtil.swift
@@ -93,7 +93,7 @@ struct SelectAllShortcutKeyPressed: StitchDocumentEvent {
         
         // If we have at least one actively selected sidebar layers,
         // then select all layers, not canvas items.
-        if state.visibleGraph.layersSidebarViewModel.isSidebarFocused {
+        if state.isSidebarFocused {
             let allLayers = graph.orderedSidebarLayers.flattenedItems.map(\.id).toSet
             graph.sidebarSelectionState.primary = graph.sidebarSelectionState.primary.union(allLayers)
             
@@ -139,11 +139,6 @@ extension StitchDocumentViewModel {
         let nodesSelectedOnShift = self.graph.nodesAlreadySelectedAtStartOfShiftNodeCursorBoxDrag
         let isCurrentlyDragging = selectionBox != .zero
         let focusedGroupNode = self.groupNodeFocused?.groupNodeId
-        
-        // Unfocus sidebar
-        if self.visibleGraph.layersSidebarViewModel.isSidebarFocused {
-            self.visibleGraph.layersSidebarViewModel.isSidebarFocused = false            
-        }
         
         // TODO: pass shift down via the UIKit gesture handler
         let shiftHeld = graphState.keypressState.shiftHeldDuringGesture

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -216,10 +216,6 @@ extension GraphState {
         if document.openPortPreview != nil {
             document.openPortPreview = nil
         }
-        
-        if document.selectedInput != nil {
-            document.selectedInput = nil
-        }
     }
 }
 
@@ -330,11 +326,6 @@ extension GraphState {
         // Unfocus sidebar
         if self.layersSidebarViewModel.isSidebarFocused {
             self.layersSidebarViewModel.isSidebarFocused = false
-        }
-        
-        // De-select input
-        if self.documentDelegate?.selectedInput.isDefined ?? false {
-            self.documentDelegate?.selectedInput = nil
         }
     }
     

--- a/Stitch/Graph/ViewModel/GraphUI.swift
+++ b/Stitch/Graph/ViewModel/GraphUI.swift
@@ -209,10 +209,6 @@ extension GraphState {
             document.showCatalystProjectTitleModal = false
         }
         
-        if self.layersSidebarViewModel.isSidebarFocused {
-            self.layersSidebarViewModel.isSidebarFocused = false
-        }
-        
         if document.openPortPreview != nil {
             document.openPortPreview = nil
         }
@@ -322,11 +318,6 @@ extension GraphState {
         // Prevent render cycles if already selected
         guard !self.isCanvasItemSelected(canvasItemId) else { return }
         self.selection.selectedCanvasItems.insert(canvasItemId)
-        
-        // Unfocus sidebar
-        if self.layersSidebarViewModel.isSidebarFocused {
-            self.layersSidebarViewModel.isSidebarFocused = false
-        }
     }
     
     // TODO: signature could be tighter, e.g. method on `SelectionState` rather than `GraphState`

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -121,9 +121,6 @@ final class StitchDocumentViewModel: Sendable {
     
     @MainActor var openPortPreview: OpenedPortPreview?
     
-    // TODO: technically, we could allow for multiple inputs to be selected at a given time?
-    @MainActor var selectedInput: InputCoordinate?
-    
     // Screen sharing UX
     @MainActor var isScreenRecording = false
     


### PR DESCRIPTION
Cleans up logic by moving state handling to `reduxFocusedField`.

There were a few issues I saw where selection state wasn't resetting properly. This PR should both improve functionality and clean up code.