### PR TITLE
Do not show nonsense inputs on Material layer

### DIFF
--- a/Stitch/Graph/Node/Layer/Type/MaterialLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/MaterialLayerNode.swift
@@ -14,8 +14,6 @@ struct MaterialLayerNode: LayerNodeDefinition {
     static let layer = Layer.material
 
     static let inputDefinitions: LayerInputPortSet = .init([
-        .shape,
-        .color,
         .position,
         .rotationX,
         .rotationY,
@@ -25,7 +23,6 @@ struct MaterialLayerNode: LayerNodeDefinition {
         .scale,
         .anchoring,
         .zIndex,
-        .coordinateSystem,
         .pivot,
         .masks,
         .shadowColor,


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7285


## before

<img width="1408" alt="Screenshot 2025-06-04 at 7 02 50 PM" src="https://github.com/user-attachments/assets/21dc77aa-fbc2-4304-b5ef-9b9039bcbdbe" />


## after

<img width="1440" alt="Screenshot 2025-06-04 at 7 05 50 PM" src="https://github.com/user-attachments/assets/e0de8ba1-6bf9-4896-9c84-4e224716257a" />
