### PR TITLE
Fixed disabled commands regressions

### DIFF
--- a/Stitch/App/Shortcut/ProjectsHomeCommands.swift
+++ b/Stitch/App/Shortcut/ProjectsHomeCommands.swift
@@ -22,7 +22,18 @@ struct ProjectsHomeCommands: Commands {
     }
     
     var textFieldFocused: Bool {
-        activeReduxFocusedField.isDefined || focusedField.isDefined
+        guard !focusedField.isDefined else {
+            return true
+        }
+        
+        switch activeReduxFocusedField {
+        case .sidebar, .prototypeWindow, .none:
+            // no text field in these cases
+            return false
+            
+        default:
+            return true
+        }
     }
     
     var disabledGraphDelete: Bool {

--- a/Stitch/App/Shortcut/ProjectsHomeCommands.swift
+++ b/Stitch/App/Shortcut/ProjectsHomeCommands.swift
@@ -25,6 +25,18 @@ struct ProjectsHomeCommands: Commands {
         activeReduxFocusedField.isDefined || focusedField.isDefined
     }
     
+    var disabledGraphDelete: Bool {
+        guard let document = store.currentDocument else {
+            return true
+        }
+        
+        if document.isSidebarFocused {
+            return document.visibleGraph.layersSidebarViewModel.selectionState.items.isEmpty
+        } else {
+            return document.visibleGraph.selectedCanvasItems.isEmpty
+        }
+    }
+    
     var body: some Commands {
         // MARK: no support for conditionally display commands--they'll never appear with an if statement
         GraphCommands(store: store,
@@ -209,7 +221,7 @@ struct ProjectsHomeCommands: Commands {
                                 key: DELETE_SELECTED_NODES_SHORTCUT,
                                 // empty list = do not require CMD
                                 eventModifiers: DELETE_SELECTED_NODES_SHORTCUT_MODIFIERS,
-                                disabled: textFieldFocused || !activeProject) {
+                                disabled: disabledGraphDelete) {
                 // deletes both selected nodes and selected comments
                 dispatch(DeleteShortcutKeyPressed())
             }


### PR DESCRIPTION
From recent changes where focus state is no longer just tracking text fields.

Also improves the delete shortcut to only be enabled for active sidebar/node selections depending on the focus state.