### PR TITLE
Do not create SetInput llm-actions when color was not actually changed

### DIFF
--- a/Stitch/Graph/Node/Patch/Type/Color/HexNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Color/HexNode.swift
@@ -14,15 +14,16 @@ func hexNode(id: NodeId,
              position: CGPoint = .zero,
              zIndex: Double = 0) -> PatchNode {
 
+    let defaultColor = falseColor
+    let hexStringForDefaultColor = defaultColor.asHexDisplay
+    
     let inputs = toInputs(
         id: id,
-        values: ("Hex", [.string(.init(""))]))
-
-    let color: Color = UIColor(hex: Color.defaultFalseColorHex)?.toColor ?? falseColor
+        values: ("Hex", [.string(.init(hexStringForDefaultColor))]))
 
     let outputs = toOutputs(
         id: id, offset: inputs.count,
-        values: ("Color", [.color(color)]))
+        values: ("Color", [.color(defaultColor)]))
 
     return PatchNode(position: position,
                      zIndex: zIndex,

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Colors/ColorUtils.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Colors/ColorUtils.swift
@@ -8,6 +8,10 @@ import SwiftUI
 import UIKit
 
 
+func colorEqualityByHex(lhs: Color, rhs: Color) -> Bool {
+    lhs.asHexDisplay == rhs.asHexDisplay
+}
+
 extension Color {
     static let trueColor = Stitch.trueColor
     static let falseColor = Stitch.falseColor

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/StepDerivation.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/StepDerivation.swift
@@ -206,11 +206,20 @@ extension StitchDocumentViewModel {
                 newConnectionSteps.append(connectionStep)
                 
             case .values(let newInputs):
-                if defaultInputs != newInputs {
-                    let value = newInputs.first!
-                    
+                if let defaultInput = defaultInputs.first,
+                   let newInput = newInputs.first,
+                   defaultInput != newInput {
+                                                            
+                    // Careful: SwiftUI.Color equality is not a simple sRGBA comparison; semantic colors are treated differently (e.g. a 'semantic color' like Color.red may have a different appearance per platform)
+                    // So, we compare colors by equality
+                    if let color1 = defaultInput.getColor,
+                       let color2 = newInput.getColor,
+                       colorEqualityByHex(lhs: color1, rhs: color2) {
+                        return
+                    }
+                
                     do {
-                        let migratedValue = try value.convert(to: CurrentStep.PortValue.self)
+                        let migratedValue = try newInput.convert(to: CurrentStep.PortValue.self)
                         
                         let setInputStep = StepActionSetInput(nodeId: port.nodeId,
                                                               port: migratedPortType,
@@ -219,7 +228,7 @@ extension StitchDocumentViewModel {
                         newSetInputSteps.append(setInputStep)
                         
                     } catch {
-                        fatalErrorIfDebug("deriveNewInputActions: unable to convert value: \(value)\nError: \(error)")
+                        fatalErrorIfDebug("deriveNewInputActions: unable to convert value: \(newInput)\nError: \(error)")
                     }
                 }
             }


### PR DESCRIPTION
<img width="1420" alt="Screenshot 2025-06-05 at 7 27 38 PM" src="https://github.com/user-attachments/assets/c3575bbe-3add-477e-847f-986a8ffb3ba7" />

### Context: SwiftUI's semantic colors like Color.black are never equal to hex-etc-created colors: https://github.com/StitchDesign/Stitch--Old/issues/7288

<img width="1039" alt="Screenshot 2025-06-05 at 7 26 45 PM" src="https://github.com/user-attachments/assets/95b7185e-170d-49a3-84c3-3bb6484c84bc" />

