### PR TITLE
New AI training uploading option from nodes selection

### DIFF
--- a/Stitch/Graph/Node/View/NodeTag/CanvasItemMenuButtonsView.swift
+++ b/Stitch/Graph/Node/View/NodeTag/CanvasItemMenuButtonsView.swift
@@ -212,23 +212,6 @@ struct CanvasItemMenuButtonsView: View {
                 }
             }
         }
-//        .sheet(isPresented: self.$willDisplayTrainingPrompt) {
-//            VStack(alignment: .leading) {
-//                Text("yo")
-//            }
-//            .padding()
-////            .background(
-////                Color(uiColor: .systemGray5)
-////                // NOTE: strangely we need `[.all, .keyboard]` on BOTH the background color AND the StitchHostingControllerView
-////                    .ignoresSafeArea([.all, .keyboard])
-////            )
-//        }
-//        .stitchSheet(isPresented: self.willDisplayTrainingPrompt,
-//                     titleLabel: "Provide a prompt for the just-recorded graph",
-//                     hideAction: document.closedLLMRecordingPrompt,
-//                     sheetBody: {
-//            LLMAssignPromptToScratchLLMExampleModalView()
-//        })
     }
 
     @MainActor @ViewBuilder

--- a/Stitch/Graph/Node/View/NodeTag/CanvasItemMenuButtonsView.swift
+++ b/Stitch/Graph/Node/View/NodeTag/CanvasItemMenuButtonsView.swift
@@ -409,11 +409,7 @@ struct CanvasItemMenuButtonsView: View {
     
     @ViewBuilder
     func aiTrainButton(aiManager: StitchAIManager) -> some View {
-        TagMenuButtonView(label: "Improve AI...") {
-            // Populate actions data for providing sidebar UX--to be removed
-            document.llmRecording.actions = AIGraphDescriptionRequest
-                .deriveStepActionsFromSelectedState(document: document)
-            
+        TagMenuButtonView(label: "Improve AI...") {            
             self.willDisplayTrainingPrompt = true
         }
     }

--- a/Stitch/Graph/Node/View/NodeTag/CanvasItemMenuButtonsView.swift
+++ b/Stitch/Graph/Node/View/NodeTag/CanvasItemMenuButtonsView.swift
@@ -410,6 +410,10 @@ struct CanvasItemMenuButtonsView: View {
     @ViewBuilder
     func aiTrainButton(aiManager: StitchAIManager) -> some View {
         TagMenuButtonView(label: "Improve AI...") {
+            // Populate actions data for providing sidebar UX--to be removed
+            document.llmRecording.actions = AIGraphDescriptionRequest
+                .deriveStepActionsFromSelectedState(document: document)
+            
             self.willDisplayTrainingPrompt = true
         }
     }

--- a/Stitch/Graph/Node/View/NodeTag/CanvasItemMenuButtonsView.swift
+++ b/Stitch/Graph/Node/View/NodeTag/CanvasItemMenuButtonsView.swift
@@ -19,6 +19,7 @@ struct CanvasItemMenuButtonsView: View {
     @Bindable var node: NodeViewModel
     @Binding var showNodesSummaryPopover: Bool
     @Binding var nodeSummariesText: AttributedString?
+    @Binding var willDisplayTrainingPrompt: Bool
 
     let canvasItemId: CanvasItemId // id for Node or LayerInputOnGraph
     
@@ -199,6 +200,11 @@ struct CanvasItemMenuButtonsView: View {
                 }
             }
             
+            // Always display training option
+            if let aiManager = document.aiManager {
+                aiTrainButton(aiManager: aiManager)
+            }
+            
             // About link to documentation for this node--only if its one of the core nodes
             if self.node.kind.insertNodeMenuOption != nil {
                 nodeTagMenuButton(label: "Get Info") {
@@ -206,6 +212,23 @@ struct CanvasItemMenuButtonsView: View {
                 }
             }
         }
+//        .sheet(isPresented: self.$willDisplayTrainingPrompt) {
+//            VStack(alignment: .leading) {
+//                Text("yo")
+//            }
+//            .padding()
+////            .background(
+////                Color(uiColor: .systemGray5)
+////                // NOTE: strangely we need `[.all, .keyboard]` on BOTH the background color AND the StitchHostingControllerView
+////                    .ignoresSafeArea([.all, .keyboard])
+////            )
+//        }
+//        .stitchSheet(isPresented: self.willDisplayTrainingPrompt,
+//                     titleLabel: "Provide a prompt for the just-recorded graph",
+//                     hideAction: document.closedLLMRecordingPrompt,
+//                     sheetBody: {
+//            LLMAssignPromptToScratchLLMExampleModalView()
+//        })
     }
 
     @MainActor @ViewBuilder
@@ -381,6 +404,13 @@ struct CanvasItemMenuButtonsView: View {
             }
         } else {
             EmptyView()
+        }
+    }
+    
+    @ViewBuilder
+    func aiTrainButton(aiManager: StitchAIManager) -> some View {
+        TagMenuButtonView(label: "Improve AI...") {
+            self.willDisplayTrainingPrompt = true
         }
     }
     

--- a/Stitch/Graph/Node/View/NodeView.swift
+++ b/Stitch/Graph/Node/View/NodeView.swift
@@ -16,6 +16,7 @@ struct NodeView: View {
     @State private var aiJsNodePrompt: String = ""
     @State private var showNodesSummaryPopover: Bool = false
     @State private var nodeSummariesText: AttributedString?
+    @State private var willDisplayTrainingPrompt = false
     
     @FocusedValue(\.focusedField) private var focusedField
     @FocusState var isFocused: Bool
@@ -95,6 +96,7 @@ struct NodeView: View {
                                               node: stitch,
                                               showNodesSummaryPopover: self.$showNodesSummaryPopover,
                                               nodeSummariesText: self.$nodeSummariesText,
+                                              willDisplayTrainingPrompt: self.$willDisplayTrainingPrompt,
                                               canvasItemId: node.id,
                                               activeGroupId: activeGroupId,
                                               canAddInput: canAddInput,
@@ -123,6 +125,7 @@ struct NodeView: View {
                                       stitch: stitch,
                                       showNodesSummaryPopover: $showNodesSummaryPopover,
                                       nodeSummariesText: $nodeSummariesText,
+                                      willDisplayTrainingPrompt: self.$willDisplayTrainingPrompt,
                                       activeGroupId: activeGroupId,
                                       canAddInput: canAddInput,
                                       canRemoveInput: canRemoveInput,
@@ -140,6 +143,12 @@ struct NodeView: View {
                                                        graph: graph,
                                                        node: node,
                                                        zIndex: zIndex))
+                   .stitchSheet(isPresented: self.willDisplayTrainingPrompt,
+                                titleLabel: "Provide a prompt for the just-recorded graph",
+                                hideAction: document.closedLLMRecordingPrompt,
+                                sheetBody: {
+                       LLMAssignPromptToScratchLLMExampleModalView()
+                   })
     }
     
     @State private var nodeBodyHovered: Bool = false
@@ -373,6 +382,7 @@ struct CanvasItemTag: View {
     @Bindable var stitch: NodeViewModel
     @Binding var showNodesSummaryPopover: Bool
     @Binding var nodeSummariesText: AttributedString?
+    @Binding var willDisplayTrainingPrompt: Bool
     let activeGroupId: GroupNodeType?
     let canAddInput: Bool
     let canRemoveInput: Bool
@@ -386,6 +396,7 @@ struct CanvasItemTag: View {
                                   node: stitch,
                                   showNodesSummaryPopover: $showNodesSummaryPopover,
                                   nodeSummariesText: $nodeSummariesText,
+                                  willDisplayTrainingPrompt: self.$willDisplayTrainingPrompt,
                                   canvasItemId: node.id,
                                   activeGroupId: activeGroupId,
                                   canAddInput: canAddInput,

--- a/Stitch/Graph/Node/View/NodeView.swift
+++ b/Stitch/Graph/Node/View/NodeView.swift
@@ -146,7 +146,7 @@ struct NodeView: View {
                    .stitchSheet(isPresented: self.willDisplayTrainingPrompt,
                                 titleLabel: "Provide a prompt for the just-recorded graph",
                                 hideAction: document.closedLLMRecordingPrompt,
-                                sheetBody: {
+                                sheetBody: {                       
                        LLMAssignPromptToScratchLLMExampleModalView()
                    })
     }

--- a/Stitch/Graph/Node/View/NodeView.swift
+++ b/Stitch/Graph/Node/View/NodeView.swift
@@ -143,11 +143,24 @@ struct NodeView: View {
                                                        graph: graph,
                                                        node: node,
                                                        zIndex: zIndex))
-                   .stitchSheet(isPresented: self.willDisplayTrainingPrompt,
-                                titleLabel: "Provide a prompt for the just-recorded graph",
-                                hideAction: document.closedLLMRecordingPrompt,
-                                sheetBody: {                       
-                       LLMAssignPromptToScratchLLMExampleModalView()
+                   .alert("Stitch AI Training Upload",
+                          isPresented: $willDisplayTrainingPrompt,
+                          actions: {
+                       TextField("Prompt", text: $document.llmRecording.promptForTrainingDataOrCompletedRequest)
+                       
+                       StitchButton("Confirm Before Uploading") {
+                           // Populate actions data for providing sidebar UX--to be removed
+                           document.llmRecording.actions = AIGraphDescriptionRequest
+                               .deriveStepActionsFromSelectedState(document: document)
+                           
+                           // Open the Edit-before-submit modal
+                           document.showEditBeforeSubmitModal()
+                       }
+                       StitchButton("Cancel", role: .cancel) {
+                           document.llmRecording.promptForTrainingDataOrCompletedRequest = ""
+                       }
+                   }, message: {
+                       Text("Describe your selected subgraph.")
                    })
     }
     

--- a/Stitch/Graph/StitchAI/DatasetRecording/LLMActionHelpers.swift
+++ b/Stitch/Graph/StitchAI/DatasetRecording/LLMActionHelpers.swift
@@ -69,10 +69,7 @@ extension StitchDocumentViewModel {
             return
         }
         
-        guard let promptForTrainingDataOrCompletedRequest = state.llmRecording.promptForTrainingDataOrCompletedRequest else {
-            fatalErrorIfDebug("SubmitLLMActionsToSupabase error: did not have prompt saved")
-            return
-        }
+        let promptForTrainingDataOrCompletedRequest = state.llmRecording.promptForTrainingDataOrCompletedRequest
         
         // When submitting actions to Supabase, we *must* have a rating.
         // Submitting a correction = 5 star rating

--- a/Stitch/Graph/StitchAI/DatasetRecording/LLMRecordingState.swift
+++ b/Stitch/Graph/StitchAI/DatasetRecording/LLMRecordingState.swift
@@ -94,7 +94,7 @@ struct LLMRecordingState {
     
     // The prompt we've manually provided for our training example;
     // OR the saved prompt from a streaming request that has been completed
-    var promptForTrainingDataOrCompletedRequest: String?
+    var promptForTrainingDataOrCompletedRequest: String = ""
     var promptFromPreviousExistingGraphSubmittedAsTrainingData: String?
     
     // id from a user inference call; used

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIGraphDescriptionRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIGraphDescriptionRequest.swift
@@ -22,12 +22,7 @@ struct AIGraphDescriptionRequest: StitchAIRequestable {
         }
         
         let graph = document.visibleGraph
-        let copiedComponent = graph
-            .createCopiedComponent(groupNodeFocused: document.groupNodeFocused,
-                                   selectedNodeIds: graph.selectedPatchAndLayerNodes)
-        let steps = StitchDocumentViewModel
-            .deriveNewAIActions(newGraphEntity: copiedComponent.component.graphEntity,
-                                visibleGraph: graph)
+        let steps = Self.deriveStepActionsFromSelectedState(document: document)
         
         // TODO: remove this step when schema improves
         let reducedSteps = steps.map(\.toStep)
@@ -94,5 +89,17 @@ struct AIGraphDescriptionRequest: StitchAIRequestable {
     
     static func buildResponse(from streamingChunks: [String]) throws -> String {
         streamingChunks.joined()
+    }
+    
+    @MainActor
+    /// Determines step actions needed to replicated selected state.
+    static func deriveStepActionsFromSelectedState(document: StitchDocumentViewModel) -> [any StepActionable] {
+        let graph = document.visibleGraph
+        let copiedComponent = graph
+            .createCopiedComponent(groupNodeFocused: document.groupNodeFocused,
+                                   selectedNodeIds: graph.selectedPatchAndLayerNodes)
+        return StitchDocumentViewModel
+            .deriveNewAIActions(newGraphEntity: copiedComponent.component.graphEntity,
+                                visibleGraph: graph)
     }
 }

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIGraphDescriptionRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIGraphDescriptionRequest.swift
@@ -21,7 +21,6 @@ struct AIGraphDescriptionRequest: StitchAIRequestable {
             throw StitchAIManagerError.secretsNotFound
         }
         
-        let graph = document.visibleGraph
         let steps = Self.deriveStepActionsFromSelectedState(document: document)
         
         // TODO: remove this step when schema improves

--- a/Stitch/Graph/View/ContentView.swift
+++ b/Stitch/Graph/View/ContentView.swift
@@ -140,6 +140,7 @@ struct ContentView: View, KeyboardReadable {
                 self.showFullScreenAnimateCompleted = true
             }
         })
+        // TODO: new method for uploadining training, not requiring recording feature
         .stitchSheet(isPresented: document.llmRecording.modal == .enterPromptForTrainingData,
                      titleLabel: "Provide a prompt for the just-recorded graph",
                      hideAction: document.closedLLMRecordingPrompt,


### PR DESCRIPTION
This PR enables AI training uploading from already-created nodes by selecting patches and layers and right-clicking for the new menu option.

This feature will eventually replace the record button UX, as it provides an easier and more flexible approach to training data.