### PR TITLE
Improved error handling for layer derivation logic

### DIFF
--- a/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
@@ -16,7 +16,7 @@ enum SwiftUISyntaxError: Error, Sendable {
     case unsupportedViewModifierForLayer(SyntaxViewModifierName, CurrentStep.Layer)
     
     // Decoding from string
-    case unsupportedSyntaxArgumentKind(ExprSyntax)
+    case unsupportedSyntaxArgumentKind(String)
     case unsupportedSyntaxArgument(String?)
     case unsupportedSyntaxViewName(String)
     case unsupportedSyntaxViewModifierName(String)

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
@@ -348,7 +348,7 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
         }
         
         guard let syntaxKind = SyntaxArgumentKind.fromExpression(expression) else {
-            self.caughtErrors.append(.unsupportedSyntaxArgumentKind(expression))
+            self.caughtErrors.append(.unsupportedSyntaxArgumentKind(expression.trimmedDescription))
             return nil
         }
         


### PR DESCRIPTION
Fixes:
* Some "silent" errors for args and view modifiers were actually throwing, cancelling the creation of some layers
* Less annoying error string for argument kind failures