### PR TITLE
AI support for new patch inputs

### DIFF
--- a/Stitch/Graph/Node/Model/Definition/NodeInfo.swift
+++ b/Stitch/Graph/Node/Model/Definition/NodeInfo.swift
@@ -46,7 +46,7 @@ extension NodeInfo {
                             outputs: PatchOrLayer.patch(patch).rowDefinitionsOldOrNewStyle(for: node.userVisibleType).outputs,
                             //                            supportedTypes: supportedTypes,
                             nodeDescription: patch.nodeDescription ?? "",
-                            supportsNewInputs: patch.inputCountChanged.isDefined)
+                            supportsNewInputs: patch.canChangeInputCounts)
         }
 
         let layerNodeInfo = Layer.allCases.map { layer in

--- a/Stitch/Graph/Node/Patch/Util/PatchNodeTypeExtensions.swift
+++ b/Stitch/Graph/Node/Patch/Util/PatchNodeTypeExtensions.swift
@@ -79,22 +79,6 @@ extension Patch {
             return nil
         }
     }
-    
-//    @MainActor
-//    func inputCountChanged(graph: GraphState,
-//                           document: StitchDocumentViewModel,
-//                           node: NodeViewModel,
-//                           isAdded: Bool) {
-//        guard let minimumInputCount = self.minimumInputs else {
-//            return nil
-//        }
-//        
-//        if added {
-//            node.inputAdded()
-//        } else {
-//            node.inputRemoved(minimumInputs: minimumInputs)
-//        }
-//    }
 
     var availableNodeTypes: Set<UserVisibleType> {
         switch self {
@@ -142,7 +126,3 @@ extension Patch {
     }
 
 }
-
-// Every input
-// (node, added?, minimum?) -> node
-//typealias InputsChangedHandler = (GraphState, StitchDocumentViewModel, NodeViewModel, Bool) -> ()

--- a/Stitch/Graph/Node/Patch/Util/PatchNodeTypeExtensions.swift
+++ b/Stitch/Graph/Node/Patch/Util/PatchNodeTypeExtensions.swift
@@ -32,20 +32,15 @@ extension UserVisibleType {
 extension NodeViewModel {
     /// Certain patch nodes can have varying input counts (i.e. "add" node).
     @MainActor
-    var canInputCountsChange: Bool {
-        self.kind.getPatch?.inputCountChanged.isDefined ?? false
-    }
-    
-    @MainActor
-    var canAddInputs: Bool {
-        self.kind.getPatch?.canAddInputs ?? false
+    var canChangeInputCounts: Bool {
+        self.kind.getPatch?.canChangeInputCounts ?? false
     }
     
     @MainActor
     var canRemoveInputs: Bool {
         if let patch = self.kind.getPatch,
         let minimumInputs = patch.minimumInputs {
-            return patch.inputCountChanged.isDefined && (self.inputsRowCount > minimumInputs)
+            return patch.canChangeInputCounts && (self.inputsRowCount > minimumInputs)
         }
         
         // Always false for LayerNodes and GroupNodes
@@ -55,8 +50,8 @@ extension NodeViewModel {
 
 extension Patch {
     @MainActor
-    var canAddInputs: Bool {
-        self.inputCountChanged.isDefined
+    var canChangeInputCounts: Bool {
+        self.minimumInputs.isDefined
     }
     
     // nil when patch node cannot add/remove inputs
@@ -85,14 +80,21 @@ extension Patch {
         }
     }
     
-    @MainActor
-    var inputCountChanged: InputsChangedHandler? {
-        guard let minimumInputCount = self.minimumInputs else {
-            return nil
-        }
-        
-        return minimumInputsChangedHandler(minimumInputs: minimumInputCount)
-    }
+//    @MainActor
+//    func inputCountChanged(graph: GraphState,
+//                           document: StitchDocumentViewModel,
+//                           node: NodeViewModel,
+//                           isAdded: Bool) {
+//        guard let minimumInputCount = self.minimumInputs else {
+//            return nil
+//        }
+//        
+//        if added {
+//            node.inputAdded()
+//        } else {
+//            node.inputRemoved(minimumInputs: minimumInputs)
+//        }
+//    }
 
     var availableNodeTypes: Set<UserVisibleType> {
         switch self {
@@ -143,15 +145,4 @@ extension Patch {
 
 // Every input
 // (node, added?, minimum?) -> node
-typealias InputsChangedHandler = (NodeViewModel, Bool) -> ()
-
-@MainActor
-func minimumInputsChangedHandler(minimumInputs: Int) -> InputsChangedHandler {
-    { (node: NodeViewModel, added: Bool) in
-        if added {
-            node.inputAdded()
-        } else {
-            node.inputRemoved(minimumInputs: minimumInputs)
-        }
-    }
-}
+//typealias InputsChangedHandler = (GraphState, StitchDocumentViewModel, NodeViewModel, Bool) -> ()

--- a/Stitch/Graph/Node/Patch/Util/PatchNodeTypeExtensions.swift
+++ b/Stitch/Graph/Node/Patch/Util/PatchNodeTypeExtensions.swift
@@ -38,7 +38,7 @@ extension NodeViewModel {
     
     @MainActor
     var canAddInputs: Bool {
-        self.kind.getPatch?.inputCountChanged.isDefined ?? false
+        self.kind.getPatch?.canAddInputs ?? false
     }
     
     @MainActor
@@ -54,6 +54,10 @@ extension NodeViewModel {
 }
 
 extension Patch {
+    @MainActor
+    var canAddInputs: Bool {
+        self.inputCountChanged.isDefined
+    }
     
     // nil when patch node cannot add/remove inputs
     var minimumInputs: Int? {

--- a/Stitch/Graph/Node/Port/Util/NodeInputChangedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/NodeInputChangedActions.swift
@@ -29,21 +29,6 @@ struct InputAddedAction: StitchDocumentEvent {
     }
 }
 
-//extension NodeViewModel {
-//    @MainActor
-//    func addInputObserver(graph: GraphState) {
-//        self.inputadd
-//
-//        guard let inputChanger = self.kind.getPatch?.inputCountChanged else {
-//            fatalErrorIfDebug()
-//            return
-//        }
-//            
-//        // (node: node, added?: true)
-//        inputChanger(self, true)
-//    }
-//}
-
 struct InputRemovedAction: GraphEventWithResponse {
     let nodeId: NodeId
 

--- a/Stitch/Graph/Node/Port/Util/NodeInputChangedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/NodeInputChangedActions.swift
@@ -9,36 +9,40 @@ import Foundation
 import SwiftUI
 import StitchSchemaKit
 
-struct InputAddedAction: GraphEventWithResponse {
+struct InputAddedAction: StitchDocumentEvent {
 
     let nodeId: NodeId
 
-    func handle(state: GraphState) -> GraphResponse {
+    func handle(state: StitchDocumentViewModel) {
         log("InputAddedAction handle called")
+        let graph = state.visibleGraph
         
-        guard let node = state.getNode(self.nodeId) else {
-            return .noChange
-        }
-
-        node.addInputObserver(graph: state)
-        
-        state.scheduleForNextGraphStep(.init([nodeId]))
-        return .persistenceResponse
-    }
-}
-
-extension NodeViewModel {
-    @MainActor
-    func addInputObserver(graph: GraphState) {
-        guard let inputChanger = self.kind.getPatch?.inputCountChanged else {
-            fatalErrorIfDebug()
+        guard let node = graph.getNode(self.nodeId) else {
             return
         }
-            
-        // (node: node, added?: true)
-        inputChanger(self, true)
+
+        node.addInputObserver(graph: graph,
+                              document: state)
+        
+        graph.scheduleForNextGraphStep(.init([nodeId]))
+        state.encodeProjectInBackground()
     }
 }
+
+//extension NodeViewModel {
+//    @MainActor
+//    func addInputObserver(graph: GraphState) {
+//        self.inputadd
+//
+//        guard let inputChanger = self.kind.getPatch?.inputCountChanged else {
+//            fatalErrorIfDebug()
+//            return
+//        }
+//            
+//        // (node: node, added?: true)
+//        inputChanger(self, true)
+//    }
+//}
 
 struct InputRemovedAction: GraphEventWithResponse {
     let nodeId: NodeId
@@ -47,7 +51,6 @@ struct InputRemovedAction: GraphEventWithResponse {
         log("InputRemovedAction handle called")
 
         if let node = state.getNode(nodeId),
-           let inputChanger = node.kind.getPatch?.inputCountChanged,
            // It's always the last input that is removed.
            let lastObserver = node.getAllInputsObservers().last {
 
@@ -55,7 +58,7 @@ struct InputRemovedAction: GraphEventWithResponse {
             lastObserver.upstreamOutputCoordinate = nil
 
             // Remove the input from the node itself.
-            inputChanger(node, false)
+            node.removeInputObserver()
             
             state.scheduleForNextGraphStep(.init([nodeId]))
             

--- a/Stitch/Graph/Node/View/NodesOnlyView.swift
+++ b/Stitch/Graph/Node/View/NodesOnlyView.swift
@@ -68,7 +68,7 @@ struct NodesOnlyView: View {
                              isSelected: graph.selection.selectedCanvasItems.contains(canvasNode.id),
                              atleastOneCommentBoxSelected: selection.selectedCommentBoxes.count >= 1,
                              activeGroupId: document.groupNodeFocused,
-                             canAddInput: node.canAddInputs,
+                             canAddInput: node.canChangeInputCounts,
                              canRemoveInput: node.canRemoveInputs,
                              boundsReaderDisabled: false,
                              updateMenuActiveSelectionBounds: false)

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModel.swift
@@ -643,19 +643,14 @@ extension NodeViewModel {
     // don't worry about making the input a loop or not --
     // the extension will happen at eval-time
     @MainActor
-    func inputAdded() {
-        guard let patchNode = self.patchNode else {
+    func addInputObserver(graph: GraphState,
+                          document: StitchDocumentViewModel) {
+        guard let patchNode = self.patchNode,
+              patchNode.patch.canChangeInputCounts else {
             fatalErrorIfDebug()
             return
         }
-        
-        
-        guard let graph = self.graphDelegate,
-              let document = graph.documentDelegate else {
-            fatalErrorIfDebug()
-            return
-        }
-        
+
         // assumes new input has no label, etc.
         log("inputAdded called")
         let allInputsObservers = self.getAllInputsObservers()
@@ -703,8 +698,9 @@ extension NodeViewModel {
     }
 
     @MainActor
-    func inputRemoved(minimumInputs: Int) {
-        guard let patchNode = self.patchNode else {
+    func removeInputObserver() {
+        guard let patchNode = self.patchNode,
+              let minimumInputs = patchNode.patch.minimumInputs else {
             fatalErrorIfDebug()
             return
         }

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
@@ -210,7 +210,7 @@ extension CurrentAIPatchBuilderResponseFormat.GraphData {
             }
             
             // MARK: BEFORE creating edges/inputs, determine if new patch nodes need extra inputs
-            let supportsNewInputs = patchNode.patch.canAddInputs
+            let supportsNewInputs = patchNode.patch.canChangeInputCounts
             if let maxModifiedInputIndex = maxModifiedPortIndex.get(oldId) {
                 let missingRowCount = maxModifiedInputIndex - patchNode.inputsObservers.count
 
@@ -220,7 +220,8 @@ extension CurrentAIPatchBuilderResponseFormat.GraphData {
                     }
                     
                     for _ in (0..<missingRowCount) {
-                        newNode.addInputObserver(graph: document.graph)
+                        newNode.addInputObserver(graph: document.graph,
+                                                 document: document)
                     }
                 }
             }

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIPatchBuilder/AIPatchBuilderResponseFormat_V0.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIPatchBuilder/AIPatchBuilderResponseFormat_V0.swift
@@ -225,7 +225,7 @@ extension AIPatchBuilderResponseFormat_V0 {
         let input_port_type: AILayerInputPort
     }
 
-    struct NodeIndexedCoordinate: Codable {
+    struct NodeIndexedCoordinate: Codable, Hashable {
         let node_id: StitchAIUUID_V0.StitchAIUUID
         let port_index: Int
     }

--- a/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
@@ -8,7 +8,7 @@
 import Foundation
 import SwiftSyntax
 
-enum SwiftUISyntaxError: Error, Hashable, Sendable {
+enum SwiftUISyntaxError: Error, Sendable {
     case unexpectedEdgeDataFound
     case viewNodeNotFound
     case couldNotParseVarBody
@@ -37,6 +37,7 @@ enum SwiftUISyntaxError: Error, Hashable, Sendable {
     case layerDecodingFailed
     case unexpectedPatchFound(CurrentStep.PatchOrLayer)
     case portValueDataDecodingFailure
+    case layerEdgeDataFailure(AIPatchBuilderResponseFormat_V0.LayerConnection)
     
     // Value decoding
     case noLabelFoundForComplexType

--- a/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
@@ -38,6 +38,7 @@ enum SwiftUISyntaxError: Error, Sendable {
     case unexpectedPatchFound(CurrentStep.PatchOrLayer)
     case portValueDataDecodingFailure
     case layerEdgeDataFailure(AIPatchBuilderResponseFormat_V0.LayerConnection)
+    case unexpectedPatchInputRowCount(Patch)
     
     // Value decoding
     case noLabelFoundForComplexType
@@ -63,7 +64,8 @@ extension SwiftUISyntaxError {
                 .unsupportedSyntaxViewLayer,
                 .unsupportedComplexValueType,
                 .unsupportedViewModifier,
-                .unsupportedViewModifierForLayer:
+                .unsupportedViewModifierForLayer,
+                .unexpectedPatchInputRowCount:
             return true
             
         default:

--- a/Stitch/Graph/Util/NodeSelection/CopyAndPasteNodesActions.swift
+++ b/Stitch/Graph/Util/NodeSelection/CopyAndPasteNodesActions.swift
@@ -75,7 +75,7 @@ struct SelectedGraphItemsPasted: StitchDocumentEvent {
 
             let graph = state.visibleGraph
             
-            graph.insertNewComponent(component: newComponent,
+            graph.insertNewComponent(graphEntity: newComponent.graphEntity,
                                      encoder: graph.documentEncoderDelegate,
                                      copiedFiles: importedFiles,
                                      isCopyPaste: true,

--- a/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
+++ b/Stitch/Graph/Util/NodeSelection/NodeDuplicationActions.swift
@@ -213,7 +213,7 @@ extension GraphState {
                                encoder: (any DocumentEncodable)?,
                                document: StitchDocumentViewModel) where T: StitchComponentable {
         
-        self.insertNewComponent(component: copiedComponentResult.component,
+        self.insertNewComponent(graphEntity: copiedComponentResult.component.graphEntity,
                                 encoder: encoder,
                                 copiedFiles: copiedComponentResult.copiedSubdirectoryFiles,
                                 isCopyPaste: isCopyPaste,
@@ -326,20 +326,20 @@ extension GraphState {
     
     // Can we use this all the time now?
     @MainActor
-    func insertNewComponent<T>(component: T,
-                               encoder: (any DocumentEncodable)?,
-                               copiedFiles: StitchDocumentDirectory,
-                               
-                               // If copy-paste, use destination project's offset, etc.
-                               isCopyPaste: Bool,
-                               
-                               // Option + Dragging a layer in the sidebar
-                               originalOptionDraggedLayer: SidebarListItemId? = nil,
-                               
-                               originGraphOutputValuesMap: OriginGraphOutputValueMap,
-                               
-                               // Destination document, just like `self` is destination graph
-                               document: StitchDocumentViewModel) where T: StitchComponentable {
+    func insertNewComponent(graphEntity: GraphEntity,
+                            encoder: (any DocumentEncodable)?,
+                            copiedFiles: StitchDocumentDirectory,
+                            
+                            // If copy-paste, use destination project's offset, etc.
+                            isCopyPaste: Bool,
+                            
+                            // Option + Dragging a layer in the sidebar
+                            originalOptionDraggedLayer: SidebarListItemId? = nil,
+                            
+                            originGraphOutputValuesMap: OriginGraphOutputValueMap,
+                            
+                            // Destination document, just like `self` is destination graph
+                            document: StitchDocumentViewModel) {
         
         // MARK: Copy files first, since copied nodes may depend on these files
         if let encoder = encoder {
@@ -349,7 +349,7 @@ extension GraphState {
         // MARK: update the to-be-inserted node entities and sidebar layer data
         let (destinationGraphEntity, newNodes, nodeIdMap) = Self.insertNodesAndSidebarLayersIntoDestinationGraph(
             destinationGraph: self.createSchema(),
-            graphToInsert: component.graphEntity,
+            graphToInsert: graphEntity,
             focusedGroupNode: document.groupNodeFocused?.groupNodeId,
             destinationGraphInfo: isCopyPaste ? document.copyPasteGraphDestinationInfo : nil,
             originGraphOutputValuesMap: originGraphOutputValuesMap,


### PR DESCRIPTION
This PR supports scenarios where new inputs need to be created for new patch nodes created from AI.

Changes:
* New AI response logic checks for patch events with custom inputs or new edges to determine if new inputs need to be created.
* New `GraphEntity` conversion logic enables in-place changes for future streaming integration.
* Cleanup with adding/removing inputs as there was quite a bit of legacy code.