### PR TITLE
Improved AI results with ScrollView

### DIFF
--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/Node/StitchAINodeSection.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/Node/StitchAINodeSection.swift
@@ -35,13 +35,16 @@ public enum NodeSection: String, CaseIterable, CustomStringConvertible {
     case deviceSystem = "Device and System Nodes"
     case arrayOperation = "Array Operation Nodes"
     case jsAINode = "Javascript AI Node"
+    case ignoredNodes = "IGNORED NODES"
 }
 
 extension NodeSection {
     // TODO: should we really be passing in a specific GraphState here? aren't these node descriptions independent of any given graph ? None of the defined nodes have connections etc., right?
     @MainActor
     static func getAllAIDescriptions(graph: GraphState) throws -> [StitchAINodeSectionDescription] {
-        try Self.allCases.map {
+        try Self.allCases
+            .filter { $0 != .ignoredNodes }
+            .map {
             try StitchAINodeSectionDescription.init($0, graph: graph)
         }
     }
@@ -144,7 +147,7 @@ extension CurrentStep.Patch {
             return .deviceSystem
             
             // MARK: Interaction Nodes
-        case .dragInteraction, .pressInteraction, .scrollInteraction,
+        case .dragInteraction, .pressInteraction,
                 .keyboard, .mouse:
             return .interaction
             
@@ -199,6 +202,9 @@ extension CurrentStep.Patch {
                 .indexOf, .subarray, .setValueForKey, .valueForKey, .valueAtIndex,
                 .valueAtPath:
             return .arrayOperation
+            
+        case .scrollInteraction:
+            return .ignoredNodes
         }
     }
 }

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/Node/StitchAINodeUtils.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/Node/StitchAINodeUtils.swift
@@ -14,7 +14,7 @@ extension CurrentStep.NodeKind {
         // Filter out the scroll interaction node
         let allDescriptions = CurrentStep.Patch.allAiDescriptions + CurrentStep.Layer.allAiDescriptions
         return allDescriptions.filter { description in
-            !description.nodeKind.contains("scrollInteraction")
+            !description.nodeKind.contains("legacyScrollInteraction")
         }
     }
 }

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/Node/StitchAINodeUtils.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/Node/StitchAINodeUtils.swift
@@ -29,6 +29,16 @@ extension CurrentStep.Layer {
     var patchOrLayer: CurrentStep.PatchOrLayer {
         .layer(self)
     }
+    
+    var isGroup: Bool {
+        switch self {
+        case .group, .realityView:
+            return true
+            
+        default:
+            return false
+        }
+    }
 }
 
 struct StitchAINodeKindDescription {

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AICodeGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AICodeGenRequest.swift
@@ -102,7 +102,7 @@ struct AICodeGenRequest: StitchAIRequestable {
                             
                             do {
                                 let graphData = CurrentAIPatchBuilderResponseFormat
-                                    .GraphData(layer_data: layerData,
+                                    .GraphData(layer_data: [layerData],
                                                patch_data: patchBuildResult)
                                 try graphData.applyAIGraph(to: document)
                             } catch {

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
@@ -62,7 +62,7 @@ struct AIPatchBuilderRequest: StitchAIRequestable {
 extension StitchDocumentViewModel {
     /// Recursively creates new sidebar layer data from AI result after creating nodes.
     @MainActor
-    func createLayerNodeFromAI(newLayer: CurrentAIPatchBuilderResponseFormat.LayerNode,
+    func createLayerNodeFromAI(newLayer: CurrentAIPatchBuilderResponseFormat.LayerData,
                                idMap: inout [UUID : UUID]) throws -> SidebarLayerData {
         let newId = UUID()
         idMap.updateValue(newId, forKey: newLayer.node_id.value)
@@ -186,7 +186,7 @@ extension CurrentAIPatchBuilderResponseFormat.GraphData {
         
         // new layer nodes
         var newLayerSidebarDataList = [SidebarLayerData]()
-        for newLayer in self.layer_data.layers {
+        for newLayer in self.layer_data {
             let newSidebarData = try document.createLayerNodeFromAI(newLayer: newLayer,
                                                                     idMap: &idMap)
             newLayerSidebarDataList.append(newSidebarData)
@@ -211,7 +211,7 @@ extension CurrentAIPatchBuilderResponseFormat.GraphData {
         }
         
         // new constants for layers
-        for newInputValueSetting in self.layer_data.custom_layer_input_values {
+        for newInputValueSetting in self.layer_data.allNestedCustomInputValues {
             let inputCoordinate = try NodeIOCoordinate(
                 from: newInputValueSetting.layer_input_coordinate,
                 idMap: idMap)

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AICodeGen/AICodeGenSystemPrompt_V0.md
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AICodeGen/AICodeGenSystemPrompt_V0.md
@@ -523,10 +523,6 @@ Each function should mimic logic composed in patch nodes in Stitch (or Origami S
     "node_kind" : "pressInteraction || Patch"
   },
   {
-    "description" : "Adds scroll interaction to a specified layer.",
-    "node_kind" : "legacyScrollInteraction || Patch"
-  },
-  {
     "description" : "A node that will fire a pulse at a defined interval.",
     "node_kind" : "repeatingPulse || Patch"
   },

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIPatchBuilder/AIPatchBuilderResponseFormat_V0.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIPatchBuilder/AIPatchBuilderResponseFormat_V0.swift
@@ -195,16 +195,16 @@ extension AIPatchBuilderResponseFormat_V0 {
         let layer_connections: [LayerConnection]
     }
     
-    struct LayerData: Codable {
-        var layers: [AIPatchBuilderResponseFormat_V0.LayerNode]
-        var custom_layer_input_values: [CustomLayerInputValue]
-    }
+//    struct LayerData: Codable {
+//        var layers: [AIPatchBuilderResponseFormat_V0.LayerNode]
+//    }
     
-    struct LayerNode {
+    struct LayerData {
         let node_id: StitchAIUUID_V0.StitchAIUUID
         var suggested_title: String?
         let node_name: StitchAIPatchOrLayer
-        var children: [LayerNode]?
+        var children: [LayerData]?
+        var custom_layer_input_values: [CustomLayerInputValue] = []
     }
     
     struct JsPatchNode: Codable {
@@ -330,18 +330,20 @@ extension AIPatchBuilderResponseFormat_V0.CustomPatchInputValue {
     }
 }
 
-extension AIPatchBuilderResponseFormat_V0.LayerNode: Codable {
+extension AIPatchBuilderResponseFormat_V0.LayerData: Codable {
     enum CodingKeys: String, CodingKey {
         case node_id
         case suggested_title
         case node_name
         case children
+        case custom_layer_input_values
     }
     
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(node_id, forKey: .node_id)
         try container.encode(node_name, forKey: .node_name)
+        try container.encode(custom_layer_input_values, forKey: .custom_layer_input_values)
         
         try container.encodeIfPresent(suggested_title, forKey: .suggested_title)
         

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIPatchBuilder/AIPatchBuilderResponseFormat_V0.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIPatchBuilder/AIPatchBuilderResponseFormat_V0.swift
@@ -43,7 +43,7 @@ enum AIPatchBuilderResponseFormat_V0 {
         
         let Layer_Nodes = OpenAISchema(
             type: .array,
-            required: ["node_id", "node_name"],
+            required: ["node_id", "node_name", "custom_layer_input_values"],
             description: "A nested list of layer nodes to be created in the graph.",
             items: OpenAIGeneric(types: [AIPatchBuilderResponseFormat_V0.LayerNodeSchema()])
         )
@@ -66,21 +66,7 @@ enum AIPatchBuilderResponseFormat_V0 {
             required: ["layer_id", "input_port_type"])
     }
     
-    // MARK: not used in structured outputs, just the system prompt inputs
-    struct LayerDataSchema: Encodable {
-        let layers = OpenAISchemaRef(ref: "Layer_Nodes")
-        
-        let custom_layer_input_values = OpenAISchema(
-            type: .array,
-            required: ["layer_input_coordinate", "value", "value_type"],
-            items: OpenAIGeneric(types: [
-                AIPatchBuilderResponseFormat_V0.CustomLayerInputValueSchema()
-            ])
-        )
-    }
-    
     struct GraphBuilderSchema: Encodable {
-        
         let javascript_patches = OpenAISchema(
             type: .array,
             required: ["node_id", "suggested_title", "javascript_source_code", "input_definitions", "output_definitions"],
@@ -118,11 +104,19 @@ enum AIPatchBuilderResponseFormat_V0 {
         )
     }
     
+    // MARK: not used for outputs, just inputs.
     struct LayerNodeSchema: Encodable {
         let node_id = OpenAISchema(type: .string)
         let suggested_title = OpenAISchema(type: .string)
         let node_name = OpenAISchemaRef(ref: "NodeName")
         let children = OpenAISchemaRef(ref: "Layer_Nodes")
+        let custom_layer_input_values = OpenAISchema(
+            type: .array,
+            required: ["layer_input_coordinate", "value", "value_type"],
+            items: OpenAIGeneric(types: [
+                AIPatchBuilderResponseFormat_V0.CustomLayerInputValueSchema()
+            ])
+        )
     }
 
     struct JsPatchNodeSchema: Encodable {

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIPatchBuilder/AIPatchBuilderResponseFormat_V0.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIPatchBuilder/AIPatchBuilderResponseFormat_V0.swift
@@ -194,11 +194,7 @@ extension AIPatchBuilderResponseFormat_V0 {
         // All connections are captured by patch data regardless of patch or layer
         let layer_connections: [LayerConnection]
     }
-    
-//    struct LayerData: Codable {
-//        var layers: [AIPatchBuilderResponseFormat_V0.LayerNode]
-//    }
-    
+
     struct LayerData {
         let node_id: StitchAIUUID_V0.StitchAIUUID
         var suggested_title: String?

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIPatchBuilder/AIPatchBuilderResponseFormat_V0.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIPatchBuilder/AIPatchBuilderResponseFormat_V0.swift
@@ -181,7 +181,7 @@ enum AIPatchBuilderResponseFormat_V0 {
 // Actual types
 extension AIPatchBuilderResponseFormat_V0 {
     struct GraphData: Codable {
-        let layer_data: LayerData
+        let layer_data: [LayerData]
         let patch_data: PatchData
     }
     
@@ -435,3 +435,23 @@ extension Step_V0.PortValue {
         try container.encode(portValue.nodeType, forKey: valueTypeKey)
     }
 }
+
+extension Array where Element == CurrentAIPatchBuilderResponseFormat.LayerData {
+    var allNestedCustomInputValues: [AIPatchBuilderResponseFormat_V0.CustomLayerInputValue] {
+        self.flatMap {
+            $0.custom_layer_input_values +
+            ($0.children?.allNestedCustomInputValues ?? [])
+        }
+    }
+}
+
+//extension AIPatchBuilderResponseFormat_V0.LayerData {
+//    func createSidebarLayerData() -> SidebarLayerData {
+//        let children = self.children?.map {
+//            $0.createSidebarLayerData()
+//        }
+//        
+//        return SidebarLayerData(id: self.node_id.value,
+//                                children: children)
+//    }
+//}

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIPatchBuilder/AIPatchBuilderResponseFormat_V0.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIPatchBuilder/AIPatchBuilderResponseFormat_V0.swift
@@ -435,13 +435,17 @@ extension Array where Element == CurrentAIPatchBuilderResponseFormat.LayerData {
     }
 }
 
-//extension AIPatchBuilderResponseFormat_V0.LayerData {
-//    func createSidebarLayerData() -> SidebarLayerData {
-//        let children = self.children?.map {
-//            $0.createSidebarLayerData()
-//        }
-//        
-//        return SidebarLayerData(id: self.node_id.value,
-//                                children: children)
-//    }
-//}
+extension AIPatchBuilderResponseFormat_V0.LayerData {
+    func createSidebarLayerData(idMap: [UUID : UUID]) throws -> SidebarLayerData {
+        guard let newId = idMap.get(self.node_id.value) else {
+            throw AIPatchBuilderRequestError.nodeIdNotFound
+        }
+        
+        let children = try self.children?.map {
+            try $0.createSidebarLayerData(idMap: idMap)
+        }
+        
+        return SidebarLayerData(id: newId,
+                                children: children)
+    }
+}

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIPatchBuilder/AIPatchBuilderSystemPrompt_V0.md
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIPatchBuilder/AIPatchBuilderSystemPrompt_V0.md
@@ -521,10 +521,6 @@ Each function should mimic logic composed in patch nodes in Stitch (or Origami S
     "node_kind" : "pressInteraction || Patch"
   },
   {
-    "description" : "Adds scroll interaction to a specified layer.",
-    "node_kind" : "legacyScrollInteraction || Patch"
-  },
-  {
     "description" : "A node that will fire a pulse at a defined interval.",
     "node_kind" : "repeatingPulse || Patch"
   },
@@ -7329,100 +7325,6 @@ Each patch and layer supports the following inputs and outputs:
               "width" : "0.0"
             },
             "valueType" : "size"
-          }
-        ]
-      },
-      {
-        "inputs" : [
-          {
-            "label" : "Layer",
-            "value" : null,
-            "valueType" : "layer"
-          },
-          {
-            "label" : "Scroll X",
-            "value" : "free",
-            "valueType" : "scrollMode"
-          },
-          {
-            "label" : "Scroll Y",
-            "value" : "free",
-            "valueType" : "scrollMode"
-          },
-          {
-            "label" : "Content Size",
-            "value" : {
-              "height" : "0.0",
-              "width" : "0.0"
-            },
-            "valueType" : "size"
-          },
-          {
-            "label" : "Direction Locking",
-            "value" : false,
-            "valueType" : "bool"
-          },
-          {
-            "label" : "Page Size",
-            "value" : {
-              "height" : "0.0",
-              "width" : "0.0"
-            },
-            "valueType" : "size"
-          },
-          {
-            "label" : "Page Padding",
-            "value" : {
-              "height" : "0.0",
-              "width" : "0.0"
-            },
-            "valueType" : "size"
-          },
-          {
-            "label" : "Jump Style X",
-            "value" : "instant",
-            "valueType" : "scrollJumpStyle"
-          },
-          {
-            "label" : "Jump to X",
-            "value" : 0,
-            "valueType" : "pulse"
-          },
-          {
-            "label" : "Jump Position X",
-            "value" : 0,
-            "valueType" : "number"
-          },
-          {
-            "label" : "Jump Style Y",
-            "value" : "instant",
-            "valueType" : "scrollJumpStyle"
-          },
-          {
-            "label" : "Jump to Y",
-            "value" : 0,
-            "valueType" : "pulse"
-          },
-          {
-            "label" : "Jump Position Y",
-            "value" : 0,
-            "valueType" : "number"
-          },
-          {
-            "label" : "Deceleration Rate",
-            "value" : "normal",
-            "valueType" : "scrollDecelerationRate"
-          }
-        ],
-        "nodeKind" : "legacyScrollInteraction || Patch",
-        "outputs" : [
-          {
-            "label" : "Position",
-            "value" : {
-              "x" : 0,
-              "y" : 0
-            },
-            "valueType" : "position"
           }
         ]
       }

--- a/Stitch/Graph/StitchAI/Mapping/Actions/VPLActions.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Actions/VPLActions.swift
@@ -10,12 +10,12 @@ import StitchSchemaKit
 import OrderedCollections
 
 
-typealias AIFlow = CurrentAIPatchBuilderResponseFormat
+//typealias AIFlow = CurrentAIPatchBuilderResponseFormat
 
 // easier names to remember
-typealias VPLActionsData = CurrentAIPatchBuilderResponseFormat.LayerData
-typealias VPLCreateNode = CurrentAIPatchBuilderResponseFormat.LayerNode
-typealias VPLSetInput = CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue
+//typealias VPLActionsData = CurrentAIPatchBuilderResponseFormat.LayerData
+//typealias VPLCreateNode = CurrentAIPatchBuilderResponseFormat.LayerNode
+//typealias VPLSetInput = CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue
 
 
 

--- a/Stitch/Graph/StitchAI/Mapping/Actions/VPLActions.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Actions/VPLActions.swift
@@ -10,15 +10,6 @@ import StitchSchemaKit
 import OrderedCollections
 
 
-//typealias AIFlow = CurrentAIPatchBuilderResponseFormat
-
-// easier names to remember
-//typealias VPLActionsData = CurrentAIPatchBuilderResponseFormat.LayerData
-//typealias VPLCreateNode = CurrentAIPatchBuilderResponseFormat.LayerNode
-//typealias VPLSetInput = CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue
-
-
-
 // MARK: 'actions' just in the sense of being something our VPL can consume
 
 //typealias VPLActions = [VPLAction]

--- a/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/FromLayerInputToSyntax.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/FromLayerInputToSyntax.swift
@@ -48,13 +48,6 @@ extension SyntaxView {
     /// - Parameter actions: The action list (layer creations, input sets, incoming edges, …).
     /// - Returns: The root `SyntaxView` or `nil` when no layer‑creation action is found.
     static func build(from actions: CurrentAIPatchBuilderResponseFormat.LayerData) throws -> Self? {
-//        // The very first `.layer` action produced by `deriveStitchActions()` is the root.
-//        guard let rootLayer = actions.first else {
-//            log("SyntaxView.build: No VPLLayer creation found – cannot rebuild view tree.")
-//            return nil
-//        }
-//
-//        return
         try node(from: actions)
     }
 

--- a/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/FromLayerInputToSyntax.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/FromLayerInputToSyntax.swift
@@ -48,21 +48,21 @@ extension SyntaxView {
     /// - Parameter actions: The action list (layer creations, input sets, incoming edges, …).
     /// - Returns: The root `SyntaxView` or `nil` when no layer‑creation action is found.
     static func build(from actions: CurrentAIPatchBuilderResponseFormat.LayerData) throws -> Self? {
-        // The very first `.layer` action produced by `deriveStitchActions()` is the root.
-        guard let rootLayer = actions.layers.first else {
-            log("SyntaxView.build: No VPLLayer creation found – cannot rebuild view tree.")
-            return nil
-        }
-
-        return try node(from: rootLayer, in: actions)
+//        // The very first `.layer` action produced by `deriveStitchActions()` is the root.
+//        guard let rootLayer = actions.first else {
+//            log("SyntaxView.build: No VPLLayer creation found – cannot rebuild view tree.")
+//            return nil
+//        }
+//
+//        return
+        try node(from: actions)
     }
 
     // MARK: - Private helpers
 
     /// Recursively create a `SyntaxView` from a `VPLLayer`, using `actions`
     /// to populate constructor arguments and modifiers.
-    private static func node(from layerData: CurrentAIPatchBuilderResponseFormat.LayerNode,
-                             in actions: CurrentAIPatchBuilderResponseFormat.LayerData) throws -> Self? {
+    private static func node(from layerData: CurrentAIPatchBuilderResponseFormat.LayerData) throws -> Self? {
 
         // TODO: provide layer group orientation
         guard let layer = layerData.node_name.value.layer,
@@ -73,7 +73,7 @@ extension SyntaxView {
         }
         
         // Gather all `layerInputSet` concepts that belong to this layer.
-        let customInputEvents = actions.custom_layer_input_values
+        let customInputEvents = layerData.custom_layer_input_values
 
         // Convert those sets into very naïve constructor‑arguments *or* modifiers.
         // For now we treat everything as a modifier unless the corresponding
@@ -106,7 +106,7 @@ extension SyntaxView {
 
         // Recurse into child layers.
         let childNodes: [Self]? = try layerData.children?
-            .compactMap { try node(from: $0, in: actions) }
+            .compactMap { try node(from: $0) }
 
         // Build the actual SyntaxView node.
         return Self(

--- a/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
@@ -14,6 +14,7 @@ enum SwiftUISyntaxError: Error {
     case unsupportedLayer(SyntaxViewName)
     case unsupportedLayerInput(CurrentStep.LayerInputPort)
     case incorrectParsing(message: String)
+    case groupLayerDecodingFailed
 }
 
 extension CurrentStep.LayerInputPort {

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewName.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewName.swift
@@ -93,7 +93,7 @@ extension SyntaxViewName {
     
     var isSupported: Bool {
         (try? self.deriveLayerData(id: .init(),
-                              args: [],
+                                   args: [],
                                    modifiers: [],
                                    childrenLayers: [])) != nil
     }

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewName.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewName.swift
@@ -94,7 +94,8 @@ extension SyntaxViewName {
     var isSupported: Bool {
         (try? self.deriveLayerData(id: .init(),
                               args: [],
-                              modifiers: [])) != nil
+                                   modifiers: [],
+                                   childrenLayers: [])) != nil
     }
     
 //    static let disabledViews: [Self] = Self.allCases.filter {

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
@@ -93,15 +93,25 @@ extension SyntaxViewName {
         switch scrollAxis {
         case .vertical:
             // Enable vertical scrolling only
-            groupLayer.custom_layer_input_values.append(
-                .init(id: nodeID, input: .scrollYEnabled, value: .bool(true))
-            )
+            groupLayer.custom_layer_input_values += [
+                .init(id: nodeID,
+                      input: .scrollYEnabled,
+                      value: .bool(true)),
+                .init(id: nodeID,
+                      input: .orientation,
+                      value: .orientation(.vertical))
+            ]
             
         case .horizontal:
             // Enable horizontal scrolling only
-            groupLayer.custom_layer_input_values.append(
-                .init(id: nodeID, input: .scrollXEnabled, value: .bool(true))
-            )
+            groupLayer.custom_layer_input_values += [
+                .init(id: nodeID,
+                      input: .scrollXEnabled,
+                      value: .bool(true)),
+                .init(id: nodeID,
+                      input: .orientation,
+                      value: .orientation(.horizontal))
+            ]
             
         case .both:
             // Enable both horizontal and vertical scrolling

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
@@ -11,10 +11,6 @@ import SwiftUI
 
 extension SyntaxView {
     func deriveStitchActions() throws -> CurrentAIPatchBuilderResponseFormat.LayerData {
-        // Instantiate with empty data
-//        var data = CurrentAIPatchBuilderResponseFormat
-//            .LayerData(layers: [],
-//                       custom_layer_input_values: [])
         var childLayers: [CurrentAIPatchBuilderResponseFormat.LayerData] = []
         
         // Recurse into children first (DFS), we might use this data for nested scenarios like ScrollView
@@ -22,10 +18,6 @@ extension SyntaxView {
             // depth-first
             let childConcepts = try child.deriveStitchActions()
             childLayers.append(childConcepts)
-            // Append child layers directly to layer at this recursive level
-//            childLayers += childConcepts.layers
-            
-//            data.custom_layer_input_values += childConcepts.custom_layer_input_values
         }
 
         // Map this node
@@ -34,10 +26,6 @@ extension SyntaxView {
             args: self.constructorArguments,
             modifiers: self.modifiers,
             childrenLayers: childLayers)
-        
-//        data.custom_layer_input_values += layerData.customLayerInputValues
-//
-//        data.layers.append(layerData.node)
         
         return layerData
     }
@@ -50,23 +38,8 @@ extension SyntaxViewName {
                                        childrenLayers: [CurrentAIPatchBuilderResponseFormat.LayerData]) throws -> CurrentAIPatchBuilderResponseFormat.LayerData {
         // Check the scroll axis from constructor arguments
         let scrollAxis = Self.detectScrollAxis(args: args)
-        
-        // Only proceed if we have a valid scroll axis and a single stack child
-//        guard 
-//            scrollAxis != .none,
-//            children.count == 1,
-//            let stack = children.first,
-//            // TODO: support `.lazyVGrid` as well
-//            (stack.name == .vStack || stack.name == .hStack || stack.name == .zStack)
-//        else {
-//            // Fall back to default handling if structure doesn't match expected pattern
-//            return nil
-//        }
-        
-//        var flattened = try stack.deriveStitchActions()
-//        var customInputs = [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue]()
-        var groupLayer: CurrentAIPatchBuilderResponseFormat.LayerData
-        
+      
+        var groupLayer: CurrentAIPatchBuilderResponseFormat.LayerData  
         let isFirstLayerGroup = childrenLayers.first?.node_name.value.layer?.isGroup ?? false
         let hasRootGroupLayer = childrenLayers.count == 1 && isFirstLayerGroup
         

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
@@ -9,11 +9,6 @@ import Foundation
 import StitchSchemaKit
 import SwiftUI
 
-//struct SyntaxViewLayerData {
-//    var node: CurrentAIPatchBuilderResponseFormat.LayerNode
-//    let customLayerInputValues: [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue]
-//}
-
 extension SyntaxViewName {
     
     /// Leaf-level mapping for **this** node only
@@ -40,10 +35,6 @@ extension SyntaxViewName {
             layerType: layerType,
             modifiers: modifiers)
 
-//        // Final bare layer (children added later)
-//        let layeNode = CurrentAIPatchBuilderResponseFormat
-//            .LayerNode(node_id: .init(value: id),
-//                       node_name: .init(value: .layer(layerType)))
         layerData.custom_layer_input_values += customInputValues
         layerData.custom_layer_input_values += customModifierValues
         

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
@@ -264,7 +264,7 @@ extension SyntaxViewName {
         var customValues = [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue]()
         
         for modifier in modifiers {
-            customValues = try deriveCustomValuesFromViewModifier(
+            customValues = try Self.deriveCustomValuesFromViewModifier(
                 id: id,
                 layerType: layerType,
                 modifier: modifier,
@@ -274,7 +274,7 @@ extension SyntaxViewName {
         return customValues
     }
     
-    private func deriveCustomValuesFromViewModifier(
+    private static func deriveCustomValuesFromViewModifier(
         id: UUID,
         layerType: CurrentStep.Layer,
         modifier: SyntaxViewModifier,
@@ -290,7 +290,7 @@ extension SyntaxViewName {
         switch derivationResult {
             
         case .simple(let port):
-            customValues = try self.deriveCustomValuesFromSimpleLayerInputTranslation(
+            customValues = try Self.deriveCustomValuesFromSimpleLayerInputTranslation(
                 id: id,
                 port: port,
                 layerType: layerType,
@@ -299,7 +299,7 @@ extension SyntaxViewName {
             
         case .rotationScenario:
             // Certain modifiers, e.g. `.rotation3DEffect` correspond to multiple layer-inputs (.rotationX, .rotationY, .rotationZ)
-            customValues = try self.deriveCustomValuesFromRotationLayerInputTranslation(
+            customValues = try Self.deriveCustomValuesFromRotationLayerInputTranslation(
                 id: id,
                 layerType: layerType,
                 modifier: modifier,
@@ -309,7 +309,7 @@ extension SyntaxViewName {
         return customValues
     }
     
-    func deriveCustomValuesFromSimpleLayerInputTranslation(
+    static func deriveCustomValuesFromSimpleLayerInputTranslation(
         id: UUID,
         port: CurrentStep.LayerInputPort, // simple because we have a single layer
         layerType: CurrentStep.Layer,
@@ -367,7 +367,7 @@ extension SyntaxViewName {
         return customValues
     }
     
-    func deriveCustomValuesFromRotationLayerInputTranslation(
+    static func deriveCustomValuesFromRotationLayerInputTranslation(
         id: UUID,
         layerType: CurrentStep.Layer,
         modifier: SyntaxViewModifier,

--- a/Stitch/Graph/StitchAI/PromptGenerator/AICodeGenSystemPromptGenerator.swift
+++ b/Stitch/Graph/StitchAI/PromptGenerator/AICodeGenSystemPromptGenerator.swift
@@ -10,10 +10,12 @@ extension StitchAIManager {
     func aiCodeGenSystemPromptGenerator(graph: GraphState) throws -> String {
         let patchDescriptions = CurrentStep.Patch.allAiDescriptions
             .filter { description in
-                !description.nodeKind.contains("scrollInteraction")
+                !description.nodeKind.contains("legacyScrollInteraction")
             }
         
         let layerDescriptions = CurrentStep.Layer.allAiDescriptions
+        
+        let nodePortDescriptions = try NodeSection.getAllAIDescriptions(graph: graph)
         
         return """
 # SwiftUI Code Creator
@@ -245,7 +247,7 @@ The schema below presents the list of inputs and outputs supported for each nati
 For layers, if the desired behavior is natively supported through a layer’s input, the patch system must prefer setting that input over simulating the behavior with patch nodes.
 
 Each patch and layer supports the following inputs and outputs:
-\(try NodeSection.getAllAIDescriptions(graph: graph).encodeToPrintableString())
+\(try nodePortDescriptions.encodeToPrintableString())
 
 
 ## Our app has specific requirements and opinions about SwiftUI views

--- a/Stitch/Graph/StitchAI/PromptGenerator/AIGraphBuilderSystemPromptGenerator.swift
+++ b/Stitch/Graph/StitchAI/PromptGenerator/AIGraphBuilderSystemPromptGenerator.swift
@@ -21,22 +21,19 @@ You are an assistant that manages the patch graph for Stitch, a visual programmi
 * Your JSON response must exactly match structured outputs.
 * You will receive as input SwiftUI source code.
 * You will receive as input a list of known layers.
-* Your goal is to create the graph building blocks necessary to update data to a set of layers, enabling the user’s original request for some prototyping functionality.
+* Your goal is to create the graph building blocks to represent functionality defined in `updateLayerInputs` function, along with to derive connections between various nodes.
 
 ## Fundamental Principles
-Your goal is to create the patch graph for a set of layers, completing some desired prototyping behavior. You receive each of the following inputs:
+Your goal is to create a patch graph, which will create logic that ultimately updates some already created set of layers. You receive each of the following inputs:
 1. **The user prompt.** Details the original prototyping behavior request.
 2. **SwiftUI source code.** This is broken down into various components, detailed below.
-## Deconstructing Inputs
-As mentioned previously, you will receive a specific set of inputs, which in our case will be presented in JSON format:
-```
-\(try CurrentAIPatchBuilderResponseFormat.LayerDataSchema().encodeToPrintableString())
-```
+3. **A list of already created layers.** These layers have been derived from the `var body` in the SwiftUI code.
 
 Layer nodes contain nested information about layers. Layers might be a “group” which in turn contain nested layers. Layer groups control functionality such as positioning across possibly multiple layers. The layer node's schema is as follows:
 ```
 \(try CurrentAIPatchBuilderResponseFormat.LayerNodeSchema().encodeToPrintableString())
 ```
+Where `custom_layer_input_values` are the values specified for some layers' inputs.
 
 ## Decoding SwiftUI Source Code
 > Note: make sure any IDs created for a node are valid UUIDs.
@@ -118,7 +115,7 @@ struct LayerConnection {
 
 struct LayerPortCoordinate {
     let layer_id: UUID
-    let input_label: String
+    let input_port_type: String
 }
 ```
 


### PR DESCRIPTION
This PR improves inference results based on views that would create a `ScrollView` instance. Changes:
* Improved logic for extracting layer data from `ScrollView` to use normal helper. This helper is used by other helpers to create a blacklist of views for AI to ignore. With this change, `ScrollView` will no longer be ignored.
* No longer enforces a top-level group view inside the `ScrollView` closure.
* Better enforcement of preventing legacy scroll patch from being created.

Also—fixes here to better handle patch creation, preventing situations where a redundant interaction patch is created with a scroll-enabled group.