### PR TITLE
New patch/layer UX for iPad

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -185,6 +185,7 @@
 		B56FFB3E2C18F52600623CC7 /* StitchFileResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56FFB3D2C18F52600623CC7 /* StitchFileResult.swift */; };
 		B56FFB422C18F7AB00623CC7 /* SafeAreaInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56FFB412C18F7AB00623CC7 /* SafeAreaInsets.swift */; };
 		B56FFB482C18FF9700623CC7 /* LoopedEval.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56FFB472C18FF9700623CC7 /* LoopedEval.swift */; };
+		B57127172DFFD87D00C5C4C7 /* ProjectTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57127162DFFD87A00C5C4C7 /* ProjectTab.swift */; };
 		B5743AED29CC128100B3230D /* PortValueComparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5743AEC29CC128100B3230D /* PortValueComparable.swift */; };
 		B57575F92A187E0600CDB0BA /* previewLayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57575F82A187E0600CDB0BA /* previewLayerTests.swift */; };
 		B5770BA32D3ACF1D0013AD09 /* Model3DView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5770BA22D3ACF1C0013AD09 /* Model3DView.swift */; };
@@ -1287,6 +1288,7 @@
 		B56FFB3D2C18F52600623CC7 /* StitchFileResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StitchFileResult.swift; sourceTree = "<group>"; };
 		B56FFB412C18F7AB00623CC7 /* SafeAreaInsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeAreaInsets.swift; sourceTree = "<group>"; };
 		B56FFB472C18FF9700623CC7 /* LoopedEval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopedEval.swift; sourceTree = "<group>"; };
+		B57127162DFFD87A00C5C4C7 /* ProjectTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectTab.swift; sourceTree = "<group>"; };
 		B5743AEC29CC128100B3230D /* PortValueComparable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortValueComparable.swift; sourceTree = "<group>"; };
 		B57575F82A187E0600CDB0BA /* previewLayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = previewLayerTests.swift; sourceTree = "<group>"; };
 		B5770BA22D3ACF1C0013AD09 /* Model3DView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model3DView.swift; sourceTree = "<group>"; };
@@ -3720,6 +3722,7 @@
 		B56FFB5E2C19664C00623CC7 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				B57127162DFFD87A00C5C4C7 /* ProjectTab.swift */,
 				ECA347D22DE2955200B6A8B8 /* PatchOrLayer.swift */,
 				B557806E2CB04CC800907BA8 /* GroupNodeType.swift */,
 				B58F9C23294AE0AA00FFBF2C /* KeyPressState.swift */,
@@ -6128,6 +6131,7 @@
 				B55500D32C1BA6810081C3F1 /* PreviewWindowSizing.swift in Sources */,
 				8B2A221926A3B5BE002D08BA /* FeatureFlags.swift in Sources */,
 				EC0B03522DF202070045E894 /* StitchAIRequestBodyFormattable_V0.swift in Sources */,
+				B57127172DFFD87D00C5C4C7 /* ProjectTab.swift in Sources */,
 				EC53F3BC287E25EE0021095B /* ArcTan2Node.swift in Sources */,
 				ECEF8D0F2BFE9BE5004FABCD /* LayerGroupInteractableViewModifier.swift in Sources */,
 				B5136F5D2DED6330007F12D0 /* StitchAINodeType_V0.swift in Sources */,

--- a/Stitch/App/Shortcut/ProjectsHomeCommands.swift
+++ b/Stitch/App/Shortcut/ProjectsHomeCommands.swift
@@ -152,13 +152,38 @@ struct ProjectsHomeCommands: Commands {
             }
             
             if activeProject {
-                SwiftUIShortcutView(title: "Toggle Sidebars",
+#if !targetEnvironment(macCatalyst)
+                SwiftUIShortcutView(title: "Show Patches",
+                                    key: "1",
+                                    eventModifiers: .command,
+                                    disabled: !activeProject) {
+                    self.store.currentDocument?.selectedTab = .patch
+                }
+                
+                SwiftUIShortcutView(title: "Show Layers",
+                                    key: "2",
+                                    eventModifiers: .command,
+                                    disabled: !activeProject) {
+                    self.store.currentDocument?.selectedTab = .layer
+                }
+#endif
+                
+#if targetEnvironment(macCatalyst)
+                let cmdDotLabel = "Toggle Sidebars"
+#else
+                let cmdDotLabel = "Toggle Tab"
+#endif
+                
+                SwiftUIShortcutView(title: cmdDotLabel,
                                     key: ".",
                                     eventModifiers: .command,
                                     disabled: !activeProject) {
+#if targetEnvironment(macCatalyst)
                     dispatch(ToggleSidebars())
+#else
+                    self.store.currentDocument?.selectedTab.toggle()
+#endif
                 }
-                
             }
             
             if activeProject {

--- a/Stitch/App/Shortcut/ProjectsHomeCommands.swift
+++ b/Stitch/App/Shortcut/ProjectsHomeCommands.swift
@@ -153,19 +153,19 @@ struct ProjectsHomeCommands: Commands {
             
             if activeProject {
 #if !targetEnvironment(macCatalyst)
-                SwiftUIShortcutView(title: "Show Patches",
-                                    key: "1",
-                                    eventModifiers: .command,
-                                    disabled: !activeProject) {
-                    self.store.currentDocument?.selectedTab = .patch
-                }
-                
                 SwiftUIShortcutView(title: "Show Layers",
                                     key: "2",
                                     eventModifiers: .command,
                                     disabled: !activeProject) {
                     self.store.currentDocument?.selectedTab = .layer
                 }
+
+                SwiftUIShortcutView(title: "Show Patches",
+                                    key: "1",
+                                    eventModifiers: .command,
+                                    disabled: !activeProject) {
+                    self.store.currentDocument?.selectedTab = .patch
+                }                
 #endif
                 
 #if targetEnvironment(macCatalyst)

--- a/Stitch/App/View/StitchRootView.swift
+++ b/Stitch/App/View/StitchRootView.swift
@@ -42,15 +42,23 @@ struct StitchRootView: View {
          }
 
          return document.insertNodeMenuState.show || document.isLoadingAI
-     }
+    }
+    
+    @ViewBuilder
+    var viewByPlatform: some View {
+#if targetEnvironment(macCatalyst)
+                splitView
+#else
+                StitchNavStack(store: store)
+#endif
+    }
     
     var body: some View {
         ZStack {
             if Stitch.isPhoneDevice {
                 iPhoneBody
             } else {
-                splitView
-//#if targetEnvironment(macCatalyst)
+                viewByPlatform
                     .overlay(alignment: .center) {
                         if let document = store.currentDocument {
                             

--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -67,6 +67,7 @@ struct LayerInspectorView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .scrollContentBackground(.hidden)
         .background(Color.WHITE_IN_LIGHT_MODE_BLACK_IN_DARK_MODE.ignoresSafeArea())
+        .inspectorColumnWidth(LayerInspectorView.LAYER_INSPECTOR_WIDTH)
     }
     
     var description: String {

--- a/Stitch/Graph/Model/ProjectTab.swift
+++ b/Stitch/Graph/Model/ProjectTab.swift
@@ -1,0 +1,35 @@
+//
+//  ProjectTab.swift
+//  Stitch
+//
+//  Created by Elliot Boschwitz on 6/15/25.
+//
+
+enum ProjectTab: String, Identifiable, CaseIterable {
+    case patch = "Patches"
+    case layer = "Layers"
+}
+
+extension ProjectTab {
+    var id: String {
+        self.rawValue
+    }
+    
+    var systemIcon: String {
+        switch self {
+        case .patch:
+            return "rectangle.3.group"
+        case .layer:
+            return "square.3.layers.3d.down.right"
+        }
+    }
+    
+    mutating func toggle() {
+        switch self {
+        case .patch:
+            self = .layer
+        case .layer:
+            self = .patch
+        }
+    }
+}

--- a/Stitch/Graph/PrototypePreview/Frame/View/FloatingWindowView.swift
+++ b/Stitch/Graph/PrototypePreview/Frame/View/FloatingWindowView.swift
@@ -59,11 +59,10 @@ struct FloatingWindowView: View {
     }
 
     var body: some View {
-        ZStack {
-            floatingWindow
-            
-            // Start the handle-circle at top-right corner ...
-            // ... then manually move down and left by the scaled preview window's dimensions
+        floatingWindow
+        
+        // Start the handle-circle at top-right corner ...
+        // ... then manually move down and left by the scaled preview window's dimensions
             .background(alignment: .topTrailing) {
                 if showPreviewWindow {
                     floatingWindowHandle
@@ -71,7 +70,6 @@ struct FloatingWindowView: View {
                 }
             } // .background            
             .matchedGeometryEffect(id: projectId, in: namespace)
-        }
     }
 
     

--- a/Stitch/Graph/PrototypePreview/Frame/View/FloatingWindowView.swift
+++ b/Stitch/Graph/PrototypePreview/Frame/View/FloatingWindowView.swift
@@ -80,6 +80,8 @@ struct FloatingWindowView: View {
                        showPreviewWindow: showPreviewWindow,
                        previewWindowSizing: document.previewWindowSizingObserver)
         .frame(self.previewWindowSizing.dimensions)
+        .animation(.spring(response: 0.35, dampingFraction: 0.85),
+                   value: previewWindowSizing.dimensions)
         .padding(.top, PREVIEW_WINDOW_Y_PADDING)
     }
     

--- a/Stitch/Graph/PrototypePreview/Frame/View/FloatingWindowView.swift
+++ b/Stitch/Graph/PrototypePreview/Frame/View/FloatingWindowView.swift
@@ -80,8 +80,6 @@ struct FloatingWindowView: View {
                        showPreviewWindow: showPreviewWindow,
                        previewWindowSizing: document.previewWindowSizingObserver)
         .frame(self.previewWindowSizing.dimensions)
-        .animation(.spring(response: 0.35, dampingFraction: 0.85),
-                   value: previewWindowSizing.dimensions)
         .padding(.top, PREVIEW_WINDOW_Y_PADDING)
     }
     

--- a/Stitch/Graph/PrototypePreview/ScreenRecorder/RecordingView.swift
+++ b/Stitch/Graph/PrototypePreview/ScreenRecorder/RecordingView.swift
@@ -51,6 +51,32 @@ struct MacScreenSharingView: View {
         store.currentDocument?.isScreenRecording = false
     }
 }
+#else
+struct IPadPrototypePreview: View {
+    @State private var windowSizingObserver = PreviewWindowSizing()
+    @State private var showFullScreenAnimateCompleted = true
+    @StateObject private var showFullScreen = AnimatableBool(true)
+
+    let store: StitchStore
+    
+    var body: some View {
+        if let document = store.currentDocument {
+            ZStack {
+                ProjectWindowSizeReader(previewWindowSizing: self.windowSizingObserver,
+                                        previewWindowSize: document.previewWindowSize,
+                                        isFullScreen: true,
+                                        showFullScreenAnimateCompleted: $showFullScreenAnimateCompleted,
+                                        showFullScreenObserver: showFullScreen,
+                                        menuHeight: 0)
+                
+                PreviewContent(document: document,
+                               isFullScreen: true,
+                               showPreviewWindow: true,
+                               previewWindowSizing: windowSizingObserver)
+            }
+        }
+    }
+}
 #endif
 
 struct RecordingView: View {

--- a/Stitch/Graph/PrototypePreview/ScreenRecorder/RecordingView.swift
+++ b/Stitch/Graph/PrototypePreview/ScreenRecorder/RecordingView.swift
@@ -58,6 +58,7 @@ struct IPadPrototypePreview: View {
     @StateObject private var showFullScreen = AnimatableBool(true)
 
     let store: StitchStore
+    let namespace: Namespace.ID
     
     var body: some View {
         if let document = store.currentDocument {
@@ -73,6 +74,8 @@ struct IPadPrototypePreview: View {
                                isFullScreen: true,
                                showPreviewWindow: true,
                                previewWindowSizing: windowSizingObserver)
+                .matchedGeometryEffect(id: document.id, in: namespace)
+                .transition(.identity)
             }
         }
     }

--- a/Stitch/Graph/PrototypePreview/ScreenRecorder/RecordingView.swift
+++ b/Stitch/Graph/PrototypePreview/ScreenRecorder/RecordingView.swift
@@ -77,6 +77,7 @@ struct IPadPrototypePreview: View {
                 .matchedGeometryEffect(id: document.id, in: namespace)
                 .transition(.identity)
             }
+            .background(.ultraThinMaterial)
         }
     }
 }

--- a/Stitch/Graph/Sidebar/View/SidebarEditButtonView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarEditButtonView.swift
@@ -27,7 +27,6 @@ struct SidebarEditButtonView<SidebarViewModel>: View where SidebarViewModel: Pro
         } label: {
             Text(sidebarViewModel.isEditing ? "Done" : "Edit")
         }
-        .font(SwiftUI.Font.system(size: 18))
         .foregroundColor(Color(.editButton))
     }
 }

--- a/Stitch/Graph/Sidebar/View/SidebarListView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarListView.swift
@@ -98,7 +98,9 @@ struct SidebarListScrollView<SidebarObservable>: View where SidebarObservable: P
                                   syncStatus: syncStatus)
             }
             
+#if !targetEnvironment(macCatalyst)
             sectionHeader
+#endif
         }
     }
     
@@ -118,9 +120,11 @@ struct SidebarListScrollView<SidebarObservable>: View where SidebarObservable: P
         // Normal layers sidebar view
         else {
             ScrollView(.vertical) {
+#if !targetEnvironment(macCatalyst)
                 // Empty view for sticky header space
                 HStack { }
                     .height(30)
+#endif
                 
                 ZStack(alignment: .topLeading) {
                     ForEach(allFlattenedItems) { item in

--- a/Stitch/Graph/Sidebar/View/SidebarListView.swift
+++ b/Stitch/Graph/Sidebar/View/SidebarListView.swift
@@ -76,12 +76,29 @@ struct SidebarListScrollView<SidebarObservable>: View where SidebarObservable: P
         self.sidebarViewModel.isEditing
     }
     
-    var body: some View {
-        VStack(spacing: 0) {
-            listView
+    var sectionHeader: some View {
+        HStack {
+            Text("Layer List")
             Spacer()
-            SidebarFooterView(sidebarViewModel: sidebarViewModel,
-                              syncStatus: syncStatus)
+            SidebarEditButtonView(sidebarViewModel: self.sidebarViewModel)
+        }
+        .font(.headline)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+        .background(Color.WHITE_IN_LIGHT_MODE_BLACK_IN_DARK_MODE.opacity(0.85))
+    }
+    
+    var body: some View {
+        ZStack(alignment: .top) {
+            VStack(spacing: 0) {
+                listView
+                Spacer()
+                SidebarFooterView(sidebarViewModel: sidebarViewModel,
+                                  syncStatus: syncStatus)
+            }
+            
+            sectionHeader
         }
     }
     
@@ -101,6 +118,10 @@ struct SidebarListScrollView<SidebarObservable>: View where SidebarObservable: P
         // Normal layers sidebar view
         else {
             ScrollView(.vertical) {
+                // Empty view for sticky header space
+                HStack { }
+                    .height(30)
+                
                 ZStack(alignment: .topLeading) {
                     ForEach(allFlattenedItems) { item in
                         SidebarListItemSwipeView(
@@ -114,11 +135,6 @@ struct SidebarListScrollView<SidebarObservable>: View where SidebarObservable: P
                        alignment: .top)
             } // ScrollView // added
             .scrollContentBackground(.hidden)
-#if !targetEnvironment(macCatalyst)
-            .toolbar {
-                SidebarEditButtonView(sidebarViewModel: self.sidebarViewModel)
-            }
-#endif
             // TODO: remove some of these animations ?
             .animation(.spring(), value: isBeingEdited)
             .onChange(of: isBeingEdited) { _, newValue in

--- a/Stitch/Graph/Sidebar/View/iPadProjectSidebarView.swift
+++ b/Stitch/Graph/Sidebar/View/iPadProjectSidebarView.swift
@@ -59,7 +59,7 @@ struct ProjectSidebarView: View {
         
         // iPad only
 #if !targetEnvironment(macCatalyst)
-        .navigationTitle("Stitch")
+//        .navigationTitle("Stitch")
 
         // Allows scrolled up content to be visible underneath other nav-stack icons; not ideal.
 //        .toolbarBackground(.hidden, for: .automatic)

--- a/Stitch/Graph/Sidebar/View/iPadProjectSidebarView.swift
+++ b/Stitch/Graph/Sidebar/View/iPadProjectSidebarView.swift
@@ -56,18 +56,6 @@ struct ProjectSidebarView: View {
         
         // Needed so that sidebar-footer does not rise up when iPad full keyboard on-screen
         .edgesIgnoringSafeArea(.bottom)
-        
-        // iPad only
-#if !targetEnvironment(macCatalyst)
-//        .navigationTitle("Stitch")
-
-        // Allows scrolled up content to be visible underneath other nav-stack icons; not ideal.
-//        .toolbarBackground(.hidden, for: .automatic)
-        
-        // We can change the color of the sidebar's top-most section
-        .toolbarBackground(.visible, for: .automatic)
-        .toolbarBackground(Color.WHITE_IN_LIGHT_MODE_BLACK_IN_DARK_MODE, for: .automatic)
-#endif
     }
 }
 

--- a/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
+++ b/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
@@ -121,10 +121,12 @@ struct CatalystTopBarGraphButtons: View {
                 PROJECT_SETTINGS_ACTION()
             }
             
+#if targetEnvironment(macCatalyst)
             CatalystNavBarButton("sidebar.right",
                                  toolTip: "Toggle Layer Inspector") {
                 dispatch(LayerInspectorToggled())
             }
+#endif
         }
     }
 }

--- a/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
+++ b/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
@@ -58,19 +58,6 @@ struct CatalystTopBarGraphButtons: View {
     
     var body: some View {
         Group {
-            CatalystNavBarButton(.GO_UP_ONE_TRAVERSAL_LEVEL_SF_SYMBOL_NAME,
-                                 toolTip: "Go up one traversal level") {
-                dispatch(GoUpOneTraversalLevel())
-            }
-            .disabled(hasActiveGroupFocused ? false : true)
-            
-            if FeatureFlags.SHOW_TRAINING_EXAMPLE_GENERATION_BUTTON {
-                CatalystNavBarButton("sparkles",
-                                     toolTip: "Submit graph as AI training example") {
-                    dispatch(ShowCreateTrainingDataFromExistingGraphModal())
-                }
-            }
-            
             CatalystNavBarButtonWithMenu(
                 systemName: .ADD_NODE_SF_SYMBOL_NAME,
                 toolTip: "Add Nodes") {
@@ -85,6 +72,19 @@ struct CatalystTopBarGraphButtons: View {
                         Text("Add Nodes")
                     }
                 }
+            
+            CatalystNavBarButton(.GO_UP_ONE_TRAVERSAL_LEVEL_SF_SYMBOL_NAME,
+                                 toolTip: "Go up one traversal level") {
+                dispatch(GoUpOneTraversalLevel())
+            }
+            .disabled(hasActiveGroupFocused ? false : true)
+            
+            if FeatureFlags.SHOW_TRAINING_EXAMPLE_GENERATION_BUTTON {
+                CatalystNavBarButton("sparkles",
+                                     toolTip: "Submit graph as AI training example") {
+                    dispatch(ShowCreateTrainingDataFromExistingGraphModal())
+                }
+            }
                         
             // TODO: only show when no nodes are on-screen?
             // and so should be placed on the far left?

--- a/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
+++ b/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
@@ -62,7 +62,7 @@ struct CatalystTopBarGraphButtons: View {
                                  toolTip: "Go up one traversal level") {
                 dispatch(GoUpOneTraversalLevel())
             }
-            .opacity(hasActiveGroupFocused ? 1 : 0)
+            .disabled(hasActiveGroupFocused ? false : true)
             
             if FeatureFlags.SHOW_TRAINING_EXAMPLE_GENERATION_BUTTON {
                 CatalystNavBarButton("sparkles",

--- a/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
+++ b/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
@@ -121,12 +121,10 @@ struct CatalystTopBarGraphButtons: View {
                 PROJECT_SETTINGS_ACTION()
             }
             
-#if targetEnvironment(macCatalyst)
             CatalystNavBarButton("sidebar.right",
                                  toolTip: "Toggle Layer Inspector") {
                 dispatch(LayerInspectorToggled())
             }
-#endif
         }
     }
 }

--- a/Stitch/Graph/Toolbar/View/TopBarButtonView.swift
+++ b/Stitch/Graph/Toolbar/View/TopBarButtonView.swift
@@ -135,57 +135,51 @@ struct iPadGraphTopBarButtons: View {
             }
             .pickerStyle(.segmented)
             
+            iPadTopBarButtonWithMenu(iconName: .sfSymbol(.ADD_NODE_SF_SYMBOL_NAME)) {
+                StitchButton {
+                    dispatch(ShowAINodePromptEntryModal())
+                } label: {
+                    Label(String.CREATE_CUSTOM_NODE_WITH_AI,
+                          systemImage: "rectangle")
+                }
+                StitchButton {
+                    dispatch(ToggleInsertNodeMenu())
+                } label: {
+                    Label("Add Nodes",
+                          systemImage: "rectangle.on.rectangle")
+                }
+            }
+            
             // go up a traversal level
             iPadNavBarButton(action: { dispatch(GoUpOneTraversalLevel()) },
                              iconName: .sfSymbol(.GO_UP_ONE_TRAVERSAL_LEVEL_SF_SYMBOL_NAME))
             .disabled(hasActiveGroupFocused ? false : true)
             
-            if FeatureFlags.SHOW_TRAINING_EXAMPLE_GENERATION_BUTTON {
+            if isDebugMode,
+               FeatureFlags.SHOW_TRAINING_EXAMPLE_GENERATION_BUTTON {
                 iPadNavBarButton(action: {
                     dispatch(ShowCreateTrainingDataFromExistingGraphModal())
                 }, iconName: .sfSymbol("sparkles"))
             }
             
-            if !isDebugMode {
-                
-                iPadTopBarButtonWithMenu(iconName: .sfSymbol(.ADD_NODE_SF_SYMBOL_NAME)) {
-                    StitchButton {
-                        dispatch(ShowAINodePromptEntryModal())
-                    } label: {
-                        Label(String.CREATE_CUSTOM_NODE_WITH_AI,
-                              systemImage: "rectangle")
-                    }
-                    StitchButton {
-                        dispatch(ToggleInsertNodeMenu())
-                    } label: {
-                        Label("Add Nodes",
-                              systemImage: "rectangle.on.rectangle")
-                    }
-                }
-                
-                // toggle preview window
-                iPadNavBarButton(
-                    action: PREVIEW_SHOW_TOGGLE_ACTION,
-                    iconName: .sfSymbol(isPreviewWindowShown ? .HIDE_PREVIEW_WINDOW_SF_SYMBOL_NAME : .SHOW_PREVIEW_WINDOW_SF_SYMBOL_NAME))
-                
-                // refresh prototype
-                iPadNavBarButton(action: RESTART_PROTOTYPE_ACTION,
-                                 iconName: .sfSymbol(.RESTART_PROTOTYPE_SF_SYMBOL_NAME),
-                                 rotationZ: restartPrototypeWindowIconRotationZ)
-                
-                // full screen
-                iPadNavBarButton(
-                    action: PREVIEW_FULL_SCREEN_ACTION,
-                    iconName: .sfSymbol(isFullscreen ? .SHRINK_FROM_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME : .EXPAND_TO_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME))
-            }
+            // toggle preview window
+            iPadNavBarButton(
+                action: PREVIEW_SHOW_TOGGLE_ACTION,
+                iconName: .sfSymbol(isPreviewWindowShown ? .HIDE_PREVIEW_WINDOW_SF_SYMBOL_NAME : .SHOW_PREVIEW_WINDOW_SF_SYMBOL_NAME))
+            
+            // refresh prototype
+            iPadNavBarButton(action: RESTART_PROTOTYPE_ACTION,
+                             iconName: .sfSymbol(.RESTART_PROTOTYPE_SF_SYMBOL_NAME),
+                             rotationZ: restartPrototypeWindowIconRotationZ)
+            
+            // full screen
+            iPadNavBarButton(
+                action: PREVIEW_FULL_SCREEN_ACTION,
+                iconName: .sfSymbol(isFullscreen ? .SHRINK_FROM_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME : .EXPAND_TO_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME))
 
             // the misc (...) button
             miscButton
                 .popoverTip(document.stitchAITrainingTip, arrowEdge: .top)
-            
-//            iPadNavBarButton(action: {
-//                dispatch(LayerInspectorToggled())
-//            }, iconName: .sfSymbol("sidebar.right"))
         }
     }
 }

--- a/Stitch/Graph/Toolbar/View/TopBarButtonView.swift
+++ b/Stitch/Graph/Toolbar/View/TopBarButtonView.swift
@@ -125,14 +125,19 @@ struct iPadGraphTopBarButtons: View {
     }
     
     var body: some View {
-
-        // TODO: why does `Group` but not `HStack` work here? Something to do with `Menu`?
         Group {
+            Picker("", selection: $document.selectedTab) {
+                ForEach(ProjectTab.allCases) { projectTab in
+                    Image(systemName: projectTab.systemIcon)
+                        .tag(projectTab)
+                }
+            }
+            .pickerStyle(.segmented)
             
             // go up a traversal level
             iPadNavBarButton(action: { dispatch(GoUpOneTraversalLevel()) },
                              iconName: .sfSymbol(.GO_UP_ONE_TRAVERSAL_LEVEL_SF_SYMBOL_NAME))
-            .opacity(hasActiveGroupFocused ? 1 : 0)
+            .disabled(hasActiveGroupFocused ? false : true)
             
             if FeatureFlags.SHOW_TRAINING_EXAMPLE_GENERATION_BUTTON {
                 iPadNavBarButton(action: {

--- a/Stitch/Graph/Toolbar/View/TopBarButtonView.swift
+++ b/Stitch/Graph/Toolbar/View/TopBarButtonView.swift
@@ -177,9 +177,9 @@ struct iPadGraphTopBarButtons: View {
             miscButton
                 .popoverTip(document.stitchAITrainingTip, arrowEdge: .top)
             
-            iPadNavBarButton(action: {
-                dispatch(LayerInspectorToggled())
-            }, iconName: .sfSymbol("sidebar.right"))
+//            iPadNavBarButton(action: {
+//                dispatch(LayerInspectorToggled())
+//            }, iconName: .sfSymbol("sidebar.right"))
         }
     }
 }

--- a/Stitch/Graph/Toolbar/View/TopBarButtonView.swift
+++ b/Stitch/Graph/Toolbar/View/TopBarButtonView.swift
@@ -110,6 +110,7 @@ struct TopBarImageButton: View {
     }
 }
 
+#if !targetEnvironment(macCatalyst)
 struct iPadGraphTopBarButtons: View {
 
     @Bindable var document: StitchDocumentViewModel
@@ -188,6 +189,7 @@ struct iPadGraphTopBarButtons: View {
         }
     }
 }
+#endif
 
 struct iPadGraphTopBarMiscMenu: View {
     @Bindable var document: StitchDocumentViewModel

--- a/Stitch/Graph/View/ContentView.swift
+++ b/Stitch/Graph/View/ContentView.swift
@@ -99,18 +99,10 @@ struct ContentView: View, KeyboardReadable {
                 // phone before showFullScreen is set
                 ProjectNavigationView(store: store,
                                       document: document,
-                                      routerNamespace: routerNamespace)
+                                      isFullScreen: showFullScreen.isTrue,
+                                      routerNamespace: routerNamespace,
+                                      graphNamespace: graphNamespace)
                 .zIndex(showFullScreen.isTrue ? -99 : 0)
-                .overlay {
-                    StitchProjectOverlayView(document: document,
-                                             store: store,
-                                             showFullScreen: showFullScreen.isTrue,
-                                             graphNamespace: graphNamespace)
-                }
-//                // Layer Inspector Flyout must sit above preview window
-                .overlay {
-                    flyout
-                }
                 .overlay {
                     catalystProjectTitleEditView
                 }
@@ -169,12 +161,6 @@ struct ContentView: View, KeyboardReadable {
             graphNamespace: graphNamespace,
             routerNamespace: routerNamespace,
             animationCompleted: showFullScreenAnimateCompleted)
-    }
-        
-    @ViewBuilder
-    var flyout: some View {
-        OpenFlyoutView(document: document,
-                       graph: document.visibleGraph)
     }
     
     @ViewBuilder

--- a/Stitch/Graph/View/ContentView.swift
+++ b/Stitch/Graph/View/ContentView.swift
@@ -99,6 +99,7 @@ struct ContentView: View, KeyboardReadable {
                 // phone before showFullScreen is set
                 ProjectNavigationView(store: store,
                                       document: document,
+                                      graph: document.visibleGraph,
                                       isFullScreen: showFullScreen.isTrue,
                                       routerNamespace: routerNamespace,
                                       graphNamespace: graphNamespace)

--- a/Stitch/Graph/View/GraphBaseView.swift
+++ b/Stitch/Graph/View/GraphBaseView.swift
@@ -120,12 +120,12 @@ struct GraphBaseView: View {
             // IMPORTANT: applying .inspector outside of this ZStack causes displacement of graph contents when graph zoom != 1
             Circle().fill(Stitch.APP_BACKGROUND_COLOR.opacity(0.001))
                 .frame(width: 1, height: 1)
+            #if targetEnvironment(macCatalyst)
                 .inspector(isPresented: $store.showsLayerInspector) {
-                    
                     LayerInspectorView(graph: graph,
                                        document: document)
-                        .inspectorColumnWidth(LayerInspectorView.LAYER_INSPECTOR_WIDTH)
                 }
+            #endif
         } // ZStack
         
         .modifier(ActivelyDrawnEdge(graph: graph,

--- a/Stitch/Graph/View/ProjectNavigationView.swift
+++ b/Stitch/Graph/View/ProjectNavigationView.swift
@@ -34,6 +34,7 @@ struct ProjectNavigationView: View {
 
     @Bindable var store: StitchStore
     @Bindable var document: StitchDocumentViewModel
+    @Bindable var graph: GraphState
     let isFullScreen: Bool
     let routerNamespace: Namespace.ID
     let graphNamespace: Namespace.ID
@@ -64,6 +65,10 @@ struct ProjectNavigationView: View {
                                        deviceScreenSize: document.frame.size,
                                        showPreviewWindow: document.showPreviewWindow && !document.isScreenRecording,
                                        namespace: graphNamespace)
+                    .inspector(isPresented: $store.showsLayerInspector) {
+                        LayerInspectorView(graph: graph,
+                                           document: document)
+                    }
                 }
             }
         } else {
@@ -85,11 +90,6 @@ struct ProjectNavigationView: View {
             }
     }
     
-//    @ViewBuilder
-//    var iPadTabView: some View {
-//        
-//    }
-    
     @ViewBuilder
     var flyout: some View {
         OpenFlyoutView(document: document,
@@ -97,10 +97,8 @@ struct ProjectNavigationView: View {
     }
 
     var body: some View {
-        @Bindable var visibleGraph = document.visibleGraph
-        
         mainProjectView
-        .alert(item: $visibleGraph.migrationWarning) { warningMessage in
+            .alert(item: $graph.migrationWarning) { warningMessage in
             Alert(title: Text("Document Migration Warning"),
                   message: Text(warningMessage.rawValue),
                   dismissButton: .default(.init("OK")) {

--- a/Stitch/Graph/View/ProjectNavigationView.swift
+++ b/Stitch/Graph/View/ProjectNavigationView.swift
@@ -8,35 +8,6 @@
 import SwiftUI
 import StitchSchemaKit
 
-enum ProjectTab: String, Identifiable, CaseIterable {
-    case patch = "Patches"
-    case layer = "Layers"
-}
-
-extension ProjectTab {
-    var id: String {
-        self.rawValue
-    }
-    
-    var systemIcon: String {
-        switch self {
-        case .patch:
-            return "rectangle.3.group"
-        case .layer:
-            return "square.3.layers.3d.down.right"
-        }
-    }
-    
-    mutating func toggle() {
-        switch self {
-        case .patch:
-            self = .layer
-        case .layer:
-            self = .patch
-        }
-    }
-}
-
 /// UI for interacting with a single project; iPad-only.
 struct ProjectNavigationView: View {
     @Environment(StitchFileManager.self) var fileManager

--- a/Stitch/Graph/View/ProjectNavigationView.swift
+++ b/Stitch/Graph/View/ProjectNavigationView.swift
@@ -71,7 +71,7 @@ struct ProjectNavigationView: View {
                                                deviceScreenSize: document.frame.size,
                                                showPreviewWindow: document.showPreviewWindow && !document.isScreenRecording,
                                                namespace: graphNamespace)
-                            .inspector(isPresented: $store.showsLayerInspector) {
+                            .inspector(isPresented: .constant(true)) {
                                 LayerInspectorView(graph: graph,
                                                    document: document)
                             }

--- a/Stitch/Graph/View/ProjectNavigationView.swift
+++ b/Stitch/Graph/View/ProjectNavigationView.swift
@@ -26,12 +26,20 @@ extension ProjectTab {
             return "square.3.layers.3d.down.right"
         }
     }
+    
+    mutating func toggle() {
+        switch self {
+        case .patch:
+            self = .layer
+        case .layer:
+            self = .patch
+        }
+    }
 }
 
 /// UI for interacting with a single project; iPad-only.
 struct ProjectNavigationView: View {
     @Environment(StitchFileManager.self) var fileManager
-    @State private var selectedTab: ProjectTab = .patch
     static private let iPadSidebarWidth: CGFloat = 300
 
     @Bindable var store: StitchStore
@@ -53,7 +61,7 @@ struct ProjectNavigationView: View {
     @ViewBuilder
     var mainProjectView: some View {
         if Self.isIPad {
-            TabView(selection: self.$selectedTab) {
+            TabView(selection: self.$document.selectedTab) {
                 Tab(ProjectTab.patch.rawValue,
                     systemImage: ProjectTab.patch.systemIcon,
                     value: ProjectTab.patch) {

--- a/Stitch/Graph/View/ProjectNavigationView.swift
+++ b/Stitch/Graph/View/ProjectNavigationView.swift
@@ -54,53 +54,49 @@ struct ProjectNavigationView: View {
         self.document.previewWindowSizingObserver
     }
     
-    static var isIPad: Bool {
-        UIDevice.current.userInterfaceIdiom == .pad
-    }
-    
     @ViewBuilder
     var mainProjectView: some View {
-        if Self.isIPad {
-            // Use a ZStack so SwiftUI can animate insertion/removal with `.transition`
-            ZStack {
-                if document.selectedTab == .patch {
-                    graphView
-                        .ignoresSafeArea()
-                        .transition(.opacity)
-                        .id(ProjectTab.patch)   // ← make the views distinct
-                } else { // .layer
-                    HStack {
-                        StitchSidebarView(syncStatus: fileManager.syncStatus)
-                            .width(Self.iPadSidebarWidth)
-
-                        Spacer()
-
-                        IPadPrototypePreview(store: store,
-                                             namespace: graphNamespace)
-
-                        Spacer()
-
-                        LayerInspectorView(graph: graph,
-                                           document: document)
-                            .ignoresSafeArea()
-                            .width(Self.iPadSidebarWidth)
-                    }
-                    .transition(.opacity)
-                    .id(ProjectTab.layer)
-                }
-            }
-            .animation(.easeInOut(duration: 0.25), value: document.selectedTab)
-        } else {
-            // iPhone / compact width
-            ZStack {
+#if !targetEnvironment(macCatalyst)
+        // Use a ZStack so SwiftUI can animate insertion/removal with `.transition`
+        ZStack {
+            if document.selectedTab == .patch {
                 graphView
-
-                // Layer Inspector Fly‑out must sit above preview window
-                flyout
+                    .ignoresSafeArea()
+                    .transition(.opacity)
+                    .id(ProjectTab.patch)   // ← make the views distinct
+            } else { // .layer
+                HStack {
+                    StitchSidebarView(syncStatus: fileManager.syncStatus)
+                        .width(Self.iPadSidebarWidth)
+                    
+                    Spacer()
+                    
+                    IPadPrototypePreview(store: store,
+                                         namespace: graphNamespace)
+                    
+                    Spacer()
+                    
+                    LayerInspectorView(graph: graph,
+                                       document: document)
+                    .ignoresSafeArea()
+                    .width(Self.iPadSidebarWidth)
+                }
+                .transition(.opacity)
+                .id(ProjectTab.layer)
             }
-            .transition(.opacity)
-            .animation(.easeInOut(duration: 0.25), value: document.selectedTab)
         }
+        .animation(.easeInOut(duration: 0.25), value: document.selectedTab)
+        .animation(.easeInOut(duration: 0.25), value: document.selectedTab)
+#else
+        // iPhone / compact width
+        ZStack {
+            graphView
+            
+            // Layer Inspector Fly‑out must sit above preview window
+            flyout
+        }
+        .transition(.opacity)
+#endif
     }
     
     var graphView: some View {

--- a/Stitch/Graph/View/ProjectNavigationView.swift
+++ b/Stitch/Graph/View/ProjectNavigationView.swift
@@ -66,6 +66,7 @@ struct ProjectNavigationView: View {
                     systemImage: ProjectTab.patch.systemIcon,
                     value: ProjectTab.patch) {
                     graphView
+                        .ignoresSafeArea()
                 }
                 Tab(ProjectTab.layer.rawValue,
                     systemImage: ProjectTab.layer.systemIcon,
@@ -82,6 +83,7 @@ struct ProjectNavigationView: View {
                         
                         LayerInspectorView(graph: graph,
                                            document: document)
+                        .ignoresSafeArea()
                         .width(Self.iPadSidebarWidth)
                     }
                 }

--- a/Stitch/Graph/View/ProjectNavigationView.swift
+++ b/Stitch/Graph/View/ProjectNavigationView.swift
@@ -68,11 +68,7 @@ struct ProjectNavigationView: View {
                         
                         Spacer()
                         
-                        FloatingWindowView(store: store,
-                                           document: document,
-                                           deviceScreenSize: document.frame.size,
-                                           showPreviewWindow: document.showPreviewWindow && !document.isScreenRecording,
-                                           namespace: graphNamespace)
+                        IPadPrototypePreview(store: store)
                         
                         Spacer()
                         

--- a/Stitch/Graph/View/ProjectNavigationView.swift
+++ b/Stitch/Graph/View/ProjectNavigationView.swift
@@ -61,31 +61,26 @@ struct ProjectNavigationView: View {
     @ViewBuilder
     var mainProjectView: some View {
         if Self.isIPad {
-            TabView(selection: self.$document.selectedTab) {
-                Tab(ProjectTab.patch.rawValue,
-                    systemImage: ProjectTab.patch.systemIcon,
-                    value: ProjectTab.patch) {
-                    graphView
-                        .ignoresSafeArea()
-                }
-                Tab(ProjectTab.layer.rawValue,
-                    systemImage: ProjectTab.layer.systemIcon,
-                    value: ProjectTab.layer) {
-                    HStack {
-                        StitchSidebarView(syncStatus: fileManager.syncStatus)
-                            .width(Self.iPadSidebarWidth)
-                        
-                        Spacer()
-                        
-                        IPadPrototypePreview(store: store)
-                        
-                        Spacer()
-                        
-                        LayerInspectorView(graph: graph,
-                                           document: document)
-                        .ignoresSafeArea()
+            switch document.selectedTab {
+            case .patch:
+                graphView
+                    .ignoresSafeArea()
+
+            case .layer:
+                HStack {
+                    StitchSidebarView(syncStatus: fileManager.syncStatus)
                         .width(Self.iPadSidebarWidth)
-                    }
+                    
+                    Spacer()
+                    
+                    IPadPrototypePreview(store: store)
+                    
+                    Spacer()
+                    
+                    LayerInspectorView(graph: graph,
+                                       document: document)
+                    .ignoresSafeArea()
+                    .width(Self.iPadSidebarWidth)
                 }
             }
         } else {

--- a/Stitch/Graph/View/ProjectNavigationView.swift
+++ b/Stitch/Graph/View/ProjectNavigationView.swift
@@ -8,22 +8,98 @@
 import SwiftUI
 import StitchSchemaKit
 
+enum ProjectTab: String, Identifiable, CaseIterable {
+    case patch = "Patches"
+    case layer = "Layers"
+}
+
+extension ProjectTab {
+    var id: String {
+        self.rawValue
+    }
+    
+    var systemIcon: String {
+        switch self {
+        case .patch:
+            return "rectangle.3.group"
+        case .layer:
+            return "square.3.layers.3d.down.right"
+        }
+    }
+}
+
 /// UI for interacting with a single project; iPad-only.
 struct ProjectNavigationView: View {
+    @State private var selectedTab: ProjectTab = .patch
+
     @Bindable var store: StitchStore
     @Bindable var document: StitchDocumentViewModel
+    let isFullScreen: Bool
     let routerNamespace: Namespace.ID
+    let graphNamespace: Namespace.ID
     @Namespace private var topButtonsNamespace
 
     var previewWindowSizing: PreviewWindowSizing {
         self.document.previewWindowSizingObserver
     }
+    
+    static var isIPad: Bool {
+        UIDevice.current.userInterfaceIdiom == .pad
+    }
+    
+    @ViewBuilder
+    var mainProjectView: some View {
+        if Self.isIPad {
+            TabView(selection: self.$selectedTab) {
+                Tab(ProjectTab.patch.rawValue,
+                    systemImage: ProjectTab.patch.systemIcon,
+                    value: ProjectTab.patch) {
+                    graphView
+                }
+                Tab(ProjectTab.layer.rawValue,
+                    systemImage: ProjectTab.layer.systemIcon,
+                    value: ProjectTab.layer) {
+                    FloatingWindowView(store: store,
+                                       document: document,
+                                       deviceScreenSize: document.frame.size,
+                                       showPreviewWindow: document.showPreviewWindow && !document.isScreenRecording,
+                                       namespace: graphNamespace)
+                }
+            }
+        } else {
+            graphView
+            // Layer Inspector Flyout must sit above preview window
+                .overlay {
+                    flyout
+                }
+        }
+    }
+    
+    var graphView: some View {
+        GraphBaseView(store: store, document: document)
+            .overlay {
+                StitchProjectOverlayView(document: document,
+                                         store: store,
+                                         showFullScreen: isFullScreen,
+                                         graphNamespace: graphNamespace)
+            }
+    }
+    
+//    @ViewBuilder
+//    var iPadTabView: some View {
+//        
+//    }
+    
+    @ViewBuilder
+    var flyout: some View {
+        OpenFlyoutView(document: document,
+                       graph: document.visibleGraph)
+    }
 
     var body: some View {
         @Bindable var visibleGraph = document.visibleGraph
         
-        GraphBaseView(store: store,
-                      document: document)
+        mainProjectView
         .alert(item: $visibleGraph.migrationWarning) { warningMessage in
             Alert(title: Text("Document Migration Warning"),
                   message: Text(warningMessage.rawValue),

--- a/Stitch/Graph/View/ProjectNavigationView.swift
+++ b/Stitch/Graph/View/ProjectNavigationView.swift
@@ -30,6 +30,7 @@ extension ProjectTab {
 
 /// UI for interacting with a single project; iPad-only.
 struct ProjectNavigationView: View {
+    @Environment(StitchFileManager.self) var fileManager
     @State private var selectedTab: ProjectTab = .patch
 
     @Bindable var store: StitchStore
@@ -60,15 +61,21 @@ struct ProjectNavigationView: View {
                 Tab(ProjectTab.layer.rawValue,
                     systemImage: ProjectTab.layer.systemIcon,
                     value: ProjectTab.layer) {
-                    FloatingWindowView(store: store,
-                                       document: document,
-                                       deviceScreenSize: document.frame.size,
-                                       showPreviewWindow: document.showPreviewWindow && !document.isScreenRecording,
-                                       namespace: graphNamespace)
-                    .inspector(isPresented: $store.showsLayerInspector) {
-                        LayerInspectorView(graph: graph,
-                                           document: document)
-                    }
+                    NavigationSplitView(
+                        columnVisibility: .constant(.all),
+                        sidebar: {
+                            StitchSidebarView(syncStatus: fileManager.syncStatus)
+                        }) {
+                            FloatingWindowView(store: store,
+                                               document: document,
+                                               deviceScreenSize: document.frame.size,
+                                               showPreviewWindow: document.showPreviewWindow && !document.isScreenRecording,
+                                               namespace: graphNamespace)
+                            .inspector(isPresented: $store.showsLayerInspector) {
+                                LayerInspectorView(graph: graph,
+                                                   document: document)
+                            }
+                        }
                 }
             }
         } else {

--- a/Stitch/Graph/View/ProjectNavigationView.swift
+++ b/Stitch/Graph/View/ProjectNavigationView.swift
@@ -65,16 +65,16 @@ struct ProjectNavigationView: View {
                     .transition(.opacity)
                     .id(ProjectTab.patch)   // ← make the views distinct
             } else { // .layer
-                HStack {
+                HStack(spacing: .zero) {
                     StitchSidebarView(syncStatus: fileManager.syncStatus)
                         .width(Self.iPadSidebarWidth)
                     
-                    Spacer()
+                    Spacer(minLength: 0)
                     
                     IPadPrototypePreview(store: store,
                                          namespace: graphNamespace)
                     
-                    Spacer()
+                    Spacer(minLength: 0)
                     
                     LayerInspectorView(graph: graph,
                                        document: document)

--- a/Stitch/Graph/View/ProjectNavigationView.swift
+++ b/Stitch/Graph/View/ProjectNavigationView.swift
@@ -32,6 +32,7 @@ extension ProjectTab {
 struct ProjectNavigationView: View {
     @Environment(StitchFileManager.self) var fileManager
     @State private var selectedTab: ProjectTab = .patch
+    static private let iPadSidebarWidth: CGFloat = 300
 
     @Bindable var store: StitchStore
     @Bindable var document: StitchDocumentViewModel
@@ -61,21 +62,24 @@ struct ProjectNavigationView: View {
                 Tab(ProjectTab.layer.rawValue,
                     systemImage: ProjectTab.layer.systemIcon,
                     value: ProjectTab.layer) {
-                    NavigationSplitView(
-                        columnVisibility: .constant(.all),
-                        sidebar: {
-                            StitchSidebarView(syncStatus: fileManager.syncStatus)
-                        }) {
-                            FloatingWindowView(store: store,
-                                               document: document,
-                                               deviceScreenSize: document.frame.size,
-                                               showPreviewWindow: document.showPreviewWindow && !document.isScreenRecording,
-                                               namespace: graphNamespace)
-                            .inspector(isPresented: .constant(true)) {
-                                LayerInspectorView(graph: graph,
-                                                   document: document)
-                            }
-                        }
+                    HStack {
+                        StitchSidebarView(syncStatus: fileManager.syncStatus)
+                            .width(Self.iPadSidebarWidth)
+                        
+                        Spacer()
+                        
+                        FloatingWindowView(store: store,
+                                           document: document,
+                                           deviceScreenSize: document.frame.size,
+                                           showPreviewWindow: document.showPreviewWindow && !document.isScreenRecording,
+                                           namespace: graphNamespace)
+                        
+                        Spacer()
+                        
+                        LayerInspectorView(graph: graph,
+                                           document: document)
+                        .width(Self.iPadSidebarWidth)
+                    }
                 }
             }
         } else {

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -129,6 +129,10 @@ final class StitchDocumentViewModel: Sendable {
     
     @MainActor var stitchAITrainingTip = StitchAITrainingTip()
     
+#if !targetEnvironment(macCatalyst)
+    @MainActor var selectedTab = ProjectTab.patch
+#endif
+    
     @MainActor weak var storeDelegate: StitchStore?
     @MainActor weak var projectLoader: ProjectLoader?
     @MainActor weak var documentEncoder: DocumentEncoder?


### PR DESCRIPTION
This PR aims to improve our graph UX for smaller form factors, starting with iPad. Previously, we had allowed layer sidebars to work alongside the patch graph. This was hopeless from a spacing standpoint—once one sidebar opens, the graph is basically inaccessible.

The solution here is a tab bar, supporting CMD + 1 or 2 for going back and forth each view.