### PR TITLE
Improved keypress detection logic + regression fix

### DIFF
--- a/Stitch/Graph/Node/Patch/Type/Interaction/Keyboard/KeyPressActions.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/Keyboard/KeyPressActions.swift
@@ -129,14 +129,8 @@ extension StitchStore {
             return
         }
     
-        if document.reduxFocusedField.isDefined {
-            // log("KEY: KeyCharacterPressBegan: ignoring key press for char \(char) since some field is focused")
-            return
-        }
-        
-        // if insert node menu is open, ignore key presses:
-        if document.insertNodeMenuState.show {
-            // log("KEY: KeyCharacterPressBegan: ignoring key press for char \(char) since insert node menu is open")
+        // key press state only applies to prototype window focus
+        guard document.isPrototypePreviewFocused else {
             return
         }
 
@@ -211,7 +205,6 @@ extension Character {
             return nil
         }
     }
-    
 }
 
 
@@ -223,7 +216,8 @@ struct KeyCharacterPressEnded: StitchDocumentEvent {
         
         // log("KEY: KeyCharacterPressEnded: char: \(char)")
         
-        if state.reduxFocusedField.isDefined {
+        // key press state only applies to prototype window focus
+        guard state.isPrototypePreviewFocused else {
             // log("KEY: KeyCharacterPressBegan: ignoring key press for char \(char) since some field is focused")
             return
         }

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/TextField/PreviewTextFieldLayerUtils.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/TextField/PreviewTextFieldLayerUtils.swift
@@ -27,6 +27,17 @@ extension StitchDocumentViewModel {
             return false
         }
     }
+    
+    @MainActor
+    var isPrototypePreviewFocused: Bool {
+        switch self.reduxFocusedField {
+        case .prototypeWindow, .prototypeTextField:
+            return true
+            
+        default:
+            return false
+        }
+    }
 }
 
 extension FocusedUserEditField {


### PR DESCRIPTION
Recent changes broke old keypress detection which automatically failed if any focus state exists. The new logic requires the prototype to be in focus.

This is an improvement from past logic which didn't require prototype preview logic. Now our behavior equals Origami's.