### PR TITLE
"Require Option for Shortcuts?" setting

### DIFF
--- a/Stitch/App/Customization/AppThemeActions.swift
+++ b/Stitch/App/Customization/AppThemeActions.swift
@@ -35,3 +35,26 @@ struct AppThemeChangedEvent: AppEvent {
         return .stateOnly(state)
     }
 }
+
+extension Bool {
+    static let defaultIsOptionRequiredForShortcuts = true
+}
+
+struct OptionRequiredForShortcutsChanged: StitchStoreEvent {
+
+    let newValue: Bool
+    
+    func handle(store: StitchStore) -> ReframeResponse<NoState> {
+        
+        log("OptionRequiredForShortcutsChanged: store.isOptionRequiredForShortcut was: \(store.isOptionRequiredForShortcut)")
+        log("OptionRequiredForShortcutsChanged: newValue.description: \(newValue.description)")
+        store.isOptionRequiredForShortcut = newValue
+        log("OptionRequiredForShortcutsChanged: store.isOptionRequiredForShortcut is now: \(store.isOptionRequiredForShortcut)")
+        
+        UserDefaults.standard.setValue(
+            newValue.description,
+            forKey: SAVED_IS_OPTION_REQUIRED_FOR_SHORTCUTS_KEY_NAME)
+        
+        return .shouldPersist
+    }
+}

--- a/Stitch/App/Shortcut/InsertNodeCommands.swift
+++ b/Stitch/App/Shortcut/InsertNodeCommands.swift
@@ -47,6 +47,14 @@ struct InsertNodeCommands: View {
         }
     }
     
+    var isOptionRequired: Bool {
+        store.isOptionRequiredForShortcut
+    }
+    
+    var modifiersAdjustedForOptionRequirement: EventModifiers {
+        isOptionRequired ? [.option] : []
+    }
+    
     var body: some View {
         Menu("Insert \(selectionLabel) Node") {
             if isLayerSidebarFocused {
@@ -86,7 +94,7 @@ struct InsertNodeCommands: View {
         SwiftUIShortcutView(title: "Value",
                             key: ADD_SPLITTER_NODE_SHORTCUT,
                             // empty list = do not require CMD
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisablePatch) {
             if hasSelectedInput {
                 dispatch(NodeCreatedWhileInputSelected(choice: .patch(.splitter)))
@@ -100,7 +108,7 @@ struct InsertNodeCommands: View {
         // Option + W = add Broadcaster
         SwiftUIShortcutView(title: "Wireless Broadcaster",
                             key: ADD_WIRELESS_NODE_SHORTCUT,
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisablePatch) {
             dispatch(NodeCreatedEvent(choice: .patch(.wirelessBroadcaster)))
             // TODO: probably not needed?
@@ -110,7 +118,7 @@ struct InsertNodeCommands: View {
         // Option + Shift + W = add Receiver
         SwiftUIShortcutView(title: "Wireless Receiver",
                             key: ADD_WIRELESS_NODE_SHORTCUT,
-                            eventModifiers: [.option, .shift],
+                            eventModifiers:  self.isOptionRequired ? [.option, .shift] : [.shift],
                             disabled: self.shouldDisablePatch) {
             dispatch(NodeCreatedEvent(choice: .patch(.wirelessReceiver)))
             // Note: the Option key seems to get stuck easily when Shift is also pressed?
@@ -123,7 +131,7 @@ struct InsertNodeCommands: View {
         // TODO: maybe it would be better if these options did not all show up in the Graph menu on Catalyst?
         SwiftUIShortcutView(title: "Add",
                             key: ADD_NODE_SHORTCUT,
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisablePatch) {
             if hasSelectedInput {
                 dispatch(NodeCreatedWhileInputSelected(choice: .patch(.add)))
@@ -134,7 +142,7 @@ struct InsertNodeCommands: View {
         
         SwiftUIShortcutView(title: "Subtract",
                             key: SUBTRACT_NODE_SHORTCUT,
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisablePatch) {
             if hasSelectedInput {
                 dispatch(NodeCreatedWhileInputSelected(choice: .patch(.subtract)))
@@ -145,7 +153,7 @@ struct InsertNodeCommands: View {
         
         SwiftUIShortcutView(title: "Multiply",
                             key: MULTIPLY_NODE_SHORTCUT,
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisablePatch) {
             if hasSelectedInput {
                 dispatch(NodeCreatedWhileInputSelected(choice: .patch(.multiply)))
@@ -156,7 +164,7 @@ struct InsertNodeCommands: View {
         
         SwiftUIShortcutView(title: "Divide",
                             key: DIVIDE_NODE_SHORTCUT,
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisablePatch) {
             if hasSelectedInput {
                 dispatch(NodeCreatedWhileInputSelected(choice: .patch(.divide)))
@@ -167,7 +175,7 @@ struct InsertNodeCommands: View {
         
         SwiftUIShortcutView(title: "Power",
                             key: POWER_NODE_SHORTCUT,
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisablePatch) {
             if hasSelectedInput {
                 dispatch(NodeCreatedWhileInputSelected(choice: .patch(.power)))
@@ -178,7 +186,7 @@ struct InsertNodeCommands: View {
         
         SwiftUIShortcutView(title: "Mod",
                             key: MOD_NODE_SHORTCUT,
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisablePatch) {
             if hasSelectedInput {
                 dispatch(NodeCreatedWhileInputSelected(choice: .patch(.mod)))
@@ -191,7 +199,7 @@ struct InsertNodeCommands: View {
         
         SwiftUIShortcutView(title: "Less Than",
                             key: LESS_THAN_NODE_SHORTCUT,
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisablePatch) {
             if hasSelectedInput {
                 dispatch(NodeCreatedWhileInputSelected(choice: .patch(.lessThan)))
@@ -202,7 +210,7 @@ struct InsertNodeCommands: View {
         
         SwiftUIShortcutView(title: "Greater Than",
                             key: GREATER_THAN_NODE_SHORTCUT,
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisablePatch) {
             if hasSelectedInput {
                 dispatch(NodeCreatedWhileInputSelected(choice: .patch(.greaterThan)))
@@ -213,7 +221,7 @@ struct InsertNodeCommands: View {
         
         SwiftUIShortcutView(title: "Equals",
                             key: EQUALS_NODE_SHORTCUT,
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisablePatch) {
             if hasSelectedInput {
                 dispatch(NodeCreatedWhileInputSelected(choice: .patch(.equals)))
@@ -226,7 +234,7 @@ struct InsertNodeCommands: View {
         
         SwiftUIShortcutView(title: "Classic Animation",
                             key: CLASSIC_ANIMATION_NODE_SHORTCUT,
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisablePatch) {
             if hasSelectedInput {
                 dispatch(NodeCreatedWhileInputSelected(choice: .patch(.classicAnimation)))
@@ -237,7 +245,7 @@ struct InsertNodeCommands: View {
         
         SwiftUIShortcutView(title: "Pop Animation",
                             key: POP_ANIMATION_NODE_SHORTCUT,
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisablePatch) {
             if hasSelectedInput {
                 dispatch(NodeCreatedWhileInputSelected(choice: .patch(.popAnimation)))
@@ -250,7 +258,7 @@ struct InsertNodeCommands: View {
         
         SwiftUIShortcutView(title: "Switch",
                             key: FLIP_SWITCH_NODE_SHORTCUT,
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisablePatch) {
             if hasSelectedInput {
                 dispatch(NodeCreatedWhileInputSelected(choice: .patch(.flipSwitch)))
@@ -261,7 +269,7 @@ struct InsertNodeCommands: View {
         
         SwiftUIShortcutView(title: "Option Picker",
                             key: OPTION_PICKER_NODE_SHORTCUT,
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisablePatch) {
             if hasSelectedInput {
                 dispatch(NodeCreatedWhileInputSelected(choice: .patch(.optionPicker)))
@@ -272,7 +280,7 @@ struct InsertNodeCommands: View {
         
         SwiftUIShortcutView(title: "Reverse Progress",
                             key: REVERSE_PROGRESS_NODE_SHORTCUT,
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisablePatch) {
             if hasSelectedInput {
                 dispatch(NodeCreatedWhileInputSelected(choice: .patch(.reverseProgress)))
@@ -283,7 +291,7 @@ struct InsertNodeCommands: View {
         
         SwiftUIShortcutView(title: "Transition",
                             key: TRANSITION_NODE_SHORTCUT,
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisablePatch) {
             if hasSelectedInput {
                 dispatch(NodeCreatedWhileInputSelected(choice: .patch(.transition)))
@@ -294,7 +302,7 @@ struct InsertNodeCommands: View {
         
         SwiftUIShortcutView(title: "Pulse",
                             key: PULSE_NODE_SHORTCUT,
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisablePatch) {
             if hasSelectedInput {
                 dispatch(NodeCreatedWhileInputSelected(choice: .patch(.pulse)))
@@ -307,7 +315,7 @@ struct InsertNodeCommands: View {
         
         SwiftUIShortcutView(title: "Delay",
                             key: DELAY_NODE_SHORTCUT,
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisablePatch) {
             if hasSelectedInput {
                 dispatch(NodeCreatedWhileInputSelected(choice: .patch(.delay)))
@@ -318,7 +326,7 @@ struct InsertNodeCommands: View {
         
         SwiftUIShortcutView(title: "Keyboard",
                             key: KEYBOARD_NODE_SHORTCUT,
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisablePatch) {
             if hasSelectedInput {
                 dispatch(NodeCreatedWhileInputSelected(choice: .patch(.keyboard)))
@@ -329,7 +337,7 @@ struct InsertNodeCommands: View {
         
         SwiftUIShortcutView(title: "Press Interaction",
                             key: PRESS_INTERACTION_NODE_SHORTCUT,
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisablePatch) {
             if hasSelectedInput {
                 dispatch(NodeCreatedWhileInputSelected(choice: .patch(.pressInteraction)))
@@ -343,7 +351,7 @@ struct InsertNodeCommands: View {
     var layers: some View {
         SwiftUIShortcutView(title: "Oval",
                             key: "O",
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisableLayer) {
             if hasSelectedInput {
                 dispatch(NodeCreatedWhileInputSelected(choice: .layer(.oval)))
@@ -354,7 +362,7 @@ struct InsertNodeCommands: View {
 
         SwiftUIShortcutView(title: "Rectangle",
                             key: "R",
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisableLayer) {
             if hasSelectedInput {
                 dispatch(NodeCreatedWhileInputSelected(choice: .layer(.rectangle)))
@@ -367,7 +375,7 @@ struct InsertNodeCommands: View {
         
         SwiftUIShortcutView(title: "Text",
                             key: "T",
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisableLayer) {
             if hasSelectedInput {
                 dispatch(NodeCreatedWhileInputSelected(choice: .layer(.text)))
@@ -380,7 +388,7 @@ struct InsertNodeCommands: View {
         
         SwiftUIShortcutView(title: "Group",
                             key: "G",
-                            eventModifiers: [.option],
+                            eventModifiers: modifiersAdjustedForOptionRequirement,
                             disabled: self.shouldDisableLayer) {
             if hasSelectedInput {
                 dispatch(NodeCreatedWhileInputSelected(choice: .layer(.group)))

--- a/Stitch/App/Shortcut/PatchNodeShortcutKeys.swift
+++ b/Stitch/App/Shortcut/PatchNodeShortcutKeys.swift
@@ -44,3 +44,51 @@ let OPTION_PICKER_NODE_SHORTCUT: KeyEquivalent = "O"
 
 
 // let SCROLL_NODE_SHORTCUT: KeyEquivalent = "Q"
+
+
+extension Character {
+    func patchFromShortcutKey() -> Patch? {
+        switch self {
+        case ADD_NODE_SHORTCUT.character.lowercased().toCharacter:
+            return .add
+        case SUBTRACT_NODE_SHORTCUT.character.lowercased().toCharacter:
+            return .subtract
+        case MULTIPLY_NODE_SHORTCUT.character.lowercased().toCharacter:
+            return .multiply
+        case DIVIDE_NODE_SHORTCUT.character.lowercased().toCharacter:
+            return .divide
+        case POWER_NODE_SHORTCUT.character.lowercased().toCharacter:
+            return .power
+        case MOD_NODE_SHORTCUT.character.lowercased().toCharacter:
+            return .mod
+        case LESS_THAN_NODE_SHORTCUT.character.lowercased().toCharacter:
+            return .lessThan
+        case GREATER_THAN_NODE_SHORTCUT.character.lowercased().toCharacter:
+            return .greaterThan
+        case CLASSIC_ANIMATION_NODE_SHORTCUT.character.lowercased().toCharacter:
+            return .classicAnimation
+        case POP_ANIMATION_NODE_SHORTCUT.character.lowercased().toCharacter:
+            return .popAnimation
+        case FLIP_SWITCH_NODE_SHORTCUT.character.lowercased().toCharacter:
+            return .flipSwitch
+        case DELAY_NODE_SHORTCUT.character.lowercased().toCharacter:
+            return .delay
+        case KEYBOARD_NODE_SHORTCUT.character.lowercased().toCharacter:
+            return .keyboard
+        case EQUALS_NODE_SHORTCUT.character.lowercased().toCharacter:
+            return .equals
+        case REVERSE_PROGRESS_NODE_SHORTCUT.character.lowercased().toCharacter:
+            return .reverseProgress
+        case TRANSITION_NODE_SHORTCUT.character.lowercased().toCharacter:
+            return .transition
+        case PULSE_NODE_SHORTCUT.character.lowercased().toCharacter:
+            return .pulse
+        case PRESS_INTERACTION_NODE_SHORTCUT.character.lowercased().toCharacter:
+            return .pressInteraction
+        case OPTION_PICKER_NODE_SHORTCUT.character.lowercased().toCharacter:
+            return .optionPicker
+        default:
+            return nil
+        }
+    }
+}

--- a/Stitch/App/Shortcut/ProjectsHomeCommands.swift
+++ b/Stitch/App/Shortcut/ProjectsHomeCommands.swift
@@ -181,10 +181,15 @@ struct ProjectsHomeCommands: Commands {
                     store.currentDocument?.keypressState.modifiers.remove(.shift)
                 }
                 
-                // TODO: maybe it would be better if these options did not all show up in the Graph menu on Catalyst?
                 SwiftUIShortcutView(title: "Insert Add Node",
                                     key: ADD_NODE_SHORTCUT,
-                                    eventModifiers: [.option],
+                                    
+                                    // Menu shows that key is "Option ="
+//                                    eventModifiers: [.option],
+                                    
+                                    // Menu shows that key is just "="
+                                    eventModifiers: [],
+                                    
                                     disabled: textFieldFocused) {
                     if hasSelectedInput {
                         dispatch(NodeCreatedWhileInputSelected(patch: .add))

--- a/Stitch/App/Shortcut/ProjectsHomeCommands.swift
+++ b/Stitch/App/Shortcut/ProjectsHomeCommands.swift
@@ -184,8 +184,7 @@ struct ProjectsHomeCommands: Commands {
                 // TODO: maybe it would be better if these options did not all show up in the Graph menu on Catalyst?
                 SwiftUIShortcutView(title: "Insert Add Node",
                                     key: ADD_NODE_SHORTCUT,
-//                                    eventModifiers: [.option],
-                                    eventModifiers: [],
+                                    eventModifiers: [.option],
                                     disabled: textFieldFocused) {
                     if hasSelectedInput {
                         dispatch(NodeCreatedWhileInputSelected(patch: .add))

--- a/Stitch/App/Shortcut/ProjectsHomeCommands.swift
+++ b/Stitch/App/Shortcut/ProjectsHomeCommands.swift
@@ -188,7 +188,9 @@ struct ProjectsHomeCommands: Commands {
 //                                    eventModifiers: [.option],
                                     
                                     // Menu shows that key is just "="
-                                    eventModifiers: [],
+//                                    eventModifiers: [],
+                                    
+                                    eventModifiers: self.isOptionRequiredForShortcut ? [.option] : [],
                                     
                                     disabled: textFieldFocused) {
                     if hasSelectedInput {

--- a/Stitch/App/Shortcut/ProjectsHomeCommands.swift
+++ b/Stitch/App/Shortcut/ProjectsHomeCommands.swift
@@ -37,7 +37,7 @@ struct ProjectsHomeCommands: Commands {
     }
     
     var hasSelectedInput: Bool {
-        self.store.currentDocument?.selectedInput.isDefined ?? false
+        self.store.currentDocument?.reduxFocusedField?.isInputPortSelected ?? false
     }
 
     // If option is NOT required for shortcuts, then we need to

--- a/Stitch/App/Shortcut/ProjectsHomeCommands.swift
+++ b/Stitch/App/Shortcut/ProjectsHomeCommands.swift
@@ -45,6 +45,11 @@ struct ProjectsHomeCommands: Commands {
         self.store.currentDocument?.selectedInput.isDefined ?? false
     }
 
+    // If option is NOT required for shortcuts, then we need to
+    var isOptionRequiredForShortcut: Bool {
+        self.store.isOptionRequiredForShortcut
+    }
+    
     var body: some Commands {
 
         CommandMenu("Graph") {
@@ -59,7 +64,7 @@ struct ProjectsHomeCommands: Commands {
                     dispatch(DirectoryUpdated())
                 }
             }
-
+                        
             if activeProject {
                 
                 Divider()
@@ -84,7 +89,7 @@ struct ProjectsHomeCommands: Commands {
                 }
                 
                 
-                // MARK: copy paste, cut paste
+                // MARK: COPY, PASTE, CUT
                 
                 // Not shown in menu when no active project;
                 // Disabled when we have focused text input
@@ -113,7 +118,11 @@ struct ProjectsHomeCommands: Commands {
                     dispatch(SelectedGraphItemsPasted())
                 }
                 
-                // MARK: insert node shortcuts
+                
+                // MARK: INSERTING NODES
+                
+                // tricky -- we still want to expose the shortcut to the user?
+                // ah, but origami doesn't show these at all, period.
                 
                 SwiftUIShortcutView(title: "Insert Unpack Node",
                                     key: ADD_UNPACK_NODE_SHORTCUT,
@@ -175,7 +184,8 @@ struct ProjectsHomeCommands: Commands {
                 // TODO: maybe it would be better if these options did not all show up in the Graph menu on Catalyst?
                 SwiftUIShortcutView(title: "Insert Add Node",
                                     key: ADD_NODE_SHORTCUT,
-                                    eventModifiers: [.option],
+//                                    eventModifiers: [.option],
+                                    eventModifiers: [],
                                     disabled: textFieldFocused) {
                     if hasSelectedInput {
                         dispatch(NodeCreatedWhileInputSelected(patch: .add))
@@ -384,6 +394,9 @@ struct ProjectsHomeCommands: Commands {
             } // if activeProject
 
         } // CommandMenu
+        
+        
+        // MARK: SHARE
         
         CommandGroup(after: .appInfo) {
             Menu {

--- a/Stitch/App/StitchApp.swift
+++ b/Stitch/App/StitchApp.swift
@@ -85,6 +85,7 @@ struct StitchApp: App {
             // Inject theme as environment variable
                 .environment(\.appTheme, self.store.appTheme)
                 .environment(\.edgeStyle, self.store.edgeStyle)
+                .environment(\.isOptionRequiredForShortcut, self.store.isOptionRequiredForShortcut)
         }
         
 

--- a/Stitch/App/View/AppSettingsView.swift
+++ b/Stitch/App/View/AppSettingsView.swift
@@ -138,6 +138,7 @@ struct PreviewWindowDeviceSelectionView: View {
 let DEFAULT_PREVIEW_WINDOW_DEVICE_KEY_NAME = "DefaultPreviewWindowDevice"
 let SAVED_APP_THEME_KEY_NAME = "SavedAppTheme"
 let SAVED_EDGE_STYLE_KEY_NAME = "SavedEdgeStyle"
+let SAVED_IS_OPTION_REQUIRED_FOR_SHORTCUTS_KEY_NAME = "SavedIsOptionRequiredForShortcuts"
 
 struct AppSettingsView: View {
     // Obtains last camera preference setting, if any
@@ -149,17 +150,23 @@ struct AppSettingsView: View {
 
     @AppStorage(SAVED_EDGE_STYLE_KEY_NAME) private var savedEdgeStyle: String = EdgeStyle.defaultEdgeStyle.rawValue
     
+    @AppStorage(SAVED_IS_OPTION_REQUIRED_FOR_SHORTCUTS_KEY_NAME) private var savedIsOptionRequiredForShortcuts: String = Bool.defaultIsOptionRequiredForShortcuts.description
+    
+    var isOptionRequiredForShortcut: Bool
+    
     @Environment(\.appTheme) var theme
     @Environment(\.edgeStyle) var edgeStyle
+//    @Environment(\.isOptionRequiredForShortcut) var isOptionRequiredForShortcut
         
     let allCameraChoices = getCameraPickerOptions()
 
     var body: some View {
-        VStack(alignment: .leading) {
+        VStack(alignment: .leading, spacing: 10) {
             cameraPicker
             themePicker
             edgeStylePicker
             defaultPreviewWindowDevicePicker
+            isOptionRequiredForShortcutsPicker
         }
     }
 
@@ -193,6 +200,7 @@ struct AppSettingsView: View {
                 .pickerStyle(.menu)
                 .padding(.leading, 10)
             }
+            
             StitchCaptionView("Set the main camera used throughout your projects")
         }
     }
@@ -258,6 +266,28 @@ struct AppSettingsView: View {
             StitchCaptionView("Set the default preview window device for new projects")
         }
     }
+
+    @ViewBuilder
+    var isOptionRequiredForShortcutsPicker: some View {
+        logInView("AppSettingsView: isOptionRequiredForShortcutsPicker: self.isOptionRequiredForShortcut: \(self.isOptionRequiredForShortcut)")
+        
+        let isRequired = self.isOptionRequiredForShortcut
+        let icon: String = isRequired ? "checkmark.square" : "square"
+        
+        VStack(alignment: .leading) {
+            HStack(alignment: .center) {
+                Text("Require Option for shortcuts?").fontWeight(.bold)
+                Image(systemName: icon)
+                    .onTapGesture {
+                        dispatch(OptionRequiredForShortcutsChanged(newValue: !isRequired))
+                    }
+            }
+            .padding(.bottom, 2)
+            
+            StitchCaptionView("If true, `Option + O`, rather than just `O`, adds an Option Picker to the canvas.")
+        }
+    }
+    
             
     func getCameraSelection(cameraID: String?) -> AVCaptureDevicePickerOption? {
         guard let cameraID = cameraID,
@@ -273,6 +303,6 @@ struct AppSettingsView: View {
 
 struct AppSettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        AppSettingsView()
+        AppSettingsView(isOptionRequiredForShortcut: true)
     }
 }

--- a/Stitch/App/View/StitchRootView.swift
+++ b/Stitch/App/View/StitchRootView.swift
@@ -27,6 +27,8 @@ struct StitchRootView: View {
     
     @AppStorage(SAVED_EDGE_STYLE_KEY_NAME) private var savedEdgeStyle: String = EdgeStyle.defaultEdgeStyle.rawValue
     
+    @AppStorage(SAVED_IS_OPTION_REQUIRED_FOR_SHORTCUTS_KEY_NAME) private var savedIsOptionRequiredForShortcuts: String = Bool.defaultIsOptionRequiredForShortcuts.description
+    
     @MainActor
     var alertState: ProjectAlertState {
         self.store.alertState
@@ -81,6 +83,7 @@ struct StitchRootView: View {
             
             dispatch(AppEdgeStyleChangedEvent(newEdgeStyle: .init(rawValue: savedEdgeStyle) ?? .defaultEdgeStyle))
             
+            dispatch(OptionRequiredForShortcutsChanged(newValue: .init(savedIsOptionRequiredForShortcuts) ?? Bool.defaultIsOptionRequiredForShortcuts))
         }
         .onChange(of: self.columnVisibility, initial: true) { oldValue, newValue in
             let fn = { (open: Bool) in dispatch(LeftSidebarSet(open: open)) }

--- a/Stitch/App/View/ViewUtil/StitchHostingController.swift
+++ b/Stitch/App/View/ViewUtil/StitchHostingController.swift
@@ -123,13 +123,13 @@ class StitchHostingController<T: View>: UIHostingController<T> {
     @MainActor
     override func pressesBegan(_ presses: Set<UIPress>,
                                with event: UIPressesEvent?) {
-        // log("KEY: StitchHostingController: name: \(name): pressesBegan: presses.first?.key: \(presses.first?.key)")
+        log("KEY: StitchHostingController: name: \(name): pressesBegan: presses.first?.key: \(presses.first?.key)")
         presses.first?.key.map(keyPressed)
         
         // If we don't have a key, we can't check whether we should
         // prevent this press from being passed down the responder chain.
         guard let key = presses.first?.key else {
-            // log("KEY: StitchHostingController: name: \(name): pressesBegan: no key")
+            log("KEY: StitchHostingController: name: \(name): pressesBegan: no key")
             super.pressesBegan(presses, with: event)
             return
         }
@@ -138,7 +138,7 @@ class StitchHostingController<T: View>: UIHostingController<T> {
         // Prevents up- and down-arrow keys from jumping the cursor to the start or end of the text when we merely want to increment or decrement the focused field's value.
         let isUpOrDownArrow = (key.keyCode == .keyboardUpArrow || key.keyCode == .keyboardDownArrow)
         if isUpOrDownArrow && self.inputTextFieldFocused {
-            // log("KEY: StitchHostingController: name: \(name): pressesBegan: will not pass arrow key down responder chain")
+            log("KEY: StitchHostingController: name: \(name): pressesBegan: will not pass arrow key down responder chain")
             return
         }
         
@@ -155,7 +155,7 @@ class StitchHostingController<T: View>: UIHostingController<T> {
          TODO: also never pass on the shift key?
          */
         if self.isOptionKey(key) {
-            // log("KEY: StitchHostingController: name: \(name): pressesBegan: option key held")
+            log("KEY: StitchHostingController: name: \(name): pressesBegan: option key held")
             return
         }
 #endif
@@ -167,7 +167,7 @@ class StitchHostingController<T: View>: UIHostingController<T> {
     @MainActor
     override func pressesEnded(_ presses: Set<UIPress>,
                                with event: UIPressesEvent?) {
-        // log("KEY: StitchHostingController: name: \(name): pressesEnded: presses.first?.key: \(presses.first?.key)")
+        log("KEY: StitchHostingController: name: \(name): pressesEnded: presses.first?.key: \(presses.first?.key)")
         presses.first?.key.map(keyReleased)
         super.pressesEnded(presses, with: event)
     }
@@ -175,7 +175,7 @@ class StitchHostingController<T: View>: UIHostingController<T> {
     @MainActor
     override func pressesCancelled(_ presses: Set<UIPress>,
                                    with event: UIPressesEvent?) {
-        // log("KEY: StitchHostingController: name: \(name): pressesCancelled: presses.first?.key: \(presses.first?.key)")
+        log("KEY: StitchHostingController: name: \(name): pressesCancelled: presses.first?.key: \(presses.first?.key)")
         presses.first?.key.map(keyReleased)
         super.pressesCancelled(presses, with: event)
     }
@@ -208,7 +208,7 @@ class StitchHostingController<T: View>: UIHostingController<T> {
 
     @MainActor
     func keyReleased(_ key: UIKey) {
-        // // log("KEY: StitchHostingController: name: \(name): keyReleased: key: \(key)")
+        log("KEY: StitchHostingController: name: \(name): keyReleased: key: \(key)")
         if let modifiers = key.asStitchKeyModifiers {
             dispatch(KeyModifierPressEnded(modifiers: modifiers))
         } else if let keyPress = key.characters.first,

--- a/Stitch/App/View/ViewUtil/StitchHostingController.swift
+++ b/Stitch/App/View/ViewUtil/StitchHostingController.swift
@@ -123,13 +123,13 @@ class StitchHostingController<T: View>: UIHostingController<T> {
     @MainActor
     override func pressesBegan(_ presses: Set<UIPress>,
                                with event: UIPressesEvent?) {
-        log("KEY: StitchHostingController: name: \(name): pressesBegan: presses.first?.key: \(presses.first?.key)")
+        // log("KEY: StitchHostingController: name: \(name): pressesBegan: presses.first?.key: \(presses.first?.key)")
         presses.first?.key.map(keyPressed)
         
         // If we don't have a key, we can't check whether we should
         // prevent this press from being passed down the responder chain.
         guard let key = presses.first?.key else {
-            log("KEY: StitchHostingController: name: \(name): pressesBegan: no key")
+            // log("KEY: StitchHostingController: name: \(name): pressesBegan: no key")
             super.pressesBegan(presses, with: event)
             return
         }
@@ -138,7 +138,7 @@ class StitchHostingController<T: View>: UIHostingController<T> {
         // Prevents up- and down-arrow keys from jumping the cursor to the start or end of the text when we merely want to increment or decrement the focused field's value.
         let isUpOrDownArrow = (key.keyCode == .keyboardUpArrow || key.keyCode == .keyboardDownArrow)
         if isUpOrDownArrow && self.inputTextFieldFocused {
-            log("KEY: StitchHostingController: name: \(name): pressesBegan: will not pass arrow key down responder chain")
+            // log("KEY: StitchHostingController: name: \(name): pressesBegan: will not pass arrow key down responder chain")
             return
         }
         
@@ -155,7 +155,7 @@ class StitchHostingController<T: View>: UIHostingController<T> {
          TODO: also never pass on the shift key?
          */
         if self.isOptionKey(key) {
-            log("KEY: StitchHostingController: name: \(name): pressesBegan: option key held")
+            // log("KEY: StitchHostingController: name: \(name): pressesBegan: option key held")
             return
         }
 #endif
@@ -167,7 +167,7 @@ class StitchHostingController<T: View>: UIHostingController<T> {
     @MainActor
     override func pressesEnded(_ presses: Set<UIPress>,
                                with event: UIPressesEvent?) {
-        log("KEY: StitchHostingController: name: \(name): pressesEnded: presses.first?.key: \(presses.first?.key)")
+        // log("KEY: StitchHostingController: name: \(name): pressesEnded: presses.first?.key: \(presses.first?.key)")
         presses.first?.key.map(keyReleased)
         super.pressesEnded(presses, with: event)
     }
@@ -175,7 +175,7 @@ class StitchHostingController<T: View>: UIHostingController<T> {
     @MainActor
     override func pressesCancelled(_ presses: Set<UIPress>,
                                    with event: UIPressesEvent?) {
-        log("KEY: StitchHostingController: name: \(name): pressesCancelled: presses.first?.key: \(presses.first?.key)")
+        // log("KEY: StitchHostingController: name: \(name): pressesCancelled: presses.first?.key: \(presses.first?.key)")
         presses.first?.key.map(keyReleased)
         super.pressesCancelled(presses, with: event)
     }
@@ -199,7 +199,10 @@ class StitchHostingController<T: View>: UIHostingController<T> {
         // TODO: key-modifiers (Tab, Shift etc.) and key-characters are not exclusive
         if let modifiers = key.asStitchKeyModifiers {
             dispatch(KeyModifierPressBegan(name: self.name, modifiers: modifiers))
-        } else if let keyPress = key.characters.first,
+        }
+        
+        // else
+        if let keyPress = key.characters.first,
                   // Don't listen to random char presses if we're only in the flyout or search bar etc.
                     !self.isOnlyForTextFieldHelp {
             dispatch(KeyCharacterPressBegan(char: keyPress))
@@ -208,7 +211,7 @@ class StitchHostingController<T: View>: UIHostingController<T> {
 
     @MainActor
     func keyReleased(_ key: UIKey) {
-        log("KEY: StitchHostingController: name: \(name): keyReleased: key: \(key)")
+        // log("KEY: StitchHostingController: name: \(name): keyReleased: key: \(key)")
         if let modifiers = key.asStitchKeyModifiers {
             dispatch(KeyModifierPressEnded(modifiers: modifiers))
         } else if let keyPress = key.characters.first,
@@ -307,7 +310,14 @@ class StitchHostingController<T: View>: UIHostingController<T> {
     override var keyCommands: [UIKeyCommand]? {
 
         if !ignoreKeyCommands {
-            let bindings = [escKeyBinding, zoomInBinding, zoomOutBinding, optionKeyBinding] + qwertyCommands + qwertyShiftCommands
+            let bindings = [escKeyBinding, zoomInBinding, zoomOutBinding, optionKeyBinding]
+            /*
+              TODO: dig deeper here, so we can use SwiftUI shortcuts consistently whether Option is required or note. For now, we want to be cautious about changing our keypress logic.
+             
+             UIKeyCommands seem to override modifier-free SwiftUI shortcuts (i.e. `.keyboardShortcut("a", modifiers: [])`;
+             but without UIKeyCommands we seem to receive a pressesBegan and pressesEnded at the same time?
+             */
+            + qwertyCommands + qwertyShiftCommands
 
             if usesArrowKeyBindings {
                 return arrowKeyBindings + bindings

--- a/Stitch/App/ViewModel/StitchStore.swift
+++ b/Stitch/App/ViewModel/StitchStore.swift
@@ -37,6 +37,7 @@ final class StitchStore: Sendable {
     // TODO: should be properly persisted
     @MainActor var edgeStyle: EdgeStyle = .defaultEdgeStyle
     @MainActor var appTheme: StitchTheme = .defaultTheme
+    @MainActor var isOptionRequiredForShortcut: Bool = .defaultIsOptionRequiredForShortcuts
     
     // MARK: must be stored here to prevent inspector retain cycle
     @MainActor var showsLayerInspector = false

--- a/Stitch/Graph/Edge/Model/EdgeStyle.swift
+++ b/Stitch/Graph/Edge/Model/EdgeStyle.swift
@@ -13,7 +13,6 @@ enum EdgeStyle: String, CaseIterable {
          curve = "Curve",
          line = "Line"
 
-//    static let defaultEdgeStyle: Self = .circuit
     static let defaultEdgeStyle: Self = .curve
 }
 

--- a/Stitch/Graph/Node/Patch/Type/Interaction/Keyboard/KeyPressActions.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/Keyboard/KeyPressActions.swift
@@ -157,8 +157,8 @@ extension StitchStore {
             if !self.isOptionRequiredForShortcut,
                let patch = char.patchFromShortcutKey() {
                 
-                if document.selectedInput.isDefined {
-                    document.nodeCreatedWhileInputSelected(patch: patch)
+                if document.reduxFocusedField?.isInputPortSelected ?? false {
+                    document.nodeCreatedWhileInputSelected(choice: .patch(patch))
                 } else {
                     document.handleNodeCreatedViaShortcut(patch: patch)
                 }

--- a/Stitch/Graph/Node/Patch/Type/Interaction/Keyboard/KeyPressActions.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/Keyboard/KeyPressActions.swift
@@ -157,10 +157,12 @@ extension StitchStore {
         if graph.edgeEditingState.isDefined {
             graph.keyCharPressedDuringEdgeEditingMode(char: char,
                                                       activeIndex: document.activeIndex)
-        } else if document.selectedInput.isDefined,
-                let patch = char.patchFromShortcutKey() {
+        }
+        else // if document.selectedInput.isDefined,
+                if let patch = char.patchFromShortcutKey() {
             document.nodeCreatedWhileInputSelected(patch: patch)
-        } else {
+        }
+        else {
             document.calculateAllKeyboardNodes()
         }
     }

--- a/Stitch/Graph/Node/Patch/Type/Interaction/Keyboard/KeyPressActions.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/Keyboard/KeyPressActions.swift
@@ -157,65 +157,31 @@ extension StitchStore {
         if graph.edgeEditingState.isDefined {
             graph.keyCharPressedDuringEdgeEditingMode(char: char,
                                                       activeIndex: document.activeIndex)
-        }
-        else if document.selectedInput.isDefined,
-                let patch = char.patchFromShortcutKey() {
-            document.nodeCreatedWhileInputSelected(patch: patch)
-        }
-        else {
+        } else {
+            
+            // If option is not required for shortcuts, treat the keypress as a shortcut too.
+            if !self.isOptionRequiredForShortcut,
+               let patch = char.patchFromShortcutKey() {
+                
+                if document.selectedInput.isDefined {
+                    document.nodeCreatedWhileInputSelected(patch: patch)
+                } else {
+                    document.handleNodeCreatedViaShortcut(patch: patch)
+                }
+            }
+            
+            // Always update the keyboard nodes
             document.calculateAllKeyboardNodes()
         }
+//        else if document.selectedInput.isDefined,
+//                let patch = char.patchFromShortcutKey() {
+//            document.nodeCreatedWhileInputSelected(patch: patch)
+//        }
+//        else {
+//            document.calculateAllKeyboardNodes()
+//        }
     }
 }
-
-extension Character {
-    func patchFromShortcutKey() -> Patch? {
-        switch self {
-        case ADD_NODE_SHORTCUT.character.lowercased().toCharacter:
-            return .add
-        case SUBTRACT_NODE_SHORTCUT.character.lowercased().toCharacter:
-            return .subtract
-        case MULTIPLY_NODE_SHORTCUT.character.lowercased().toCharacter:
-            return .multiply
-        case DIVIDE_NODE_SHORTCUT.character.lowercased().toCharacter:
-            return .divide
-        case POWER_NODE_SHORTCUT.character.lowercased().toCharacter:
-            return .power
-        case MOD_NODE_SHORTCUT.character.lowercased().toCharacter:
-            return .mod
-        case LESS_THAN_NODE_SHORTCUT.character.lowercased().toCharacter:
-            return .lessThan
-        case GREATER_THAN_NODE_SHORTCUT.character.lowercased().toCharacter:
-            return .greaterThan
-        case CLASSIC_ANIMATION_NODE_SHORTCUT.character.lowercased().toCharacter:
-            return .classicAnimation
-        case POP_ANIMATION_NODE_SHORTCUT.character.lowercased().toCharacter:
-            return .popAnimation
-        case FLIP_SWITCH_NODE_SHORTCUT.character.lowercased().toCharacter:
-            return .flipSwitch
-        case DELAY_NODE_SHORTCUT.character.lowercased().toCharacter:
-            return .delay
-        case KEYBOARD_NODE_SHORTCUT.character.lowercased().toCharacter:
-            return .keyboard
-        case EQUALS_NODE_SHORTCUT.character.lowercased().toCharacter:
-            return .equals
-        case REVERSE_PROGRESS_NODE_SHORTCUT.character.lowercased().toCharacter:
-            return .reverseProgress
-        case TRANSITION_NODE_SHORTCUT.character.lowercased().toCharacter:
-            return .transition
-        case PULSE_NODE_SHORTCUT.character.lowercased().toCharacter:
-            return .pulse
-        case PRESS_INTERACTION_NODE_SHORTCUT.character.lowercased().toCharacter:
-            return .pressInteraction
-        case OPTION_PICKER_NODE_SHORTCUT.character.lowercased().toCharacter:
-            return .optionPicker
-        default:
-            return nil
-        }
-    }
-    
-}
-
 
 struct KeyCharacterPressEnded: StitchDocumentEvent {
     let char: Character

--- a/Stitch/Graph/Node/Patch/Type/Interaction/Keyboard/KeyPressActions.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/Keyboard/KeyPressActions.swift
@@ -158,8 +158,8 @@ extension StitchStore {
             graph.keyCharPressedDuringEdgeEditingMode(char: char,
                                                       activeIndex: document.activeIndex)
         }
-        else // if document.selectedInput.isDefined,
-                if let patch = char.patchFromShortcutKey() {
+        else if document.selectedInput.isDefined,
+                let patch = char.patchFromShortcutKey() {
             document.nodeCreatedWhileInputSelected(patch: patch)
         }
         else {

--- a/Stitch/Graph/Node/Patch/Type/Interaction/Keyboard/KeyboardNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Interaction/Keyboard/KeyboardNode.swift
@@ -39,8 +39,11 @@ func keyboardEval(node: PatchNode,
 
     return node.loopedEval { values, _ in
         let character = values.first?.getString?.string ?? ""
-        // log("keyboardEval: op: character: \(character)")
-        // log("keyboardEval: op: keypressState.characters: \(keypressState.characters)")
-        return PortValues([.bool(keypressState.characters.contains(character))])
+        let keyPressed = keypressState.characters.contains(character)
+        //        if keyPressed {
+        //            log("keyboardEval: op: character: \(character)")
+        //            log("keyboardEval: op: keypressState.characters: \(keypressState.characters)")
+        //        }
+        return PortValues([.bool(keyPressed)])
     }
 }

--- a/Stitch/Graph/Node/Util/NodeCreatedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeCreatedAction.swift
@@ -107,6 +107,15 @@ struct NodeCreatedEvent: StitchDocumentEvent {
 
 extension StitchDocumentViewModel {
     
+    @MainActor
+    func handleNodeCreatedViaShortcut(patch: Patch) {
+        guard let node = self.nodeInserted(choice: .patch(patch)) else {
+            fatalErrorIfDebug()
+            return
+        }
+        self.visibleGraph.persistNewNode(node)
+    }
+    
     /// Only for insert-node-menu creation of nodes; shortcut key creation of nodes uses `viewPortCenter`
     @MainActor
     var newCanvasItemInsertionLocation: CGPoint {

--- a/Stitch/Graph/Node/Util/NodeCreatedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeCreatedAction.swift
@@ -23,6 +23,7 @@ struct NodeCreatedWhileInputSelected: StitchDocumentEvent {
 
 extension StitchDocumentViewModel {
     
+    // TODO: this can actually only ever be for creating a PatchNode ?
     @MainActor
     func nodeCreatedWhileInputSelected(choice: NodeKind) {
         let state = self

--- a/Stitch/Graph/View/Util/EnvironmentValues.swift
+++ b/Stitch/Graph/View/Util/EnvironmentValues.swift
@@ -20,6 +20,11 @@ struct EdgeStyleKey: EnvironmentKey {
     static let defaultValue: EdgeStyle = .defaultEdgeStyle
 }
 
+// default true
+struct IsOptionRequiredForShortcut: EnvironmentKey, Hashable {
+    static let defaultValue: Bool = true
+}
+
 struct SafeAreaInsetsEnvironmentKey: EnvironmentKey, Hashable {
     static let defaultValue = SafeAreaInsets()
 }
@@ -36,6 +41,11 @@ extension EnvironmentValues {
         set { self[AppThemeKey.self] = newValue }
     }
 
+    var isOptionRequiredForShortcut: Bool {
+        get { self[IsOptionRequiredForShortcut.self] }
+        set { self[IsOptionRequiredForShortcut.self] = newValue }
+    }
+    
     var edgeStyle: EdgeStyle {
         get { self[EdgeStyleKey.self] }
         set { self[EdgeStyleKey.self] = newValue }

--- a/Stitch/Home/View/ProjectsHomeView.swift
+++ b/Stitch/Home/View/ProjectsHomeView.swift
@@ -80,7 +80,9 @@ struct ProjectsHomeView: View {
         .stitchSheet(isPresented: alertState.showAppSettings,
                      titleLabel: "Settings",
                      hideAction: store.hideAppSettingsSheet,
-                     sheetBody: { AppSettingsView() })
+                     sheetBody: {
+            AppSettingsView(isOptionRequiredForShortcut: store.isOptionRequiredForShortcut)
+        })
         .stitchSheet(isPresented: store.showsSampleProjectModal,
                      titleLabel: "Sample Projects",
                      hideAction: { store.showsSampleProjectModal = false }) {


### PR DESCRIPTION

### prototype window vs canvas focus is important when option is not required

https://github.com/user-attachments/assets/95ae0ccc-5a36-45b2-9410-f19b7555c954

### different file menu shortcut depends when option required vs not

<img width="591" alt="Screenshot 2025-05-19 at 11 51 03 PM" src="https://github.com/user-attachments/assets/056874db-1674-44bd-b173-97f0b4923682" />

<img width="530" alt="Screenshot 2025-05-19 at 11 51 16 PM" src="https://github.com/user-attachments/assets/16c105f4-7a38-4073-84c3-0ead378de954" />




