### PR TITLE
Default enable spellcheck; Use placeholder color that shows up against common white prototype background

### DIFF
--- a/Stitch/Graph/Node/Model/RowData/LayerInputType.swift
+++ b/Stitch/Graph/Node/Model/RowData/LayerInputType.swift
@@ -309,7 +309,7 @@ extension LayerInputPort {
         case .isSecureEntry:
             return boolDefaultFalse
         case .isSpellCheckEnabled:
-            return boolDefaultFalse
+            return boolDefaultTrue
         case .keyboardType:
             return KeyboardType.defaultKeyboardTypePortValue
         }

--- a/Stitch/Graph/PrototypePreview/Layer/View/Type/TextField/PreviewTextFieldLayer.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/Type/TextField/PreviewTextFieldLayer.swift
@@ -103,12 +103,18 @@ struct PreviewTextFieldLayer: View {
     var regularVsSecureEntryField: some View {
         Group {
             if self.isSecureEntry {
-                SecureField(placeholder,
-                            text: $viewModel.textFieldInput)
+                SecureField("",
+                            text: $viewModel.textFieldInput,
+                            // Use a color that shows up against the common scenario of a white prototype window background
+                            prompt: Text(placeholder).foregroundColor(Color(.lightGray))
+                )
                 .textContentType(.password)
             } else {
-                TextField(placeholder,
-                          text: $viewModel.textFieldInput)
+                TextField("",
+                          text: $viewModel.textFieldInput,
+                          // Use a color that shows up against the common scenario of a white prototype window background
+                          prompt: Text(placeholder).foregroundColor(Color(.lightGray))
+                )
             }
         }
     }


### PR DESCRIPTION
<img width="1440" alt="Screenshot 2025-06-05 at 10 49 36 PM" src="https://github.com/user-attachments/assets/2721a7ad-9c5e-487c-a5c9-2437b8c3659d" />
