### PR TITLE
Separate inspector section for TextField-specific inputs

### DIFF
--- a/Stitch/Graph/LayerInspector/Model/LayerInspectorSection.swift
+++ b/Stitch/Graph/LayerInspector/Model/LayerInspectorSection.swift
@@ -20,6 +20,7 @@ enum LayerInspectorSection: String, CaseIterable, Identifiable, Hashable {
     case scrolling = "Scrolling" // Better?: "Group Scrolling"
     case pinning = "Pinning"
     case typography = "Typography"
+    case textInput = "Text Input"
     case stroke = "Stroke"
     case rotation = "Rotation"
     case layerEffects = "Layer Effects"
@@ -178,12 +179,16 @@ extension LayerInspectorSection {
         case .typography:
             return [
                 .text,
-                .placeholderText,
                 .textFont,
                 .fontSize,
                 .textAlignment,
                 .verticalAlignment,
-                .textDecoration,
+                .textDecoration
+            ]
+            
+        case .textInput:
+            return [
+                .placeholderText,
                 .beginEditing,
                 .endEditing,
                 .setText,

--- a/Stitch/Graph/Node/Layer/Type/Text/TextFieldLayerNode.swift
+++ b/Stitch/Graph/Node/Layer/Type/Text/TextFieldLayerNode.swift
@@ -52,6 +52,7 @@ struct TextFieldLayerNode: LayerNodeDefinition {
         .union(.layerPaddingAndMargin)
         .union(.offsetInGroup)
         .union(.typographyWithoutText)
+        .union(.textFieldInputs)
     
     static func content(document: StitchDocumentViewModel,
                         graph: GraphState,


### PR DESCRIPTION
<img width="1440" alt="Screenshot 2025-06-06 at 9 47 20 AM" src="https://github.com/user-attachments/assets/9d7f2d36-ece1-401f-bed7-97a60aeb486c" />
<img width="1440" alt="Screenshot 2025-06-06 at 9 47 14 AM" src="https://github.com/user-attachments/assets/3b1d6420-8b5f-4504-b39e-1d3724b96df9" />
