### PR TITLE
Proof of concept: using `PortValue` in the actions <-> code AI flow

### DIFF
--- a/Stitch/Graph/Node/Port/Util/Field/FieldValueUtils.swift
+++ b/Stitch/Graph/Node/Port/Util/Field/FieldValueUtils.swift
@@ -11,7 +11,6 @@ import StitchSchemaKit
 
 extension PortValue {
     /// Coercion logic from port value to fields. Contains a 2D list of field values given a 1-many mapping between a field group type and its field values.
-    @MainActor
     func createFieldValuesList(nodeIO: NodeIO,
                                layerInputPort: LayerInputPort?,
                                isLayerInspector: Bool) -> [FieldValues] {

--- a/Stitch/Graph/StitchAI/Mapping/ASTExplorerViewExamples.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ASTExplorerViewExamples.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 
 extension ASTExplorerView {
@@ -63,9 +64,9 @@ extension ASTExplorerView {
         let id = UUID()
         return [
             .layer(.init(id: id, name: .rectangle, children: [])),
-            .layerInputSet(.init(id: id, input: .color, value: "Color.red")),
-            .layerInputSet(.init(id: id, input: .opacity, value: "0.5")),
-            .layerInputSet(.init(id: id, input: .scale, value: "2")),
+            .layerInputSet(.init(id: id, input: .color, value: PortValue.color(Color.red))),
+            .layerInputSet(.init(id: id, input: .opacity, value: PortValue.number(0.5))),
+            .layerInputSet(.init(id: id, input: .scale, value: PortValue.number(2))),
         ]
     }()
     
@@ -73,9 +74,9 @@ extension ASTExplorerView {
         let id = UUID()
         return [
             .layer(.init(id: id, name: .oval, children: [])),
-            .layerInputSet(.init(id: id, input: .color, value: "Color.blue")),
-            .layerInputSet(.init(id: id, input: .opacity, value: "0.5")),
-            .layerInputSet(.init(id: id, input: .scale, value: "2")),
+            .layerInputSet(.init(id: id, input: .color, value: PortValue.color(Color.blue))),
+            .layerInputSet(.init(id: id, input: .opacity, value: PortValue.number(0.5))),
+            .layerInputSet(.init(id: id, input: .scale, value: PortValue.number(2))),
         ]
     }()
     
@@ -83,10 +84,10 @@ extension ASTExplorerView {
         let id = UUID()
         return [
             .layer(.init(id: id, name: .text, children: [])),
-            .layerInputSet(.init(id: id, input: .color, value: "Color.green")),
-            .layerInputSet(.init(id: id, input: .zIndex, value: "88")),
-            .layerInputSet(.init(id: id, input: .clipped, value: "true")),
-            .layerInputSet(.init(id: id, input: .scale, value: "2")),
+            .layerInputSet(.init(id: id, input: .color, value: PortValue.color(Color.green))),
+            .layerInputSet(.init(id: id, input: .zIndex, value: .number(88))),
+            .layerInputSet(.init(id: id, input: .clipped, value: .bool(true))),
+            .layerInputSet(.init(id: id, input: .scale, value: PortValue.number(2))),
         ]
     }()
     
@@ -94,9 +95,9 @@ extension ASTExplorerView {
         let id = UUID()
         return [
             .layer(.init(id: id, name: .sfSymbol, children: [])),
-            .layerInputSet(.init(id: id, input: .color, value: "Color.green")),
-            .layerInputSet(.init(id: id, input: .sfSymbol, value: "star.fill")),
-            .layerInputSet(.init(id: id, input: .scale, value: "2")),
+            .layerInputSet(.init(id: id, input: .color, value: PortValue.color(Color.green))),
+            .layerInputSet(.init(id: id, input: .sfSymbol, value: .string(.init("star.fill")))),
+            .layerInputSet(.init(id: id, input: .scale, value: PortValue.number(2))),
         ]
     }()
     
@@ -107,9 +108,9 @@ extension ASTExplorerView {
         return [
             .layer(.init(id: id, name: .group, children: [childLayer])),
             .layer(childLayer),
-            .layerInputSet(.init(id: idChild, input: .color, value: "Color.green")),
-            .layerInputSet(.init(id: idChild, input: .sfSymbol, value: "star.fill")),
-            .layerInputSet(.init(id: id, input: .scale, value: "2")),
+            .layerInputSet(.init(id: idChild, input: .color, value: PortValue.color(Color.green))),
+            .layerInputSet(.init(id: idChild, input: .sfSymbol, value: .string(.init("star.fill")))),
+            .layerInputSet(.init(id: id, input: .scale, value: PortValue.number(2))),
         ]
     }()
     

--- a/Stitch/Graph/StitchAI/Mapping/Actions/VPLActions.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Actions/VPLActions.swift
@@ -35,8 +35,8 @@ struct VPLLayerInputSet: Equatable, Codable, Hashable {
     let input: LayerInputPort
     
     // TODO: JUNE 24: use PortValue instead of String; reuse parsing logic from StepAction parsing etc. ?
-    // let value: PortValue  // literal the user entered
-    let value: String  // literal the user entered
+    let value: PortValue  // literal the user entered
+//    let value: String  // literal the user entered
 }
 
 // an edge coming into the layer input

--- a/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/FromLayerInputToSyntax.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/FromLayerInputToSyntax.swift
@@ -96,7 +96,8 @@ extension SyntaxView {
 //            if let viewModifierName = inputSet.input.toSwiftUIViewModifierName
             let syntaxScenario: FromLayerInputToSyntax = inputSet.input.toSwiftUISyntax(
                 // TODO: JUNE 24: handle proper PortValue here
-                port: .value(PortValue.string(.init(inputSet.value))),
+//                port: .value(PortValue.string(.init(inputSet.value))),
+                port: .value(inputSet.value),
                 layer: layer.name)
             
             switch syntaxScenario {

--- a/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/FromLayerInputToSyntax.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/FromLayerInputToSyntax.swift
@@ -97,7 +97,7 @@ extension SyntaxView {
             let syntaxScenario: FromLayerInputToSyntax = inputSet.input.toSwiftUISyntax(
                 // TODO: JUNE 24: handle proper PortValue here
 //                port: .value(PortValue.string(.init(inputSet.value))),
-                port: .value(inputSet.value),
+                valueOrEdge: .value(inputSet.value),
                 layer: layer.name)
             
             switch syntaxScenario {

--- a/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
@@ -17,7 +17,7 @@ extension LayerInputPort {
         let buildModifier = { (kind: SyntaxViewModifierName) -> SyntaxViewModifier in
             SyntaxViewModifier(kind: kind,
                      arguments: [
-                        SyntaxViewModifierArgument(label: nil, // assumes unlabeled
+                        SyntaxViewModifierArgument(label: .noLabel, // assumes unlabeled
                                  value: port.asSwiftUILiteralOrVariable,
                                  syntaxKind: port.asSwiftSyntaxKind)
                      ])
@@ -55,17 +55,18 @@ extension LayerInputPort {
             // TODO: JUNE 24: how to handle PortValue.position(CGPoint) as a SwiftUI `.position(x:y:)` modifier? ... But also, this particular mapping is much more complicated, and Stitch only ever relies on the SwiftUI `.offset(width:height:)` modifier.
         case .position:
             // return .modifier(.position)
-            return .modifier(SyntaxViewModifier(kind: .position,
-                                      arguments: [
-                                        // NOT CORRECT?: discrepancy between
-                                        SyntaxViewModifierArgument(label: "x",
-                                                 // NEED TO UNPACK THE PORT VALUE ?
-                                                 value: port.asSwiftUILiteralOrVariable,
-                                                 syntaxKind: port.asSwiftSyntaxKind),
-                                        SyntaxViewModifierArgument(label: "y",
-                                                 value: port.asSwiftUILiteralOrVariable,
-                                                 syntaxKind: port.asSwiftSyntaxKind)
-                                      ]))
+            return .modifier(SyntaxViewModifier(
+                kind: .position,
+                arguments: [
+                    // NOT CORRECT?: discrepancy between
+                    SyntaxViewModifierArgument(label: .x,
+                                               // NEED TO UNPACK THE PORT VALUE ?
+                                               value: port.asSwiftUILiteralOrVariable,
+                                               syntaxKind: port.asSwiftSyntaxKind),
+                    SyntaxViewModifierArgument(label: .y,
+                                               value: port.asSwiftUILiteralOrVariable,
+                                               syntaxKind: port.asSwiftSyntaxKind)
+                ]))
             
 
             

--- a/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
@@ -14,8 +14,8 @@ extension LayerInputPort {
                          layer: Layer) -> FromLayerInputToSyntax {
         
         // TODO: JUNE 24: ASSUMES SINGLE-PARAMETER PORT VALUE, i.e. can handle .opacity but not .frame
-        let buildModifier = { (kind: SyntaxViewModifierName) -> SyntaxViewModifier in
-            SyntaxViewModifier(kind: kind,
+        let buildModifier = { (name: SyntaxViewModifierName) -> SyntaxViewModifier in
+            SyntaxViewModifier(name: name,
                      arguments: [
                         SyntaxViewModifierArgument(label: .noLabel, // assumes unlabeled
                                  value: port.asSwiftUILiteralOrVariable,
@@ -34,7 +34,7 @@ extension LayerInputPort {
             // return .constructorArgument(.text(.noLabel))
             return .constructorArgument(.init(
                 
-                label: .unlabeled,
+                label: .noLabel,
                 
                 // TODO: JUNE 24: tricky: how to go from a VPL literal or edge to SwiftUI code contained with a
                 // `value` is either a literal (manually-set value) or an expression (incoming edge);
@@ -56,7 +56,7 @@ extension LayerInputPort {
         case .position:
             // return .modifier(.position)
             return .modifier(SyntaxViewModifier(
-                kind: .position,
+                name: .position,
                 arguments: [
                     // NOT CORRECT?: discrepancy between
                     SyntaxViewModifierArgument(label: .x,

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
@@ -92,7 +92,7 @@ class SwiftUIViewVisitor: SyntaxVisitor {
     
     // Helper to add a modifier to the current view node
     private func addModifier(_ modifier: SyntaxViewModifier) {
-        let modName = modifier.kind.rawValue
+        let modName = modifier.name.rawValue
         dbg("addModifier → \(modName) to current index \(String(describing: currentNodeIndex))")
         guard let index = currentNodeIndex, index < viewStack.count else {
             log("⚠️ Cannot add modifier: no current view node")
@@ -289,7 +289,7 @@ class SwiftUIViewVisitor: SyntaxVisitor {
                 finalArgs = [SyntaxViewModifierArgument(label: .noLabel, value: "", syntaxKind: .literal(.unknown))]
             }
             let modifier = SyntaxViewModifier(
-                kind: SyntaxViewModifierName(rawValue: modifierName),
+                name: SyntaxViewModifierName(rawValue: modifierName),
                 arguments: finalArgs
             )
 
@@ -319,7 +319,7 @@ func testSwiftUIToViewNode(swiftUICode: String) {
         print("Arguments: \(viewNode.constructorArguments)")
         print("Modifiers (\(viewNode.modifiers.count)):")
         for (index, modifier) in viewNode.modifiers.enumerated() {
-            print("  [\(index)] \(modifier.kind.rawValue))")
+            print("  [\(index)] \(modifier.name.rawValue))")
             if !modifier.arguments.isEmpty {
                 print("    Arguments:")
                 for arg in modifier.arguments {

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
@@ -178,7 +178,6 @@ class SwiftUIViewVisitor: SyntaxVisitor {
             }
             
             let expression = argument.expression
-            
             return SyntaxViewConstructorArgument(
                 label: label,
                 value: expression.trimmedDescription,
@@ -193,8 +192,13 @@ class SwiftUIViewVisitor: SyntaxVisitor {
     
     // Parse arguments from function call
     private func parseArgumentsForModifier(from node: FunctionCallExprSyntax) -> [SyntaxViewModifierArgument] {
-        let arguments = node.arguments.map { argument in
-            let label = argument.label?.text
+        let arguments = node.arguments.compactMap { (argument) -> SyntaxViewModifierArgument? in
+            
+            guard let label = SyntaxViewModifierArgumentLabel.from(argument.label?.text) else {
+                log("could not create view modifier argument label for argument.label: \(String(describing: argument.label))")
+                return nil
+            }
+            
             let expression = argument.expression
             return SyntaxViewModifierArgument(
                 label: label,
@@ -282,7 +286,7 @@ class SwiftUIViewVisitor: SyntaxVisitor {
             var finalArgs = modifierArguments
             if finalArgs.isEmpty {
                 // `.padding()` → synthetic unknown literal
-                finalArgs = [SyntaxViewModifierArgument(label: nil, value: "", syntaxKind: .literal(.unknown))]
+                finalArgs = [SyntaxViewModifierArgument(label: .noLabel, value: "", syntaxKind: .literal(.unknown))]
             }
             let modifier = SyntaxViewModifier(
                 kind: SyntaxViewModifierName(rawValue: modifierName),
@@ -319,7 +323,7 @@ func testSwiftUIToViewNode(swiftUICode: String) {
             if !modifier.arguments.isEmpty {
                 print("    Arguments:")
                 for arg in modifier.arguments {
-                    print("      \(arg.label ?? "_"): \(arg.value)")
+                    print("      \(arg.label): \(arg.value)")
                 }
             }
         }

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxExamples.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxExamples.swift
@@ -21,9 +21,9 @@ let complexModifierExample = SyntaxView(
         SyntaxViewModifier(
             kind: .frame,
             arguments: [
-                SyntaxViewModifierArgument(label: "width",  value: "200", syntaxKind: .literal(.integer)),
-                SyntaxViewModifierArgument(label: "height", value: "100", syntaxKind: .literal(.integer)),
-                SyntaxViewModifierArgument(label: "alignment", value: ".center", syntaxKind: .variable(.memberAccess))
+                SyntaxViewModifierArgument(label: .width,  value: "200", syntaxKind: .literal(.integer)),
+                SyntaxViewModifierArgument(label: .height, value: "100", syntaxKind: .literal(.integer)),
+                SyntaxViewModifierArgument(label: .alignment, value: ".center", syntaxKind: .variable(.memberAccess))
             ]
         )
     ],
@@ -48,7 +48,7 @@ let example1 = SyntaxView(
             modifiers: [
                 SyntaxViewModifier(
                     kind: .fill,
-                    arguments: [SyntaxViewModifierArgument(label: nil, value: "Color.blue", syntaxKind: .variable(.memberAccess))]
+                    arguments: [SyntaxViewModifierArgument(label: .noLabel, value: "Color.blue", syntaxKind: .variable(.memberAccess))]
                 )
             ],
             children: [],
@@ -60,7 +60,7 @@ let example1 = SyntaxView(
             modifiers: [
                 SyntaxViewModifier(
                     kind: .fill,
-                    arguments: [SyntaxViewModifierArgument(label: nil, value: "Color.green", syntaxKind: .variable(.memberAccess))]
+                    arguments: [SyntaxViewModifierArgument(label: .noLabel, value: "Color.green", syntaxKind: .variable(.memberAccess))]
                 )
             ],
             children: [],
@@ -98,11 +98,11 @@ let example3 = SyntaxView(
     modifiers: [
         SyntaxViewModifier(
             kind: .foregroundColor,
-            arguments: [SyntaxViewModifierArgument(label: nil, value: "Color.yellow", syntaxKind: .variable(.memberAccess))]
+            arguments: [SyntaxViewModifierArgument(label: .noLabel, value: "Color.yellow", syntaxKind: .variable(.memberAccess))]
         ),
         SyntaxViewModifier(
             kind: .padding,
-            arguments: [SyntaxViewModifierArgument(label: nil, value: "", syntaxKind: .literal(.unknown))]
+            arguments: [SyntaxViewModifierArgument(label: .noLabel, value: "", syntaxKind: .literal(.unknown))]
         )
     ],
     children: [],
@@ -129,7 +129,7 @@ let example4 = SyntaxView(
             modifiers: [
                 SyntaxViewModifier(
                     kind: .fill,
-                    arguments: [SyntaxViewModifierArgument(label: nil, value: "Color.blue", syntaxKind: .variable(.memberAccess))]
+                    arguments: [SyntaxViewModifierArgument(label: .noLabel, value: "Color.blue", syntaxKind: .variable(.memberAccess))]
                 )
             ],
             children: [],
@@ -146,7 +146,7 @@ let example4 = SyntaxView(
                     modifiers: [
                         SyntaxViewModifier(
                             kind: .fill,
-                            arguments: [SyntaxViewModifierArgument(label: nil, value: "Color.green", syntaxKind: .variable(.memberAccess))]
+                            arguments: [SyntaxViewModifierArgument(label: .noLabel, value: "Color.green", syntaxKind: .variable(.memberAccess))]
                         )
                     ],
                     children: [],
@@ -158,7 +158,7 @@ let example4 = SyntaxView(
                     modifiers: [
                         SyntaxViewModifier(
                             kind: .fill,
-                            arguments: [SyntaxViewModifierArgument(label: nil, value: "Color.red", syntaxKind: .variable(.memberAccess))]
+                            arguments: [SyntaxViewModifierArgument(label: .noLabel, value: "Color.red", syntaxKind: .variable(.memberAccess))]
                         )
                     ],
                     children: [],

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxExamples.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxExamples.swift
@@ -19,7 +19,7 @@ let complexModifierExample = SyntaxView(
     constructorArguments: [],
     modifiers: [
         SyntaxViewModifier(
-            kind: .frame,
+            name: .frame,
             arguments: [
                 SyntaxViewModifierArgument(label: .width,  value: "200", syntaxKind: .literal(.integer)),
                 SyntaxViewModifierArgument(label: .height, value: "100", syntaxKind: .literal(.integer)),
@@ -47,7 +47,7 @@ let example1 = SyntaxView(
             constructorArguments: [],
             modifiers: [
                 SyntaxViewModifier(
-                    kind: .fill,
+                    name: .fill,
                     arguments: [SyntaxViewModifierArgument(label: .noLabel, value: "Color.blue", syntaxKind: .variable(.memberAccess))]
                 )
             ],
@@ -59,7 +59,7 @@ let example1 = SyntaxView(
             constructorArguments: [],
             modifiers: [
                 SyntaxViewModifier(
-                    kind: .fill,
+                    name: .fill,
                     arguments: [SyntaxViewModifierArgument(label: .noLabel, value: "Color.green", syntaxKind: .variable(.memberAccess))]
                 )
             ],
@@ -76,7 +76,7 @@ let example1 = SyntaxView(
 let example2 = SyntaxView(
     name: .init(from: "Text"),
     constructorArguments: [
-        SyntaxViewConstructorArgument(label: .unlabeled,
+        SyntaxViewConstructorArgument(label: .noLabel,
                             value: "\"salut\"",
                             syntaxKind: .literal(.string))
     ],
@@ -90,18 +90,18 @@ let example2 = SyntaxView(
 let example3 = SyntaxView(
     name: .init(from: "Text"),
     constructorArguments: [
-        SyntaxViewConstructorArgument(label: .unlabeled,
+        SyntaxViewConstructorArgument(label: .noLabel,
                             value: "\"salut\"",
                             syntaxKind: .literal(.string))
         
     ],
     modifiers: [
         SyntaxViewModifier(
-            kind: .foregroundColor,
+            name: .foregroundColor,
             arguments: [SyntaxViewModifierArgument(label: .noLabel, value: "Color.yellow", syntaxKind: .variable(.memberAccess))]
         ),
         SyntaxViewModifier(
-            kind: .padding,
+            name: .padding,
             arguments: [SyntaxViewModifierArgument(label: .noLabel, value: "", syntaxKind: .literal(.unknown))]
         )
     ],
@@ -128,7 +128,7 @@ let example4 = SyntaxView(
             constructorArguments: [],
             modifiers: [
                 SyntaxViewModifier(
-                    kind: .fill,
+                    name: .fill,
                     arguments: [SyntaxViewModifierArgument(label: .noLabel, value: "Color.blue", syntaxKind: .variable(.memberAccess))]
                 )
             ],
@@ -145,7 +145,7 @@ let example4 = SyntaxView(
                     constructorArguments: [],
                     modifiers: [
                         SyntaxViewModifier(
-                            kind: .fill,
+                            name: .fill,
                             arguments: [SyntaxViewModifierArgument(label: .noLabel, value: "Color.green", syntaxKind: .variable(.memberAccess))]
                         )
                     ],
@@ -157,7 +157,7 @@ let example4 = SyntaxView(
                     constructorArguments: [],
                     modifiers: [
                         SyntaxViewModifier(
-                            kind: .fill,
+                            name: .fill,
                             arguments: [SyntaxViewModifierArgument(label: .noLabel, value: "Color.red", syntaxKind: .variable(.memberAccess))]
                         )
                     ],

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxUtils.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxUtils.swift
@@ -55,7 +55,7 @@ func formatSyntaxView(_ node: SyntaxView, indent: String = "") -> String {
             result += "\n\(indent)            arguments: ["
             if !modifier.arguments.isEmpty {
                 for (j, arg) in modifier.arguments.enumerated() {
-                    let label = arg.label != nil ? "\"\(arg.label!)\"" : "nil"
+                    let label = arg.label == .noLabel ? "" : "\"\(arg.label)\""
                     let argKindDesc = describe(arg.syntaxKind)
                     result += "\n\(indent)                (label: \(label), value: \"\(arg.value)\", kind: \(argKindDesc))"
                     if j < modifier.arguments.count - 1 {

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxUtils.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxUtils.swift
@@ -49,7 +49,7 @@ func formatSyntaxView(_ node: SyntaxView, indent: String = "") -> String {
     if !node.modifiers.isEmpty {
         for (i, modifier) in node.modifiers.enumerated() {
             result += "\n\(indent)        SyntaxViewModifier("
-            result += "\n\(indent)            kind: \"\(modifier.kind)\","
+            result += "\n\(indent)            kind: \"\(modifier.name)\","
             // value field removed
             // Format modifier arguments
             result += "\n\(indent)            arguments: ["

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewConstructorArgument.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewConstructorArgument.swift
@@ -32,7 +32,7 @@ enum SyntaxConstructorArgumentLabel: String, Equatable, Hashable {
     // argument without a label, e.g. SwiftUI Text: `Text("love")`;
     // Note: SwiftUI views that do not take arguments at all (e.g. `Rectangle()`) will not actually have constructor-args
     // https://developer.apple.com/documentation/swiftui/text#Creating-a-text-view
-    case unlabeled = ""
+    case noLabel = ""
     
     // case verbatim = "verbatim"
     
@@ -55,7 +55,7 @@ extension SyntaxConstructorArgumentLabel {
     static func from(_ string: String?) -> SyntaxConstructorArgumentLabel? {
         switch string {
         case .none:
-            return .unlabeled
+            return .noLabel
         case .some(let x):
             return Self(rawValue: x)
         }

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewConstructorArgument.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewConstructorArgument.swift
@@ -43,10 +43,7 @@ enum SyntaxConstructorArgumentLabel: String, Equatable, Hashable {
     // HStack, VStack, ZStack
     // case alignment = "alignment"
     // case spacing = "spacing"
-    
-    // case hStack(HStackConstructorArgument)
-    // case vStack(VStackConstructorArgument)
-    
+        
     // Use `Argument` to capture unsupported constructors on SwiftUI Views,
     // e.g. `Text(Date, style: Text.DateStyle)`
     

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
@@ -10,11 +10,10 @@ import SwiftSyntax
 import SwiftParser
 
 
-
 struct SyntaxViewModifier: Equatable, Hashable {
 
     // representation of a SwiftUI view modifier name
-    let kind: SyntaxViewModifierName
+    let name: SyntaxViewModifierName
     
     // representation of argument(s) to SwiftUI view modifer
     var arguments: [SyntaxViewModifierArgument]
@@ -26,7 +25,7 @@ struct SyntaxViewModifier: Equatable, Hashable {
  TODO: `Argument.value` should be `enum ArgumentValue { case value(String), actionClosure(???), viewClosure(ViewNode) }`
  
  Note: per chat with Vatsal, can also ask LLM to rewrite certain SwiftUI View closure-styles into non-closure versions etc. in an additional pass.
- 
+
  ```swift
  Button(
     action: { ... }, // patch logic?
@@ -35,16 +34,16 @@ struct SyntaxViewModifier: Equatable, Hashable {
  ```
  */
 struct SyntaxViewModifierArgument: Equatable, Hashable {
-    let label: SyntaxViewModifierArgumentLabel // TODO: JUNE 25: use `SyntaxViewModifierArgumentLabel`
+    let label: SyntaxViewModifierArgumentLabel
     let value: String
     
     // literal vs declared var vs expression
     let syntaxKind: SyntaxArgumentKind
 }
 
-// all possible modifier arg labels together
+
 enum SyntaxViewModifierArgumentLabel: String, Equatable, Hashable {
-    case noLabel = "", // e.g. `.fill()`, `.foregroundColor()`
+    case noLabel = "", // e.g. `.fill(Color.red)`, `.foregroundColor(Color.green)`
          
          // e.g. `.frame(width:height:alignment:)`
          width = "width",
@@ -66,6 +65,7 @@ extension SyntaxViewModifierArgumentLabel {
         }
     }
 }
+
 
 // MARK: representation of
 

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
@@ -10,6 +10,7 @@ import SwiftSyntax
 import SwiftParser
 
 
+
 struct SyntaxViewModifier: Equatable, Hashable {
 
     // representation of a SwiftUI view modifier name
@@ -34,13 +35,37 @@ struct SyntaxViewModifier: Equatable, Hashable {
  ```
  */
 struct SyntaxViewModifierArgument: Equatable, Hashable {
-    let label: String?
+    let label: SyntaxViewModifierArgumentLabel // TODO: JUNE 25: use `SyntaxViewModifierArgumentLabel`
     let value: String
     
     // literal vs declared var vs expression
     let syntaxKind: SyntaxArgumentKind
 }
 
+// all possible modifier arg labels together
+enum SyntaxViewModifierArgumentLabel: String, Equatable, Hashable {
+    case noLabel = "", // e.g. `.fill()`, `.foregroundColor()`
+         
+         // e.g. `.frame(width:height:alignment:)`
+         width = "width",
+         height = "height",
+         alignment = "alignment",
+         
+         // e.g. position(x:y:)
+         x = "x",
+         y = "y"
+}
+
+extension SyntaxViewModifierArgumentLabel {
+    static func from(_ string: String?) -> SyntaxViewModifierArgumentLabel? {
+        switch string {
+        case .none:
+            return .noLabel
+        case .some(let x):
+            return Self(rawValue: x)
+        }
+    }
+}
 
 // MARK: representation of
 

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/SyntaxToActionsUtils.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/SyntaxToActionsUtils.swift
@@ -37,18 +37,37 @@ enum StitchValueOrEdge: Equatable {
             return SyntaxArgumentKind.variable(.identifier) // `x`
         }
     }
+    
+    var getValue: PortValue? {
+        switch self {
+        case .value(let x): return x
+        default: return nil
+        }
+    }
+    
+    var getIncomingEdge: (NodeId, Int)? {
+        switch self {
+        case .edge(let x, let y): return (x, y)
+        default: return nil
+        }
+    }
 }
 
 extension PortValue {
+    
     // TODO: JUNE 24: should return a Codable ? ... How do you map between Swift/SwiftUI types and Stitch's PortValue types ? ... see note in `LayerInputPort.toSwiftUI`
     var asSwiftUILiteral: String {
-        switch self {
-        case .number(let x):
-            return x.description
-        case .string(let x):
-            return x.string
-        default:
+        
+        // TODO: JUNE 25: where did our `PortValue.usesMultipleFields` method go? ... Could use a check
+        let isMultifield = self.createFieldValuesList(
+            nodeIO: .input,
+            layerInputPort: nil,
+            isLayerInspector: false).count > 1
+        
+        if isMultifield {
             return "IMPLEMENT ME: \(self.display)"
+        } else {
+            return self.display
         }
     }
 }

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
@@ -56,8 +56,15 @@ extension SyntaxView {
         // iterate through constructor arguments
         for arg in self.constructorArguments {
             
-            guard let port = arg.toLayerInput(layer) else {
+            guard let port: LayerInputPort = arg.deriveLayerInputPort(layer) else {
                 log("deriveSetInputAndIncomingEdgeActions: could not handle constructor argument label: \(arg.label)")
+                // fatalErrorIfDebug()
+                continue
+            }
+            
+            // TODO: alternatively, rely on the layer input port's default port-value and user-input-edit logic?
+            guard let portValue = arg.derivePortValue(layer) else {
+                log("deriveSetInputAndIncomingEdgeActions: could not handle constructor argument value: \(arg.value)")
                 // fatalErrorIfDebug()
                 continue
             }
@@ -66,9 +73,11 @@ extension SyntaxView {
             
             case .literal:
                 actions.append(
-                    .layerInputSet(VPLLayerInputSet(id: id,
-                                                    input: port,
-                                                    value: arg.value))
+                    .layerInputSet(VPLLayerInputSet(
+                        id: id,
+                        input: port,
+                        value: portValue
+                    ))
                 )
                 
             case .expression, .variable:
@@ -82,47 +91,42 @@ extension SyntaxView {
         // iterate through modifiers
         for modifier in self.modifiers {
             
-            guard let port = modifier.kind.toLayerInput(layer) else {
+            guard let port = modifier.name.deriveLayerInputPort(layer) else {
                 log("could not create layer input for modifier \(modifier)")
                 continue
             }
             
-            // JUNE 24: PROPERLY HANDLE WHEN INPUT HAS ONE FIELD WITH A LITERAL AND ANOTHER FIELD WITH AN INCOMING EDGE
-            let allLiteral = modifier.arguments.allSatisfy {
-                if case .literal = $0.syntaxKind { return true }
-                return false
+            
+            // Start with a default port value of the correct kind for this layer input
+            var portValue = port.getDefaultValue(for: layer)
+            
+            // Iterate through the modifier's arguments,
+            // parsing each arg's `value` as if it were a user-edit;
+            // workings equally well
+            for (index, arg) in modifier.arguments.enumerated() {
+                portValue = portValue.parseInputEdit(
+                    fieldValue: .string(.init(arg.value)),
+                    fieldIndex: index)
             }
-            if allLiteral {
-                // Emit ONE SASetLayerInput: kind = modifier.kind, value = joined literal list
-                // Format: "label1: value1, value2"
-                let parts: [String] = modifier.arguments.map {
-                    let label = $0.label
-                    if !label.rawValue.isEmpty {
-                        return "\(label): \($0.value)"
-                    } else {
-                        return $0.value
-                    }
-                }
-                
-                let joined = parts.joined(separator: ", ")
-                actions.append(.layerInputSet(VPLLayerInputSet(id: id,
-                                                               input: port,
-                                                               value: joined)))
-            } else {
-                // Emit ONE action per argument
-                for arg in modifier.arguments {
-                    switch arg.syntaxKind {
-                    case .literal:
-                        actions.append(.layerInputSet(VPLLayerInputSet(
-                            id: id,
-                            input: port,
-                            value: arg.value)))
-                        
-                    case .variable, .expression:
-                        actions.append(.incomingEdge(VPLIncomingEdge(name: port)))
-                    }
-                }
-            }
+            
+            actions.append(.layerInputSet(
+                VPLLayerInputSet(id: id,
+                                 input: port,
+                                 value: portValue)
+            ))
+            
+            
+            // TODO: handle incoming edges
+            // TODO: handle unpacked layer inputs where some fields receive edges, others manually-set values
+            //            for arg in modifier.arguments {
+            //                switch arg.syntaxKind {
+            //                case .variable, .expression:
+            //                    actions.append(.incomingEdge(VPLIncomingEdge(name: port)))
+            //                default:
+            //                    continue
+            //                }
+            //            }
+            
             
         } // for modifier in ...
         

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
@@ -96,7 +96,8 @@ extension SyntaxView {
                 // Emit ONE SASetLayerInput: kind = modifier.kind, value = joined literal list
                 // Format: "label1: value1, value2"
                 let parts: [String] = modifier.arguments.map {
-                    if let label = $0.label, !label.isEmpty {
+                    let label = $0.label
+                    if !label.rawValue.isEmpty {
                         return "\(label): \($0.value)"
                     } else {
                         return $0.value

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToCode/StitchSyntaxToCode.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToCode/StitchSyntaxToCode.swift
@@ -42,7 +42,7 @@ func swiftUICode(from node: SyntaxView, indentation: String = "") -> String {
     // Add modifiers
     for modifier in node.modifiers {
         code += "\n\(indentation)    ."
-        code += modifier.kind.rawValue
+        code += modifier.name.rawValue
         
         // Handle the modifier value or arguments
         if !modifier.arguments.isEmpty {

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToCode/StitchSyntaxToCode.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToCode/StitchSyntaxToCode.swift
@@ -50,7 +50,7 @@ func swiftUICode(from node: SyntaxView, indentation: String = "") -> String {
             code += "("
             
             let args = modifier.arguments.enumerated().map { index, arg -> String in
-                let label = arg.label != nil ? "\(arg.label!): " : ""
+                let label = arg.label.rawValue.isEmpty ? "" : "\(arg.label): "
                 return "\(label)\(arg.value)"
             }.joined(separator: ", ")
             


### PR DESCRIPTION
examples: 
- works well with .frame and PortValue.size
- awkward for PortValue.color

<img width="1414" alt="Screenshot 2025-06-25 at 11 42 41 PM" src="https://github.com/user-attachments/assets/cca3ceb8-3e2e-44e1-959b-c8bd46209de5" />
<img width="1424" alt="Screenshot 2025-06-25 at 11 42 25 PM" src="https://github.com/user-attachments/assets/ad4a61a3-9b01-4956-ab68-6b3d1efdf6c7" />
