### PR TITLE
Fixed regression where logs alert doesn't appear

### DIFF
--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuSearchBar.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuSearchBar.swift
@@ -26,7 +26,6 @@ struct InsertNodeMenuSearchBar: View {
     
     @Bindable var document: StitchDocumentViewModel
     let launchTip: StitchAILaunchTip
-    @Binding var isLoadingStitchAI: Bool
     @Binding var queryString: String
     let userSubmitted: () -> Void
 

--- a/StitchTests/openAIRequestTests.swift
+++ b/StitchTests/openAIRequestTests.swift
@@ -13,6 +13,11 @@ import SwiftyJSON
 
 class OpenAIRequestTests: XCTestCase {
     func testSecretsNotNil() throws {
+        // Make sure we simulate first-run experience
+        UserDefaults.standard.setValue(
+            nil,
+            forKey: StitchAppSettings.CAN_SHARE_AI_DATA.rawValue)
+        
         do {
             let secrets = try Secrets()
             XCTAssertNotNil(secrets)

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -5,6 +5,7 @@ Headlines
 - New 5-star review system for providing feedback on Stitch AI results
 
 Improvements/Fixes
+- Support for newer iPhones for device preview sizing
 - Project settings improved to include app-wide settings
 - Graph remains interactive while AI loads
 - Insert Node toolbar button returns to iPad


### PR DESCRIPTION
The issue was caused from changes which simplified state controller the insert node menu's appearance.