### PR TITLE
Fix 'option not required' shortcuts for pack, unpack and splitter

### DIFF
--- a/Stitch/App/Shortcut/PatchNodeShortcutKeys.swift
+++ b/Stitch/App/Shortcut/PatchNodeShortcutKeys.swift
@@ -105,6 +105,15 @@ extension Character {
         
         switch lowercaseCharacter {
         
+        case ADD_PACK_NODE_SHORTCUT.character.lowercased().toCharacter:
+            return .sizePack
+            
+        case ADD_UNPACK_NODE_SHORTCUT.character.lowercased().toCharacter:
+            return .sizeUnpack
+
+        case ADD_SPLITTER_NODE_SHORTCUT.character.lowercased().toCharacter:
+            return .splitter
+            
         case ADD_WIRELESS_NODE_SHORTCUT.character.lowercased().toCharacter:
             return isShiftDown ? .wirelessReceiver : .wirelessBroadcaster
             


### PR DESCRIPTION
In the future an enum of all our shortcuts would be a good idea, so we don't miss any.