### PR TITLE
Enable training-example button

### DIFF
--- a/Stitch/App/FeatureFlags.swift
+++ b/Stitch/App/FeatureFlags.swift
@@ -13,13 +13,15 @@ struct FeatureFlags {
     static let USE_COMMENT_BOX_FLAG: Bool = false
     static let USE_COMPONENTS = false
     static let USE_AI_MODE = true
-    
+
+    // TODO: why did the `Stitch AI Reasoning` build-scheme
+    // TODO: remove before proper release
     // TODO: put this behind a different compiler flag? ... Want to make available for Adam as well.
-#if STITCH_AI_REASONING || DEBUG || DEV_DEBUG
+//#if STITCH_AI_REASONING || DEBUG || DEV_DEBUG
     static let SHOW_TRAINING_EXAMPLE_GENERATION_BUTTON = true
-#else
-    static let SHOW_TRAINING_EXAMPLE_GENERATION_BUTTON = false
-#endif
+//#else
+//    static let SHOW_TRAINING_EXAMPLE_GENERATION_BUTTON = false
+//#endif
     
     
 #if STITCH_AI_REASONING


### PR DESCRIPTION
Why didn't our Xcode Cloud `Stitch AI Reasoning` work here? The `Stitch AI Reasoning` build scheme had worked locally...