### PR TITLE
Support for memberAccess literal for SwiftArgumentKind

### DIFF
--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxArgumentKind.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxArgumentKind.swift
@@ -67,6 +67,8 @@ extension SyntaxArgumentKind {
             kind = .literal(.tuple)
         } else if expression.is(RegexLiteralExprSyntax.self) {
             kind = .literal(.regex)
+        } else if expression.is(MemberAccessExprSyntax.self) {
+            kind = .literal(.memberAccess)
         }
         
         //            else if expression.is(ColorLiteralExprSyntax.self) {
@@ -87,9 +89,10 @@ extension SyntaxArgumentKind {
             } else {
                 kind = .variable(.identifier)
             }
+        }
             
         // Expressions
-        } else if expression.is(InfixOperatorExprSyntax.self) {
+        else if expression.is(InfixOperatorExprSyntax.self) {
             kind = .expression(.infixOperator)
         } else if expression.is(PrefixOperatorExprSyntax.self) {
             kind = .expression(.prefixOperator)
@@ -127,6 +130,7 @@ enum SyntaxArgumentLiteralKind: String, Equatable, Hashable, Codable {
     case colorLiteral     = "ColorLiteral"          // `#colorLiteral(...)`
     case imageLiteral     = "ImageLiteral"          // `#imageLiteral(...)`
     case fileLiteral      = "FileLiteral"           // `#fileLiteral(...)`
+    case memberAccess     = "MemberAccess"          // `Color.blue` or `.blue`
 }
 
 /// Possible syntactic shapes for a variable reference.

--- a/StitchTests/SwiftUIParsingTests/StackTests.swift
+++ b/StitchTests/SwiftUIParsingTests/StackTests.swift
@@ -58,15 +58,13 @@ final class StackTests: XCTestCase {
         XCTAssertEqual(argument.label, .noLabel, "Fill argument should have no label")
         
         // Verify the argument value is Color.blue
-        // TODO: come back here after exploring decoding
         if case let .simple(data) = argument.value {
             XCTAssertEqual(data.value, "Color.blue", "Color should be blue")
             XCTAssertNotEqual(data.value, "Color.red", "Color should not be red")
             XCTAssertNotEqual(data.value, "blue", "Color should be fully qualified")
             
             // Check the syntax kind
-//            XCTAssertEqual(data.syntaxKind, .literal(.unknown), "Color syntax kind should be unknown literal")
-//            XCTAssertNotEqual(data.syntaxKind, .literal(.integer), "Color should not be an integer")
+            XCTAssertEqual(data.syntaxKind, .literal(.memberAccess), "Color syntax kind should be memberAccess literal")
         } else {
             XCTFail("Expected simple argument value")
         }


### PR DESCRIPTION
Fixes commented out unit test which supported Color.fill decoding.