### PR TITLE
Handle SwiftUI ZStack vs Stitch sidebar z-ordering difference

### DIFF
--- a/Stitch/App/StitchApp.swift
+++ b/Stitch/App/StitchApp.swift
@@ -41,15 +41,15 @@ struct StitchApp: App {
         FirebaseApp.configure()
     }
 
-#if DEV_DEBUG
-    var body: some Scene {
-        WindowGroup {
-            ConstructorDemoView()
-//             VarBodyParserDemoView()
-//             ASTExplorerView()
-        }
-    }
-#else
+//#if DEV_DEBUG
+//    var body: some Scene {
+//        WindowGroup {
+//            ConstructorDemoView()
+////             VarBodyParserDemoView()
+////             ASTExplorerView()
+//        }
+//    }
+//#else
     var body: some Scene {
         WindowGroup {
             
@@ -115,6 +115,6 @@ struct StitchApp: App {
         }
         #endif
     }
-#endif
+//#endif
 }
 

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct SwiftSyntaxActionsResult: Encodable {
-    let actions: [CurrentAIPatchBuilderResponseFormat.LayerData]
+    var actions: [CurrentAIPatchBuilderResponseFormat.LayerData]
     var caughtErrors: [SwiftUISyntaxError]
 }
 
@@ -28,7 +28,17 @@ extension SyntaxView {
         var silentErrors = [SwiftUISyntaxError]()
         
         // Recurse into children first (DFS), we might use this data for nested scenarios like ScrollView
-        let childResults = try self.children.deriveStitchActions()
+        var childResults = try self.children.deriveStitchActions()
+        
+        // Flip the children if we have a ZStack,
+        // since "top" layer in Stitch sidebar corresponds to "bottom" of declared-child in SwiftUI ZStack.
+        if self.name == .zStack {
+            childResults.actions = childResults.actions.reversed()
+            
+            // TODO: do we really need to reverse the errors?
+            childResults.caughtErrors = childResults.caughtErrors.reversed()
+        }
+        
         silentErrors += childResults.caughtErrors
 
         // Map this node


### PR DESCRIPTION
## example 1
<img width="1429" height="442" alt="Screenshot 2025-07-14 at 9 50 42 AM" src="https://github.com/user-attachments/assets/0595808e-5439-463c-80ad-1e69ed22d48a" />
<img width="1440" height="900" alt="Screenshot 2025-07-14 at 9 47 50 AM" src="https://github.com/user-attachments/assets/25ba496f-4645-4340-9dc1-b3769831618e" />

## example 2
<img width="1440" height="900" alt="Screenshot 2025-07-14 at 9 52 03 AM" src="https://github.com/user-attachments/assets/ea0a8d0a-87cc-4d69-aa74-72d7b56a2dfa" />
<img width="1440" height="900" alt="Screenshot 2025-07-14 at 9 51 06 AM" src="https://github.com/user-attachments/assets/ce7317fe-034d-472a-8c3f-17154444500b" />
