### PR TITLE
Do not disable patch shortcut when input selected

### DIFF
--- a/Stitch/App/Shortcut/InsertNodeCommands.swift
+++ b/Stitch/App/Shortcut/InsertNodeCommands.swift
@@ -30,7 +30,7 @@ struct InsertNodeCommands: View {
     
     var shouldDisablePatch: Bool {
         switch document.reduxFocusedField {
-        case .any, .none:
+        case .any, .none, .nodeInputPortSelection:
             // Disable all scenarios except when there's any selection, no selection, or an input port is selected
             return false
         default:


### PR DESCRIPTION
Regression from cleaning up the patch shortcuts.

<img width="544" alt="Screenshot 2025-05-20 at 10 31 55 AM" src="https://github.com/user-attachments/assets/2c6abc72-7a1b-4632-84b9-8885bf33bf9d" />
