### PR TITLE
Fixed UUID decoding issues from AI response

### DIFF
--- a/Stitch/Graph/Node/Group/GroupNodeCreationActions.swift
+++ b/Stitch/Graph/Node/Group/GroupNodeCreationActions.swift
@@ -407,7 +407,8 @@ extension GraphState {
                 
                 let _ = self.nodeTypeChanged(nodeId: newSplitterNodeId,
                                              newNodeType: nodeType,
-                                             activeIndex: activeIndex)
+                                             activeIndex: activeIndex,
+                                             graphTime: self.graphStepState.graphTime)
             }
             
         } else if splitterType == .output {
@@ -415,7 +416,8 @@ extension GraphState {
                let nodeType = values.first?.toNodeType {
                 let _ = self.nodeTypeChanged(nodeId: newSplitterNodeId,
                                              newNodeType: nodeType,
-                                             activeIndex: activeIndex)
+                                             activeIndex: activeIndex,
+                                             graphTime: self.graphStepState.graphTime)
             }
         }
 

--- a/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
+++ b/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
@@ -140,12 +140,15 @@ extension PatchNodeViewModel: SchemaObserver {
             
             if let graph = self.inputsObservers.first?.nodeDelegate?.graphDelegate,
                let node = graph.getNode(self.id) {
+                let document = graph.documentDelegate
+                
                 // Ensures fields correctly update on events like undo which wouldn't otherwise
                 // call the changeType helper
                 let _ = graph.changeType(for: node,
                                          oldType: oldType,
                                          newType: newType,
-                                         activeIndex: graph.documentDelegate?.activeIndex ?? .init(.zero))
+                                         activeIndex: document?.activeIndex ?? .init(.zero),
+                                         graphTime: document?.graphStepState.graphTime ?? .zero)
             }
         }
         

--- a/Stitch/Graph/Node/Port/Util/PortValue/JSONCoercionUtils.swift
+++ b/Stitch/Graph/Node/Port/Util/PortValue/JSONCoercionUtils.swift
@@ -164,7 +164,11 @@ extension JSON {
             return nil
         }
         
-        guard let decodedPortValue = try? nodeType.coerceToPortValueForStitchAI(from: decodedAnyValue) else {
+        // ID map is for AI responses, unused here
+        let idMap = [String : UUID]()
+        
+        guard let decodedPortValue = try? nodeType.coerceToPortValueForStitchAI(from: decodedAnyValue,
+                                                                                idMap: idMap) else {
             // log("coerceToPortValue: could not decode port value for json \(self) as \(nodeType)")
             return nil
         }

--- a/Stitch/Graph/Node/Port/Util/TypeChange/NodeTypeChangedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/TypeChange/NodeTypeChangedActions.swift
@@ -24,7 +24,8 @@ struct NodeTypeChangedFromCanvasItemMenu: StitchDocumentEvent {
                 
                 let _ = graph.nodeTypeChanged(nodeId: patchNode.id,
                                               newNodeType: newNodeType,
-                                              activeIndex: state.activeIndex)
+                                              activeIndex: state.activeIndex,
+                                              graphTime: state.graphStepState.graphTime)
                 
             }
                
@@ -40,7 +41,8 @@ extension GraphState {
     @MainActor
     func nodeTypeChanged(nodeId: NodeId,
                          newNodeType: UserVisibleType,
-                         activeIndex: ActiveIndex) -> NodeIdSet? {
+                         activeIndex: ActiveIndex,
+                         graphTime: TimeInterval) -> NodeIdSet? {
 
         guard let node = self.getNode(nodeId) else {
             log("NodeTypeChangedAction: no change...")
@@ -57,7 +59,8 @@ extension GraphState {
             for: node,
             oldType: oldType,
             newType: newNodeType,
-            activeIndex: activeIndex)
+            activeIndex: activeIndex,
+            graphTime: graphTime)
 
         // Recalculate the graph from each of the changed nodes' incoming edges
         let ids = changedNodeIds
@@ -74,8 +77,8 @@ extension GraphState {
     func changeType(for node: NodeViewModel,
                     oldType: UserVisibleType,
                     newType: UserVisibleType,
-                    activeIndex: ActiveIndex) -> NodeIdSet {
-        let graphTime = self.graphStepManager.graphTime
+                    activeIndex: ActiveIndex,
+                    graphTime: TimeInterval) -> NodeIdSet {
 
         guard let patchNode = node.patchNode else {
             fatalErrorIfDebug()

--- a/Stitch/Graph/Node/Util/NodeCreatedAction.swift
+++ b/Stitch/Graph/Node/Util/NodeCreatedAction.swift
@@ -59,7 +59,8 @@ extension StitchDocumentViewModel {
         if patch.availableNodeTypes.contains(selectedInputType) {
             let _ = graph.nodeTypeChanged(nodeId: node.id,
                                           newNodeType: selectedInputType,
-                                          activeIndex: state.activeIndex)
+                                          activeIndex: state.activeIndex,
+                                          graphTime: self.graphStepState.graphTime)
         }
         
         // TODO: use Patch's .graphNode method; right now, however, NodeKind.rowDefinitions properly retrieves row definitions whether new or old style

--- a/Stitch/Graph/StitchAI/GraphPrompting/API/OpenAIRequestConfig.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/OpenAIRequestConfig.swift
@@ -17,7 +17,7 @@ struct OpenAIRequestConfig: Equatable, Hashable {
     /// Default configuration with optimized retry settings
     static let `default` = OpenAIRequestConfig(
         maxRetries: 3,
-        timeoutInterval: 300,
+        timeoutInterval: 360,
         retryDelay: 2,
         maxTimeoutErrors: 4
     )

--- a/Stitch/Graph/StitchAI/GraphPrompting/API/OpenAIRequestConfig.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/OpenAIRequestConfig.swift
@@ -17,7 +17,7 @@ struct OpenAIRequestConfig: Equatable, Hashable {
     /// Default configuration with optimized retry settings
     static let `default` = OpenAIRequestConfig(
         maxRetries: 3,
-        timeoutInterval: 180,
+        timeoutInterval: 300,
         retryDelay: 2,
         maxTimeoutErrors: 4
     )

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/OpenAIResponseStructs.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/OpenAIResponseStructs.swift
@@ -116,7 +116,7 @@ extension StitchAIRequestable {
         
         do {
             let result = try decoder.decode(Self.InitialDecodedResult.self, from: contentData)
-            print("MessageStruct: successfully decoded with \(result)")
+            print("MessageStruct: successfully decoded with \(try? result.encodeToPrintableString() ?? "")")
             return result
         } catch let error as StitchAIManagerError {
             throw error

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AICodeGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AICodeGenRequest.swift
@@ -97,7 +97,7 @@ struct AICodeGenRequest: StitchAIRequestable {
                 do {
                     let actionsResult = try viewNode.deriveStitchActions()
                     
-                    print("Derived Stitch layer data:\n\(actionsResult)")
+                    print("Derived Stitch layer data:\n\((try? actionsResult.encodeToPrintableString()) ?? "")")
                     
                     let layerDataList = actionsResult.actions
                     allDiscoveredErrors += actionsResult.caughtErrors

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
@@ -333,6 +333,7 @@ extension CurrentAIPatchBuilderResponseFormat.GraphData {
         }
         
         let graphEntity = document.graph.createSchema()
+        
         return graphEntity
     }
 }

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
@@ -92,7 +92,7 @@ extension StitchDocumentViewModel {
     @MainActor
     func updateCustomInputValueFromAI(inputCoordinate: NodeIOCoordinate,
                                       valueType: Step_V0.NodeType,
-                                      data: Data,
+                                      data: (any Codable & Sendable),
                                       idMap: inout [String : UUID]) throws {
         let graph = self.visibleGraph
         

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
@@ -63,9 +63,9 @@ extension StitchDocumentViewModel {
     /// Recursively creates new sidebar layer data from AI result after creating nodes.
     @MainActor
     func createLayerNodeFromAI(newLayer: CurrentAIPatchBuilderResponseFormat.LayerData,
-                               idMap: inout [UUID : UUID]) throws {
+                               idMap: inout [String : UUID]) throws {
         let newId = UUID()
-        idMap.updateValue(newId, forKey: newLayer.node_id.value)
+        idMap.updateValue(newId, forKey: newLayer.node_id)
         let graph = self.visibleGraph
         
         let migratedNodeName = try newLayer.node_name.value.convert(to: PatchOrLayer.self)
@@ -91,40 +91,45 @@ extension StitchDocumentViewModel {
     
     @MainActor
     func updateCustomInputValueFromAI(inputCoordinate: NodeIOCoordinate,
-                                      value: CurrentStep.PortValue,
-                                      idMap: [UUID : UUID]) throws {
+                                      valueType: Step_V0.NodeType,
+                                      data: Data,
+                                      idMap: inout [String : UUID]) throws {
         let graph = self.visibleGraph
-        var migratedValue = try value.migrate()
         
-        // remap values with UUID
-        switch migratedValue {
-        case .assignedLayer(let layerNodeId):
-            guard let layerNodeId = layerNodeId else {
-                break
-            }
-            
-            guard let newId = idMap[layerNodeId.asNodeId] else {
-                fatalErrorIfDevDebug("updateCustomInputValueFromAI: idMap did not have layerNodeId \(layerNodeId.asNodeId), idMap: \(idMap)")
-                throw AIPatchBuilderRequestError.nodeIdNotFound
-            }
-            
-            migratedValue = .assignedLayer(.init(newId))
-            
-        case .anchorEntity(let nodeId):
-            guard let nodeId = nodeId else {
-                break
-            }
-            
-            guard let newId = idMap[nodeId] else {
-                fatalErrorIfDevDebug("updateCustomInputValueFromAI: idMap did not have nodeId \(nodeId), idMap: \(idMap)")
-                throw AIPatchBuilderRequestError.nodeIdNotFound
-            }
-            
-            migratedValue = .anchorEntity(.init(newId))
-
-        default:
-            break
-        }
+        let value = try Step_V0.PortValue.decodeFromAI(data: data,
+                                                       valueType: valueType,
+                                                       idMap: &idMap)
+        let migratedValue = try value.migrate()
+        
+//        // remap values with UUID
+//        switch migratedValue {
+//        case .assignedLayer(let layerNodeId):
+//            guard let layerNodeId = layerNodeId else {
+//                break
+//            }
+//            
+//            guard let newId = idMap[layerNodeId.asNodeId] else {
+//                fatalErrorIfDevDebug("updateCustomInputValueFromAI: idMap did not have layerNodeId \(layerNodeId.asNodeId), idMap: \(idMap)")
+//                throw AIPatchBuilderRequestError.nodeIdNotFound
+//            }
+//            
+//            migratedValue = .assignedLayer(.init(newId))
+//            
+//        case .anchorEntity(let nodeId):
+//            guard let nodeId = nodeId else {
+//                break
+//            }
+//            
+//            guard let newId = idMap[nodeId] else {
+//                fatalErrorIfDevDebug("updateCustomInputValueFromAI: idMap did not have nodeId \(nodeId), idMap: \(idMap)")
+//                throw AIPatchBuilderRequestError.nodeIdNotFound
+//            }
+//            
+//            migratedValue = .anchorEntity(.init(newId))
+//
+//        default:
+//            break
+//        }
 
         guard let input = graph.getInputObserver(coordinate: inputCoordinate) else {
             log("applyAction: could not apply setInput")
@@ -161,15 +166,15 @@ extension CurrentAIPatchBuilderResponseFormat.GraphData {
         let graph = document.visibleGraph
         
         // Track node ID map to create new IDs, fixing ID reusage issue
-        var idMap = [UUID: UUID]()
+        var idMap = [String : UUID]()
         
         // Tracks all patch input coordinates we either make connections or custom vaues for, used for determining if extra rows need to be created
         let allModifiedPatchIds = self.patch_data.custom_patch_input_values.map(\.patch_input_coordinate) + self.patch_data.patch_connections.map(\.dest_port)
         let allModifiedPatchIdsSet = Set(allModifiedPatchIds)
 //        assertInDebug(allModifiedPatchIdsSet.count == allModifiedPatchIds.count)
         
-        let maxModifiedPortIndex: [UUID : Int] = allModifiedPatchIdsSet.reduce(into: .init()) { result, patchInputId in
-            let nodeId = patchInputId.node_id.value
+        let maxModifiedPortIndex: [String : Int] = allModifiedPatchIdsSet.reduce(into: .init()) { result, patchInputId in
+            let nodeId = patchInputId.node_id
             let existingMaxCount = result.get(nodeId) ?? -1
             result.updateValue(max(patchInputId.port_index + 1, existingMaxCount),
                                forKey: nodeId)
@@ -178,7 +183,7 @@ extension CurrentAIPatchBuilderResponseFormat.GraphData {
         // new js patches
         for newPatch in self.patch_data.javascript_patches {
             let newId = UUID()
-            idMap.updateValue(newId, forKey: newPatch.node_id.value)
+            idMap.updateValue(newId, forKey: newPatch.node_id)
             let newNode = document.nodeInserted(choice: .patch(.javascript),
                                                 nodeId: newId)
             
@@ -196,7 +201,7 @@ extension CurrentAIPatchBuilderResponseFormat.GraphData {
         
         // new native patches
         for newPatch in self.patch_data.native_patches {
-            let oldId = newPatch.node_id.value
+            let oldId = newPatch.node_id
             let newId = UUID()
             idMap.updateValue(newId, forKey: oldId)
             let migratedNodeName = try newPatch.node_name.value.convert(to: PatchOrLayer.self)
@@ -210,7 +215,7 @@ extension CurrentAIPatchBuilderResponseFormat.GraphData {
             }
             
             // Set custom value type here
-            if let customValueType = self.patch_data.native_patch_value_type_settings.first(where: { $0.node_id.value == oldId })?.value_type {
+            if let customValueType = self.patch_data.native_patch_value_type_settings.first(where: { $0.node_id == oldId })?.value_type {
                 guard let oldType = newNode.userVisibleType else {
                     // fatalErrorIfDebug()
                     break
@@ -265,8 +270,9 @@ extension CurrentAIPatchBuilderResponseFormat.GraphData {
                 from: newInputValueSetting.patch_input_coordinate,
                 idMap: idMap)
             try document.updateCustomInputValueFromAI(inputCoordinate: inputCoordinate,
-                                                      value: newInputValueSetting.value,
-                                                      idMap: idMap)
+                                                      valueType: newInputValueSetting.value_type.value,
+                                                      data: newInputValueSetting.value,
+                                                      idMap: &idMap)
         }
         
         // new constants for layers
@@ -275,8 +281,9 @@ extension CurrentAIPatchBuilderResponseFormat.GraphData {
                 from: newInputValueSetting.layer_input_coordinate,
                 idMap: idMap)
             try document.updateCustomInputValueFromAI(inputCoordinate: inputCoordinate,
-                                                      value: newInputValueSetting.value,
-                                                      idMap: idMap)
+                                                      valueType: newInputValueSetting.value_type.value,
+                                                      data: newInputValueSetting.value,
+                                                      idMap: &idMap)
         }
         
         // new edges to downstream patches
@@ -332,8 +339,8 @@ extension CurrentAIPatchBuilderResponseFormat.GraphData {
 
 extension NodeIOCoordinate {
     init(from aiPatchCoordinate: CurrentAIPatchBuilderResponseFormat.NodeIndexedCoordinate,
-         idMap: [UUID : UUID]) throws {
-        guard let newId = idMap.get(aiPatchCoordinate.node_id.value) else {
+         idMap: [String : UUID]) throws {
+        guard let newId = idMap.get(aiPatchCoordinate.node_id) else {
             fatalErrorIfDevDebug("updateCustomInputValueFromAI: idMap did not have aiPatchCoordinate.node_id \(aiPatchCoordinate.node_id), idMap: \(idMap)")
             throw AIPatchBuilderRequestError.nodeIdNotFound
         }
@@ -343,8 +350,8 @@ extension NodeIOCoordinate {
     }
     
     init(from aiLayerCoordinate: CurrentAIPatchBuilderResponseFormat.LayerInputCoordinate,
-         idMap: [UUID : UUID]) throws {
-        guard let newId = idMap.get(aiLayerCoordinate.layer_id.value) else {
+         idMap: [String : UUID]) throws {
+        guard let newId = idMap.get(aiLayerCoordinate.layer_id) else {
             fatalErrorIfDevDebug("updateCustomInputValueFromAI: idMap did not have aiLayerCoordinate.layer_id \(aiLayerCoordinate.layer_id), idMap: \(idMap)")
             throw AIPatchBuilderRequestError.nodeIdNotFound
         }

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
@@ -100,36 +100,6 @@ extension StitchDocumentViewModel {
                                                        valueType: valueType,
                                                        idMap: &idMap)
         let migratedValue = try value.migrate()
-        
-//        // remap values with UUID
-//        switch migratedValue {
-//        case .assignedLayer(let layerNodeId):
-//            guard let layerNodeId = layerNodeId else {
-//                break
-//            }
-//            
-//            guard let newId = idMap[layerNodeId.asNodeId] else {
-//                fatalErrorIfDevDebug("updateCustomInputValueFromAI: idMap did not have layerNodeId \(layerNodeId.asNodeId), idMap: \(idMap)")
-//                throw AIPatchBuilderRequestError.nodeIdNotFound
-//            }
-//            
-//            migratedValue = .assignedLayer(.init(newId))
-//            
-//        case .anchorEntity(let nodeId):
-//            guard let nodeId = nodeId else {
-//                break
-//            }
-//            
-//            guard let newId = idMap[nodeId] else {
-//                fatalErrorIfDevDebug("updateCustomInputValueFromAI: idMap did not have nodeId \(nodeId), idMap: \(idMap)")
-//                throw AIPatchBuilderRequestError.nodeIdNotFound
-//            }
-//            
-//            migratedValue = .anchorEntity(.init(newId))
-//
-//        default:
-//            break
-//        }
 
         guard let input = graph.getInputObserver(coordinate: inputCoordinate) else {
             log("applyAction: could not apply setInput")

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/StitchAIRequestable.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/StitchAIRequestable.swift
@@ -14,7 +14,7 @@ let OPEN_AI_BASE_URL: URL = URL(string: OPEN_AI_BASE_URL_STRING)!
 
 // Note: an event is usually not a long-lived data structure; but this is used for retry attempts.
 /// Main event handler for initiating OpenAI API requests
-protocol StitchAIRequestable: Sendable where InitialDecodedResult: Decodable, TokenDecodedResult: Decodable {
+protocol StitchAIRequestable: Sendable where InitialDecodedResult: Codable, TokenDecodedResult: Decodable {
     associatedtype Body: Encodable
     // Initial payload that's expected from OpenAI response
     associatedtype InitialDecodedResult

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIPatchBuilder/AIPatchBuilderResponseFormat_V0.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIPatchBuilder/AIPatchBuilderResponseFormat_V0.swift
@@ -432,16 +432,7 @@ extension AIPatchBuilderResponseFormat_V0.CustomLayerInputValue {
 extension Step_V0.PortValue {
     static func decodeFromAI(data: (any Codable & Sendable),
                              valueType: Step_V0.NodeType,
-                             idMap: inout [String : UUID]) throws -> Step_V0.PortValue {
-//        let nodeTypeString = try container.decode(String.self, forKey: valueTypeKey)
-//        
-//        guard let nodeType = Step_V0.NodeType(llmString: nodeTypeString) else {
-//            throw StitchAIParsingError.nodeTypeParsing(nodeTypeString)
-//        }
-        
-        // Parse value given node type
-//        let portValueType = valueType.portValueTypeForStitchAI
-        
+                             idMap: inout [String : UUID]) throws -> Step_V0.PortValue {        
         do {
             let value = try valueType.coerceToPortValueForStitchAI(from: data,
                                                                    idMap: idMap)

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/Node/NodeType_V0.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/Node/NodeType_V0.swift
@@ -137,7 +137,8 @@ extension StitchAIPortValue_V0.NodeType {
         }
     }
     
-    func coerceToPortValueForStitchAI(from anyValue: Any) throws -> StitchAIPortValue_V0.PortValue {
+    func coerceToPortValueForStitchAI(from anyValue: Any,
+                                      idMap: [String : UUID]) throws -> StitchAIPortValue_V0.PortValue {
         switch self {
         case .int:
             fatalErrorIfDebug()
@@ -237,22 +238,21 @@ extension StitchAIPortValue_V0.NodeType {
             }
             return .cameraDirection(x)
         case .interactionId:
-            guard let x = anyValue as? StitchAIUUID_V0.StitchAIUUID? else {
-                if let xString = anyValue as? String,
-                   // TODO: how did "None" get wrapped with extra quotes?
-                   (xString == "None") {
-//                   (xString == "None" || xString == "\"None\"") {
-                    return .assignedLayer(nil)
-                }
-                
-                throw StitchAIParsingError.typeCasting
+            guard let xString = anyValue as? String else {
+                return .assignedLayer(nil)
             }
             
-            if let x = x {
-                return .assignedLayer(.init(x.value))
+            if (xString == "None") {
+                //                   (xString == "None" || xString == "\"None\"") {
+                return .assignedLayer(nil)
             }
             
-            return .assignedLayer(nil)
+            // Remap ID if from AI result
+            guard let newId = idMap.get(xString) else {
+                fatalErrorIfDebug()
+                return .assignedLayer(nil)
+            }
+            return .assignedLayer(.init(newId))
             
         case .scrollMode:
             guard let x = anyValue as? StitchAIPortValue_V0.PortValueVersion.ScrollMode else {

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/Value/StitchAIPortValue_V0.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/Value/StitchAIPortValue_V0.swift
@@ -34,7 +34,7 @@ enum StitchAIPortValue_V0: StitchSchemaVersionable {
         
         init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-
+            
             // extract type
             let nodeTypeString = try container.decode(String.self, forKey: .type)
             guard let nodeType = NodeType(llmString: nodeTypeString) else {
@@ -44,7 +44,11 @@ enum StitchAIPortValue_V0: StitchSchemaVersionable {
             // portvalue
             let portValueType = nodeType.portValueTypeForStitchAI
             let decodedValue = try container.decode(portValueType, forKey: .value)
-            let value = try nodeType.coerceToPortValueForStitchAI(from: decodedValue)
+            
+            // this is unused from here
+            var idMap = [String : UUID]()
+            let value = try nodeType.coerceToPortValueForStitchAI(from: decodedValue,
+                                                                  idMap: idMap)
             self.value = value
         }
         
@@ -75,7 +79,11 @@ extension StitchAIPortValue_V0.PortValue {
             return nil
         }
         
-        let value = try type.coerceToPortValueForStitchAI(from: decodedValue)
+        // unused here
+        let idMap = [String : UUID]()
+        
+        let value = try type.coerceToPortValueForStitchAI(from: decodedValue,
+                                                          idMap: idMap)
         self = value
     }
     
@@ -118,9 +126,9 @@ extension StitchAIPortValue_V0.PortValue {
             return x
         case .assignedLayer(let x):
             guard let x = x else {
-                return nil as StitchAIUUID_V0.StitchAIUUID?
+                return nil as String?
             }
-            return StitchAIUUID_V0.StitchAIUUID(value: x.id)
+            return x.id.description
         case .scrollMode(let x):
             return x
         case .textAlignment(let x):
@@ -195,9 +203,9 @@ extension StitchAIPortValue_V0.PortValue {
             return x
         case .anchorEntity(let x):
             guard let x = x else {
-                return nil as StitchAIUUID_V0.StitchAIUUID?
+                return nil as String?
             }
-            return StitchAIUUID_V0.StitchAIUUID(value: x)
+            return x.description
         case .none, .int:
             fatalError()
         }

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V1/Value/StitchAIPortValue_V1.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V1/Value/StitchAIPortValue_V1.swift
@@ -45,7 +45,12 @@ enum StitchAIPortValue_V1: StitchSchemaVersionable {
             // portvalue
             let portValueType = nodeType.portValueTypeForStitchAI
             let decodedValue = try container.decode(portValueType, forKey: .value)
-            let value = try nodeType.coerceToPortValueForStitchAI(from: decodedValue)
+            
+            // this is unused from here
+            var idMap = [String : UUID]()
+            let value = try nodeType.coerceToPortValueForStitchAI(from: decodedValue,
+                                                                  idMap: idMap)
+            
             self.value = value
         }
         
@@ -76,7 +81,11 @@ extension StitchAIPortValue_V1.PortValue {
             return nil
         }
         
-        let value = try type.coerceToPortValueForStitchAI(from: decodedValue)
+        // unused here
+        let idMap = [String : UUID]()
+        
+        let value = try type.coerceToPortValueForStitchAI(from: decodedValue,
+                                                          idMap: idMap)
         self = value
     }
     

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V1/Value/StitchAIPortValue_V1.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V1/Value/StitchAIPortValue_V1.swift
@@ -120,9 +120,9 @@ extension StitchAIPortValue_V1.PortValue {
             return x
         case .assignedLayer(let x):
             guard let x = x else {
-                return nil as StitchAIUUID_V1.StitchAIUUID?
+                return nil as String?
             }
-            return StitchAIUUID_V1.StitchAIUUID(value: x.id)
+            return x.id.description
         case .scrollMode(let x):
             return x
         case .textAlignment(let x):
@@ -197,9 +197,9 @@ extension StitchAIPortValue_V1.PortValue {
             return x
         case .anchorEntity(let x):
             guard let x = x else {
-                return nil as StitchAIUUID_V1.StitchAIUUID?
+                return nil as String?
             }
-            return StitchAIUUID_V1.StitchAIUUID(value: x)
+            return x.description
         case .keyboardType(let x):
             return x
         case .none:

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/StepAction.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/StepAction.swift
@@ -290,7 +290,8 @@ extension StepActionChangeValueType: StepActionable {
             // NodeType etc. for this patch was already validated in `[StepTypeAction].areValidLLMSteps`
             let _ = document.visibleGraph.nodeTypeChanged(nodeId: self.nodeId,
                                                           newNodeType: migratedType,
-                                                          activeIndex: document.activeIndex)
+                                                          activeIndex: document.activeIndex,
+                                                          graphTime: document.graphStepState.graphTime)
         } catch {
             return .typeMigrationFailed(self.valueType)
         }

--- a/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
@@ -58,6 +58,14 @@ enum SwiftUISyntaxError: Error, Sendable {
     case syntaxValueDecodingFailed(SyntaxArgumentKind)
 }
 
+extension SwiftUISyntaxError: Encodable {
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        let string = "\(self)"
+        try container.encode(string)
+    }
+}
+
 extension SwiftUISyntaxError {
     /// Errors that should allow request to continue.
     var shouldFailSilently: Bool {

--- a/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
@@ -38,7 +38,7 @@ enum SwiftUISyntaxError: Error, Sendable {
     case unsupportedSyntaxViewLayer(CurrentStep.Layer)
     
     case unsupportedLayerIdParsing([SyntaxViewArgumentData])
-    case layerUUIDDecodingFailed(String)
+//    case layerUUIDDecodingFailed(String)
     
     case incorrectParsing(message: String)
     case groupLayerDecodingFailed

--- a/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
@@ -38,7 +38,6 @@ enum SwiftUISyntaxError: Error, Sendable {
     case unsupportedSyntaxViewLayer(CurrentStep.Layer)
     
     case unsupportedLayerIdParsing([SyntaxViewArgumentData])
-//    case layerUUIDDecodingFailed(String)
     
     case incorrectParsing(message: String)
     case groupLayerDecodingFailed

--- a/Stitch/Graph/StitchAI/Mapping/Declarative/DeclarativeViewConstructors.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Declarative/DeclarativeViewConstructors.swift
@@ -29,7 +29,7 @@ protocol FromSwiftUIViewToStitch {
 
 extension ViewConstructor {
     
-    func getCustomValueEvents(id: UUID) -> [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue]? {
+    func getCustomValueEvents(id: UUID) throws -> [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue]? {
         
         guard let toStitchResult = self.toStitch else {
             return nil
@@ -37,23 +37,19 @@ extension ViewConstructor {
         
         let inputs = toStitchResult.1
         
-        return inputs.compactMap { (valueOrEdge: ValueOrEdge) in
+        return try inputs.compactMap { (valueOrEdge: ValueOrEdge) in
             switch valueOrEdge {
             case .edge:
                 return nil
             case .value(let x):
-                if let downgradedInput = try? x.input.convert(to: CurrentStep.LayerInputPort.self),
-                   let downgradedValue = try? x.value.convert(to: CurrentStep.PortValue.self) {
-                    return CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue.init(
-                        id: id,
-                        input: downgradedInput,
-                        value: downgradedValue)
-                } else {
-                    return nil
-                }
+                let downgradedInput = try x.input.convert(to: CurrentStep.LayerInputPort.self)
+                let downgradedValue = try x.value.convert(to: CurrentStep.PortValue.self)
+                return try CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue.init(
+                    id: id,
+                    input: downgradedInput,
+                    value: downgradedValue)
             }
         }
-        
     }
 }
 

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
@@ -91,7 +91,7 @@ extension SyntaxViewName {
         } else if !hasRootGroupLayer {
             // Add new node as middle-man
             let newGroupNode = CurrentAIPatchBuilderResponseFormat
-                .LayerData(node_id: .init(value: .init()),
+                .LayerData(node_id: UUID().description,
                            node_name: .init(value: .layer(.group)),
                            children: childrenLayers)
             

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
@@ -8,7 +8,7 @@
 import Foundation
 import SwiftUI
 
-struct SwiftSyntaxActionsResult {
+struct SwiftSyntaxActionsResult: Encodable {
     let actions: [CurrentAIPatchBuilderResponseFormat.LayerData]
     var caughtErrors: [SwiftUISyntaxError]
 }

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
@@ -385,7 +385,7 @@ extension SyntaxViewName {
         var customInputValuesFromViewConstructor = [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue]()
 
         // Try to access the SyntaxView.ViewConstructor, if we have one
-        if let customInputValues = viewConstructor?.getCustomValueEvents(id: id) {
+        if let customInputValues = try viewConstructor?.getCustomValueEvents(id: id) {
             customInputValuesFromViewConstructor = customInputValues
         }
         

--- a/Stitch/Graph/Util/HardcodedSizes/PseudoScriptForHardcodedSizes.swift
+++ b/Stitch/Graph/Util/HardcodedSizes/PseudoScriptForHardcodedSizes.swift
@@ -168,7 +168,8 @@ extension StitchDocumentViewModel {
                         for: node,
                         oldType: oldType,
                         newType: nodeType,
-                        activeIndex: .defaultActiveIndex
+                        activeIndex: .defaultActiveIndex,
+                        graphTime: self.graphStepState.graphTime
                     )
                 }
             }

--- a/StitchTests/nodeTypeTests.swift
+++ b/StitchTests/nodeTypeTests.swift
@@ -28,7 +28,8 @@ final class nodeTypeTests: XCTestCase {
                 
         let _ = document.graph.nodeTypeChanged(nodeId: node.id,
                                                newNodeType: .size,
-                                               activeIndex: document.activeIndex)
+                                               activeIndex: document.activeIndex,
+                                               graphTime: document.graphStepState.graphTime)
         
         let sizeInputs = node.inputsObservers.allSatisfy { (input: InputNodeRowObserver) in
             input.allLoopedValues.allSatisfy { (value: PortValue) in


### PR DESCRIPTION
Fixes an issue where OpenAI attempts to create a UUID that cannot be decoded on Stitch due to UUID requirement.

The fix is no longer requiring the UUID enforcement, instead decoding all IDs as strings. This includes IDs used as PortValues for interaction layers, which also needs to be assumed as a string type.

Considerations:
* Part of the solution here leverages are existing `idMap` used for ensure ID uniqueness. It's been broadened to use strings instead of UUID as its key, providing support for OpenAI's response.
* Because of the new requirement for String instead of UUID decoding for PortValues, we needed to tweak the decoding/encoding logic to no longer eagerly encode or decode a PortValue. This is because the type used for PortValue is UUID, which we don't want to change. Tweaks were needed to handling PortValue decoding a bit after the initial decode because we are unable to pass the idMap into a decode constructor. So now we:
1. Loosely decode PortValue by simply creating an `any Codable` type—this allows for String IDs before converting to UUID
2. Then, fully decode into `PortValue` using existing helpers
