### PR TITLE
"About" popover for patches and layers

### DIFF
--- a/Guides/Layer.md
+++ b/Guides/Layer.md
@@ -93,7 +93,19 @@ A cylinder 3D shape, which can be used inside a Reality View.
 * Metallic
 
 ## Group
+Groups multiple layers into a single composite layer. Use this to organize layers hierarchically and apply transforms, clipping, or effects to an entire set of child layers at once.
 
+*Inputs*
+* Layer contents (the child layers to render inside the group)
+* Position (X/Y)
+* Rotation X
+* Rotation Y
+* Rotation Z
+* Size (Width/Height)
+* Opacity
+* Scale
+* Anchoring
+* Z-Index
 
 ## Hit Area
 Adds interaction to a specific rectangle in the Preview Window.

--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -55,7 +55,6 @@
 		B50BC9E42D77881900311551 /* StitchEngine in Frameworks */ = {isa = PBXBuildFile; productRef = B50BC9E32D77881900311551 /* StitchEngine */; };
 		B50C897B2864E2750032E95D /* DelayedEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C897A2864E2750032E95D /* DelayedEffect.swift */; };
 		B50CE3082908D0C40065378E /* StitchTextEditingField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50CE3072908D0C40065378E /* StitchTextEditingField.swift */; };
-		B50F41682C1EB4320082262F /* StitchViewKit in Frameworks */ = {isa = PBXBuildFile; productRef = B50F41672C1EB4320082262F /* StitchViewKit */; };
 		B50F41712C1F52C00082262F /* LayerInspectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50F41702C1F52C00082262F /* LayerInspectorView.swift */; };
 		B51523BA2B8C2F7A000042CF /* ProjectLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51523B92B8C2F79000042CF /* ProjectLoader.swift */; };
 		B51523BC2B8C2FB1000042CF /* DocumentLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51523BB2B8C2FB1000042CF /* DocumentLoader.swift */; };
@@ -177,6 +176,7 @@
 		B5770BA32D3ACF1D0013AD09 /* Model3DView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5770BA22D3ACF1C0013AD09 /* Model3DView.swift */; };
 		B57967522B5F2BF8007F5F24 /* SchemaObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57967512B5F2BF8007F5F24 /* SchemaObserver.swift */; };
 		B57B27392A77522A007D6A4F /* FieldValueNumberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57B27382A77522A007D6A4F /* FieldValueNumberView.swift */; };
+		B57C8EAF2DE5408300942EDF /* GroupCandidate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57C8EAE2DE5407E00942EDF /* GroupCandidate.swift */; };
 		B57F3A802946CE4700DFC0AE /* VisibleNodesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57F3A7F2946CE4700DFC0AE /* VisibleNodesViewModel.swift */; };
 		B57F3A822947B4BC00DFC0AE /* SideEffectCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57F3A812947B4BC00DFC0AE /* SideEffectCoordinator.swift */; };
 		B57F3A84294A85EC00DFC0AE /* GraphBackgroundGestureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57F3A83294A85EC00DFC0AE /* GraphBackgroundGestureView.swift */; };
@@ -1198,6 +1198,7 @@
 		B5770BA22D3ACF1C0013AD09 /* Model3DView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model3DView.swift; sourceTree = "<group>"; };
 		B57967512B5F2BF8007F5F24 /* SchemaObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaObserver.swift; sourceTree = "<group>"; };
 		B57B27382A77522A007D6A4F /* FieldValueNumberView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldValueNumberView.swift; sourceTree = "<group>"; };
+		B57C8EAE2DE5407E00942EDF /* GroupCandidate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupCandidate.swift; sourceTree = "<group>"; };
 		B57F3A7F2946CE4700DFC0AE /* VisibleNodesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisibleNodesViewModel.swift; sourceTree = "<group>"; };
 		B57F3A812947B4BC00DFC0AE /* SideEffectCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideEffectCoordinator.swift; sourceTree = "<group>"; };
 		B57F3A83294A85EC00DFC0AE /* GraphBackgroundGestureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphBackgroundGestureView.swift; sourceTree = "<group>"; };
@@ -2018,7 +2019,6 @@
 				ECE585792DB6CC8700749ED3 /* StitchEngine in Frameworks */,
 				B5DB632E2C61A8C900B78B68 /* StitchEngine in Frameworks */,
 				EC7784CF27053D9700B662DD /* ZIPFoundation in Frameworks */,
-				B50F41682C1EB4320082262F /* StitchViewKit in Frameworks */,
 				EC1137382719F9B400ADCA72 /* OrderedCollections in Frameworks */,
 				B51D8A022CD13D420016CCDA /* StitchEngine in Frameworks */,
 				E42AAE4C2D4844EE002D187D /* Sentry in Frameworks */,
@@ -2599,6 +2599,7 @@
 		B55500F12C1BC1AC0081C3F1 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				B57C8EAE2DE5407E00942EDF /* GroupCandidate.swift */,
 				B5CB68312CC99FD400DFC660 /* ProjectSidebarTab.swift */,
 				B555010E2C1BD1810081C3F1 /* SidebarItem */,
 				B55501082C1BCBF20081C3F1 /* Gesture */,
@@ -4844,7 +4845,6 @@
 				EC17DF0828F626660042BF4F /* MathParser */,
 				EC91034929109DF3007C548E /* SoulverCore */,
 				ECD5438D29A003F8009D0A30 /* DisplayLink */,
-				B50F41672C1EB4320082262F /* StitchViewKit */,
 				B5FBE3C32C4195B3006DA0A7 /* DirectoryWatcher */,
 				B5386FAF2C9A929B00AD8065 /* StitchEngine */,
 				B51D8A012CD13D420016CCDA /* StitchEngine */,
@@ -4949,7 +4949,6 @@
 				EC17DF0728F626660042BF4F /* XCRemoteSwiftPackageReference "DDMathParser" */,
 				EC91034829109DF3007C548E /* XCRemoteSwiftPackageReference "SoulverCore" */,
 				ECD5438C29A003F8009D0A30 /* XCRemoteSwiftPackageReference "DisplayLink" */,
-				B50F41662C1EB4320082262F /* XCRemoteSwiftPackageReference "StitchViewKit" */,
 				B5FBE3C22C4195B3006DA0A7 /* XCRemoteSwiftPackageReference "DirectoryWatcher" */,
 				E4A848A92D32FCFA0029AFDE /* XCRemoteSwiftPackageReference "supabase-swift" */,
 				E42AAE4A2D4844EE002D187D /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
@@ -5394,6 +5393,7 @@
 				B5EFD5C12D64EC5F006A68FB /* StitchAIRequest.swift in Sources */,
 				ECA92A28260A6A3400281B52 /* DelayNode.swift in Sources */,
 				ECB9A86B2AEB4935006E65EE /* SaturationSliderView.swift in Sources */,
+				B57C8EAF2DE5408300942EDF /* GroupCandidate.swift in Sources */,
 				EC5C6C3A2C2DAE690023D0C0 /* LLMActionRecording.swift in Sources */,
 				E41685E128A3FA5800731889 /* PreviewModel3DLayer.swift in Sources */,
 				EC1D03BD2CFF86FA0094EE9F /* NativeScrollInteraction.swift in Sources */,
@@ -6834,14 +6834,6 @@
 				revision = 937b763c43c1bc7cd5b3182455b9eef01c218a5b;
 			};
 		};
-		B50F41662C1EB4320082262F /* XCRemoteSwiftPackageReference "StitchViewKit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/StitchDesign/StitchViewKit.git";
-			requirement = {
-				kind = revision;
-				revision = f771d9ae644935d1e1acfb861be00f403de083b5;
-			};
-		};
 		B5FBE3C22C4195B3006DA0A7 /* XCRemoteSwiftPackageReference "DirectoryWatcher" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GianniCarlo/DirectoryWatcher.git";
@@ -6971,11 +6963,6 @@
 		B50BC9E32D77881900311551 /* StitchEngine */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = StitchEngine;
-		};
-		B50F41672C1EB4320082262F /* StitchViewKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = B50F41662C1EB4320082262F /* XCRemoteSwiftPackageReference "StitchViewKit" */;
-			productName = StitchViewKit;
 		};
 		B51D8A012CD13D420016CCDA /* StitchEngine */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stitch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9e165734ead499e7e0eeef385a8613539873df54cf2db7c5dbd5b819fd5dbee3",
+  "originHash" : "5b1ad2afa273b5db914d430621bb07a7c36cbecbab389ff5b68383186fc9a8f8",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -176,14 +176,6 @@
       "location" : "https://github.com/StitchDesign/StitchSchemaKit",
       "state" : {
         "revision" : "937b763c43c1bc7cd5b3182455b9eef01c218a5b"
-      }
-    },
-    {
-      "identity" : "stitchviewkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StitchDesign/StitchViewKit.git",
-      "state" : {
-        "revision" : "f771d9ae644935d1e1acfb861be00f403de083b5"
       }
     },
     {

--- a/Stitch/Graph/Menu/InsertNodeMenu/Model/InsertNodeMenuOption.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/Model/InsertNodeMenuOption.swift
@@ -13,22 +13,23 @@ struct ComponentDisplayData: Equatable, Hashable {
     var name: String // i.e. GroupNode.name
 }
 
-struct InsertNodeMenuOptionData: Hashable, Identifiable, Equatable {
-    var id = UUID() // id not needed?
-    var data: InsertNodeMenuOption
-}
-
 extension NodeViewModel {
     @MainActor
-    var asActiveSelection: InsertNodeMenuOptionData {
-        switch self.kind {
+    var asActiveSelection: InsertNodeMenuOption {
+        self.kind.insertNodeMenuOption
+    }
+}
+
+extension NodeKind {
+    var insertNodeMenuOption: InsertNodeMenuOption {
+        switch self {
         case .patch(let x):
-            return .init(data: .patch(x))
+            return .patch(x)
         case .layer(let x):
-            return .init(data: .layer(x))
+            return .layer(x)
         default:
             fatalErrorIfDebug()
-            return .init(data: .patch(.splitter))
+            return .patch(.splitter)
         }
     }
 }
@@ -38,6 +39,12 @@ enum InsertNodeMenuOption: Hashable, Equatable {
          layer(Layer),
          customComponent(ComponentDisplayData),
          defaultComponent(DefaultComponents)
+}
+
+extension InsertNodeMenuOption: Identifiable {
+    var id: String {
+        self.displayTitle
+    }
 }
 
 extension InsertNodeMenuOption {
@@ -93,16 +100,16 @@ extension InsertNodeMenuOption {
     }
 }
 
-extension [InsertNodeMenuOptionData] {
-    var defaultComponents: [InsertNodeMenuOptionData] {
-        self.filter(\.data.isDefaultComponent)
+extension [InsertNodeMenuOption] {
+    var defaultComponents: [InsertNodeMenuOption] {
+        self.filter(\.isDefaultComponent)
     }
 
-    var customComponents: [InsertNodeMenuOptionData] {
-        self.filter(\.data.isCustomComponent)
+    var customComponents: [InsertNodeMenuOption] {
+        self.filter(\.isCustomComponent)
     }
 
-    var nodes: [InsertNodeMenuOptionData] {
-        self.filter { !$0.data.isCustomComponent && !$0.data.isDefaultComponent }
+    var nodes: [InsertNodeMenuOption] {
+        self.filter { !$0.isCustomComponent && !$0.isDefaultComponent }
     }
 }

--- a/Stitch/Graph/Menu/InsertNodeMenu/Model/InsertNodeMenuState.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/Model/InsertNodeMenuState.swift
@@ -31,10 +31,10 @@ struct InsertNodeMenuState: Hashable {
     var show = false
     // Moved here from StitchDocumentViewModel, since only used by 
     var doubleTapLocation: CGPoint?
-    var searchResults: [InsertNodeMenuOptionData] = allSearchOptions
+    var searchResults: [InsertNodeMenuOption] = allSearchOptions
     // Ensures an option is selected when the menu appears
     // Assumption: can be nil if user filters for a string no node matches, e.g. "QW@#1"
-    var activeSelection: InsertNodeMenuOptionData? = Self.startingActiveSelection
+    var activeSelection: InsertNodeMenuOption? = Self.startingActiveSelection
     var searchQuery: String?
     var isGeneratingAINode: Bool = false
     var isFromAIGeneration: Bool = false {
@@ -50,13 +50,13 @@ struct InsertNodeMenuState: Hashable {
     static let startingActiveSelection = allSearchOptions.first
     // TODO: needs to be dynamic, since we now must load in custom components
     
-    static var allSearchOptions: [InsertNodeMenuOptionData] {
+    static var allSearchOptions: [InsertNodeMenuOption] {
         // Must appear in the same order as we display them in InsertNodeMenu,
         // else key up and down break.
         Layer.searchableLayers
-            .map { InsertNodeMenuOptionData(data: .layer($0)) } +
+            .map { .layer($0) } +
             Patch.searchablePatches
-            .map { InsertNodeMenuOptionData(data: .patch($0)) }
+            .map { .patch($0) }
         //            Layer.searchableLayers
         //            .map { InsertNodeMenuOptionData(data: .layer($0)) }
         //            + DefaultComponents.allCases

--- a/Stitch/Graph/Menu/InsertNodeMenu/Util/InsertNodeMenuActions.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/Util/InsertNodeMenuActions.swift
@@ -76,7 +76,7 @@ struct CloseAndResetInsertNodeMenu: StitchDocumentEvent {
 struct AddNodeButtonPressed: StitchDocumentEvent {
     func handle(state: StitchDocumentViewModel) {
         
-        guard let nodeKind = state.insertNodeMenuState.activeSelection?.data.kind else {
+        guard let nodeKind = state.insertNodeMenuState.activeSelection?.kind else {
             return
         }
         

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuNodeDescriptionView.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuNodeDescriptionView.swift
@@ -27,6 +27,16 @@ struct InsertNodeMenuNodeDescriptionView: View {
     }
 }
 
+struct GraphNodeDescriptionView: View {
+    let option: InsertNodeMenuOption
+    
+    var body: some View {
+        NodeDescriptionView(option: option)
+            .frame(width: 500)  // maxWidth breaks the popover, cutting content short at times
+            .padding()
+    }
+}
+
 struct NodeDescriptionView: View {
     let option: InsertNodeMenuOption
     

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuNodeDescriptionView.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuNodeDescriptionView.swift
@@ -10,32 +10,40 @@ import StitchSchemaKit
 
 /// Displays the resulting node based on the presented query in `InsertNodeMenu`.
 struct InsertNodeMenuNodeDescriptionView: View {
-    let activeSelection: InsertNodeMenuOptionData?
+    let activeSelection: InsertNodeMenuOption?
 
     var body: some View {
         VStack(alignment: .leading, spacing: .zero) {
             if let activeSelection = activeSelection {
                 ScrollView(showsIndicators: false) {
-                    VStack(alignment: .leading, spacing: .zero) {
-                        let descriptionTitle = try? AttributedString(
-                            styledMarkdown: "# \(activeSelection.data.displayTitle)",
-                            isTitle: true)
-                        
-                        Text(descriptionTitle ?? "Failed to retrieve Markdown-formatted title")
-                        
-                        let descriptionBody = try? AttributedString(
-                            styledMarkdown: activeSelection.data.displayDescription,
-                            isTitle: false)
-                        
-                        Text(descriptionBody ?? "Failed to retrieve Markdown-formatted body")
-                            .padding(.bottom, INSERT_NODE_MENU_SCROLL_LIST_BOTTOM_PADDING)
-                    }
+                    NodeDescriptionView(option: activeSelection)
                     .padding([.leading], 8)
                 }
             }
         }
         //        .frame(width: 460, height: 300, alignment: .leading)
         .frame(width: 460, alignment: .leading)
+    }
+}
+
+struct NodeDescriptionView: View {
+    let option: InsertNodeMenuOption
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: .zero) {
+            let descriptionTitle = try? AttributedString(
+                styledMarkdown: "# \(option.displayTitle)",
+                isTitle: true)
+            
+            Text(descriptionTitle ?? "Failed to retrieve Markdown-formatted title")
+            
+            let descriptionBody = try? AttributedString(
+                styledMarkdown: option.displayDescription,
+                isTitle: false)
+            
+            Text(descriptionBody ?? "Failed to retrieve Markdown-formatted body")
+                .padding(.bottom, INSERT_NODE_MENU_SCROLL_LIST_BOTTOM_PADDING)
+        }
     }
 }
 

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuNodeDescriptionView.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuNodeDescriptionView.swift
@@ -17,7 +17,8 @@ struct InsertNodeMenuNodeDescriptionView: View {
             if let activeSelection = activeSelection {
                 ScrollView(showsIndicators: false) {
                     NodeDescriptionView(option: activeSelection)
-                    .padding([.leading], 8)
+                        .padding(.bottom, INSERT_NODE_MENU_SCROLL_LIST_BOTTOM_PADDING)
+                        .padding([.leading], 8)
                 }
             }
         }
@@ -42,7 +43,6 @@ struct NodeDescriptionView: View {
                 isTitle: false)
             
             Text(descriptionBody ?? "Failed to retrieve Markdown-formatted body")
-                .padding(.bottom, INSERT_NODE_MENU_SCROLL_LIST_BOTTOM_PADDING)
         }
     }
 }

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuSearchResults.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuSearchResults.swift
@@ -10,15 +10,15 @@ import StitchSchemaKit
 
 struct InsertNodeMenuSearchResults: View {
 
-    @State private var nodeResultSizes: [UUID: CGRect] = .init()
+    @State private var nodeResultSizes: [InsertNodeMenuOption: CGRect] = .init()
     @State private var localId = UUID()
 
     @Environment(\.appTheme) var theme
 
     // All the nodes and components (default or custom) that met the entered search criteria
-    let searchResults: [InsertNodeMenuOptionData]
+    let searchResults: [InsertNodeMenuOption]
 
-    let activeSelection: InsertNodeMenuOptionData?
+    let activeSelection: InsertNodeMenuOption?
 
     // Updated by bottomFooter's FooterSizeReader
     @Binding var footerRect: CGRect
@@ -26,15 +26,15 @@ struct InsertNodeMenuSearchResults: View {
     let show: Bool
     
     // TODO: iterate through DefaultComponents enum
-    var defaultComponents: [InsertNodeMenuOptionData] {
+    var defaultComponents: [InsertNodeMenuOption] {
         searchResults.defaultComponents
     }
 
-    var customComponents: [InsertNodeMenuOptionData] {
+    var customComponents: [InsertNodeMenuOption] {
         searchResults.customComponents
     }
 
-    var nodes: [InsertNodeMenuOptionData] {
+    var nodes: [InsertNodeMenuOption] {
         searchResults.nodes
     }
 
@@ -45,7 +45,7 @@ struct InsertNodeMenuSearchResults: View {
                     
                     if !nodes.isEmpty {
                         Section {
-                            ForEach(nodes, id: \.self) {
+                            ForEach(nodes) {
 
                                 let isLast = $0.id == nodes.last?.id
 
@@ -56,8 +56,8 @@ struct InsertNodeMenuSearchResults: View {
                                     // else we lose `.ultraThinMaterial` effect
                                     .padding(.bottom, isLast ? INSERT_NODE_MENU_SCROLL_LIST_BOTTOM_PADDING : 0)
                                     .background(InsertNodeResultSizeReader(
-                                                    id: $0.id,
-                                                    title: $0.data.displayTitle,
+                                                    option: $0,
+                                                    title: $0.displayTitle,
                                                     nodeResultSizes: self.$nodeResultSizes))
                             }
                         } header: {
@@ -79,24 +79,24 @@ struct InsertNodeMenuSearchResults: View {
             .onChange(of: activeSelection, initial: true) { _, newActiveSelection in
                 
                 // Note: using guard statements for easier debugging
-                guard let newActiveSelection: InsertNodeMenuOptionData = newActiveSelection else {
+                guard let newActiveSelection: InsertNodeMenuOption = newActiveSelection else {
                     // log("InsertNodeMenuSearchResults: no active selection")
                     return
                 }
                 
-                guard let bounds = self.nodeResultSizes[newActiveSelection.id] else {
-                    // log("InsertNodeMenuSearchResults: no bounds for selection \(newActiveSelection.data.displayTitle), will default to regular proxy.scrollTo")
+                guard let bounds = self.nodeResultSizes[newActiveSelection] else {
+                    // log("InsertNodeMenuSearchResults: no bounds for selection \(newActiveSelection.displayTitle), will default to regular proxy.scrollTo")
                     proxy.scrollTo(newActiveSelection.id)
                     return
                 }
                 
                 guard self.footerRect.intersects(bounds) else {
-                    // log("InsertNodeMenuSearchResults: no intersection for footerRect \(footerRect) and bounds \(bounds) of selection \(newActiveSelection.data.displayTitle), will default to regular proxy.scrollTo")
+                    // log("InsertNodeMenuSearchResults: no intersection for footerRect \(footerRect) and bounds \(bounds) of selection \(newActiveSelection.displayTitle), will default to regular proxy.scrollTo")
                     proxy.scrollTo(newActiveSelection.id)
                     return
                 }
                 
-                // log("InsertNodeMenuSearchResults: special API: had intersection for footerRect \(footerRect) and bounds \(bounds) of selection \(newActiveSelection.data.displayTitle)")
+                // log("InsertNodeMenuSearchResults: special API: had intersection for footerRect \(footerRect) and bounds \(bounds) of selection \(newActiveSelection.displayTitle)")
                 
                 proxy.scrollTo(newActiveSelection.id,
                                anchor: .init(x: 0, y: 0.775))
@@ -115,21 +115,21 @@ struct InsertNodeMenuSearchResults: View {
     }
 
     @MainActor
-    func searchResultButton(_ option: InsertNodeMenuOptionData) -> some View {
+    func searchResultButton(_ option: InsertNodeMenuOption) -> some View {
         VStack(spacing: 0) {
 
             StitchButton(action: {
                 dispatch(InsertNodeSelectionChanged(selection: option))
             }, label: {
                 HStack {
-                    StitchTextView(string: option.data.displayTitle)
+                    StitchTextView(string: option.displayTitle)
                         .fontWeight(.light)
                         .offset(x: 8)
                     Spacer()
                 }
                 .background {
                     RoundedRectangle(cornerRadius: 8)
-                        .fill(option.data == activeSelection?.data ? selectionColor : Color.clear)
+                        .fill(option == activeSelection ? selectionColor : Color.clear)
                         .frame(width: INSERT_NODE_MENU_SEARCH_RESULTS_BUTTON_WIDTH,
                                height: INSERT_NODE_MENU_SEARCH_RESULTS_BUTTON_HEIGHT)
                 }

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuSizeReadingData.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuSizeReadingData.swift
@@ -36,9 +36,9 @@ struct InsertNodeFooterSizeReader: View {
 
 struct InsertNodeResultSizeReader: View {
 
-    let id: UUID // id of InsertNodeMenuOptionData
+    let option: InsertNodeMenuOption
     let title: String // debug
-    @Binding var nodeResultSizes: [UUID: CGRect]
+    @Binding var nodeResultSizes: [InsertNodeMenuOption: CGRect]
 
     var body: some View {
         GeometryReader { proxy in
@@ -49,7 +49,7 @@ struct InsertNodeResultSizeReader: View {
                     // log("InsertNodeResultSizeReader: onChange: newValue.size: \(newValue.size)")
                     nodeResultSizes.updateValue(
                         newValue,
-                        forKey: id)
+                        forKey: option)
                 }
         }
     }

--- a/Stitch/Graph/Node/Model/GraphCopyable.swift
+++ b/Stitch/Graph/Node/Model/GraphCopyable.swift
@@ -9,8 +9,6 @@ import Foundation
 import SwiftUI
 import UniformTypeIdentifiers
 import StitchSchemaKit
-import StitchViewKit
-
 
 typealias AsyncCallback = @Sendable () async -> Void
 
@@ -554,7 +552,7 @@ extension Array where Element: StitchNestedListElement {
     }
 }
 
-extension Array where Element: StitchNestedListElementObservable {
+extension Array where Element: SidebarItemSwipable {
     /// Returns a subset of layers in sidebar given some selected set.
     @MainActor func getSubset(from ids: Set<Element.ID>) -> [Element] {
         self.flatMap { sidebarData in

--- a/Stitch/Graph/Node/View/NodeTag/CanvasItemMenuButtonsView.swift
+++ b/Stitch/Graph/Node/View/NodeTag/CanvasItemMenuButtonsView.swift
@@ -27,10 +27,9 @@ struct CanvasItemMenuButtonsView: View {
     let canAddInput: Bool
     // Also false when we only have minimum number of inputs
     let canRemoveInput: Bool
-    
     let atleastOneCommentBoxSelected: Bool
-    
     var loopIndices: [Int]?
+    @Binding var showAboutPopover: Bool
 
     // MARK: very important to process this outside of NodeTagMenuButtonsView: doing so fixes a bug where the node type menu becomes unresponsive if values are constantly changing on iPad.
     @MainActor
@@ -190,6 +189,11 @@ struct CanvasItemMenuButtonsView: View {
                     //                    createCommentBoxButton
                     //                }
                 }
+            }
+            
+            // About link to documentation for this node
+            nodeTagMenuButton(label: "About") {
+                self.showAboutPopover = true
             }
         }
     }

--- a/Stitch/Graph/Node/View/NodeView.swift
+++ b/Stitch/Graph/Node/View/NodeView.swift
@@ -53,6 +53,7 @@ struct NodeView: View {
             nodeBody
                 .popover(isPresented: $showAboutPopover) {
                     NodeDescriptionView(option: self.stitch.kind.insertNodeMenuOption)
+                        .frame(width: 500)  // maxWidth breaks the popover, cutting content short at times
                         .padding()
                 }
                 .opacity(node.viewCache.isDefined ? 1 : 0)

--- a/Stitch/Graph/Node/View/NodeView.swift
+++ b/Stitch/Graph/Node/View/NodeView.swift
@@ -52,7 +52,7 @@ struct NodeView: View {
                    existingCache: node.viewCache) {
             nodeBody
                 .popover(isPresented: $showAboutPopover) {
-                    Text("Popover Content")
+                    NodeDescriptionView(option: self.stitch.kind.insertNodeMenuOption)
                         .padding()
                 }
                 .opacity(node.viewCache.isDefined ? 1 : 0)

--- a/Stitch/Graph/Node/View/NodeView.swift
+++ b/Stitch/Graph/Node/View/NodeView.swift
@@ -10,6 +10,8 @@ import UIKit
 import StitchSchemaKit
 
 struct NodeView: View {
+    @State private var showAboutPopover = false
+    
     @Bindable var node: CanvasItemViewModel
     @Bindable var stitch: NodeViewModel
     @Bindable var document: StitchDocumentViewModel
@@ -49,6 +51,10 @@ struct NodeView: View {
         NodeLayout(observer: node,
                    existingCache: node.viewCache) {
             nodeBody
+                .popover(isPresented: $showAboutPopover) {
+                    Text("Popover Content")
+                        .padding()
+                }
                 .opacity(node.viewCache.isDefined ? 1 : 0)
             .onAppear {
                 self.node.updateVisibilityStatus(with: true, graph: graph)
@@ -64,16 +70,17 @@ struct NodeView: View {
             }
 #if targetEnvironment(macCatalyst)
             // Catalyst right-click to open canvas item menu
-                .contextMenu {
-                    CanvasItemMenuButtonsView(graph: graph,
-                                              document: document,
-                                              node: stitch,
-                                              canvasItemId: node.id,
-                                              activeGroupId: activeGroupId,
-                                              canAddInput: canAddInput,
-                                              canRemoveInput: canRemoveInput,
-                                              atleastOneCommentBoxSelected: atleastOneCommentBoxSelected)
-                }
+            .contextMenu {
+                CanvasItemMenuButtonsView(graph: graph,
+                                          document: document,
+                                          node: stitch,
+                                          canvasItemId: node.id,
+                                          activeGroupId: activeGroupId,
+                                          canAddInput: canAddInput,
+                                          canRemoveInput: canRemoveInput,
+                                          atleastOneCommentBoxSelected: atleastOneCommentBoxSelected,
+                                          showAboutPopover: self.$showAboutPopover)
+            }
 #endif
                 .modifier(NodeViewTapGestureModifier(graph: graph,
                                                      document: document,
@@ -96,7 +103,8 @@ struct NodeView: View {
                                       activeGroupId: activeGroupId,
                                       canAddInput: canAddInput,
                                       canRemoveInput: canRemoveInput,
-                                      atleastOneCommentBoxSelected: atleastOneCommentBoxSelected)
+                                      atleastOneCommentBoxSelected: atleastOneCommentBoxSelected,
+                                      showAboutPopover: self.$showAboutPopover)
                     }
                 }
                 .modifier(CanvasItemInputChangeHandleViewModier(
@@ -280,18 +288,20 @@ struct CanvasItemTag: View {
     let canAddInput: Bool
     let canRemoveInput: Bool
     let atleastOneCommentBoxSelected: Bool
+    @Binding var showAboutPopover: Bool
     
     // fka `nodeTagMenu`
     @ViewBuilder var canvasItemMenu: CanvasItemMenuButtonsView {
         CanvasItemMenuButtonsView(graph: graph,
-                               document: document,
-                               node: stitch,
-                               canvasItemId: node.id,
-                               activeGroupId: activeGroupId,
-                               canAddInput: canAddInput,
-                               canRemoveInput: canRemoveInput,
-                               atleastOneCommentBoxSelected: atleastOneCommentBoxSelected,
-                               loopIndices: self.loopIndices)
+                                  document: document,
+                                  node: stitch,
+                                  canvasItemId: node.id,
+                                  activeGroupId: activeGroupId,
+                                  canAddInput: canAddInput,
+                                  canRemoveInput: canRemoveInput,
+                                  atleastOneCommentBoxSelected: atleastOneCommentBoxSelected,
+                                  loopIndices: self.loopIndices,
+                                  showAboutPopover: self.$showAboutPopover)
     }
     
     @MainActor

--- a/Stitch/Graph/Node/View/NodeView.swift
+++ b/Stitch/Graph/Node/View/NodeView.swift
@@ -52,9 +52,7 @@ struct NodeView: View {
                    existingCache: node.viewCache) {
             nodeBody
                 .popover(isPresented: $showAboutPopover) {
-                    NodeDescriptionView(option: self.stitch.kind.insertNodeMenuOption)
-                        .frame(width: 500)  // maxWidth breaks the popover, cutting content short at times
-                        .padding()
+                    GraphNodeDescriptionView(option: self.stitch.kind.insertNodeMenuOption)
                 }
                 .opacity(node.viewCache.isDefined ? 1 : 0)
             .onAppear {

--- a/Stitch/Graph/PrototypePreview/Layer/Util/LayerNodesSorting.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/Util/LayerNodesSorting.swift
@@ -451,7 +451,6 @@ func getLayerTypesForPinnedViews(pinnedData: LayerPinData, // views pinned to th
     return layerTypesAtThisLevel
 }
 
-import StitchViewKit
 extension Array where Element: StitchNestedListElement & Equatable {
     
     func insertSidebarLayerData(_ itemId: Element.ID, parent: Element.ID) -> Element? {

--- a/Stitch/Graph/Sidebar/Model/GroupCandidate.swift
+++ b/Stitch/Graph/Sidebar/Model/GroupCandidate.swift
@@ -1,0 +1,35 @@
+//
+//  GroupCandidate.swift
+//  Stitch
+//
+//  Created by Elliot Boschwitz on 5/26/25.
+//
+
+import SwiftUI
+
+enum GroupCandidate<Element: SidebarItemSwipable> {
+    // Nil for root case
+    case valid(Element.ID?)
+    case invalid
+}
+
+extension GroupCandidate {
+    var isValidGroup: Bool {
+        switch self {
+        case .valid:
+            return true
+        case .invalid:
+            return false
+        }
+    }
+    
+    public var parentId: Element.ID? {
+        switch self {
+        case .valid(let id):
+            return id
+        case .invalid:
+            return nil
+        }
+    }
+}
+

--- a/Stitch/Graph/Sidebar/Util/LayerGrouping/SidebarLayerData.swift
+++ b/Stitch/Graph/Sidebar/Util/LayerGrouping/SidebarLayerData.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import StitchSchemaKit
-import StitchViewKit
 import SwiftUI
 import OrderedCollections
 
@@ -15,7 +14,7 @@ typealias SidebarLayerList = [SidebarLayerData]
 
 typealias OrderedSidebarLayers = SidebarLayerList
 
-extension Array where Element: StitchNestedListElementObservable {
+extension Array where Element: SidebarItemSwipable {
     /// Returns ids just at a single hierarchy without recursively gathering other ids.
     var idsAtHierarchy: Set<Element.ID> {
         self.map { $0.id }

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarGroupCreated.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarGroupCreated.swift
@@ -38,20 +38,21 @@ extension LayersSidebarViewModel {
         
         let candidateGroup = self.items.containsValidGroup(from: primarilySelectedLayers)
         
-        guard let newGroupData = self.items
-            .createGroup(newGroupId: newNode.id,
-                         parentLayerGroupId: candidateGroup.parentId,
-                         selections: primarilySelectedLayers) else {
-            fatalErrorIfDebug()
-            return
-        }
-        
         newNode.graphDelegate = graph // redundant?
                 
         // Add to state
         state.handleNewlyCreatedNode(node: newNode)
             
-        // Update sidebar state
+        // Update sidebar state after node has been added to graph
+        guard let newGroupData = self.items
+            .createGroup(newGroupId: newNode.id,
+                         parentLayerGroupId: candidateGroup.parentId,
+                         selections: primarilySelectedLayers,
+                         sidebarViewModel: self) else {
+            fatalErrorIfDebug()
+            return
+        }
+        
         self.items.insertGroup(group: newGroupData,
                                selections: primarilySelectedLayers)
    
@@ -94,21 +95,160 @@ extension LayersSidebarViewModel {
 extension GraphState {
     @MainActor
     func layerGroupForSelections(_ selections: NodeIdSet) -> NodeId? {
+        
+        // Assumes `selections` all have single parent;
+        // this is guaranteed by the way we select layers in the sidebar
+        // TODO: is it possible to primarily-select a
+        
+        var parentId: NodeId?
+        selections.forEach { layerId in
+            if let layerNode = self.getLayerNode(layerId),
+               let parent = layerNode.layerGroupId(self.layersSidebarViewModel) {
+                parentId = parent
+            }
+        }
+        
+        // log("layerGroupForSelections: parentId: \(parentId)")
+        
+        return parentId
+    }
+}
 
-         // Assumes `selections` all have single parent;
-         // this is guaranteed by the way we select layers in the sidebar
-         // TODO: is it possible to primarily-select a
-
-         var parentId: NodeId?
-         selections.forEach { layerId in
-             if let layerNode = self.getLayerNode(layerId),
-                let parent = layerNode.layerGroupId(self.layersSidebarViewModel) {
-                 parentId = parent
-             }
-         }
-
-         // log("layerGroupForSelections: parentId: \(parentId)")
-
-         return parentId
-     }
-  }
+extension Array where Element: SidebarItemSwipable {
+    /// Returns `true` if selections meet the following criteria:
+    /// 1. All top-level selections are located in same hierarchy (contain the same parent)
+    /// 2. All top-level selections in turn have all of their children selected
+    @MainActor func containsValidGroup(from selections: Set<Element.ID>,
+                                       // Tracks the parent hierarchy of this candidate group, nil = root
+                                       parentLayerGroupId: Element.ID? = nil) -> GroupCandidate<Element> {
+        // Invalid if data or selections are empty
+        guard !self.isEmpty && !selections.isEmpty else {
+            return .invalid
+        }
+        
+        // Keeps track of of what a valid selection set would look like given top-level selections,
+        // meaning if some children aren't selected it won't match this.
+        let validSelectedSet = self.reduce(into: Set<Element.ID>()) { result, element in
+            guard selections.contains(element.id) else {
+                return
+            }
+            
+            result = result.union(element.allElementIds)
+        }
+        
+        // Recursively check children if no selections found at this hierarachy
+        guard !validSelectedSet.isEmpty else {
+            let recursiveChecks = self.compactMap {
+                $0.children?.containsValidGroup(from: selections,
+                                                parentLayerGroupId: $0.id)
+            }
+            for result in recursiveChecks {
+                switch result {
+                case .invalid:
+                    continue
+                case .valid(let parentId):
+                    return .valid(parentId)
+                }
+            }
+            
+            return .invalid
+        }
+        
+        // Non-empty selections mean we've identified the highest hierarchy of selections, and
+        // therefore must match our valid selection set
+        guard validSelectedSet == selections else {
+            return .invalid
+        }
+        
+        // All elements are at same hierarchy so we return current visited group
+        return .valid(parentLayerGroupId)
+    }
+    
+    @MainActor func createGroup(newGroupId: Element.ID,
+                                parentLayerGroupId: Element.ID?,
+                                currentVisitedGroupId: Element.ID? = nil, // for recursion
+                                selections: Set<Element.ID>,
+                                sidebarViewModel: Element.SidebarViewModel) -> Element? {
+        let atCorrectHierarchy = parentLayerGroupId == currentVisitedGroupId
+        var parentDelegate: Element?
+        
+        guard atCorrectHierarchy else {
+            // Recursively search children until we find the parent layer ID
+            return self.compactMap { element in
+                element.children?.createGroup(newGroupId: newGroupId,
+                                              parentLayerGroupId: parentLayerGroupId,
+                                              currentVisitedGroupId: element.id,
+                                              selections: selections,
+                                              sidebarViewModel: sidebarViewModel)
+            }
+            .first
+        }
+        
+        if let parentLayerGroupId = parentLayerGroupId {
+            parentDelegate = self.get(parentLayerGroupId)
+        }
+        
+        let newGroupData = Element(data: .init(id: newGroupId,
+                                               children: [],
+                                               isExpandedInSidebar: true),
+                                   parentDelegate: parentDelegate,
+                                   sidebarViewModel: sidebarViewModel)
+        
+        // Update selected nodes to report to new group node
+        newGroupData.children = self.getSelectedChildrenForNewGroup(selections)
+        
+        return newGroupData
+    }
+    
+    @MainActor mutating func insertGroup(group: Element,
+                                         selections: Set<Element.ID>) {
+        // Find the selected element at the minimum index to determine location of new group node
+        // Recursively search until selections are found
+        guard let newGroupIndex = self.findLowestIndex(amongst: selections) else {
+            self = self.map { element in
+                element.children?.insertGroup(group: group,
+                                              selections: selections)
+                return element
+            }
+            return
+        }
+        
+        // Remove selections from list, complete in order due to grouping
+        var newList = self.removeSelections(selections)
+        
+        // Add new group node to sidebar
+        newList.insert(group, at: newGroupIndex)
+        self = newList
+    }
+    
+    /// Returns the lowest index amonst a list of selections. Nil result means none found.
+    private func findLowestIndex(amongst ids: Set<Element.ID>) -> Int? {
+        self.enumerated()
+            .filter { ids.contains($0.element.id) }
+            .min { $0.offset < $1.offset }?.offset
+    }
+    
+    @MainActor func removeSelections(_ selections: Set<Element.ID>) -> [Element] {
+        self.compactMap { item in
+            if selections.contains(item.id) {
+                return nil
+            }
+            
+            item.children = item.children?.removeSelections(selections)
+            return item
+        }
+    }
+    
+    @MainActor func getSelectedChildrenForNewGroup(_ selections: Set<Element.ID>) -> [Element] {
+        self.flatMap { element -> [Element] in
+            // Get layer data from sidebar to add to group
+            if selections.contains(element.id) {
+                return [element]
+            }
+            
+            // Check children
+            guard let children = element.children else { return [] }
+            return children.getSelectedChildrenForNewGroup(selections)
+        }
+    }
+}

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarGroupUncreated.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarGroupUncreated.swift
@@ -70,3 +70,18 @@ extension LayersSidebarViewModel {
         graph.updateGraphData(document)
     }
 }
+
+extension Array where Element: SidebarItemSwipable {
+    @MainActor func ungroup(selectedGroupId: Element.ID) -> [Element] {
+        self.flatMap { element -> [Element] in
+            guard element.id == selectedGroupId else {
+                // Recursively search children
+                element.children = element.children?.ungroup(selectedGroupId: selectedGroupId)
+                return [element]
+            }
+            
+            // If match for selected group: remove group and add its children
+            return element.children ?? []
+        }
+    }
+}

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarListItemSelectionHelpers.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarListItemSelectionHelpers.swift
@@ -8,7 +8,6 @@
 import StitchSchemaKit
 import Foundation
 import SwiftUI
-import StitchViewKit
 
 extension ProjectSidebarObservable {
     // TODO: finalize this logic; it's not as simple as "the range between last-clicked and just-clicked" nor is it "the range between just-clicked and least-distant-currently-selected"

--- a/Stitch/Graph/Sidebar/Util/ListModification/SidebarSelectedItemsDeleted.swift
+++ b/Stitch/Graph/Sidebar/Util/ListModification/SidebarSelectedItemsDeleted.swift
@@ -50,3 +50,36 @@ extension LayersSidebarViewModel {
         }
     }
 }
+
+extension Array where Element: SidebarItemSwipable {
+    /// Places an element after the location of some ID.
+    @MainActor mutating func remove(_ elementWithId: Element.ID) {
+        for (index, item) in self.enumerated() {
+            // Remove here if matching case
+            if item.id == elementWithId {
+                self.remove(at: index)
+                
+                // Exit recursion on success
+                return
+            }
+            
+            // Recursively check children
+            item.children?.remove(elementWithId)
+            self[index] = item
+        }
+    }
+    
+    /// Places an element after the location of some ID.
+    @MainActor mutating func remove(_ elementIdSet: Set<Element.ID>) {
+        self = self.compactMap { item -> Element? in
+            if elementIdSet.contains(item.id) {
+                return nil
+            }
+            
+            // Recursively check children
+            item.children?.remove(elementIdSet)
+            
+            return item
+        }
+    }
+}

--- a/Stitch/Graph/Sidebar/View/SidebarFooterView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarFooterView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 import StitchSchemaKit
-import StitchViewKit
 
 struct SidebarFooterView<SidebarViewModel: ProjectSidebarObservable>: View {
 

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemGestureRecognizerView.swift
@@ -318,20 +318,20 @@ extension SidebarItemGestureViewModel {
             var buttons: [UIMenuElement] = []
             
             if sidebarViewModel.canUngroup() {
-                buttons.append(UIAction(title: "Ungroup", image: nil) { action in
+                buttons.stitchAppend(title: "Ungroup") {
                     // Handle action here
                     self.sidebarDelegate?.sidebarGroupUncreated()
-                })
+                }
             }
             
             if sidebarViewModel.canBeGrouped() {
-                buttons.append(UIAction(title: "Group", image: nil) { action in
+                buttons.stitchAppend(title: "Group") {
                     sidebarViewModel.sidebarGroupCreated()
-                })
+                }
             }
             
             if sidebarViewModel.canDuplicate() {
-                let groupButton = UIAction(title: "Duplicate", image: nil) { action in
+                let groupButton = UIAction(title: "Duplicate") { _ in
                     dispatch(SidebarSelectedItemsDuplicated())
                 }
                 buttons.append(groupButton)
@@ -342,9 +342,9 @@ extension SidebarItemGestureViewModel {
             let atLeastOneSelected = !activeSelections.isEmpty
             
             if atLeastOneSelected {
-                buttons.append(UIAction(title: "Delete", image: nil) { action in
+                buttons.stitchAppend(title: "Delete") {
                     dispatch(SidebarSelectedItemsDeleted())
-                })
+                }
             }
                       
             let onlyOneSelected = activeSelections.count == 1
@@ -353,10 +353,10 @@ extension SidebarItemGestureViewModel {
                let layerNodeId = selections.primary.first,
                let isVisible = graph.getLayerNode(layerNodeId)?.hasSidebarVisibility {
                 
-                buttons.append(UIAction(title: isVisible ? "Hide Layer" : "Unhide Layer", image: nil) { action in
+                buttons.stitchAppend(title: isVisible ? "Hide Layer" : "Unhide Layer") {
                     // dispatch(SidebarItemHiddenStatusToggled(clickedId: layerNodeId))
                     dispatch(SelectedLayersVisiblityUpdated(selectedLayers: .init([layerNodeId])))
-                })
+                }
             }
             
             if activeSelections.count > 1 {
@@ -366,23 +366,37 @@ extension SidebarItemGestureViewModel {
                 // If all selections already hidden, do not show option to hide them
                 let allSelectionsHidden = activelySelectedLayerNodes.allSatisfy { !$0.hasSidebarVisibility }
                 if !allSelectionsHidden {
-                    buttons.append(UIAction(title: "Hide Layers", image: nil) { action in
+                    buttons.stitchAppend(title: "Hide Layers") {
                         dispatch(SelectedLayersVisiblityUpdated(selectedLayers: selections.primary,
                                                                 newVisibilityStatus: false))
-                    })
+                    }
                 }
                 
                 // If all selections already shown, do not show option to "unhide" them
                 let allSelectionsShown = activelySelectedLayerNodes.allSatisfy { $0.hasSidebarVisibility }
                 if !allSelectionsShown {
-                    buttons.append(UIAction(title: "Unhide Layers", image: nil) { action in
+                    buttons.stitchAppend(title: "Unhide Layers") {
                         dispatch(SelectedLayersVisiblityUpdated(selectedLayers: selections.primary,
                                                                 newVisibilityStatus: true))
-                    })
+                    }
                 }
+            }
+            
+            // About info
+            buttons.stitchAppend(title: "About") {
+                self.showAboutPopover = true
             }
             
             return UIMenu(title: "", children: buttons)
         }
+    }
+}
+
+extension Array where Element == UIMenuElement {
+    @MainActor
+    mutating func stitchAppend(title: String, callback: @escaping () -> Void) {
+        self.append(UIAction(title: title, image: nil) { _ in
+            callback()
+        })
     }
 }

--- a/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarItem/SwipeView/SidebarListItemSwipeView.swift
@@ -79,6 +79,9 @@ struct SidebarListItemSwipeView<SidebarViewModel>: View where SidebarViewModel: 
             theme.fontColor
                 .opacity(backgroundOpacity)
         }
+        .popover(isPresented: self.$gestureViewModel.showAboutPopover) {
+            self.gestureViewModel.aboutPopoverView()
+        }
         .onHover { [weak gestureViewModel, weak sidebarViewModel] hovering in
             // MARK: - SUPER DUPER IMPORTANT TO WEAKLY REFERENCE **EVERYTHING** ELSE SEE RETAIN CYCLES
             

--- a/Stitch/Graph/Sidebar/ViewModel/ProjectSidebarObservable.swift
+++ b/Stitch/Graph/Sidebar/ViewModel/ProjectSidebarObservable.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import StitchViewKit
 
 protocol ProjectSidebarObservable: AnyObject, Observable where ItemViewModel.ID == EncodedItemData.ID,
                                                                Self.ItemViewModel.SidebarViewModel == Self {

--- a/Stitch/Graph/Sidebar/ViewModel/SidebarItemGestureViewModel.swift
+++ b/Stitch/Graph/Sidebar/ViewModel/SidebarItemGestureViewModel.swift
@@ -30,6 +30,8 @@ let CUSTOM_LIST_ITEM_INDENTATION_LEVEL: Int = 24
 @Observable
 final class SidebarItemGestureViewModel: SidebarItemSwipable {
     let id: NodeId
+    let layer: Layer
+    
     @MainActor var sidebarIndex: SidebarIndex = .init(groupIndex: .zero, rowIndex: .zero)
     @MainActor var children: [SidebarItemGestureViewModel]?
     
@@ -45,6 +47,8 @@ final class SidebarItemGestureViewModel: SidebarItemSwipable {
     
     @MainActor var isHovered = false
     
+    @MainActor var showAboutPopover = false
+    
     @MainActor weak var sidebarDelegate: LayersSidebarViewModel?
     
     @MainActor weak var parentDelegate: SidebarItemGestureViewModel? {
@@ -58,7 +62,13 @@ final class SidebarItemGestureViewModel: SidebarItemSwipable {
     init(data: SidebarLayerData,
          parentDelegate: SidebarItemGestureViewModel?,
          sidebarViewModel: LayersSidebarViewModel) {
+        guard let layer = sidebarViewModel.graphDelegate?.getNode(data.id)?.layerNode?.layer else {
+            fatalErrorIfDebug()
+            return
+        }
+        
         self.id = data.id
+        self.layer = layer
         self.isExpandedInSidebar = data.isExpandedInSidebar
         self.parentDelegate = parentDelegate
         self.sidebarDelegate = sidebarViewModel
@@ -70,13 +80,18 @@ final class SidebarItemGestureViewModel: SidebarItemSwipable {
         }
     }
     
-    @MainActor
-    init(id: NodeViewModel.ID,
-         children: [SidebarItemGestureViewModel]?,
-         isExpandedInSidebar: Bool?) {
-        self.id = id
-        self.children = children
-        self.isExpandedInSidebar = isExpandedInSidebar
+//    @MainActor
+//    init(id: NodeViewModel.ID,
+//         children: [SidebarItemGestureViewModel]?,
+//         isExpandedInSidebar: Bool?) {
+//        self.id = id
+//        self.children = children
+//        self.isExpandedInSidebar = isExpandedInSidebar
+//    }
+    
+    @ViewBuilder
+    func aboutPopoverView() -> some View {
+        NodeDescriptionView(option: NodeKind.layer(self.layer).insertNodeMenuOption)
     }
 }
 

--- a/Stitch/Graph/Sidebar/ViewModel/SidebarItemGestureViewModel.swift
+++ b/Stitch/Graph/Sidebar/ViewModel/SidebarItemGestureViewModel.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import StitchViewKit
 
 // MARK: SIDEBAR ITEM SWIPE CONSTANTS
 
@@ -62,13 +61,12 @@ final class SidebarItemGestureViewModel: SidebarItemSwipable {
     init(data: SidebarLayerData,
          parentDelegate: SidebarItemGestureViewModel?,
          sidebarViewModel: LayersSidebarViewModel) {
-        guard let layer = sidebarViewModel.graphDelegate?.getNode(data.id)?.layerNode?.layer else {
-            fatalErrorIfDebug()
-            return
-        }
+        
+        let layer = sidebarViewModel.graphDelegate?.getNode(data.id)?.layerNode?.layer
+        assertInDebug(layer != nil)
         
         self.id = data.id
-        self.layer = layer
+        self.layer = layer ?? .rectangle
         self.isExpandedInSidebar = data.isExpandedInSidebar
         self.parentDelegate = parentDelegate
         self.sidebarDelegate = sidebarViewModel
@@ -79,15 +77,6 @@ final class SidebarItemGestureViewModel: SidebarItemSwipable {
                                         sidebarViewModel: sidebarViewModel)
         }
     }
-    
-//    @MainActor
-//    init(id: NodeViewModel.ID,
-//         children: [SidebarItemGestureViewModel]?,
-//         isExpandedInSidebar: Bool?) {
-//        self.id = id
-//        self.children = children
-//        self.isExpandedInSidebar = isExpandedInSidebar
-//    }
     
     @ViewBuilder
     func aboutPopoverView() -> some View {

--- a/Stitch/Graph/Sidebar/ViewModel/SidebarItemGestureViewModel.swift
+++ b/Stitch/Graph/Sidebar/ViewModel/SidebarItemGestureViewModel.swift
@@ -80,7 +80,7 @@ final class SidebarItemGestureViewModel: SidebarItemSwipable {
     
     @ViewBuilder
     func aboutPopoverView() -> some View {
-        NodeDescriptionView(option: NodeKind.layer(self.layer).insertNodeMenuOption)
+        GraphNodeDescriptionView(option: NodeKind.layer(self.layer).insertNodeMenuOption)
     }
 }
 

--- a/Stitch/Graph/Sidebar/ViewModel/SidebarItemSwipable.swift
+++ b/Stitch/Graph/Sidebar/ViewModel/SidebarItemSwipable.swift
@@ -6,9 +6,20 @@
 //
 
 import SwiftUI
-import StitchViewKit
 
-protocol SidebarItemSwipable: StitchNestedListElementObservable, Sendable, Identifiable where Self.ID: Equatable & CustomStringConvertible,
+protocol StitchNestedListElement: Identifiable, Equatable where Self.ID: Equatable {
+    var children: [Self]? { get set }
+    
+    var isExpandedInSidebar: Bool? { get set }
+
+    init(id: Self.ID,
+         children: [Self]?,
+         isExpandedInSidebar: Bool?)
+    
+    static func createId() -> Self.ID
+}
+
+protocol SidebarItemSwipable: AnyObject, Observable, Sendable, Identifiable where Self.ID: Equatable & CustomStringConvertible,
                                                                                                  SidebarViewModel.ItemViewModel == Self {
     associatedtype SidebarViewModel: ProjectSidebarObservable
     associatedtype AboutPopoverView: View
@@ -94,6 +105,17 @@ extension SidebarItemSwipable {
     @MainActor
     func isSelected(sidebar: Self.SidebarViewModel) -> Bool {
         self.isPrimarilySelected(sidebar: sidebar)
+    }
+    
+    /// Recursively grabs all elements from self and children.
+    @MainActor var allElementIds: Set<Self.ID> {
+        let ids = Set([self.id])
+        guard let children = self.children else {
+            return ids
+        }
+        
+        let childrenIds = Set(children.flatMap { $0.allElementIds })
+        return ids.union(childrenIds)
     }
     
     @MainActor
@@ -699,5 +721,22 @@ extension Array where Element: SidebarItemSwipable {
         
         // Default scenarios result in placing after some other element
         return .afterElement(recommendedItem)
+    }
+}
+
+extension Array where Element: SidebarItemSwipable {
+    @MainActor func get(_ id: Element.ID) -> Element? {
+        for item in self {
+            if id == item.id {
+                return item
+            }
+            
+            // Recursively check children
+            if let result = item.children?.get(id) {
+                return result
+            }
+        }
+        
+        return nil
     }
 }

--- a/Stitch/Graph/Sidebar/ViewModel/SidebarItemSwipable.swift
+++ b/Stitch/Graph/Sidebar/ViewModel/SidebarItemSwipable.swift
@@ -11,6 +11,7 @@ import StitchViewKit
 protocol SidebarItemSwipable: StitchNestedListElementObservable, Sendable, Identifiable where Self.ID: Equatable & CustomStringConvertible,
                                                                                                  SidebarViewModel.ItemViewModel == Self {
     associatedtype SidebarViewModel: ProjectSidebarObservable
+    associatedtype AboutPopoverView: View
     typealias ActiveGesture = SidebarListActiveGesture<Self.ID>
     typealias EncodedItemData = SidebarViewModel.EncodedItemData
     
@@ -45,6 +46,8 @@ protocol SidebarItemSwipable: StitchNestedListElementObservable, Sendable, Ident
     @MainActor func isMasking(graph: GraphReader) -> Bool
     
     @MainActor var isHovered: Bool { get set }
+    
+    @MainActor var showAboutPopover: Bool { get set }
     
     @MainActor
     init(data: Self.EncodedItemData,
@@ -82,6 +85,9 @@ protocol SidebarItemSwipable: StitchNestedListElementObservable, Sendable, Ident
     
     @MainActor
     func update(from schema: Self.EncodedItemData)
+    
+    @ViewBuilder
+    func aboutPopoverView() -> AboutPopoverView
 }
 
 extension SidebarItemSwipable {

--- a/Stitch/Graph/Util/GraphUIActions.swift
+++ b/Stitch/Graph/Util/GraphUIActions.swift
@@ -158,7 +158,7 @@ struct ToggleSidebars: StitchStoreEvent {
 }
 
 struct InsertNodeSelectionChanged: StitchDocumentEvent {
-    let selection: InsertNodeMenuOptionData
+    let selection: InsertNodeMenuOption
 
     func handle(state: StitchDocumentViewModel) {
         state.insertNodeMenuState.activeSelection = selection
@@ -225,12 +225,12 @@ struct InsertNodeQuery: StitchDocumentEvent {
     }
 }
 
-extension [InsertNodeMenuOptionData] {
+extension [InsertNodeMenuOption] {
     static let ALL_NODE_SEARCH_OPTIONS = InsertNodeMenuState.allSearchOptions
 }
 
 func searchForNodes(by query: String,
-                    searchOptions: [InsertNodeMenuOptionData]) -> [InsertNodeMenuOptionData] {
+                    searchOptions: [InsertNodeMenuOption]) -> [InsertNodeMenuOption] {
 
     let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
 
@@ -245,7 +245,7 @@ func searchForNodes(by query: String,
         if targetPhrase.hasPrefix(trimmedQuery) {
             // If what they typed is the start of our target phrase, show the node
             if let prototypeStartNode = searchOptions.first(where: {
-                $0.data.displayTitle.lowercased().contains("on prototype start")
+                $0.displayTitle.lowercased().contains("on prototype start")
             }) {
                 return [prototypeStartNode]
             }
@@ -257,7 +257,7 @@ func searchForNodes(by query: String,
 //        if targetPhrase.hasPrefix(trimmedQuery) {
 //            // If what they typed is the start of our target phrase, show the node
 //            if let splitTextNode = searchOptions.first(where: {
-//                $0.data.displayTitle.lowercased().contains("split text")
+//                $0.displayTitle.lowercased().contains("split text")
 //            }) {
 //                return [splitTextNode]
 //            }
@@ -266,21 +266,21 @@ func searchForNodes(by query: String,
 
     // Handle exact symbol matches next
     switch trimmedQuery {
-    case "+": return [.init(data: .patch(.add))]
-    case "-": return [.init(data: .patch(.subtract))]
-    case "*": return [.init(data: .patch(.multiply))]
-    case "/": return [.init(data: .patch(.divide))]
-    case "**", "^": return [.init(data: .patch(.power))]
+    case "+": return [.patch(.add)]
+    case "-": return [.patch(.subtract)]
+    case "*": return [.patch(.multiply)]
+    case "/": return [.patch(.divide)]
+    case "**", "^": return [.patch(.power)]
     default: break
     }
     
     // Split results into title matches and description matches
     let titleMatches = searchOptions.filter { option in
-        option.data.displayTitle.localizedCaseInsensitiveContains(trimmedQuery)
+        option.displayTitle.localizedCaseInsensitiveContains(trimmedQuery)
     }
     
     let descriptionMatches = searchOptions.filter { option in
-        option.data.displayDescription
+        option.displayDescription
             .replacingOccurrences(of: "*", with: "")
             .replacingOccurrences(of: "/", with: "")
             .localizedCaseInsensitiveContains(trimmedQuery)
@@ -293,7 +293,7 @@ func searchForNodes(by query: String,
     let textBasedMatches = searchOptions.filter { option in
         guard !results.contains(option) else { return false }
         
-        if case .patch(let patchData) = option.data {
+        if case .patch(let patchData) = option {
             switch patchData {
             case .add: return "add".hasPrefix(trimmedQuery) || "plus".hasPrefix(trimmedQuery)
             case .subtract: return "subtract".hasPrefix(trimmedQuery) || "minus".hasPrefix(trimmedQuery)
@@ -318,8 +318,8 @@ func searchForNodes(by query: String,
             return firstInTitleMatches
         }
         
-        let firstTitle = first.data.displayTitle.lowercased()
-        let secondTitle = second.data.displayTitle.lowercased()
+        let firstTitle = first.displayTitle.lowercased()
+        let secondTitle = second.displayTitle.lowercased()
 
         // Then exact matches
         if firstTitle == trimmedQuery { return true }
@@ -358,14 +358,14 @@ struct InsertNodeQuery_REPL: View {
 
     let query: String = "a"
 
-    var results: [InsertNodeMenuOptionData] {
+    var results: [InsertNodeMenuOption] {
         searchForNodes(by: query,
                        searchOptions: .ALL_NODE_SEARCH_OPTIONS)
     }
 
     var body: some View {
         ForEach(results, id: \.id) {
-            Text($0.data.displayTitle)
+            Text($0.displayTitle)
         }
     }
 }

--- a/Stitch/Graph/Util/KeyBindingActions.swift
+++ b/Stitch/Graph/Util/KeyBindingActions.swift
@@ -62,7 +62,7 @@ struct ArrowKeyPressed: StitchDocumentEvent {
     }
 
     @MainActor
-    private static func willNavigateActiveNodeSelection(_ document: StitchDocumentViewModel) -> InsertNodeMenuOptionData? {
+    private static func willNavigateActiveNodeSelection(_ document: StitchDocumentViewModel) -> InsertNodeMenuOption? {
         let insertNodeMenuState = document.insertNodeMenuState
 
         guard insertNodeMenuState.show else {
@@ -71,11 +71,11 @@ struct ArrowKeyPressed: StitchDocumentEvent {
         return insertNodeMenuState.activeSelection
     }
 
-    private static func nodeMenuSelectionArrowUp(activeSelection: InsertNodeMenuOptionData,
-                                                 queryResults: [InsertNodeMenuOptionData]) -> InsertNodeMenuOptionData {
+    private static func nodeMenuSelectionArrowUp(activeSelection: InsertNodeMenuOption,
+                                                 queryResults: [InsertNodeMenuOption]) -> InsertNodeMenuOption {
         // Find current index of active selection
         guard let currentIndex = queryResults
-                .firstIndex(where: { $0.data == activeSelection.data }),
+                .firstIndex(where: { $0 == activeSelection }),
               let nextResult = queryResults[safe: currentIndex - 1] else {
             return activeSelection
         }
@@ -83,11 +83,11 @@ struct ArrowKeyPressed: StitchDocumentEvent {
         return nextResult
     }
 
-    private static func nodeMenuSelectionArrowDown(activeSelection: InsertNodeMenuOptionData,
-                                                   queryResults: [InsertNodeMenuOptionData]) -> InsertNodeMenuOptionData {
+    private static func nodeMenuSelectionArrowDown(activeSelection: InsertNodeMenuOption,
+                                                   queryResults: [InsertNodeMenuOption]) -> InsertNodeMenuOption {
 
         // Find current index of active selection
-        guard let currentIndex = queryResults.firstIndex(where: { $0.data == activeSelection.data}),
+        guard let currentIndex = queryResults.firstIndex(where: { $0 == activeSelection}),
               let prevResult = queryResults[safe: currentIndex + 1] else {
             return activeSelection
         }

--- a/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
+++ b/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
@@ -8,7 +8,6 @@
 import Foundation
 import SwiftUI
 import StitchSchemaKit
-import StitchViewKit
 
 struct CopyPasteGraphDestinationInfo: Equatable {
     let destinationGraphOffset: CGPoint


### PR DESCRIPTION
This PR adds new popovers for nodes and layers.

Some other housekeeping:
* StitchViewKit has been removed as a dependency
* `InsertNodeMenuOptionData` struct has been removed in favor of just using the underlying enum