### PR TITLE
Improved layer ID handling; improved error capturing

### DIFF
--- a/Stitch/Graph/StitchAI/GraphPrompting/API/OpenAIStreamHelpers.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/OpenAIStreamHelpers.swift
@@ -169,13 +169,13 @@ extension StitchAIManager {
         switch result {
         case .success(let success):
             let jsonResponse = String(data: success.0, encoding: .utf8)
-            print("Successful AI response:\n\(jsonResponse)")
+            print("Successful AI response:\n\(jsonResponse ?? "none")")
             do {
                 let response = try JSONDecoder().decode(OpenAIResponse.self, from: success.0)
                 
                 guard let firstChoice = response.choices.first else {
                     fatalErrorIfDebug()
-                    return .failure(StitchAIManagerError.responseDecodingFailure("No choice found."))
+                    return .failure(StitchAIManagerError.firstChoiceNotDecoded)
                 }
                 
                 let initialDecodedResult = try AIRequest.parseOpenAIResponse(content: firstChoice.message.content)
@@ -185,7 +185,7 @@ extension StitchAIManager {
                 return .success((result, success.1))
             } catch {
                 print(error)
-                return .failure(StitchAIManagerError.responseDecodingFailure(error.localizedDescription))
+                return .failure(StitchAIManagerError.responseDecodingFailure("\(error)"))
             }
         case .failure(let failure):
             print("makeNonStreamedRequest failure: \(failure)")

--- a/Stitch/Graph/StitchAI/GraphPrompting/API/StitchAIManagerError.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/StitchAIManagerError.swift
@@ -156,6 +156,7 @@ enum StitchAIManagerError: Error {
     case nodeTypeNotSupported(String)
     case responseDecodingFailure(String)
     case portValueDescriptionNotSupported(String)
+    case firstChoiceNotDecoded
 }
 
 extension StitchAIManagerError: CustomStringConvertible {
@@ -168,9 +169,11 @@ extension StitchAIManagerError: CustomStringConvertible {
         case .nodeTypeNotSupported(let nodeType):
             return "No node type found for: \(nodeType)"
         case .responseDecodingFailure(let errorMessage):
-            return "OpenAI respopnse decoding failed with the following error: \(errorMessage)"
+            return "OpenAI response decoding failed with the following error: \(errorMessage)"
         case .portValueDescriptionNotSupported(let nodeKindString):
             return "PortValue descriptions aren't supported for node kind: \(nodeKindString) due to PorValue version mismatch between the AI schema and SSK."
+        case .firstChoiceNotDecoded:
+            return "OpenAI response couldn't decode first choice in API call."
         }
     }
 }

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AICodeGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AICodeGenRequest.swift
@@ -85,10 +85,7 @@ struct AICodeGenRequest: StitchAIRequestable {
                 }
                 
                 do {
-                    // IDs we remap to guarantee uniquness
-                    var idMap = [UUID : UUID]()
-                    
-                    let actionsResult = try viewNode.deriveStitchActions(idMap: &idMap)
+                    let actionsResult = try viewNode.deriveStitchActions()
                     let layerDataList = actionsResult.actions
                     allDiscoveredErrors += actionsResult.caughtErrors
                     
@@ -112,8 +109,7 @@ struct AICodeGenRequest: StitchAIRequestable {
                                 let graphData = CurrentAIPatchBuilderResponseFormat
                                     .GraphData(layer_data_list: layerDataList,
                                                patch_data: patchBuildResult)
-                                try graphData.applyAIGraph(to: document,
-                                                           idMap: idMap)
+                                try graphData.applyAIGraph(to: document)
                                 
 #if STITCH_AI_TESTING || DEBUG || DEV_DEBUG
                                 // Display parsing warnings

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
@@ -141,11 +141,12 @@ extension StitchDocumentViewModel {
 
 extension CurrentAIPatchBuilderResponseFormat.GraphData {
     @MainActor
-    func applyAIGraph(to document: StitchDocumentViewModel) throws {
+    func applyAIGraph(to document: StitchDocumentViewModel,
+                      idMap: [UUID : UUID]) throws {
         let graph = document.visibleGraph
         
         // Track node ID map to create new IDs, fixing ID reusage issue
-        var idMap = [UUID : UUID]()
+        var idMap = idMap
         
         // new js patches
         for newPatch in self.patch_data.javascript_patches {

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
@@ -141,12 +141,11 @@ extension StitchDocumentViewModel {
 
 extension CurrentAIPatchBuilderResponseFormat.GraphData {
     @MainActor
-    func applyAIGraph(to document: StitchDocumentViewModel,
-                      idMap: [UUID : UUID]) throws {
+    func applyAIGraph(to document: StitchDocumentViewModel) throws {
         let graph = document.visibleGraph
         
         // Track node ID map to create new IDs, fixing ID reusage issue
-        var idMap = idMap
+        var idMap = [UUID: UUID]()
         
         // new js patches
         for newPatch in self.patch_data.javascript_patches {

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AICodeGen/AICodeGenSystemPrompt_V0.md
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AICodeGen/AICodeGenSystemPrompt_V0.md
@@ -25,6 +25,8 @@ Your SwiftUI code must decouple view from logic as much as possible. Code must b
 Code components **not** allowed in our view are:
 * **Top-level view arguments.** Our view must be able to be invoked without any arguments.
 * **Top-level constants other than layer IDs.** Do not create constants defined at the view level. Instead, use `@State` variables and update them from `updateLayerInputs` function. Define values directly in view if no constant needs to be made.
+## Rules for `var body`
+If a layer ID is statically declared in the view, you **must** assign a `.id(LAYER_ID)` view modifier to that view using the statically defined layer ID.
 ## Updating View State with `updateLayerInputs`
 The view must have a `updateLayerInputs()` function, representing the only function allowed to update state variables. This is effectively the runtime of the backend service. It is called on every display update **by outside callers**, which can be as frequent as 120 FPS. This frequency enables interactive views despite strong  decoupling of logic from the view.
 Logic should be decoupled from `updateLayerInputs` whenever possible for the purpose of creating "patch" functions, described next.

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AICodeGen/AICodeGenSystemPrompt_V0.md
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AICodeGen/AICodeGenSystemPrompt_V0.md
@@ -19,14 +19,14 @@ Your result must be a valid SwiftUI view. All views must be declared in the sing
 Your SwiftUI code must decouple view from logic as much as possible. Code must be broken into the following components:
 * **`var body`:** a single body variable is allowed for creating SwiftUI views
 * **@State variables:** must be used for any dynamic logic needed to update a view.
-* **Static constants for layer IDs:** the only permissible constant allowed in the view, used for connecting behavior between view-events and logic in `updateLayerInputs`. The ID must be a declared string in the form of some UUID. 
+* **No constants or variables allowed for layer IDs:** you must declare the string ID each time without usage of variables. These IDs are used for connecting behavior between view-events and logic in `updateLayerInputs`. The ID must be a declared string in the form of some UUID.
 * **`updateLayerInputs()` function:** the only caller allowed to update state variables in the view directly. Called on every frame update.
 * **All other view functions:** must be static and represent the behavior of a patch node, detailed later.
 Code components **not** allowed in our view are:
 * **Top-level view arguments.** Our view must be able to be invoked without any arguments.
 * **Top-level constants other than layer IDs.** Do not create constants defined at the view level. Instead, use `@State` variables and update them from `updateLayerInputs` function. Define values directly in view if no constant needs to be made.
 ## Rules for `var body`
-If a layer ID is statically declared in the view, you **must** assign a `.id(LAYER_ID)` view modifier to that view using the statically defined layer ID.
+* Each declared view inside the `var body` **must** assign a `layerId` view modifier, like: `.layerId("17A9A565-20FF-4686-85C7-2794CF548369")`. This is a view modifier that's defined elsewhere and is used for mapping IDs to specific view objects. **You are NOT allowed to use constants or variables as the value payload**.
 ## Updating View State with `updateLayerInputs`
 The view must have a `updateLayerInputs()` function, representing the only function allowed to update state variables. This is effectively the runtime of the backend service. It is called on every display update **by outside callers**, which can be as frequent as 120 FPS. This frequency enables interactive views despite strong  decoupling of logic from the view.
 Logic should be decoupled from `updateLayerInputs` whenever possible for the purpose of creating "patch" functions, described next.

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIPatchBuilder/AIPatchBuilderResponseFormat_V0.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIPatchBuilder/AIPatchBuilderResponseFormat_V0.swift
@@ -190,7 +190,7 @@ extension AIPatchBuilderResponseFormat_V0 {
     }
 
     struct LayerData {
-        let node_id: StitchAIUUID_V0.StitchAIUUID
+        var node_id: StitchAIUUID_V0.StitchAIUUID
         var suggested_title: String?
         let node_name: StitchAIPatchOrLayer
         var children: [LayerData]?

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIPatchBuilder/AIPatchBuilderResponseFormat_V0.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIPatchBuilder/AIPatchBuilderResponseFormat_V0.swift
@@ -221,7 +221,7 @@ extension AIPatchBuilderResponseFormat_V0 {
     }
     
     struct LayerInputCoordinate: Codable {
-        let layer_id: StitchAIUUID_V0.StitchAIUUID
+        var layer_id: StitchAIUUID_V0.StitchAIUUID
         let input_port_type: AILayerInputPort
     }
 
@@ -236,7 +236,7 @@ extension AIPatchBuilderResponseFormat_V0 {
     }
     
     struct CustomLayerInputValue: Codable {
-        let layer_input_coordinate: LayerInputCoordinate
+        var layer_input_coordinate: LayerInputCoordinate
         let value: Step_V0.PortValue
     }
     

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIPatchBuilder/AIPatchBuilderSystemPrompt_V0.md
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIPatchBuilder/AIPatchBuilderSystemPrompt_V0.md
@@ -106,7 +106,7 @@ The source code’s top-level function, `updateLayerInputs(…)`, calls other me
 `LayerConnection` uses the following schema:
 ```
 struct LayerConnection {
-    let src_patch_port: PatchNodeCoordinate   // source patch node's output port
+    let src_port: PatchNodeCoordinate   // source patch node's output port
     let dest_port: LayerPortCoordinate          // destination node's input port
 }
 struct LayerPortCoordinate {

--- a/Stitch/Graph/StitchAI/Mapping/ASTExplorerView.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ASTExplorerView.swift
@@ -221,15 +221,16 @@ struct ASTExplorerView: View {
             return
         }
         firstSyntax = syntax
+        
+        silentlyCaughtErrors += codeParserResult.caughtErrors
 
         do {
             // Syntax → Actions
             var idMap = [UUID: UUID]()
             let stitchActionsResult = try syntax.deriveStitchActions(idMap: &idMap)
-            let allErrors = stitchActionsResult.caughtErrors + codeParserResult.caughtErrors
             
             stitchActions = stitchActionsResult.actions
-            silentlyCaughtErrors = allErrors
+            silentlyCaughtErrors += stitchActionsResult.caughtErrors
             
             // Actions → Syntax
             rebuiltSyntax = try SyntaxView.build(from: stitchActions)

--- a/Stitch/Graph/StitchAI/Mapping/ASTExplorerView.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ASTExplorerView.swift
@@ -224,7 +224,8 @@ struct ASTExplorerView: View {
 
         do {
             // Syntax → Actions
-            let stitchActionsResult = try syntax.deriveStitchActions()
+            var idMap = [UUID: UUID]()
+            let stitchActionsResult = try syntax.deriveStitchActions(idMap: &idMap)
             let allErrors = stitchActionsResult.caughtErrors + codeParserResult.caughtErrors
             
             stitchActions = stitchActionsResult.actions

--- a/Stitch/Graph/StitchAI/Mapping/ASTExplorerView.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ASTExplorerView.swift
@@ -226,8 +226,7 @@ struct ASTExplorerView: View {
 
         do {
             // Syntax → Actions
-            var idMap = [UUID: UUID]()
-            let stitchActionsResult = try syntax.deriveStitchActions(idMap: &idMap)
+            let stitchActionsResult = try syntax.deriveStitchActions()
             
             stitchActions = stitchActionsResult.actions
             silentlyCaughtErrors += stitchActionsResult.caughtErrors

--- a/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
@@ -23,10 +23,34 @@ enum SwiftUISyntaxError: Error, Hashable, Sendable {
     case unsupportedLayer(SyntaxViewName)
     case unsupportedSyntaxFromLayerInput(CurrentStep.LayerInputPort)
     case unsupportedSyntaxViewLayer(CurrentStep.Layer)
+    
+    case unsupportedLayerIdParsing([SyntaxViewModifierArgument])
+    case layerUUIDDecodingFailed(String)
+    
     case incorrectParsing(message: String)
     case groupLayerDecodingFailed
     case layerDecodingFailed
     case unexpectedPatchFound(CurrentStep.PatchOrLayer)
+}
+
+extension SwiftUISyntaxError {
+    /// Errors that should allow request to continue.
+    var shouldFailSilently: Bool {
+        switch self {
+        case .unsupportedSyntaxArgumentKind,
+                .unsupportedSyntaxArgument,
+                .unsupportedSyntaxViewName,
+                .unsupportedSyntaxViewModifierName,
+                .unsupportedSyntaxViewModifierArgumentName,
+                .unsupportedLayer,
+                .unsupportedSyntaxFromLayerInput,
+                .unsupportedSyntaxViewLayer:
+            return true
+            
+        default:
+            return false
+        }
+    }
 }
 
 extension CurrentStep.LayerInputPort {

--- a/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
@@ -6,16 +6,23 @@
 //
 
 import Foundation
+import SwiftSyntax
 
 enum SwiftUISyntaxError: Error, Hashable, Sendable {
     case unexpectedEdgeDataFound
     case viewNodeNotFound
     case unsupportedViewModifier(SyntaxViewModifierName)
+    
+    // Decoding from string
+    case unsupportedSyntaxArgumentKind(ExprSyntax)
     case unsupportedSyntaxArgument(String?)
-    case unsupportedSyntaxName(String)
+    case unsupportedSyntaxViewName(String)
+    case unsupportedSyntaxViewModifierName(String)
+    case unsupportedSyntaxViewModifierArgumentName(String)
+    
     case unsupportedLayer(SyntaxViewName)
     case unsupportedSyntaxFromLayerInput(CurrentStep.LayerInputPort)
-    case unsupportedSyntaxViewName(CurrentStep.Layer)
+    case unsupportedSyntaxViewLayer(CurrentStep.Layer)
     case incorrectParsing(message: String)
     case groupLayerDecodingFailed
     case layerDecodingFailed

--- a/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxViewName.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxViewName.swift
@@ -47,15 +47,15 @@ extension CurrentStep.Layer {
         case .canvasSketch:
             return .canvas
         case .realityView:
-            throw SwiftUISyntaxError.unsupportedSyntaxViewName(self)
+            throw SwiftUISyntaxError.unsupportedSyntaxViewLayer(self)
         case .shape:
-            throw SwiftUISyntaxError.unsupportedSyntaxViewName(self)
+            throw SwiftUISyntaxError.unsupportedSyntaxViewLayer(self)
         case .colorFill:
             return .color
         case .hitArea:
             return .color
         case .progressIndicator:
-            throw SwiftUISyntaxError.unsupportedSyntaxViewName(self)
+            throw SwiftUISyntaxError.unsupportedSyntaxViewLayer(self)
         case .switchLayer:
             return .toggle
         case .videoStreaming:

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
@@ -28,9 +28,11 @@ extension SwiftUIViewVisitor {
         // but add our own post-processing for modifiers
         let sourceFile = Parser.parse(source: swiftUICode)
         
+#if DEV_DEBUG
         print("\n==== DEBUG: SOURCE FILE STRUCTURE ====\n")
         dump(sourceFile)
         print("\n==== END DEBUG DUMP ====\n")
+#endif
         
         // Create a visitor that will extract the view structure
         let visitor = SwiftUIViewVisitor(viewMode: .sourceAccurate)
@@ -63,7 +65,9 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
 
     // Debug logging for tracing the parsing process
     private func log(_ message: String) {
+#if DEV_DEBUG
         print("[SwiftUIParser] \(message)")
+#endif
     }
     
     private func dbg(_ message: String) {

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
@@ -487,15 +487,7 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
         var finalArgs = modifierArguments
         if finalArgs.isEmpty {
             // For modifiers with no arguments
-            finalArgs = [
-//                SyntaxViewModifierArgument(
-//                    label: .noLabel,
-//                    value: .simple(SyntaxViewModifierArgumentData(
-//                        value: "",
-//                        syntaxKind: .literal(.unknown)
-//                    ))
-//                )
-            ]
+            finalArgs = []
         }
         
         let modifier = SyntaxViewModifier(

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
@@ -500,7 +500,7 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
         
         let modifier = SyntaxViewModifier(
             name: modifierName,
-            arguments: []
+            arguments: finalArgs
         )
         addModifier(modifier)
     }

--- a/Stitch/Graph/StitchAI/Mapping/Examples/SyntaxExamples.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Examples/SyntaxExamples.swift
@@ -143,15 +143,7 @@ extension MappingExamples {
             ),
             SyntaxViewModifier(
                 name: .padding,
-                arguments: [
-                    SyntaxViewModifierArgument(
-                        label: .noLabel,
-                        value: .simple(SyntaxViewModifierArgumentData(
-                            value: "",
-                            syntaxKind: .literal(.unknown)
-                        ))
-                    )
-                ]
+                arguments: []
             )
         ],
         children: [],

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxArgumentKind.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxArgumentKind.swift
@@ -43,7 +43,7 @@ enum SyntaxArgumentKind: Equatable, Hashable, Codable, Sendable {
 }
 
 extension SyntaxArgumentKind {
-    static func fromExpression(_ expression: ExprSyntax) -> Self {
+    static func fromExpression(_ expression: ExprSyntax) -> Self? {
         
         // Determine argument type clearly:
         let kind: SyntaxArgumentKind // = .literal(.unknown)
@@ -105,9 +105,8 @@ extension SyntaxArgumentKind {
             kind = .expression(.closure)
         }
         
-        // unknown ? crash here?
         else {
-            kind = .literal(.unknown)
+            return nil
         }
         
         return kind
@@ -128,7 +127,6 @@ enum SyntaxArgumentLiteralKind: String, Equatable, Hashable, Codable {
     case colorLiteral     = "ColorLiteral"          // `#colorLiteral(...)`
     case imageLiteral     = "ImageLiteral"          // `#imageLiteral(...)`
     case fileLiteral      = "FileLiteral"           // `#fileLiteral(...)`
-    case unknown          = "UnknownLiteral"
 }
 
 /// Possible syntactic shapes for a variable reference.
@@ -146,5 +144,4 @@ enum SyntaxArgumentExpressionKind: String, Equatable, Hashable, Codable {
     case ternary          = "TernaryConditional"    // `cond ? x : y`
     case tuple            = "TupleExpr"             // `(x, y)`
     case closure          = "Closure"               // `{ ... }`
-    case unknown          = "UnknownExpr"
 }

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxView.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxView.swift
@@ -27,5 +27,5 @@ struct SyntaxView: Equatable, Hashable, Sendable {
     var id: UUID  // Unique identifier for the node
     
     // Catches errors
-    var errors: [SwiftUISyntaxError] = []
+//    var errors: [SwiftUISyntaxError] = []
 }

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
@@ -63,7 +63,19 @@ enum SyntaxViewModifierArgumentType: Equatable, Hashable, Sendable, Codable {
     case axis(x: SyntaxViewModifierArgumentData,
               y: SyntaxViewModifierArgumentData,
               z: SyntaxViewModifierArgumentData)
+}
+
+extension SyntaxViewModifierArgumentType {
+    var simpleValue: String? {
+        switch self {
+        case .simple(let data):
+            return data.value
+            
+        default:
+            return nil
+        }
     }
+}
 
 // TODO: JULY 2: the argument .rotation3DEffect(_ angle: Angle) could be either Angle.degrees or Angle.radians, but Stitch's rotation layer inputs always uses degrees
 // https://developer.apple.com/documentation/swiftui/view/rotation3deffect(_:axis:anchor:)

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
@@ -126,113 +126,38 @@ extension SyntaxViewModifierArgumentLabel {
 /// (No such list or enum is otherwise already exposed by SwiftUI for us programmatically.)
 /// `rawValue` is **always** the textual name of the modifier as it appears in
 /// source (e.g. `"fill"`, `"frame"`). Any unknown name is stored using `.custom`.
-enum SyntaxViewModifierName: Codable, Hashable, Equatable, Sendable {
-    case fill
-    case frame
-    case padding
-    case foregroundColor
-    case opacity
-    case cornerRadius
-    case blur
-    case scaleEffect
-    case hueRotation
-    case rotation3DEffect
-    case rotationEffect
-    case zIndex
-    case blendMode
-    case brightness
-    case colorInvert
-    case saturation
-    case disabled
-    case background
-    case font
-    case multilineTextAlignment
-    case underline
+enum SyntaxViewModifierName: String, Codable, Hashable, Equatable, Sendable {
+    case fill = "fill"
+    case frame = "frame"
+    case padding = "padding"
+    case foregroundColor = "foregroundColor"
+    case opacity = "opacity"
+    case cornerRadius = "cornerRadius"
+    case blur = "blur"
+    case scaleEffect = "scaleEffect"
+    case hueRotation = "hueRotation"
+    case rotation3DEffect = "rotation3DEffect"
+    case rotationEffect = "rotationEffect"
+    case zIndex = "zIndex"
+    case blendMode = "blendMode"
+    case brightness = "brightness"
+    case colorInvert = "colorInvert"
+    case saturation = "saturation"
+    case disabled = "disabled"
+    case background = "background"
+    case font = "font"
+    case multilineTextAlignment = "multilineTextAlignment"
+    case underline = "underline"
     
     // TODO: support after v1
-//    case keyboardType
+//    case keyboardType = "keyboardType"
     
-    case disableAutocorrection
-    case contrast
-    case clipped
-    case position
-    case offset
+    case disableAutocorrection = "disableAutocorrection"
+    case contrast = "contrast"
+    case clipped = "clipped"
+    case position = "position"
+    case offset = "offset"
+    case id = "id"
+    
     // …add more as needed …
-
-    // TODO: JULY 1: REMOVE THIS CASE, SO WE CAN HAVE CASE-ITERABLE VIEW-MODIFIER-NAMES? EFFECTIVELY THIS IS JUST A
-    /// Any modifier name not yet mapped to a first-class case.
-    case custom(String)
-}
-
-// MARK: - RawRepresentable conformance
-extension SyntaxViewModifierName: RawRepresentable {
-    init(rawValue: String) {
-        switch rawValue {
-        case "fill":              self = .fill
-        case "frame":             self = .frame
-        case "padding":           self = .padding
-        case "foregroundColor":   self = .foregroundColor
-        case "opacity":           self = .opacity
-        case "cornerRadius":      self = .cornerRadius
-        case "blur":              self = .blur
-        case "scaleEffect":       self = .scaleEffect
-        case "hueRotation":       self = .hueRotation
-        case "rotationEffect":    self = .rotationEffect
-        case "rotation3DEffect":  self = .rotation3DEffect
-        case "zIndex":            self = .zIndex
-        case "blendMode":         self = .blendMode
-        case "brightness":        self = .brightness
-        case "colorInvert":       self = .colorInvert
-        case "saturation":        self = .saturation
-        case "disabled":          self = .disabled
-        case "background":        self = .background
-        case "font":              self = .font
-        case "multilineTextAlignment":
-                                   self = .multilineTextAlignment
-        case "underline":         self = .underline
-//        case "keyboardType":      self = .keyboardType
-        case "disableAutocorrection":
-                                   self = .disableAutocorrection
-        case "contrast":          self = .contrast
-        case "clipped":           self = .clipped
-        case "position":          self = .position
-        case "offset":            self = .offset
-        default:                  self = .custom(rawValue)
-        }
-    }
-
-    var rawValue: String {
-        switch self {
-        case .fill:              return "fill"
-        case .frame:             return "frame"
-        case .padding:           return "padding"
-        case .foregroundColor:   return "foregroundColor"
-        case .opacity:           return "opacity"
-        case .cornerRadius:      return "cornerRadius"
-        case .blur:              return "blur"
-        case .scaleEffect:       return "scaleEffect"
-        case .hueRotation:       return "hueRotation"
-        case .rotation3DEffect:  return "rotation3DEffect"
-        case .rotationEffect:    return "rotationEffect"
-        case .zIndex:            return "zIndex"
-        case .blendMode:         return "blendMode"
-        case .brightness:        return "brightness"
-        case .colorInvert:       return "colorInvert"
-        case .saturation:        return "saturation"
-        case .disabled:          return "disabled"
-        case .background:        return "background"
-        case .font:              return "font"
-        case .multilineTextAlignment:
-                                    return "multilineTextAlignment"
-        case .underline:         return "underline"
-//        case .keyboardType:      return "keyboardType"
-        case .disableAutocorrection:
-                                    return "disableAutocorrection"
-        case .contrast:          return "contrast"
-        case .clipped:           return "clipped"
-        case .position:          return "position"
-        case .offset:            return "offset"
-        case .custom(let name):  return name
-        }
-    }
 }

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
@@ -169,7 +169,9 @@ enum SyntaxViewModifierName: String, Codable, Hashable, Equatable, Sendable {
     case clipped = "clipped"
     case position = "position"
     case offset = "offset"
-    case id = "id"
+    
+    // Custom event defined by code gen to create an ID for each layer
+    case layerId = "layerId"
     
     // …add more as needed …
 }

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewName.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewName.swift
@@ -92,14 +92,10 @@ extension SyntaxViewName {
     }
     
     var isSupported: Bool {
-        // unused
-        var map = [UUID : UUID]()
-        
-        return (try? self.deriveLayerData(id: .init(),
-                                          args: [],
-                                          modifiers: [],
-                                          childrenLayers: [],
-                                          idMap: &map)) != nil
+        (try? self.deriveLayerData(id: .init(),
+                                   args: [],
+                                   modifiers: [],
+                                   childrenLayers: [])) != nil
     }
     
     /// Returns true if this view type can have child views via closures

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewName.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewName.swift
@@ -92,10 +92,14 @@ extension SyntaxViewName {
     }
     
     var isSupported: Bool {
-        (try? self.deriveLayerData(id: .init(),
-                                   args: [],
-                                   modifiers: [],
-                                   childrenLayers: [])) != nil
+        // unused
+        var map = [UUID : UUID]()
+        
+        return (try? self.deriveLayerData(id: .init(),
+                                          args: [],
+                                          modifiers: [],
+                                          childrenLayers: [],
+                                          idMap: &map)) != nil
     }
     
     /// Returns true if this view type can have child views via closures

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
@@ -14,8 +14,8 @@ struct SwiftSyntaxActionsResult {
 }
 
 extension Array where Element == SyntaxView {
-    func deriveStitchActions(idMap: inout [UUID : UUID]) throws -> SwiftSyntaxActionsResult {
-        let allResults = try self.map { try $0.deriveStitchActions(idMap: &idMap) }
+    func deriveStitchActions() throws -> SwiftSyntaxActionsResult {
+        let allResults = try self.map { try $0.deriveStitchActions() }
         
         return .init(actions: allResults.flatMap { $0.actions },
                      caughtErrors: allResults.flatMap { $0.caughtErrors })
@@ -23,9 +23,9 @@ extension Array where Element == SyntaxView {
 }
 
 extension SyntaxView {
-    func deriveStitchActions(idMap: inout [UUID : UUID]) throws -> SwiftSyntaxActionsResult {
+    func deriveStitchActions() throws -> SwiftSyntaxActionsResult {
         // Recurse into children first (DFS), we might use this data for nested scenarios like ScrollView
-        let childResults = try self.children.deriveStitchActions(idMap: &idMap)
+        let childResults = try self.children.deriveStitchActions()
 
         // Map this node
         do {
@@ -33,8 +33,7 @@ extension SyntaxView {
                 id: self.id,
                 args: self.constructorArguments,
                 modifiers: self.modifiers,
-                childrenLayers: childResults.actions,
-                idMap: &idMap)
+                childrenLayers: childResults.actions)
             
             guard let layer = layerData.node_name.value.layer else {
                 fatalErrorIfDebug("deriveStitchActions error: no layer found for \(layerData.node_name.value)")

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
@@ -15,8 +15,7 @@ extension SyntaxViewName {
     func deriveLayerData(id: UUID,
                          args: [SyntaxViewConstructorArgument],
                          modifiers: [SyntaxViewModifier],
-                         childrenLayers: [CurrentAIPatchBuilderResponseFormat.LayerData],
-                         idMap: inout [UUID : UUID]) throws -> CurrentAIPatchBuilderResponseFormat.LayerData {
+                         childrenLayers: [CurrentAIPatchBuilderResponseFormat.LayerData]) throws -> CurrentAIPatchBuilderResponseFormat.LayerData {
 
         // ── Base mapping from SyntaxViewName → Layer ────────────────────────
         var (layerType, layerData) = try self
@@ -48,14 +47,8 @@ extension SyntaxViewName {
                     throw SwiftUISyntaxError.layerUUIDDecodingFailed(string)
                 }
                 
-                // Create new ID to ensure uniqueness
-                let newId = UUID()
-                
-                // Update mapping so later logic can use this new ID if read from port values
-                idMap.updateValue(newId, forKey: uuidValue)
-                
                 // Update ID to that assigned from view
-                layerData.node_id = .init(value: newId)
+                layerData.node_id = .init(value: uuidValue)
             }
         }
         

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
@@ -15,8 +15,9 @@ extension SyntaxViewName {
     func deriveLayerData(id: UUID,
                          args: [SyntaxViewConstructorArgument],
                          modifiers: [SyntaxViewModifier],
-                         childrenLayers: [CurrentAIPatchBuilderResponseFormat.LayerData]) throws -> CurrentAIPatchBuilderResponseFormat.LayerData {
-        
+                         childrenLayers: [CurrentAIPatchBuilderResponseFormat.LayerData],
+                         idMap: inout [UUID : UUID]) throws -> CurrentAIPatchBuilderResponseFormat.LayerData {
+
         // ── Base mapping from SyntaxViewName → Layer ────────────────────────
         var (layerType, layerData) = try self
             .deriveLayerAndCustomValuesFromName(id: id,
@@ -30,13 +31,33 @@ extension SyntaxViewName {
             args: args)
         
         // Handle modifiers
-        let customModifierValues = try Self.deriveCustomValuesFromViewModifiers(
+        let customModifierEvents = try Self.deriveCustomValuesFromViewModifiers(
             id: id,
             layerType: layerType,
             modifiers: modifiers)
         
         layerData.custom_layer_input_values += customInputValues
-        layerData.custom_layer_input_values += customModifierValues
+        
+        // Parse view modifier events
+        for modifierEvent in customModifierEvents {
+            switch modifierEvent {
+            case .layerInputValues(let valuesList):
+                layerData.custom_layer_input_values += valuesList
+            case .layerIdAssignment(let string):
+                guard let uuidValue = UUID(uuidString: string) else {
+                    throw SwiftUISyntaxError.layerUUIDDecodingFailed(string)
+                }
+                
+                // Create new ID to ensure uniqueness
+                let newId = UUID()
+                
+                // Update mapping so later logic can use this new ID if read from port values
+                idMap.updateValue(newId, forKey: uuidValue)
+                
+                // Update ID to that assigned from view
+                layerData.node_id = .init(value: newId)
+            }
+        }
         
         return layerData
     }
@@ -254,63 +275,57 @@ extension SyntaxViewName {
     static func deriveCustomValuesFromViewModifiers(
         id: UUID,
         layerType: CurrentStep.Layer,
-        modifiers: [SyntaxViewModifier]) throws -> [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue] {
-            
-            var customValues = [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue]()
-            
-            for modifier in modifiers {
-                customValues = try Self.deriveCustomValuesFromViewModifier(
+        modifiers: [SyntaxViewModifier]) throws -> [LayerInputViewModification] {
+            try modifiers.map { modifier in
+                try Self.deriveCustomValuesFromViewModifier(
                     id: id,
                     layerType: layerType,
-                    modifier: modifier,
-                    customValues: customValues)
+                    modifier: modifier)
             }
-            
-            return customValues
-        }
+    }
     
     private static func deriveCustomValuesFromViewModifier(
         id: UUID,
         layerType: CurrentStep.Layer,
-        modifier: SyntaxViewModifier,
-        customValues: [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue]
-    ) throws -> [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue] {
-        
-        var customValues = customValues
-        
+        modifier: SyntaxViewModifier) throws -> LayerInputViewModification {
         let derivationResult = try modifier.name.deriveLayerInputPort(layerType)
         
         switch derivationResult {
-            
         case .simple(let port):
-            customValues = try Self.deriveCustomValuesFromSimpleLayerInputTranslation(
+            let newValues = try Self.deriveCustomValuesFromSimpleLayerInputTranslation(
                 id: id,
                 port: port,
                 layerType: layerType,
-                modifier: modifier,
-                customValues: customValues)
+                modifier: modifier)
+            
+            return .layerInputValues(newValues)
             
         case .rotationScenario:
             // Certain modifiers, e.g. `.rotation3DEffect` correspond to multiple layer-inputs (.rotationX, .rotationY, .rotationZ)
-            customValues = try Self.deriveCustomValuesFromRotationLayerInputTranslation(
+            let newValues = try Self.deriveCustomValuesFromRotationLayerInputTranslation(
                 id: id,
                 layerType: layerType,
-                modifier: modifier,
-                customValues: customValues)
+                modifier: modifier)
+            
+            return .layerInputValues(newValues)
+            
+        case .layerId:
+            guard let idString = modifier.arguments.first?.value.simpleValue else {
+                throw SwiftUISyntaxError.unsupportedLayerIdParsing(modifier.arguments)
+            }
+            
+            return .layerIdAssignment(idString)
         }
-        
-        return customValues
     }
     
     static func deriveCustomValuesFromSimpleLayerInputTranslation(
         id: UUID,
         port: CurrentStep.LayerInputPort, // simple because we have a single layer
         layerType: CurrentStep.Layer,
-        modifier: SyntaxViewModifier,
-        customValues: [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue]
+        modifier: SyntaxViewModifier
     ) throws -> [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue] {
         
-        var customValues = customValues
+        var customValues = [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue]()
         
         let migratedPort = try port.convert(to: LayerInputPort.self)
         let migratedLayerType = try layerType.convert(to: Layer.self)
@@ -363,11 +378,9 @@ extension SyntaxViewName {
     static func deriveCustomValuesFromRotationLayerInputTranslation(
         id: UUID,
         layerType: CurrentStep.Layer,
-        modifier: SyntaxViewModifier,
-        customValues: [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue]
-    ) throws -> [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue] {
+        modifier: SyntaxViewModifier) throws -> [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue] {
         
-        var customValues = customValues
+        var customValues = [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue]()
         
         
         guard let angleArgument = modifier.arguments[safe: 0],

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
@@ -310,11 +310,14 @@ extension SyntaxViewName {
             return .layerInputValues(newValues)
             
         case .layerId:
-            guard let idString = modifier.arguments.first?.value.simpleValue else {
+            guard let rawValue = modifier.arguments.first?.value.simpleValue else {
                 throw SwiftUISyntaxError.unsupportedLayerIdParsing(modifier.arguments)
             }
-            
-            return .layerIdAssignment(idString)
+            // Remove escape characters from any quoted substrings
+            let unescaped = rawValue.replacingOccurrences(of: "\\\"", with: "\"")
+            // Trim any surrounding quotes
+            let cleanString = unescaped.trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+            return .layerIdAssignment(cleanString)
         }
     }
     

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
@@ -52,6 +52,14 @@ extension SyntaxViewName {
             }
         }
         
+        // Re-map all node IDs after processing layerIdAssignment
+        layerData.custom_layer_input_values = layerData.custom_layer_input_values
+            .map { customInputValue in
+                var customInputValue = customInputValue
+                customInputValue.layer_input_coordinate.layer_id = layerData.node_id
+                return customInputValue
+            }
+        
         return layerData
     }
     

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayerInputPort.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayerInputPort.swift
@@ -62,6 +62,14 @@ enum DerivedLayerInputPortsResult: Equatable, Hashable, Sendable {
     
     // Special case: .rotation3DEffect modifier corresponds to *three* different layer inputs; .rotation also requires special parsing of its `.degrees(x)` arguments
     case rotationScenario
+    
+    // Tracks some layer ID assigned to a view
+    case layerId
+}
+
+enum LayerInputViewModification {
+    case layerInputValues([CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue])
+    case layerIdAssignment(String)
 }
 
 extension SyntaxViewModifierName {
@@ -167,10 +175,10 @@ extension SyntaxViewModifierName {
 //        case (.keyboardType, _): return .simple(.keyboardType)
         case (.disableAutocorrection, _):
             throw SwiftUISyntaxError.unsupportedViewModifier(self)
-        case (.clipped, _): return .simple(.clipped) // return .isClipped
-            
-        case (.custom(_), _):
-            throw SwiftUISyntaxError.unsupportedViewModifier(self)
+        case (.clipped, _):
+            return .simple(.clipped) // return .isClipped
+        case (.id, _):
+            return .layerId
         }
     }
 }

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayerInputPort.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayerInputPort.swift
@@ -177,7 +177,7 @@ extension SyntaxViewModifierName {
             throw SwiftUISyntaxError.unsupportedViewModifier(self)
         case (.clipped, _):
             return .simple(.clipped) // return .isClipped
-        case (.id, _):
+        case (.layerId, _):
             return .layerId
         }
     }

--- a/Stitch/Graph/StitchAI/PromptGenerator/AICodeGenSystemPromptGenerator.swift
+++ b/Stitch/Graph/StitchAI/PromptGenerator/AICodeGenSystemPromptGenerator.swift
@@ -30,7 +30,7 @@ You are an assistant that **generates source code for a SwiftUI view**. This cod
 * All other functions besides `updateLayerInputs` will be referred to as patch functions for now on. They can only contain a single input argument of `[[PortValueDescription]]`, and must return an output of `[[PortValueDescription]]`. No other functions are allowed to exist. Helper logic must be contained in the patch function.
 * `updateLayerInputs` is allowed to call patch functions, however patch functions cannot make calls to each other.
 * Try to break down code into as many patch functions as possible, mimicing patch logic to patch nodes seen in Origami Studio.
-* You must create a genuine UUID whenever layer IDs are created
+* You must create a string ID whenever layer IDs are created. The string must represent a UUID.
 
 # Fundamental Principles
 You are aiding an assistant which will eventually create graph components for a tool called Stitch. Stitch uses a visual programming language and is similar to Meta's Origami Studio. Like Origami, Stitch contains “patches”, which is the set of functions which power the logic to an app, and “layers”, which represent the visual elements of an app.
@@ -45,7 +45,7 @@ Your result must be a valid SwiftUI view. All views must be declared in the sing
 Your SwiftUI code must decouple view from logic as much as possible. Code must be broken into the following components:
 * **`var body`:** a single body variable is allowed for creating SwiftUI views
 * **@State variables:** must be used for any dynamic logic needed to update a view.
-* **Static constants for layer UUIDs:** the only permissible constant allowed in the view, used for connecting behavior between view-events and logic in `updateLayerInputs`. 
+* **Static constants for layer IDs:** the only permissible constant allowed in the view, used for connecting behavior between view-events and logic in `updateLayerInputs`. The ID must be a declared string in the form of some UUID. 
 * **`updateLayerInputs()` function:** the only caller allowed to update state variables in the view directly. Called on every frame update.
 * **All other view functions:** must be static and represent the behavior of a patch node, detailed later.
 
@@ -140,7 +140,7 @@ let native_drag_interaction_patch_function = NATIVE_STITCH_PATCH_FUNCTIONS["drag
 You can view the list of inputs and outputs supported by each node by reference the node name's input and output definitions below in "Inputs and Outputs Definitions for Patches and Layers". Support for native patch functions are listed below:
 
 ### Gesture Patch Nodes
-Gesture patch nodes track specific events to some specified layer. The input value for a selected layer is specified as a `"Layer"` value type, with its underlying UUID matching the layer ID of some layer.
+Gesture patch nodes track specific events to some specified layer. The input value for a selected layer is specified as a `"Layer"` value type, with its underlying ID matching the layer ID of some layer.
 
 Sometimes, a specific layer is looped, meaning one of the layers inputs receives a loop of values, causing the layer itself to be repeated n times for an n-length size of values in a loop. Native Stitch patch functions for gestures automatically handle loops and will process each looped instance of a layer in its eval.
 

--- a/Stitch/Graph/StitchAI/PromptGenerator/AICodeGenSystemPromptGenerator.swift
+++ b/Stitch/Graph/StitchAI/PromptGenerator/AICodeGenSystemPromptGenerator.swift
@@ -45,7 +45,7 @@ Your result must be a valid SwiftUI view. All views must be declared in the sing
 Your SwiftUI code must decouple view from logic as much as possible. Code must be broken into the following components:
 * **`var body`:** a single body variable is allowed for creating SwiftUI views
 * **@State variables:** must be used for any dynamic logic needed to update a view.
-* **Static constants for layer IDs:** the only permissible constant allowed in the view, used for connecting behavior between view-events and logic in `updateLayerInputs`. The ID must be a declared string in the form of some UUID. 
+* **No constants or variables allowed for layer IDs:** you must declare the string ID each time without usage of variables. These IDs are used for connecting behavior between view-events and logic in `updateLayerInputs`. The ID must be a declared string in the form of some UUID.
 * **`updateLayerInputs()` function:** the only caller allowed to update state variables in the view directly. Called on every frame update.
 * **All other view functions:** must be static and represent the behavior of a patch node, detailed later.
 
@@ -54,7 +54,7 @@ Code components **not** allowed in our view are:
 * **Top-level constants other than layer IDs.** Do not create constants defined at the view level. Instead, use `@State` variables and update them from `updateLayerInputs` function. Define values directly in view if no constant needs to be made.
 
 ## Rules for `var body`
-If a layer ID is statically declared in the view, you **must** assign a `.id(LAYER_ID)` view modifier to that view using the statically defined layer ID.
+Each declared view inside the `var body` **must** assign a `layerId` view modifier, like: `.layerId("17A9A565-20FF-4686-85C7-2794CF548369")`. This is a view modifier that's defined elsewhere and is used for mapping IDs to specific view objects. **You are NOT allowed to use constants or variables as the value payload**.
 
 ## Updating View State with `updateLayerInputs`
 The view must have a `updateLayerInputs()` function, representing the only function allowed to update state variables. This is effectively the runtime of the backend service. It is called on every display update **by outside callers**, which can be as frequent as 120 FPS. This frequency enables interactive views despite strong  decoupling of logic from the view.

--- a/Stitch/Graph/StitchAI/PromptGenerator/AICodeGenSystemPromptGenerator.swift
+++ b/Stitch/Graph/StitchAI/PromptGenerator/AICodeGenSystemPromptGenerator.swift
@@ -53,6 +53,9 @@ Code components **not** allowed in our view are:
 * **Top-level view arguments.** Our view must be able to be invoked without any arguments.
 * **Top-level constants other than layer IDs.** Do not create constants defined at the view level. Instead, use `@State` variables and update them from `updateLayerInputs` function. Define values directly in view if no constant needs to be made.
 
+## Rules for `var body`
+If a layer ID is statically declared in the view, you **must** assign a `.id(LAYER_ID)` view modifier to that view using the statically defined layer ID.
+
 ## Updating View State with `updateLayerInputs`
 The view must have a `updateLayerInputs()` function, representing the only function allowed to update state variables. This is effectively the runtime of the backend service. It is called on every display update **by outside callers**, which can be as frequent as 120 FPS. This frequency enables interactive views despite strong  decoupling of logic from the view.
 

--- a/Stitch/Graph/StitchAI/PromptGenerator/AIGraphBuilderSystemPromptGenerator.swift
+++ b/Stitch/Graph/StitchAI/PromptGenerator/AIGraphBuilderSystemPromptGenerator.swift
@@ -109,7 +109,7 @@ The source code’s top-level function, `updateLayerInputs(…)`, calls other me
 `LayerConnection` uses the following schema:
 ```
 struct LayerConnection {
-    let src_patch_port: PatchNodeCoordinate   // source patch node's output port
+    let src_port: PatchNodeCoordinate   // source patch node's output port
     let dest_port: LayerPortCoordinate          // destination node's input port
 }
 

--- a/StitchTests/SwiftUIParsingTests/ConstructorTests.swift
+++ b/StitchTests/SwiftUIParsingTests/ConstructorTests.swift
@@ -19,7 +19,7 @@ final class ConstructorTests: XCTestCase {
         """
         
         // When - Parse the SwiftUI code into a SyntaxView
-        guard let syntaxView = SwiftUIViewVisitor.parseSwiftUICode(code) else {
+        guard let syntaxView = SwiftUIViewVisitor.parseSwiftUICode(code).rootView else {
             XCTFail("Failed to parse RoundedRectangle example")
             return
         }
@@ -57,7 +57,10 @@ final class ConstructorTests: XCTestCase {
         XCTAssertNotEqual(value.syntaxKind, .literal(.string), "Corner radius should not be a string")
         
         // When - Convert to LayerData
-        let layerData = try syntaxView.deriveStitchActions()
+        guard let layerData = try syntaxView.deriveStitchActions().actions.first else {
+            XCTFail()
+            return
+        }
         
         // Then - Verify the structure of the LayerData
         // 1. Check that we have exactly one root layer (the RoundedRectangle)
@@ -124,7 +127,7 @@ final class ConstructorTests: XCTestCase {
         let code = #"Text("salut")"#
         
         // When - Parse the SwiftUI code into a SyntaxView
-        guard let syntaxView = SwiftUIViewVisitor.parseSwiftUICode(code) else {
+        guard let syntaxView = SwiftUIViewVisitor.parseSwiftUICode(code).rootView else {
             XCTFail("Failed to parse Text example")
             return
         }
@@ -155,7 +158,10 @@ final class ConstructorTests: XCTestCase {
         XCTAssertTrue(syntaxView.children.isEmpty, "Text should have no children")
         
         // When - Convert to LayerData
-        let layerData = try syntaxView.deriveStitchActions()
+        guard let layerData = try syntaxView.deriveStitchActions().actions.first else {
+            XCTFail()
+            return
+        }
         
         // Then - Verify the structure of the LayerData
         // 1. Check that we have exactly one layer (the Text)
@@ -210,7 +216,7 @@ final class ConstructorTests: XCTestCase {
         let code = #"Image(systemName: "star.fill")"#
         
         // When - Parse the SwiftUI code into a SyntaxView
-        guard let syntaxView = SwiftUIViewVisitor.parseSwiftUICode(code) else {
+        guard let syntaxView = SwiftUIViewVisitor.parseSwiftUICode(code).rootView else {
             XCTFail("Failed to parse Image with SF Symbol example")
             return
         }
@@ -240,7 +246,10 @@ final class ConstructorTests: XCTestCase {
         XCTAssertTrue(syntaxView.children.isEmpty, "Image should have no children")
         
         // When - Convert to LayerData
-        let layerData = try syntaxView.deriveStitchActions()
+        guard let layerData = try syntaxView.deriveStitchActions().actions.first else {
+            XCTFail()
+            return
+        }
         
         // Then - Verify the structure of the LayerData
         // 1. Check that we have exactly one layer (the SF Symbol)

--- a/StitchTests/SwiftUIParsingTests/ModifierTests.swift
+++ b/StitchTests/SwiftUIParsingTests/ModifierTests.swift
@@ -20,7 +20,7 @@ final class ModifierTests: XCTestCase {
         """
         
         // When - Parse the SwiftUI code into a SyntaxView
-        guard let syntaxView = SwiftUIViewVisitor.parseSwiftUICode(code) else {
+        guard let syntaxView = SwiftUIViewVisitor.parseSwiftUICode(code).rootView else {
             XCTFail("Failed to parse Rectangle with position example")
             return
         }
@@ -65,7 +65,10 @@ final class ModifierTests: XCTestCase {
         }
         
         // When - Convert to LayerData
-        let layerData = try syntaxView.deriveStitchActions()
+        guard let layerData = try syntaxView.deriveStitchActions().actions.first else {
+            XCTFail()
+            return
+        }
         
         // Then - Verify the structure of the LayerData
         // 1. Check that we have exactly one root layer (the Rectangle)
@@ -134,7 +137,7 @@ final class ModifierTests: XCTestCase {
         """
         
         // When - Parse the SwiftUI code into a SyntaxView
-        guard let syntaxView = SwiftUIViewVisitor.parseSwiftUICode(code) else {
+        guard let syntaxView = SwiftUIViewVisitor.parseSwiftUICode(code).rootView else {
             XCTFail("Failed to parse Rectangle with offset example")
             return
         }
@@ -169,7 +172,10 @@ final class ModifierTests: XCTestCase {
         }
         
         // When - Convert to LayerData
-        let layerData = try syntaxView.deriveStitchActions()
+        guard let layerData = try syntaxView.deriveStitchActions().actions.first else {
+            XCTFail()
+            return
+        }
         
         // Then - Verify the structure of the LayerData
         // 1. Check that we have exactly one root layer (the Rectangle)
@@ -216,7 +222,7 @@ final class ModifierTests: XCTestCase {
         """
         
         // When - Parse the SwiftUI code into a SyntaxView
-        guard let syntaxView = SwiftUIViewVisitor.parseSwiftUICode(code) else {
+        guard let syntaxView = SwiftUIViewVisitor.parseSwiftUICode(code).rootView else {
             XCTFail("Failed to parse Rectangle with frame example")
             return
         }
@@ -261,7 +267,10 @@ final class ModifierTests: XCTestCase {
         }
         
         // When - Convert to LayerData
-        let layerData = try syntaxView.deriveStitchActions()
+        guard let layerData = try syntaxView.deriveStitchActions().actions.first else {
+            XCTFail()
+            return
+        }
         
         // Then - Verify the structure of the LayerData
         // 1. Check that we have exactly one root layer (the Rectangle)
@@ -329,7 +338,7 @@ final class ModifierTests: XCTestCase {
         """
         
         // When - Parse the SwiftUI code into a SyntaxView
-        guard let syntaxView = SwiftUIViewVisitor.parseSwiftUICode(code) else {
+        guard let syntaxView = SwiftUIViewVisitor.parseSwiftUICode(code).rootView else {
             XCTFail("Failed to parse Rectangle with rotation effect example")
             return
         }
@@ -366,7 +375,10 @@ final class ModifierTests: XCTestCase {
         XCTAssertTrue(syntaxView.children.isEmpty, "Rectangle should have no children")
         
         // When - Convert to LayerData
-        let layerData = try syntaxView.deriveStitchActions()
+        guard let layerData = try syntaxView.deriveStitchActions().actions.first else {
+            XCTFail()
+            return
+        }
         
         // Then - Verify the structure of the LayerData
         // 1. Check that we have exactly one layer (the Rectangle)
@@ -424,7 +436,7 @@ final class ModifierTests: XCTestCase {
         """
         
         // When - Parse the SwiftUI code into a SyntaxView
-        guard let syntaxView = SwiftUIViewVisitor.parseSwiftUICode(code) else {
+        guard let syntaxView = SwiftUIViewVisitor.parseSwiftUICode(code).rootView else {
             XCTFail("Failed to parse Rectangle with 3D rotation effect example")
             return
         }
@@ -462,7 +474,10 @@ final class ModifierTests: XCTestCase {
         XCTAssertTrue(syntaxView.children.isEmpty, "Rectangle should have no children")
         
         // When - Convert to LayerData
-        let layerData = try syntaxView.deriveStitchActions()
+        guard let layerData = try syntaxView.deriveStitchActions().actions.first else {
+            XCTFail()
+            return
+        }
         
         // Then - Verify the structure of the LayerData
         // 1. Check that we have exactly one layer (the Rectangle)

--- a/StitchTests/SwiftUIParsingTests/StackTests.swift
+++ b/StitchTests/SwiftUIParsingTests/StackTests.swift
@@ -21,7 +21,7 @@ final class StackTests: XCTestCase {
         """
         
         // When
-        guard let syntaxView = SwiftUIViewVisitor.parseSwiftUICode(vstackExample) else {
+        guard let syntaxView = SwiftUIViewVisitor.parseSwiftUICode(vstackExample).rootView else {
             XCTFail("Failed to parse VStack example")
             return
         }
@@ -58,14 +58,15 @@ final class StackTests: XCTestCase {
         XCTAssertEqual(argument.label, .noLabel, "Fill argument should have no label")
         
         // Verify the argument value is Color.blue
+        // TODO: come back here after exploring decoding
         if case let .simple(data) = argument.value {
             XCTAssertEqual(data.value, "Color.blue", "Color should be blue")
             XCTAssertNotEqual(data.value, "Color.red", "Color should not be red")
             XCTAssertNotEqual(data.value, "blue", "Color should be fully qualified")
             
             // Check the syntax kind
-            XCTAssertEqual(data.syntaxKind, .literal(.unknown), "Color syntax kind should be unknown literal")
-            XCTAssertNotEqual(data.syntaxKind, .literal(.integer), "Color should not be an integer")
+//            XCTAssertEqual(data.syntaxKind, .literal(.unknown), "Color syntax kind should be unknown literal")
+//            XCTAssertNotEqual(data.syntaxKind, .literal(.integer), "Color should not be an integer")
         } else {
             XCTFail("Expected simple argument value")
         }
@@ -80,12 +81,15 @@ final class StackTests: XCTestCase {
         """
         
         // When
-        guard let syntaxView = SwiftUIViewVisitor.parseSwiftUICode(vstackExample) else {
+        guard let syntaxView = SwiftUIViewVisitor.parseSwiftUICode(vstackExample).rootView else {
             XCTFail("Failed to parse VStack example")
             return
         }
         
-        let layerData = try syntaxView.deriveStitchActions()
+        guard let layerData = try syntaxView.deriveStitchActions().actions.first else {
+            XCTFail()
+            return
+        }
         
         // Then - Verify the structure of the LayerData
         // 1. Check that we have exactly one root layer (the VStack)


### PR DESCRIPTION
Changes here:
* Fixed issue where mapping was unequipped to map layers to interactions. Fix uses a new fake `layerId` modifier in code gen to map IDs in the code, and allowing us to create specific layer IDs.
* More error capturing to bubble-up missed mapping logic upon inference request or debugging view.