### PR TITLE
Fixed new layer regression causing crash

### DIFF
--- a/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
+++ b/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
@@ -496,6 +496,11 @@ extension LayerNodeViewModel: SchemaObserver {
             $0.onPrototypeRestart(document: document)
         }
     }
+    
+    @MainActor
+    var isGroupLayer: Bool {
+        layer == .group || layer == .realityView
+    }
 }
 
 extension LayerNodeViewModel {

--- a/Stitch/Graph/Node/Util/NodeViewModelUtils.swift
+++ b/Stitch/Graph/Node/Util/NodeViewModelUtils.swift
@@ -209,12 +209,6 @@ extension NodeViewModel {
     var layerNodeId: LayerNodeId {
         LayerNodeId(self.id)
     }
-
-    @MainActor
-    var isGroupLayer: Bool {
-        guard let layer = self.kind.getLayer else { return false }
-        return layer == .group || layer == .realityView
-    }
     
     @MainActor
     func inputCoordinate(at portId: Int) -> InputCoordinate? {


### PR DESCRIPTION
Caused by recent changes which enforce a node is created and added to `VisibleNodesViewModel` before being added to the sidebar. The reason for that described change is due to needing layer information upon sidebar item instantiation.

Here a new layer node is added to the sidebar before `VisibleNodesViewModel`, causing the crash.