### PR TITLE
Handling Color constructor in a view modifier

### DIFF
--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
@@ -207,10 +207,6 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
                         log("⚠️ Error: No current node to add child to")
                     }
                     
-                    // Add to stack so modifiers can be attached
-                    viewStack.append(viewNode)
-                    currentNodeIndex = viewStack.count - 1
-                    
                 case .arguments, .root:
                     // We're parsing function arguments - this might be a modifier argument
                     // Check if this is actually being used as a modifier argument

--- a/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/ColorCodeExamples.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/ColorCodeExamples.swift
@@ -14,7 +14,7 @@ struct ColorCodeExamples {
         code:
     """
     Rectangle()
-        .fill(Color("yellow") as! String)
+        .fill(Color("yellow" as! String))
     """
     )
 

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewName.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewName.swift
@@ -98,6 +98,42 @@ extension SyntaxViewName {
                                    childrenLayers: [])) != nil
     }
     
+    /// Returns true if this view type can have child views via closures
+    /// (e.g., VStack { ... }, HStack { ... })
+    var canHaveChildren: Bool {
+        switch self {
+        // Stack containers
+        case .vStack, .hStack, .zStack:
+            return true
+        case .lazyVStack, .lazyHStack, .lazyVGrid, .lazyHGrid:
+            return true
+        
+        // Layout containers
+        case .grid, .group:
+            return true
+        
+        // Scrollable containers
+        case .scrollView, .list:
+            return true
+        
+        // Navigation containers
+        case .navigationStack, .navigationSplit, .tabView:
+            return true
+        
+        // Form containers
+        case .form, .section:
+            return true
+        
+        // Special containers
+        case .forEach, .geometryReader:
+            return true
+        
+        // All other views cannot have children via closures
+        default:
+            return false
+        }
+    }
+    
 //    static let disabledViews: [Self] = Self.allCases.filter {
 //        $0.deriveLayer() == nil
 //    }

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
@@ -98,7 +98,6 @@ extension SyntaxViewName {
             throw SwiftUISyntaxError.unsupportedLayer(self) // Canvas sketch ?
         case .color:
             throw SwiftUISyntaxError.unsupportedLayer(self) // both Layer.hitArea AND Layer.colorFill
-            
         case .label:
             throw SwiftUISyntaxError.unsupportedLayer(self)
         case .asyncImage:

--- a/StitchTests/SwiftUIParsingTests/ConstructorTests.swift
+++ b/StitchTests/SwiftUIParsingTests/ConstructorTests.swift
@@ -61,11 +61,7 @@ final class ConstructorTests: XCTestCase {
         
         // Then - Verify the structure of the LayerData
         // 1. Check that we have exactly one root layer (the RoundedRectangle)
-        XCTAssertEqual(layerData.layers.count, 1, "Should have exactly one layer")
-        XCTAssertNotEqual(layerData.layers.count, 0, "Should have at least one layer")
-        XCTAssertNotEqual(layerData.layers.count, 2, "Should not have multiple layers")
-        
-        let roundedRectLayer = layerData.layers[0]
+        let roundedRectLayer = layerData
         
         // 2. Check that it's a rectangle layer (RoundedRectangle maps to .rectangle with cornerRadius input)
         if case let .layer(layerType) = roundedRectLayer.node_name.value {
@@ -163,11 +159,7 @@ final class ConstructorTests: XCTestCase {
         
         // Then - Verify the structure of the LayerData
         // 1. Check that we have exactly one layer (the Text)
-        XCTAssertEqual(layerData.layers.count, 1, "Should have exactly one layer")
-        XCTAssertNotEqual(layerData.layers.count, 0, "Should have at least one layer")
-        XCTAssertNotEqual(layerData.layers.count, 2, "Should not have multiple layers")
-        
-        let textLayer = layerData.layers[0]
+        let textLayer = layerData
         
         // 2. Check that the layer is a text layer
         if case let .layer(layerType) = textLayer.node_name.value {
@@ -252,10 +244,7 @@ final class ConstructorTests: XCTestCase {
         
         // Then - Verify the structure of the LayerData
         // 1. Check that we have exactly one layer (the SF Symbol)
-        XCTAssertEqual(layerData.layers.count, 1, "Should have exactly one layer")
-        XCTAssertNotEqual(layerData.layers.count, 0, "Should have at least one layer")
-        
-        let symbolLayer = layerData.layers[0]
+        let symbolLayer = layerData
         
         // 2. Check that the layer is an SF Symbol layer
         if case let .layer(layerType) = symbolLayer.node_name.value {

--- a/StitchTests/SwiftUIParsingTests/ModifierTests.swift
+++ b/StitchTests/SwiftUIParsingTests/ModifierTests.swift
@@ -69,11 +69,8 @@ final class CodeToSyntaxToActionsTests: XCTestCase {
         
         // Then - Verify the structure of the LayerData
         // 1. Check that we have exactly one root layer (the Rectangle)
-        XCTAssertEqual(layerData.layers.count, 1, "Should have exactly one layer")
-        XCTAssertNotEqual(layerData.layers.count, 0, "Should have at least one layer")
-        XCTAssertNotEqual(layerData.layers.count, 2, "Should not have multiple layers")
         
-        let rectangleLayer = layerData.layers[0]
+        let rectangleLayer = layerData
         
         // 2. Check that the layer is a rectangle
         if case let .layer(layerType) = rectangleLayer.node_name.value {
@@ -176,9 +173,7 @@ final class CodeToSyntaxToActionsTests: XCTestCase {
         
         // Then - Verify the structure of the LayerData
         // 1. Check that we have exactly one root layer (the Rectangle)
-        XCTAssertEqual(layerData.layers.count, 1, "Should have exactly one layer")
-        
-        let rectangleLayer = layerData.layers[0]
+        let rectangleLayer = layerData
         
         // 2. Check that the layer is a rectangle
         if case let .layer(layerType) = rectangleLayer.node_name.value {
@@ -270,11 +265,7 @@ final class CodeToSyntaxToActionsTests: XCTestCase {
         
         // Then - Verify the structure of the LayerData
         // 1. Check that we have exactly one root layer (the Rectangle)
-        XCTAssertEqual(layerData.layers.count, 1, "Should have exactly one layer")
-        XCTAssertNotEqual(layerData.layers.count, 0, "Should have at least one layer")
-        XCTAssertNotEqual(layerData.layers.count, 2, "Should not have multiple layers")
-        
-        let rectangleLayer = layerData.layers[0]
+        let rectangleLayer = layerData
         
         // 2. Check that the layer is a rectangle
         if case let .layer(layerType) = rectangleLayer.node_name.value {
@@ -379,10 +370,7 @@ final class CodeToSyntaxToActionsTests: XCTestCase {
         
         // Then - Verify the structure of the LayerData
         // 1. Check that we have exactly one layer (the Rectangle)
-        XCTAssertEqual(layerData.layers.count, 1, "Should have exactly one layer")
-        XCTAssertNotEqual(layerData.layers.count, 0, "Should have at least one layer")
-        
-        let rectangleLayer = layerData.layers[0]
+        let rectangleLayer = layerData
         
         // 2. Check that the layer is a rectangle
         if case let .layer(layerType) = rectangleLayer.node_name.value {
@@ -478,9 +466,7 @@ final class CodeToSyntaxToActionsTests: XCTestCase {
         
         // Then - Verify the structure of the LayerData
         // 1. Check that we have exactly one layer (the Rectangle)
-        XCTAssertEqual(layerData.layers.count, 1, "Should have exactly one layer")
-        
-        let rectangleLayer = layerData.layers[0]
+        let rectangleLayer = layerData
         
         // 2. Check that the layer is a rectangle
         if case let .layer(layerType) = rectangleLayer.node_name.value {

--- a/StitchTests/SwiftUIParsingTests/StackTests.swift
+++ b/StitchTests/SwiftUIParsingTests/StackTests.swift
@@ -88,11 +88,7 @@ final class StackTests: XCTestCase {
         
         // Then - Verify the structure of the LayerData
         // 1. Check that we have exactly one root layer (the VStack)
-        XCTAssertEqual(layerData.layers.count, 1, "Should have exactly one root layer")
-        XCTAssertNotEqual(layerData.layers.count, 0, "Should have at least one layer")
-        XCTAssertNotEqual(layerData.layers.count, 2, "Should not have multiple root layers")
-        
-        let vstackLayer = layerData.layers[0]
+        let vstackLayer = layerData
         
         // 2. Check that the VStack is a group with vertical orientation
         if case let .layer(layerType) = vstackLayer.node_name.value {


### PR DESCRIPTION
Also fixes test compilation.

We now no longer incorrectly create a child view when we encounter e.g. `.fill(Color("someString"))` etc.