### PR TITLE
Show userPrompt when AI Code Gen request succeeds

### DIFF
--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AICodeGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AICodeGenRequest.swift
@@ -74,6 +74,7 @@ struct AICodeGenRequest: StitchAIRequestable {
                                                aiManager: aiManager)
             switch result {
             case .success(let swiftUISourceCode):
+                logToServerIfRelease("SUCCESS userPrompt: \(userPrompt)")
                 logToServerIfRelease("SUCCESS Code Gen:\n\(swiftUISourceCode)")
                 
                 guard let parsedVarBody = VarBodyParser.extract(from: swiftUISourceCode) else {


### PR DESCRIPTION
Makes easier debugging; easy to forget what the user prompt had been.