### PR TITLE
Getting contents of `var body: some View` as a code string

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -967,6 +967,7 @@
 		ECC558A3294A941B0025BB42 /* LayerDragEndedHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC558A2294A941B0025BB42 /* LayerDragEndedHelpers.swift */; };
 		ECC558A7294A9B340025BB42 /* ScrollInteractionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC558A6294A9B340025BB42 /* ScrollInteractionUtils.swift */; };
 		ECC558A9294A9B3A0025BB42 /* DragInteractionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC558A8294A9B3A0025BB42 /* DragInteractionUtils.swift */; };
+		ECC6992D2E16E38D00D8D509 /* VarBodyParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC6992C2E16E38D00D8D509 /* VarBodyParser.swift */; };
 		ECC6F00928BFBBC600535493 /* LayerNamesDropDownChoiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC6F00828BFBBC600535493 /* LayerNamesDropDownChoiceView.swift */; };
 		ECC734742E0DE95A00AC266C /* CodeExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC734732E0DE95A00AC266C /* CodeExamples.swift */; };
 		ECC734762E0DE9AE00AC266C /* ActionExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC734752E0DE9AE00AC266C /* ActionExamples.swift */; };
@@ -2087,6 +2088,7 @@
 		ECC558A2294A941B0025BB42 /* LayerDragEndedHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerDragEndedHelpers.swift; sourceTree = "<group>"; };
 		ECC558A6294A9B340025BB42 /* ScrollInteractionUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollInteractionUtils.swift; sourceTree = "<group>"; };
 		ECC558A8294A9B3A0025BB42 /* DragInteractionUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragInteractionUtils.swift; sourceTree = "<group>"; };
+		ECC6992C2E16E38D00D8D509 /* VarBodyParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VarBodyParser.swift; sourceTree = "<group>"; };
 		ECC6F00828BFBBC600535493 /* LayerNamesDropDownChoiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerNamesDropDownChoiceView.swift; sourceTree = "<group>"; };
 		ECC734732E0DE95A00AC266C /* CodeExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeExamples.swift; sourceTree = "<group>"; };
 		ECC734752E0DE9AE00AC266C /* ActionExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionExamples.swift; sourceTree = "<group>"; };
@@ -5252,6 +5254,7 @@
 			isa = PBXGroup;
 			children = (
 				EC66D03C2E07123F00355ED8 /* CodeToStitchSyntax.swift */,
+				ECC6992C2E16E38D00D8D509 /* VarBodyParser.swift */,
 			);
 			path = CodeToSyntax;
 			sourceTree = "<group>";
@@ -6466,6 +6469,7 @@
 				ECA92A0C260A69A000281B52 /* AddNode.swift in Sources */,
 				EC9D16E22808D97A00684978 /* InputFieldView.swift in Sources */,
 				B56FFB2D2C18B7B400623CC7 /* SupportedMediaFormat.swift in Sources */,
+				ECC6992D2E16E38D00D8D509 /* VarBodyParser.swift in Sources */,
 				B5849FFB2DFC8F8C00D668ED /* StepTypeDefinitions_V1.swift in Sources */,
 				B55500BD2C1B9A1B0081C3F1 /* JSONReplViews.swift in Sources */,
 				EC49069D2CCACD4000165554 /* StitchCustomColorPickerView.swift in Sources */,

--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -968,6 +968,7 @@
 		ECC558A7294A9B340025BB42 /* ScrollInteractionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC558A6294A9B340025BB42 /* ScrollInteractionUtils.swift */; };
 		ECC558A9294A9B3A0025BB42 /* DragInteractionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC558A8294A9B3A0025BB42 /* DragInteractionUtils.swift */; };
 		ECC6992D2E16E38D00D8D509 /* VarBodyParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC6992C2E16E38D00D8D509 /* VarBodyParser.swift */; };
+		ECC699302E16EBB000D8D509 /* VarBodyParserDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC6992F2E16EBB000D8D509 /* VarBodyParserDemoView.swift */; };
 		ECC6F00928BFBBC600535493 /* LayerNamesDropDownChoiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC6F00828BFBBC600535493 /* LayerNamesDropDownChoiceView.swift */; };
 		ECC734742E0DE95A00AC266C /* CodeExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC734732E0DE95A00AC266C /* CodeExamples.swift */; };
 		ECC734762E0DE9AE00AC266C /* ActionExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC734752E0DE9AE00AC266C /* ActionExamples.swift */; };
@@ -2089,6 +2090,7 @@
 		ECC558A6294A9B340025BB42 /* ScrollInteractionUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollInteractionUtils.swift; sourceTree = "<group>"; };
 		ECC558A8294A9B3A0025BB42 /* DragInteractionUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragInteractionUtils.swift; sourceTree = "<group>"; };
 		ECC6992C2E16E38D00D8D509 /* VarBodyParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VarBodyParser.swift; sourceTree = "<group>"; };
+		ECC6992F2E16EBB000D8D509 /* VarBodyParserDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VarBodyParserDemoView.swift; sourceTree = "<group>"; };
 		ECC6F00828BFBBC600535493 /* LayerNamesDropDownChoiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerNamesDropDownChoiceView.swift; sourceTree = "<group>"; };
 		ECC734732E0DE95A00AC266C /* CodeExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeExamples.swift; sourceTree = "<group>"; };
 		ECC734752E0DE9AE00AC266C /* ActionExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionExamples.swift; sourceTree = "<group>"; };
@@ -5254,7 +5256,7 @@
 			isa = PBXGroup;
 			children = (
 				EC66D03C2E07123F00355ED8 /* CodeToStitchSyntax.swift */,
-				ECC6992C2E16E38D00D8D509 /* VarBodyParser.swift */,
+				ECC6992E2E16EBA000D8D509 /* VarBodyParser */,
 			);
 			path = CodeToSyntax;
 			sourceTree = "<group>";
@@ -5360,6 +5362,15 @@
 				ECB238C62E0A111800D55A25 /* SyntaxToCode */,
 			);
 			path = Mapping;
+			sourceTree = "<group>";
+		};
+		ECC6992E2E16EBA000D8D509 /* VarBodyParser */ = {
+			isa = PBXGroup;
+			children = (
+				ECC6992C2E16E38D00D8D509 /* VarBodyParser.swift */,
+				ECC6992F2E16EBB000D8D509 /* VarBodyParserDemoView.swift */,
+			);
+			path = VarBodyParser;
 			sourceTree = "<group>";
 		};
 		ECC734722E0DE92F00AC266C /* Examples */ = {
@@ -6440,6 +6451,7 @@
 				ECB9A86D2AEB4944006E65EE /* LightnessSliderView.swift in Sources */,
 				EC631402265C418D00BD45B2 /* LoopSelectNode.swift in Sources */,
 				B52A3E632B7F337400B4F1DA /* GraphCopyable.swift in Sources */,
+				ECC699302E16EBB000D8D509 /* VarBodyParserDemoView.swift in Sources */,
 				EC16587F2B6AFA8D00FE4AE6 /* EdgeEditingActions.swift in Sources */,
 				20308FA725AD1721008CE3BE /* ContentView.swift in Sources */,
 				B58E97D72DF0B87B007913E3 /* AIEditJsNodeRequestBody_V0.swift in Sources */,

--- a/Stitch/App/StitchApp.swift
+++ b/Stitch/App/StitchApp.swift
@@ -44,7 +44,8 @@ struct StitchApp: App {
 #if DEV_DEBUG
     var body: some Scene {
         WindowGroup {
-            ASTExplorerView()
+            VarBodyParserDemoView()
+            // ASTExplorerView()
         }
     }
 #else

--- a/Stitch/App/StitchApp.swift
+++ b/Stitch/App/StitchApp.swift
@@ -44,8 +44,8 @@ struct StitchApp: App {
 #if DEV_DEBUG
     var body: some Scene {
         WindowGroup {
-            VarBodyParserDemoView()
-            // ASTExplorerView()
+            // VarBodyParserDemoView()
+            ASTExplorerView()
         }
     }
 #else

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/VarBodyParser.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/VarBodyParser.swift
@@ -1,0 +1,179 @@
+//
+//  VarBodyParser.swift
+//  Stitch
+//
+//  Created by Christian J Clampitt on 7/3/25.
+//
+
+import Foundation
+import SwiftSyntax
+import SwiftUI
+import SwiftParser
+
+
+/// A tiny utility for extracting the exact source text of the
+/// `var body: some View { … }` declaration from arbitrary Swift code.
+///
+/// This relies on **SwiftSyntax/SwiftParser**, so it respects Swift grammar:
+/// occurrences of “var body” inside comments, strings, or nested types are ignored.
+public enum VarBodyParser {
+    /// Parses `source` and returns the text slice that corresponds to the
+    /// `var body: some View` declaration (including its braces and original
+    /// indentation). Returns `nil` if no matching declaration is found.
+    public static func extract(from source: String) throws -> String? {
+        let tree   = Parser.parse(source: source)
+        let finder = BodyFinder(viewMode: .sourceAccurate)
+        finder.walk(tree)
+        
+        guard let decl = finder.result else { return nil }
+        
+        // Remove blank lines (and trailing spaces) *before* `var body`
+        // and *after* the closing `}` while keeping the interior
+        // indentation untouched.
+        var text = decl.description
+        
+        // Trim leading newline / carriage‑return only
+        while let first = text.first, first == "\n" || first == "\r" {
+            text.removeFirst()
+        }
+        // Trim trailing whitespace & newlines
+        while let last = text.last, last.isWhitespace || last.isNewline {
+            text.removeLast()
+        }
+        return text
+    }
+    
+    // MARK: - Private
+    
+    /// Visits each `VariableDeclSyntax` until it finds the first declaration that:
+    ///   * is named “body”
+    ///   * has a single binding
+    ///   * has a type annotation exactly equal to `some View`
+    private final class BodyFinder: SyntaxVisitor {
+        var result: VariableDeclSyntax?
+        
+        override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+            // Bail early once we've captured a match.
+            guard result == nil else { return .skipChildren }
+            
+            guard
+                node.bindings.count == 1,
+                let binding      = node.bindings.first,
+                let identPattern = binding.pattern.as(IdentifierPatternSyntax.self),
+                identPattern.identifier.text == "body",
+                let typeAnn      = binding.typeAnnotation?.type,
+                typeAnn.trimmedDescription == "some View"
+            else {
+                return .skipChildren
+            }
+            
+            // Capture the declaration exactly as it appeared in the source file.
+            result = node
+            return .skipChildren
+        }
+    }
+}
+
+// MARK: - 🚀 Interactive demo
+// A lightweight playground view that lets you edit example SwiftUI files and
+// instantly see the `VarBodyParser.extract` result next to it.
+//
+// Inspired by ASTExplorerView, but scoped just to body‑extraction.
+struct VarBodyParserDemoView: View {
+    
+    // Demo snippets lifted from `VarBodyCodeExamples`.
+    static let examples = [
+        VarBodyCodeExamples.var_body,
+        VarBodyCodeExamples.var_body_method,
+        VarBodyCodeExamples.file_views
+    ]
+    
+    // MARK: – UI state
+    @State var codes: [String] = examples.map(\.code)
+    
+    @State var extracted: [String] = examples.map { code in
+        (try? VarBodyParser.extract(from: code.code)) ?? "—"
+    }
+    @State var selectedTab = 0
+    
+    @State var errorStrings: [String?] = Array(repeating: nil,
+                                               count: examples.count)
+    
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("VarBodyParser Demo")
+                .font(.title2).bold()
+            
+            Button("Parse Current Tab") { refresh(tab: selectedTab) }
+                .buttonStyle(.borderedProminent)
+            
+            TabView(selection: $selectedTab) {
+                ForEach(Self.examples.indices, id: \.self) { idx in
+                    demoPane(for: idx)
+                        .tabItem { Text(Self.examples[idx].title) }
+                        .tag(idx)
+                }
+            }
+            .tabViewStyle(.automatic)
+            .onChange(of: selectedTab, initial: true) { _, newIdx in
+                refresh(tab: newIdx)
+            }
+        }
+        .padding()
+    }
+    
+    // MARK: – Single‑tab layout
+    @ViewBuilder
+    func demoPane(for idx: Int) -> some View {
+        let codeBinding = Binding<String>(
+            get: { codes[idx] },
+            set: { codes[idx] = $0; refresh(tab: idx) }
+        )
+        
+        HStack(spacing: 18) {
+            stageView(title: "Source Code",
+                      text: codes[idx],
+                      isEditor: true,
+                      editorBinding: codeBinding)
+            stageView(title: "Extracted `var body`",
+                      text: extracted[idx].isEmpty ? "—" : extracted[idx])
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+    
+    // MARK: – Helpers
+    func refresh(tab idx: Int) {
+        do {
+            let result = try VarBodyParser.extract(from: codes[idx])
+            extracted[idx] = result ?? "—"
+            errorStrings[idx] = nil
+        } catch {
+            extracted[idx] = "—"
+            errorStrings[idx] = "\(error)"
+        }
+    }
+    
+    /// Re‑usable stage panel.
+    @ViewBuilder
+    func stageView(title: String,
+                   text: String,
+                   isEditor: Bool = false,
+                   editorBinding: Binding<String>? = nil) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title).font(.headline)
+            if isEditor, let binding = editorBinding {
+                TextEditor(text: binding)
+                    .font(.system(.body, design: .monospaced))
+                    .padding()
+                    .border(Color.secondary)
+            } else {
+                TextEditor(text: .constant(text))
+                    .font(.system(.body, design: .monospaced))
+                    .padding()
+                    .border(Color.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+}

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/VarBodyParser/VarBodyParser.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/VarBodyParser/VarBodyParser.swift
@@ -1,0 +1,79 @@
+//
+//  VarBodyParser.swift
+//  Stitch
+//
+//  Created by Christian J Clampitt on 7/3/25.
+//
+
+import Foundation
+import SwiftSyntax
+import SwiftUI
+import SwiftParser
+
+
+/// A tiny utility for extracting the exact source text of the
+/// `var body: some View { … }` declaration from arbitrary Swift code.
+///
+/// This relies on **SwiftSyntax/SwiftParser**, so it respects Swift grammar:
+/// occurrences of “var body” inside comments, strings, or nested types are ignored.
+public enum VarBodyParser {
+    /// Parses `source` and returns *only* the source between the braces of
+    /// `var body: some View { … }`, preserving every character exactly as
+    /// written (indentation, comments, blank lines).
+    /// - Returns: The interior text, or `nil` if no matching declaration exists.
+    public static func extract(from source: String) throws -> String? {
+        // Parse the source.
+        let tree   = Parser.parse(source: source)
+        let finder = BodyFinder(viewMode: .sourceAccurate)
+        finder.walk(tree)
+        guard
+            let decl     = finder.result,
+            let binding  = decl.bindings.first,
+            let accessor = binding.accessorBlock
+        else { return nil }
+
+        // Slice the original string using absolute UTF‑8 offsets so that we
+        // keep trivia (whitespace/comments) exactly as typed.
+        let startOffset = accessor.leftBrace.endPosition.utf8Offset
+        let endOffset   = accessor.rightBrace.position.utf8Offset
+
+        guard endOffset >= startOffset, endOffset <= source.utf8.count else {
+            return nil
+        }
+
+        // Convert offsets to String.Index and return the substring.
+        let startIndex = String.Index(utf16Offset: startOffset, in: source)
+        let endIndex   = String.Index(utf16Offset: endOffset, in: source)
+        return String(source[startIndex..<endIndex])
+    }
+    
+    // MARK: - Private
+    
+    /// Visits each `VariableDeclSyntax` until it finds the first declaration that:
+    ///   * is named “body”
+    ///   * has a single binding
+    ///   * has a type annotation exactly equal to `some View`
+    private final class BodyFinder: SyntaxVisitor {
+        var result: VariableDeclSyntax?
+        
+        override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+            // Bail early once we've captured a match.
+            guard result == nil else { return .skipChildren }
+            
+            guard
+                node.bindings.count == 1,
+                let binding      = node.bindings.first,
+                let identPattern = binding.pattern.as(IdentifierPatternSyntax.self),
+                identPattern.identifier.text == "body",
+                let typeAnn      = binding.typeAnnotation?.type,
+                typeAnn.trimmedDescription == "some View"
+            else {
+                return .skipChildren
+            }
+            
+            // Capture the declaration exactly as it appeared in the source file.
+            result = node
+            return .skipChildren
+        }
+    }
+}

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/VarBodyParser/VarBodyParserDemoView.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/VarBodyParser/VarBodyParserDemoView.swift
@@ -1,82 +1,12 @@
 //
-//  VarBodyParser.swift
+//  VarBodyParserDemoView.swift
 //  Stitch
 //
 //  Created by Christian J Clampitt on 7/3/25.
 //
 
-import Foundation
-import SwiftSyntax
 import SwiftUI
-import SwiftParser
 
-
-/// A tiny utility for extracting the exact source text of the
-/// `var body: some View { … }` declaration from arbitrary Swift code.
-///
-/// This relies on **SwiftSyntax/SwiftParser**, so it respects Swift grammar:
-/// occurrences of “var body” inside comments, strings, or nested types are ignored.
-public enum VarBodyParser {
-    /// Parses `source` and returns *only* the source between the braces of
-    /// `var body: some View { … }`, preserving every character exactly as
-    /// written (indentation, comments, blank lines).
-    /// - Returns: The interior text, or `nil` if no matching declaration exists.
-    public static func extract(from source: String) throws -> String? {
-        // Parse the source.
-        let tree   = Parser.parse(source: source)
-        let finder = BodyFinder(viewMode: .sourceAccurate)
-        finder.walk(tree)
-        guard
-            let decl     = finder.result,
-            let binding  = decl.bindings.first,
-            let accessor = binding.accessorBlock
-        else { return nil }
-
-        // Slice the original string using absolute UTF‑8 offsets so that we
-        // keep trivia (whitespace/comments) exactly as typed.
-        let startOffset = accessor.leftBrace.endPosition.utf8Offset
-        let endOffset   = accessor.rightBrace.position.utf8Offset
-
-        guard endOffset >= startOffset, endOffset <= source.utf8.count else {
-            return nil
-        }
-
-        // Convert offsets to String.Index and return the substring.
-        let startIndex = String.Index(utf16Offset: startOffset, in: source)
-        let endIndex   = String.Index(utf16Offset: endOffset, in: source)
-        return String(source[startIndex..<endIndex])
-    }
-    
-    // MARK: - Private
-    
-    /// Visits each `VariableDeclSyntax` until it finds the first declaration that:
-    ///   * is named “body”
-    ///   * has a single binding
-    ///   * has a type annotation exactly equal to `some View`
-    private final class BodyFinder: SyntaxVisitor {
-        var result: VariableDeclSyntax?
-        
-        override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
-            // Bail early once we've captured a match.
-            guard result == nil else { return .skipChildren }
-            
-            guard
-                node.bindings.count == 1,
-                let binding      = node.bindings.first,
-                let identPattern = binding.pattern.as(IdentifierPatternSyntax.self),
-                identPattern.identifier.text == "body",
-                let typeAnn      = binding.typeAnnotation?.type,
-                typeAnn.trimmedDescription == "some View"
-            else {
-                return .skipChildren
-            }
-            
-            // Capture the declaration exactly as it appeared in the source file.
-            result = node
-            return .skipChildren
-        }
-    }
-}
 
 // MARK: - 🚀 Interactive demo
 // A lightweight playground view that lets you edit example SwiftUI files and

--- a/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/VarBodyCodeExamples.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/VarBodyCodeExamples.swift
@@ -11,68 +11,69 @@ import Foundation
 struct VarBodyCodeExamples {
     static let var_body = MappingCodeExample(
         title: "var body",
-        code: """
-        struct ContentView: View {
-            var body: some View {
-                ZStack {
-                    Image(systemName: "globe")
-                        .foregroundColor(Color.red)
-                    Text("Hello, world!")
-                }
-            }
+        code:
+"""
+struct ContentView: View {
+    var body: some View {
+        ZStack {
+            Image(systemName: "globe")
+                .foregroundColor(Color.red)
+            Text("Hello, world!")
         }
-        """
+    }
+}
+"""
     )
 
     static let var_body_method = MappingCodeExample(
         title: "var body + method",
-        code: """
-        struct ContentView: View {
-        
-            func myMethod() -> Bool {
-                true
-            }
-        
-            var body: some View {
-                ZStack {
-                    Image(systemName: "globe")
-                        .foregroundColor(Color.red)
-                    Text("Hello, world!")
-                }
-            }
+        code:
+"""
+struct ContentView: View {
+
+    let x = 1
+
+    var body: some View {
+        ZStack {
+            Image(systemName: "globe")
+                .foregroundColor(Color.red)
+            Text("Hello, world!")
         }
-        """
+    }
+}
+"""
     )
 
     static let file_views = MappingCodeExample(
         title: "File, views",
-        code: """
-        import SwiftUI
-        
-        struct ContentView: View {
-            
-            @State var myState: String = ""
-            
-            var myComputedVar: Bool {
-                true
-            }
-            
-            func myMethod() -> Int {
-                1
-            }
-            
-            var body: some View {
-                ZStack {
-                    Image(systemName: "globe")
-                        .foregroundColor(Color.red)
-                    Text("Hello, world!")
-                }
-            }
-        
-            var myView: some View {
-                Rectangle()
-            }
+        code:
+"""
+import SwiftUI
+
+struct ContentView: View {
+    
+    @State var myState: String = ""
+    
+    var myComputedVar: Bool {
+        true
+    }
+    
+    func myMethod() -> Int {
+        1
+    }
+    
+    var body: some View {
+        ZStack {
+            Image(systemName: "globe")
+                .foregroundColor(Color.red)
+            Text("Hello, world!")
         }
-        """
+    }
+
+    var myView: some View {
+        Rectangle()
+    }
+}
+"""
     )
 }

--- a/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/VarBodyCodeExamples.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/VarBodyCodeExamples.swift
@@ -15,7 +15,7 @@ struct VarBodyCodeExamples {
 """
 struct ContentView: View {
     var body: some View {
-        ZStack {
+        HStack {
             Image(systemName: "globe")
                 .foregroundColor(Color.red)
             Text("Hello, world!")
@@ -24,7 +24,7 @@ struct ContentView: View {
 }
 """
     )
-
+    
     static let var_body_method = MappingCodeExample(
         title: "var body + method",
         code:
@@ -33,11 +33,24 @@ struct ContentView: View {
 
     let x = 1
 
+    func myMethod() -> Int {
+        1
+    }
+
     var body: some View {
-        ZStack {
-            Image(systemName: "globe")
-                .foregroundColor(Color.red)
-            Text("Hello, world!")
+        HStack {
+            HStack {
+                Text("Title")
+                Ellipse().frame(width: 120, height: 30)
+            }
+            VStack {
+                Image(systemName: "star.fill")
+                    .foregroundColor(Color.blue)
+                Text("Some text here")
+                    .opacity(0.5)
+                Text("More text here")
+                    .scaleEffect(1 + 2)
+            }
         }
     }
 }
@@ -63,11 +76,11 @@ struct ContentView: View {
     }
     
     var body: some View {
-        ZStack {
+        Group {
             Image(systemName: "globe")
-                .foregroundColor(Color.red)
-            Text("Hello, world!")
+            Text("Bonjour")
         }
+        .scaleEffect(9 * 0.1)
     }
 
     var myView: some View {


### PR DESCRIPTION
### API: `try VarBodyParser.extract(from: someCodeString)`
### demo view: `VarBodyParserDemoView()`

<img width="1440" alt="Screenshot 2025-07-03 at 10 46 28 AM" src="https://github.com/user-attachments/assets/7e6df764-272e-4e6d-9189-c095f89705cb" />
<img width="1440" alt="Screenshot 2025-07-03 at 10 46 26 AM" src="https://github.com/user-attachments/assets/7cc370b6-381a-4fd8-92a5-af96e3e33e03" />
<img width="1440" alt="Screenshot 2025-07-03 at 10 46 24 AM" src="https://github.com/user-attachments/assets/f98ce821-52d6-4833-8729-6ab42a522dd3" />
