### PR TITLE
Improved new view constructor logic to use existing helpers

### DIFF
--- a/Stitch/App/StitchApp.swift
+++ b/Stitch/App/StitchApp.swift
@@ -115,6 +115,6 @@ struct StitchApp: App {
         }
         #endif
     }
-//#endif
+#endif
 }
 

--- a/Stitch/App/StitchApp.swift
+++ b/Stitch/App/StitchApp.swift
@@ -41,15 +41,15 @@ struct StitchApp: App {
         FirebaseApp.configure()
     }
 
-//#if DEV_DEBUG
-//    var body: some Scene {
-//        WindowGroup {
+#if DEV_DEBUG
+    var body: some Scene {
+        WindowGroup {
 //            ConstructorDemoView()
-////             VarBodyParserDemoView()
-////             ASTExplorerView()
-//        }
-//    }
-//#else
+//             VarBodyParserDemoView()
+             ASTExplorerView()
+        }
+    }
+#else
     var body: some Scene {
         WindowGroup {
             

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Anchoring/Anchoring.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Anchoring/Anchoring.swift
@@ -15,6 +15,21 @@ import StitchSchemaKit
 // TODO: if you have e.g. (0.25, 0.75), what (0 vs 0.5 vs 1) anchor point does that become?
 // Round up? Round down?
 
+extension CurrentStitchAIPortValue.PortValueVersion.Anchoring { // : PortValueEnum {
+    
+    // The traditional
+    static let topLeft: Self = .init(x: Self.left, y: Self.top)
+    static let topCenter: Self = .init(x: Self.center, y: Self.top)
+    static let topRight: Self = .init(x: Self.right, y: Self.top)
+    static let centerLeft: Self = .init(x: Self.left, y: Self.center)
+    // fka `center`
+    static let centerCenter: Self = .init(x: Self.center, y: Self.center)
+    static let centerRight: Self = .init(x: Self.right, y: Self.center)
+    static let bottomLeft: Self = .init(x: Self.left, y: Self.bottom)
+    static let bottomCenter: Self = .init(x: Self.center, y: Self.bottom)
+    static let bottomRight: Self = .init(x: Self.right, y: Self.bottom)
+}
+
 
 // "how a view anchors itself within the parent"
 extension Anchoring { // : PortValueEnum {

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/OpenAIResponseStructs.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/OpenAIResponseStructs.swift
@@ -116,7 +116,7 @@ extension StitchAIRequestable {
         
         do {
             let result = try decoder.decode(Self.InitialDecodedResult.self, from: contentData)
-            print("MessageStruct: successfully decoded with \(try? result.encodeToPrintableString() ?? "")")
+            print("MessageStruct: successfully decoded with:\n\((try? result.encodeToPrintableString()) ?? "")")
             return result
         } catch let error as StitchAIManagerError {
             throw error

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AICodeGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AICodeGenRequest.swift
@@ -113,7 +113,7 @@ struct AICodeGenRequest: StitchAIRequestable {
                     
                     switch patchBuilderResult {
                     case .success(let patchBuildResult):
-                        logToServerIfRelease("SUCCESS Patch Builder:\n\(patchBuildResult)")
+                        logToServerIfRelease("SUCCESS Patch Builder:\n\((try? patchBuildResult.encodeToPrintableString()) ?? "")")
                         
                         DispatchQueue.main.async { [weak document] in
                             guard let document = document else { return }

--- a/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
@@ -31,6 +31,7 @@ enum SwiftUISyntaxError: Error, Sendable {
     case unsupportedSyntaxViewModifierArgumentName(String)
     case unsupportedComplexValueType(String)
     case unsupportedPortValueTypeDecoding(SyntaxViewModifierArgumentType)
+    case unsupportedConstructorForPortValueDecoding(ViewConstructor)
     
     case unsupportedLayer(SyntaxViewName)
 //    case unsupportedConstructorArgument(SyntaxViewArgumentData)
@@ -80,7 +81,8 @@ extension SwiftUISyntaxError {
                 .unsupportedComplexValueType,
                 .unsupportedViewModifier,
                 .unsupportedViewModifierForLayer,
-                .unexpectedPatchInputRowCount:
+                .unexpectedPatchInputRowCount,
+                .unsupportedConstructorForPortValueDecoding:
             return true
             
         default:

--- a/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
@@ -47,6 +47,7 @@ enum SwiftUISyntaxError: Error, Sendable {
     case portValueDataDecodingFailure
     case layerEdgeDataFailure(AIPatchBuilderResponseFormat_V0.LayerConnection)
     case unexpectedPatchInputRowCount(Patch)
+    case portValueNotFound
     
     // Value decoding
     case noLabelFoundForComplexType
@@ -82,7 +83,8 @@ extension SwiftUISyntaxError {
                 .unsupportedViewModifier,
                 .unsupportedViewModifierForLayer,
                 .unexpectedPatchInputRowCount,
-                .unsupportedConstructorForPortValueDecoding:
+                .unsupportedConstructorForPortValueDecoding,
+                .portValueNotFound:
             return true
             
         default:

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
@@ -164,13 +164,13 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
     // MARK: - Attach strongly-typed constructor
     /// Adds a `ViewConstructor` to the *current* SyntaxView and keeps the
     /// root/ancestors in sync.
-    private func attachConstructor(_ ctor: ViewConstructor) {
-        guard let idx = currentNodeIndex, idx < viewStack.count else { return }
-        var node = viewStack[idx]
-        node.constructor = ctor          // ⇐ requires `var constructor: ViewConstructor?` on SyntaxView
-        viewStack[idx] = node
-        bubbleChangeUp(from: idx)
-    }
+//    private func attachConstructor(_ ctor: ViewConstructor) {
+//        guard let idx = currentNodeIndex, idx < viewStack.count else { return }
+//        var node = viewStack[idx]
+//        node.constructor = ctor          // ⇐ requires `var constructor: ViewConstructor?` on SyntaxView
+//        viewStack[idx] = node
+//        bubbleChangeUp(from: idx)
+//    }
     
     // Helper to add a modifier to the current view node
     private func addModifier(_ modifier: SyntaxViewModifier) {
@@ -193,78 +193,79 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
     
     /// Runs every `…ViewConstructor.from(node)` helper once. If an enum is
     /// returned, attach it to the *current* SyntaxView.
-    private func tryAttachConstructor(from node: FunctionCallExprSyntax) {
+    private static func createKnownViewConstructor(from node: FunctionCallExprSyntax,
+                                                   arguments: [SyntaxViewArgumentData]) -> ViewConstructor? {
         
         guard let name = node.calledExpression.as(DeclReferenceExprSyntax.self)?.baseName.text,
               let viewName = SyntaxViewName(rawValue: name) else {
-            return
+            return nil
         }
         
         switch viewName {
         case .text:
-            if let ctor = TextViewConstructor.from(node).map(ViewConstructor.text) {
-                attachConstructor(ctor)
+            if let ctor = TextViewConstructor.from(arguments) {
+                return .text(ctor)
             }
         case .image:
-            if let ctor = ImageViewConstructor.from(node).map(ViewConstructor.image) {
-                attachConstructor(ctor)
+            if let ctor = ImageViewConstructor.from(arguments) {
+                return .image(ctor)
             }
         case .hStack:
-            if let ctor = HStackViewConstructor.from(node).map(ViewConstructor.hStack) {
-                attachConstructor(ctor)
+            if let ctor = HStackViewConstructor.from(arguments) {
+                return .hStack(ctor)
             }
-        case .vStack:
-            if let ctor = VStackViewConstructor.from(node).map(ViewConstructor.vStack) {
-                attachConstructor(ctor)
-            }
-        case .lazyHStack:
-            if let ctor = LazyHStackViewConstructor.from(node).map(ViewConstructor.lazyHStack) {
-                attachConstructor(ctor)
-            }
-        case .lazyVStack:
-            if let ctor = LazyVStackViewConstructor.from(node).map(ViewConstructor.lazyVStack) {
-                attachConstructor(ctor)
-            }
-        case .circle:
-            if let ctor = CircleViewConstructor.from(node).map(ViewConstructor.circle) {
-                attachConstructor(ctor)
-            }
-        case .ellipse:
-            if let ctor = EllipseViewConstructor.from(node).map(ViewConstructor.ellipse) {
-                attachConstructor(ctor)
-            }
-        case .rectangle:
-            if let ctor = RectangleViewConstructor.from(node).map(ViewConstructor.rectangle) {
-                attachConstructor(ctor)
-            }
-        case .roundedRectangle:
-            if let ctor = RoundedRectangleViewConstructor.from(node).map(ViewConstructor.roundedRectangle) {
-                attachConstructor(ctor)
-            }
-        case .scrollView:
-            if let ctor = ScrollViewViewConstructor.from(node).map(ViewConstructor.scrollView) {
-                attachConstructor(ctor)
-            }
-        case .zStack:
-            if let ctor = ZStackViewConstructor.from(node).map(ViewConstructor.zStack) {
-                attachConstructor(ctor)
-            }
-        case .textField:
-            if let ctor = TextFieldViewConstructor.from(node).map(ViewConstructor.textField) {
-                attachConstructor(ctor)
-            }
-        case .angularGradient:
-            if let ctor = AngularGradientViewConstructor.from(node).map(ViewConstructor.angularGradient) {
-                attachConstructor(ctor)
-            }
-        case .linearGradient:
-            if let ctor = LinearGradientViewConstructor.from(node).map(ViewConstructor.linearGradient) {
-                attachConstructor(ctor)
-            }
-        case .radialGradient:
-            if let ctor = RadialGradientViewConstructor.from(node).map(ViewConstructor.radialGradient) {
-                attachConstructor(ctor)
-            }
+//        case .vStack:
+//            if let ctor = VStackViewConstructor.from(node).map(ViewConstructor.vStack) {
+//                attachConstructor(ctor)
+//            }
+//        case .lazyHStack:
+//            if let ctor = LazyHStackViewConstructor.from(node).map(ViewConstructor.lazyHStack) {
+//                attachConstructor(ctor)
+//            }
+//        case .lazyVStack:
+//            if let ctor = LazyVStackViewConstructor.from(node).map(ViewConstructor.lazyVStack) {
+//                attachConstructor(ctor)
+//            }
+//        case .circle:
+//            if let ctor = CircleViewConstructor.from(node).map(ViewConstructor.circle) {
+//                attachConstructor(ctor)
+//            }
+//        case .ellipse:
+//            if let ctor = EllipseViewConstructor.from(node).map(ViewConstructor.ellipse) {
+//                attachConstructor(ctor)
+//            }
+//        case .rectangle:
+//            if let ctor = RectangleViewConstructor.from(node).map(ViewConstructor.rectangle) {
+//                attachConstructor(ctor)
+//            }
+//        case .roundedRectangle:
+//            if let ctor = RoundedRectangleViewConstructor.from(node).map(ViewConstructor.roundedRectangle) {
+//                attachConstructor(ctor)
+//            }
+//        case .scrollView:
+//            if let ctor = ScrollViewViewConstructor.from(node).map(ViewConstructor.scrollView) {
+//                attachConstructor(ctor)
+//            }
+//        case .zStack:
+//            if let ctor = ZStackViewConstructor.from(node).map(ViewConstructor.zStack) {
+//                attachConstructor(ctor)
+//            }
+//        case .textField:
+//            if let ctor = TextFieldViewConstructor.from(node).map(ViewConstructor.textField) {
+//                attachConstructor(ctor)
+//            }
+//        case .angularGradient:
+//            if let ctor = AngularGradientViewConstructor.from(node).map(ViewConstructor.angularGradient) {
+//                attachConstructor(ctor)
+//            }
+//        case .linearGradient:
+//            if let ctor = LinearGradientViewConstructor.from(node).map(ViewConstructor.linearGradient) {
+//                attachConstructor(ctor)
+//            }
+//        case .radialGradient:
+//            if let ctor = RadialGradientViewConstructor.from(node).map(ViewConstructor.radialGradient) {
+//                attachConstructor(ctor)
+//            }
         default:
             break
         }
@@ -328,7 +329,7 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
                     //                errors: self.caughtErrors
                 )
                 
-                log("Created new ViewNode for \(viewName) with \(viewNode.constructorArguments.count) arguments")
+                log("Created new ViewNode for \(viewName)")
                 
                 // Set as root or add as child to current node (context-aware)
                 if viewStack.isEmpty {
@@ -336,7 +337,7 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
                     viewStack.append(viewNode)
                     currentNodeIndex = 0
                     rootViewNode = viewNode
-                    self.tryAttachConstructor(from: node)
+
                     log("Current node index set to: \(String(describing: currentNodeIndex))")
                 } else {
                     // Check if this view initialization should be treated as a child
@@ -356,7 +357,6 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
                             // Push the new node onto the stack and update current node index
                             viewStack.append(viewNode)
                             currentNodeIndex = viewStack.count - 1
-                            self.tryAttachConstructor(from: node)
                                                         
                             log("Pushed \(viewName) onto stack, new index: \(String(describing: currentNodeIndex))")
                         } else {
@@ -373,7 +373,6 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
                             // Just add it to the stack temporarily so it can be processed
                             viewStack.append(viewNode)
                             currentNodeIndex = viewStack.count - 1
-                            self.tryAttachConstructor(from: node)
                         } else {
                             log("⚠️ Found view \(viewName) in argument context - skipping child addition")
                             log("This view should be handled as an argument, not as a child")
@@ -399,8 +398,7 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
     }
 
     // Parse arguments from function call
-    func parseArguments(from node: FunctionCallExprSyntax) -> [SyntaxViewArgumentData] {
-        
+    func parseArguments(from node: FunctionCallExprSyntax) -> ViewConstructorType {
         // Default handling for other modifiers
         let arguments = node.arguments.compactMap { (argument) -> SyntaxViewArgumentData? in
             self.parseArgument(argument)
@@ -408,7 +406,13 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
         
         dbg("parseArguments → for \(node.calledExpression.trimmedDescription)  |  \(arguments.count) arg(s): \(arguments)")
         
-        return arguments
+        guard let knownViewConstructor = SwiftUIViewVisitor
+            .createKnownViewConstructor(from: node,
+                                        arguments: arguments) else {
+            return .other(arguments)
+        }
+        
+        return .trackedConstructor(knownViewConstructor)
     }
     
     func parseArgument(_ argument: LabeledExprSyntax) -> SyntaxViewArgumentData? {

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
@@ -290,6 +290,8 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
 //        {
 //            attachConstructor(ctor)
 //        }
+        
+        return nil
     }
     
     // Visit function call expressions (which represent view initializations and modifiers)

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
@@ -160,17 +160,6 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
         viewStack[index] = newNode
         bubbleChangeUp(from: index)
     }
-        
-    // MARK: - Attach strongly-typed constructor
-    /// Adds a `ViewConstructor` to the *current* SyntaxView and keeps the
-    /// root/ancestors in sync.
-//    private func attachConstructor(_ ctor: ViewConstructor) {
-//        guard let idx = currentNodeIndex, idx < viewStack.count else { return }
-//        var node = viewStack[idx]
-//        node.constructor = ctor          // ⇐ requires `var constructor: ViewConstructor?` on SyntaxView
-//        viewStack[idx] = node
-//        bubbleChangeUp(from: idx)
-//    }
     
     // Helper to add a modifier to the current view node
     private func addModifier(_ modifier: SyntaxViewModifier) {

--- a/Stitch/Graph/StitchAI/Mapping/Declarative/DeclarativeUtils.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Declarative/DeclarativeUtils.swift
@@ -302,7 +302,6 @@ extension SyntaxViewMemberAccess {
 //        }
 //        return .expression(expression)
 //    }
-}
 
 //extension Parameter where Value: CustomStringConvertible {
 //    /// Fragment suitable for regenerating Swift source.

--- a/Stitch/Graph/StitchAI/Mapping/Declarative/DeclarativeUtils.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Declarative/DeclarativeUtils.swift
@@ -30,7 +30,7 @@ extension LocalizedStringKey {
 // ── Alignment → Anchoring helpers ───────────────────────────────────────
 
 extension VerticalAlignment {
-    var toAnchoring: Anchoring {
+    var toAnchoring: CurrentStitchAIPortValue.PortValueVersion.Anchoring {
         switch self {
         case .top:               return .topCenter
         case .bottom:            return .bottomCenter
@@ -227,9 +227,10 @@ extension SyntaxViewModifierArgumentType {
             case "bottom":         return .bottom
             case "bottomTrailing": return .bottomTrailing
             default: return nil
-        }
+            }
         default:
             return nil
+        }
     }
     
     var cgFloatValue: CGFloat? {
@@ -245,111 +246,89 @@ extension SyntaxViewModifierArgumentType {
             return nil
         }
     }
-    
-    // New helper: vertical alignment literal
-    var vertAlignLiteral: VerticalAlignment? {
-        switch self {
-        case .memberAccess(let syntaxViewMemberAccess):
-            if let ident = syntaxViewMemberAccess.base {
-                switch ident {
-                case "top": return .top
-                case "bottom": return .bottom
-                case "firstTextBaseline": return .firstTextBaseline
-                case "lastTextBaseline": return .lastTextBaseline
-                case "center": return .center
-                default: return nil
-                }
-            }
-            
-        default:
-            return nil
-        }
-    }
-    
+}
+
+extension SyntaxViewMemberAccess {
     // New helper: horizontal alignment literal
     var horizAlignLiteral: HorizontalAlignment? {
-        if let ident = expression.as(MemberAccessExprSyntax.self)?
-            .declName.baseName.text {
-            switch ident {
-            case "leading": return .leading
-            case "trailing": return .trailing
-            case "center": return .center
-            default: return nil
-            }
+        let ident = self.base
+        switch ident {
+        case "leading": return .leading
+        case "trailing": return .trailing
+        case "center": return .center
+        default: return nil
         }
-        return nil
     }
-    
-//    func asParameterString() -> Parameter<String> {
-//        if let lit = expression.as(StringLiteralExprSyntax.self) {
-//            return .literal(lit.decoded())
+        
+    var vertAlignLiteral: VerticalAlignment? {
+        let ident = self.base
+        switch ident {
+        case "top": return .top
+        case "bottom": return .bottom
+        case "firstTextBaseline": return .firstTextBaseline
+        case "lastTextBaseline": return .lastTextBaseline
+        case "center": return .center
+        default: return nil
+        }
+    }
+}
+//
+//    func asParameterCGSize() -> Parameter<CGSize> {
+//        if let tuple = expression.as(TupleExprSyntax.self),
+//           let wLit = tuple.elements.first?.expression.as(FloatLiteralExprSyntax.self),
+//           let hLit = tuple.elements[safe: 1]?.expression.as(FloatLiteralExprSyntax.self),
+//           let w = Double(wLit.literal.text),
+//           let h = Double(hLit.literal.text) {
+//            return .literal(CGSize(width: w, height: h))
 //        }
 //        return .expression(expression)
 //    }
 //    
-//    func asParameterCGFloat() -> Parameter<CGFloat> {
-//        if let lit = cgFloatValue {
-//            return .literal(lit)
+//    func asParameterAxisSet() -> Parameter<Axis.Set> {
+//        if let ident = expression.as(MemberAccessExprSyntax.self)?
+//            .declName.baseName.text {
+//            switch ident {
+//            case "vertical":   return .literal(.vertical)
+//            case "horizontal": return .literal(.horizontal)
+//            default: break
+//            }
 //        }
 //        return .expression(expression)
 //    }
-    
-    func asParameterCGSize() -> Parameter<CGSize> {
-        if let tuple = expression.as(TupleExprSyntax.self),
-           let wLit = tuple.elements.first?.expression.as(FloatLiteralExprSyntax.self),
-           let hLit = tuple.elements[safe: 1]?.expression.as(FloatLiteralExprSyntax.self),
-           let w = Double(wLit.literal.text),
-           let h = Double(hLit.literal.text) {
-            return .literal(CGSize(width: w, height: h))
-        }
-        return .expression(expression)
-    }
-    
-    func asParameterAxisSet() -> Parameter<Axis.Set> {
-        if let ident = expression.as(MemberAccessExprSyntax.self)?
-            .declName.baseName.text {
-            switch ident {
-            case "vertical":   return .literal(.vertical)
-            case "horizontal": return .literal(.horizontal)
-            default: break
-            }
-        }
-        return .expression(expression)
-    }
-    
-    func asParameterBool() -> Parameter<Bool> {
-        if let bool = expression.as(BooleanLiteralExprSyntax.self) {
-            return .literal(bool.literal.text == "true")
-        }
-        return .expression(expression)
-    }
+//    
+//    func asParameterBool() -> Parameter<Bool> {
+//        if let bool = expression.as(BooleanLiteralExprSyntax.self) {
+//            return .literal(bool.literal.text == "true")
+//        }
+//        return .expression(expression)
+//    }
 }
 
-extension Parameter where Value: CustomStringConvertible {
-    /// Fragment suitable for regenerating Swift source.
-    var swiftFragment: String {
-        switch self {
-        case .literal(let v):    return String(describing: v)
-        case .expression(let e): return e.description
-        }
-    }
-}
-
-extension ExprSyntax {
-    /// If this expression is `.constant("string")` return the literal string.
-    /// Otherwise return `nil`.
-    func stringLiteralFromConstantBinding() -> String? {
-        guard
-            let call = self.as(FunctionCallExprSyntax.self),
-            let baseName = call.calledExpression.as(MemberAccessExprSyntax.self)?
-                .declName.baseName.text ?? call.calledExpression
-                .as(DeclReferenceExprSyntax.self)?
-                .baseName.text,
-            baseName == "constant",
-            let first = call.arguments.first,
-            let lit   = first.expression.as(StringLiteralExprSyntax.self)
-        else { return nil }
-        
-        return lit.decoded()
-    }
-}
+//extension Parameter where Value: CustomStringConvertible {
+//    /// Fragment suitable for regenerating Swift source.
+//    var swiftFragment: String {
+//        switch self {
+//        case .literal(let v):    return String(describing: v)
+//        case .expression(let e): return e.description
+//        }
+//    }
+//}
+//
+//extension ExprSyntax {
+//    /// If this expression is `.constant("string")` return the literal string.
+//    /// Otherwise return `nil`.
+//    func stringLiteralFromConstantBinding() -> String? {
+//        guard
+//            let call = self.as(FunctionCallExprSyntax.self),
+//            let baseName = call.calledExpression.as(MemberAccessExprSyntax.self)?
+//                .declName.baseName.text ?? call.calledExpression
+//                .as(DeclReferenceExprSyntax.self)?
+//                .baseName.text,
+//            baseName == "constant",
+//            let first = call.arguments.first,
+//            let lit   = first.expression.as(StringLiteralExprSyntax.self)
+//        else { return nil }
+//        
+//        return lit.decoded()
+//    }
+//}

--- a/Stitch/Graph/StitchAI/Mapping/Declarative/DeclarativeViewConstructors.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Declarative/DeclarativeViewConstructors.swift
@@ -192,17 +192,23 @@ enum ImageViewConstructor: Equatable, FromSwiftUIViewToStitch {
         case .asset(let arg),
                 .decorative(let arg),
                 .uiImage(let arg):
-            let portValues = try arg.derivePortValues()
+            guard let portValue = try arg.derivePortValues().first else {
+                throw SwiftUISyntaxError.portValueNotFound
+            }
+            
             return [
                 .init(input: .image,
-                      values: portValues)
+                      value: portValue)
             ]
             
         case .sfSymbol(let arg):
-            let portValues = try arg.derivePortValues()
+            guard let portValue = try arg.derivePortValues().first else {
+                throw SwiftUISyntaxError.portValueNotFound
+            }
+            
             return [
                 .init(input: .sfSymbol,
-                      values: portValues)
+                      value: portValue)
             ]
         }
     }
@@ -259,7 +265,7 @@ enum HStackViewConstructor: Equatable, FromSwiftUIViewToStitch {
     
     func createCustomValueEvents() throws -> [ASTCustomInputValue] {
         var list: [ASTCustomInputValue] = [
-            .init(input: .orientation, values: [.orientation(.horizontal)])
+            .init(input: .orientation, value: .orientation(.horizontal))
         ]
 
         guard case let .parameters(alignmentArg, spacingArg) = self else { return [] }
@@ -268,7 +274,7 @@ enum HStackViewConstructor: Equatable, FromSwiftUIViewToStitch {
         case .none:
             // Default to center align
             list.append(.init(input: .layerGroupAlignment,
-                              values: [.anchoring(.centerCenter)]))
+                              value: .anchoring(.centerCenter)))
             
         case .memberAccess(let memberAccess):
             // Alignment values without PortValueDescription
@@ -276,16 +282,24 @@ enum HStackViewConstructor: Equatable, FromSwiftUIViewToStitch {
                 throw SwiftUISyntaxError.unsupportedConstructorForPortValueDecoding(.hStack(self))
             }
             list.append(.init(input: .layerGroupAlignment,
-                              values: [.anchoring(vertAlignment.toAnchoring)]))
+                              value: .anchoring(vertAlignment.toAnchoring)))
             
         case .some(let alignmentArg):
+            guard let value = try alignmentArg.derivePortValues().first else {
+                throw SwiftUISyntaxError.portValueNotFound
+            }
+            
             list.append(.init(input: .layerGroupAlignment,
-                              values: try alignmentArg.derivePortValues()))
+                              value: value))
         }
         
         if let spacingArg = spacingArg {
+            guard let value = try spacingArg.derivePortValues().first else {
+                throw SwiftUISyntaxError.portValueNotFound
+            }
+            
             list.append(.init(input: .spacing,
-                              values: try spacingArg.derivePortValues()))
+                              value: value))
         }
 
         return list

--- a/Stitch/Graph/StitchAI/Mapping/Declarative/DeclarativeViewConstructors.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Declarative/DeclarativeViewConstructors.swift
@@ -31,33 +31,6 @@ protocol FromSwiftUIViewToStitch: Encodable {
 }
 
 
-//extension ViewConstructor {
-//    
-//    func getCustomValueEvents(id: UUID) throws -> [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue]? {
-//        
-//        guard let toStitchResult = self.toStitch else {
-//            return nil
-//        }
-//        
-//        let inputs = toStitchResult.1
-//        
-//        return try inputs.compactMap { (valueOrEdge: ValueOrEdge) in
-//            switch valueOrEdge {
-//            case .edge:
-//                return nil
-//            case .value(let x):
-//                let downgradedInput = try x.input.convert(to: CurrentStep.LayerInputPort.self)
-//                let downgradedValue = try x.value.convert(to: CurrentStep.PortValue.self)
-//                return try CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue.init(
-//                    id: id,
-//                    input: downgradedInput,
-//                    value: downgradedValue)
-//            }
-//        }
-//    }
-//}
-
-
 // TODO: can we just the `FromSwiftUIViewToStitch` protocol instead? But tricky, since `FromSwiftUIViewToStitch` has an associated i.e. generic type, which would bubble up elsewhere.
 enum ViewConstructor: Equatable, Encodable {
     case text(TextViewConstructor)
@@ -224,7 +197,6 @@ enum ImageViewConstructor: Equatable, FromSwiftUIViewToStitch {
 
         // 2. Image("asset"[, bundle:])
         if first.label == nil {
-//            let bundle: Parameter<Bundle?> = .literal(nil)
             return .asset(name: first.value)
         }
 

--- a/Stitch/Graph/StitchAI/Mapping/Declarative/DeclarativeViewConstructors.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Declarative/DeclarativeViewConstructors.swift
@@ -18,40 +18,44 @@ protocol FromSwiftUIViewToStitch {
     associatedtype T
     
     // nil if ViewConstructor could not be turned into Stitch concepts
-    var toStitch: (
-        Layer?, // nil e.g. for ScrollView, which contributes custom-values but not own layer
-        [ValueOrEdge]
-    )? { get }
+//    var toStitch: (
+//        Layer?, // nil e.g. for ScrollView, which contributes custom-values but not own layer
+//        [ValueOrEdge]
+//    )? { get }
     
-    static func from(_ node: FunctionCallExprSyntax) -> T?
+    static func from(_ args: [SyntaxViewArgumentData]) -> T?
+    
+    static var layer: CurrentStep.Layer { get }
+    
+    func createCustomValueEvents() throws -> [ASTCustomInputValue]
 }
 
 
-extension ViewConstructor {
-    
-    func getCustomValueEvents(id: UUID) throws -> [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue]? {
-        
-        guard let toStitchResult = self.toStitch else {
-            return nil
-        }
-        
-        let inputs = toStitchResult.1
-        
-        return try inputs.compactMap { (valueOrEdge: ValueOrEdge) in
-            switch valueOrEdge {
-            case .edge:
-                return nil
-            case .value(let x):
-                let downgradedInput = try x.input.convert(to: CurrentStep.LayerInputPort.self)
-                let downgradedValue = try x.value.convert(to: CurrentStep.PortValue.self)
-                return try CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue.init(
-                    id: id,
-                    input: downgradedInput,
-                    value: downgradedValue)
-            }
-        }
-    }
-}
+//extension ViewConstructor {
+//    
+//    func getCustomValueEvents(id: UUID) throws -> [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue]? {
+//        
+//        guard let toStitchResult = self.toStitch else {
+//            return nil
+//        }
+//        
+//        let inputs = toStitchResult.1
+//        
+//        return try inputs.compactMap { (valueOrEdge: ValueOrEdge) in
+//            switch valueOrEdge {
+//            case .edge:
+//                return nil
+//            case .value(let x):
+//                let downgradedInput = try x.input.convert(to: CurrentStep.LayerInputPort.self)
+//                let downgradedValue = try x.value.convert(to: CurrentStep.PortValue.self)
+//                return try CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue.init(
+//                    id: id,
+//                    input: downgradedInput,
+//                    value: downgradedValue)
+//            }
+//        }
+//    }
+//}
 
 
 // TODO: can we just the `FromSwiftUIViewToStitch` protocol instead? But tricky, since `FromSwiftUIViewToStitch` has an associated i.e. generic type, which would bubble up elsewhere.
@@ -59,202 +63,192 @@ enum ViewConstructor: Equatable {
     case text(TextViewConstructor)
     case image(ImageViewConstructor)
     case hStack(HStackViewConstructor)
-    case vStack(VStackViewConstructor)
-    case lazyHStack(LazyHStackViewConstructor)
-    case lazyVStack(LazyVStackViewConstructor)
-    case circle(CircleViewConstructor)
-    case ellipse(EllipseViewConstructor)
-    case rectangle(RectangleViewConstructor)
-    case roundedRectangle(RoundedRectangleViewConstructor)
-    case scrollView(ScrollViewViewConstructor)
-    case zStack(ZStackViewConstructor)
-    case textField(TextFieldViewConstructor)
-    case angularGradient(AngularGradientViewConstructor)
-    case linearGradient(LinearGradientViewConstructor)
-    case radialGradient(RadialGradientViewConstructor)
+//    case vStack(VStackViewConstructor)
+//    case lazyHStack(LazyHStackViewConstructor)
+//    case lazyVStack(LazyVStackViewConstructor)
+//    case circle(CircleViewConstructor)
+//    case ellipse(EllipseViewConstructor)
+//    case rectangle(RectangleViewConstructor)
+//    case roundedRectangle(RoundedRectangleViewConstructor)
+//    case scrollView(ScrollViewViewConstructor)
+//    case zStack(ZStackViewConstructor)
+//    case textField(TextFieldViewConstructor)
+//    case angularGradient(AngularGradientViewConstructor)
+//    case linearGradient(LinearGradientViewConstructor)
+//    case radialGradient(RadialGradientViewConstructor)
     
-    var toStitch: (Layer?, [ValueOrEdge])? {
-        switch self {
-        case .text(let c):             return c.toStitch
-        case .image(let c):            return c.toStitch
-        case .hStack(let c):           return c.toStitch
-        case .vStack(let c):           return c.toStitch
-        case .lazyHStack(let c):       return c.toStitch
-        case .lazyVStack(let c):       return c.toStitch
-        case .circle(let c):           return c.toStitch
-        case .ellipse(let c):          return c.toStitch
-        case .rectangle(let c):        return c.toStitch
-        case .roundedRectangle(let c): return c.toStitch
-        case .scrollView(let c):       return c.toStitch
-        case .zStack(let c):           return c.toStitch
-        case .textField(let c):        return c.toStitch
-        case .angularGradient(let c):  return c.toStitch
-        case .linearGradient(let c):   return c.toStitch
-        case .radialGradient(let c):   return c.toStitch
-        }
-    }
+//    var toStitch: (Layer?, [ValueOrEdge])? {
+//        switch self {
+//        case .text(let c):             return c.toStitch
+//        case .image(let c):            return c.toStitch
+//        case .hStack(let c):           return c.toStitch
+//        case .vStack(let c):           return c.toStitch
+//        case .lazyHStack(let c):       return c.toStitch
+//        case .lazyVStack(let c):       return c.toStitch
+//        case .circle(let c):           return c.toStitch
+//        case .ellipse(let c):          return c.toStitch
+//        case .rectangle(let c):        return c.toStitch
+//        case .roundedRectangle(let c): return c.toStitch
+//        case .scrollView(let c):       return c.toStitch
+//        case .zStack(let c):           return c.toStitch
+//        case .textField(let c):        return c.toStitch
+//        case .angularGradient(let c):  return c.toStitch
+//        case .linearGradient(let c):   return c.toStitch
+//        case .radialGradient(let c):   return c.toStitch
+//        }
+//    }
 }
     
 
-enum TextViewConstructor: Equatable, FromSwiftUIViewToStitch {
+enum TextViewConstructor: Equatable { //}, FromSwiftUIViewToStitch {
     /// `Text("Hello")`
-    case string(_ content: Parameter<String>)
+    case string //(_ content: SyntaxViewModifierArgumentType)
     
     /// `Text(_ key: LocalizedStringKey)`
-    case localized(_ key: Parameter<LocalizedStringKey>)
+    case localized //(_ key: SyntaxViewModifierArgumentType)
     
     /// `Text(verbatim: "Raw")`
-    case verbatim(_ content: Parameter<String>)
+    case verbatim //(_ content: SyntaxViewModifierArgumentType)
     
     /// `Text(_ attributed: AttributedString)`
-    case attributed(_ content: Parameter<AttributedString>)
+    case attributed //(_ content: SyntaxViewModifierArgumentType)
 
-    var toStitch: (Layer?, [ValueOrEdge])? {
-        switch self {
-
-        case .string(let p), .verbatim(let p):
-            switch p {
-            case .literal(let s):
-                return (.text,
-                        [ .value(.init(.text, .string(.init(s)))) ])
-            case .expression(let expr):
-                return (.text,
-                        [ .edge(expr) ])
-            }
-
-        case .localized(let p):
-            switch p {
-            case .literal(let key):
-                return (.text,
-                        [ .value(.init(.text,
-                                       .string(.init(key.resolved)))) ])
-            case .expression(let expr):
-                return (.text, [ .edge(expr) ])
-            }
-
-        case .attributed(let p):
-            switch p {
-            case .literal(let attr):
-                return (.text,
-                        [ .value(.init(.text,
-                                       .string(.init(attr.plainText)))) ])
-            case .expression(let expr):
-                return (.text, [ .edge(expr) ])
-            }
-        }
-    }
+    
+    static let layer: CurrentStep.Layer = .text
+//    var toStitch: (Layer?, [ValueOrEdge])? {
+//        switch self {
+//
+//        case .string(let p), .verbatim(let p):
+//            switch p {
+//            case .literal(let s):
+//                return (.text,
+//                        [ .value(.init(.text, .string(.init(s)))) ])
+//            case .expression(let expr):
+//                return (.text,
+//                        [ .edge(expr) ])
+//            }
+//
+//        case .localized(let p):
+//            switch p {
+//            case .literal(let key):
+//                return (.text,
+//                        [ .value(.init(.text,
+//                                       .string(.init(key.resolved)))) ])
+//            case .expression(let expr):
+//                return (.text, [ .edge(expr) ])
+//            }
+//
+//        case .attributed(let p):
+//            switch p {
+//            case .literal(let attr):
+//                return (.text,
+//                        [ .value(.init(.text,
+//                                       .string(.init(attr.plainText)))) ])
+//            case .expression(let expr):
+//                return (.text, [ .edge(expr) ])
+//            }
+//        }
+//    }
 
     // Factory that infers the correct overload from a `FunctionCallExprSyntax`
-    static func from(_ node: FunctionCallExprSyntax) -> TextViewConstructor? {
-        let args = node.arguments
-
-        // 1. Text("Hello")
-        if args.count == 1, args.first!.label == nil,
-           let lit = args.first!.expression.as(StringLiteralExprSyntax.self) {
-            return .string(.literal(lit.decoded()))
-        }
-
-        // 2. Text(verbatim: "Raw")
-        if let first = args.first,
-           first.label?.text == "verbatim",
-           let lit = first.expression.as(StringLiteralExprSyntax.self) {
-            return .verbatim(.literal(lit.decoded()))
-        }
-
-        // 3. Text(LocalizedStringKey("key"))
-        if args.count == 1,
-           args.first!.label == nil,
-           let call = args.first!.expression.as(FunctionCallExprSyntax.self),
-           let id = call.calledExpression.as(DeclReferenceExprSyntax.self)?.baseName.text,
-           id == "LocalizedStringKey",
-           let lit = call.arguments.first?.expression.as(StringLiteralExprSyntax.self) {
-            return .localized(.literal(LocalizedStringKey(lit.decoded())))
-        }
-
-        // 4. Text(AttributedString("Fancy"))
-        if args.count == 1,
-           args.first!.label == nil,
-           let call = args.first!.expression.as(FunctionCallExprSyntax.self),
-           let id = call.calledExpression.as(DeclReferenceExprSyntax.self)?.baseName.text,
-           id == "AttributedString",
-           let lit = call.arguments.first?.expression.as(StringLiteralExprSyntax.self) {
-            return .attributed(.literal(AttributedString(lit.decoded())))
-        }
-
-        // If it's some other expression like Text(title)
-        return .string(.expression(args.first!.expression))
-    }
+//    static func from(_ node: FunctionCallExprSyntax) -> TextViewConstructor? {
+//        let args = node.arguments
+//
+//        // 1. Text("Hello")
+//        if args.count == 1, args.first!.label == nil,
+//           let lit = args.first!.expression.as(StringLiteralExprSyntax.self) {
+//            return .string(.literal(lit.decoded()))
+//        }
+//
+//        // 2. Text(verbatim: "Raw")
+//        if let first = args.first,
+//           first.label?.text == "verbatim",
+//           let lit = first.expression.as(StringLiteralExprSyntax.self) {
+//            return .verbatim(.literal(lit.decoded()))
+//        }
+//
+//        // 3. Text(LocalizedStringKey("key"))
+//        if args.count == 1,
+//           args.first!.label == nil,
+//           let call = args.first!.expression.as(FunctionCallExprSyntax.self),
+//           let id = call.calledExpression.as(DeclReferenceExprSyntax.self)?.baseName.text,
+//           id == "LocalizedStringKey",
+//           let lit = call.arguments.first?.expression.as(StringLiteralExprSyntax.self) {
+//            return .localized(.literal(LocalizedStringKey(lit.decoded())))
+//        }
+//
+//        // 4. Text(AttributedString("Fancy"))
+//        if args.count == 1,
+//           args.first!.label == nil,
+//           let call = args.first!.expression.as(FunctionCallExprSyntax.self),
+//           let id = call.calledExpression.as(DeclReferenceExprSyntax.self)?.baseName.text,
+//           id == "AttributedString",
+//           let lit = call.arguments.first?.expression.as(StringLiteralExprSyntax.self) {
+//            return .attributed(.literal(AttributedString(lit.decoded())))
+//        }
+//
+//        // If it's some other expression like Text(title)
+//        return .string(.expression(args.first!.expression))
+//    }
 }
 
 
 enum ImageViewConstructor: Equatable, FromSwiftUIViewToStitch {
     /// `Image("assetName", bundle: nil)`
-    case asset(name: Parameter<String>, bundle: Parameter<Bundle?> = .literal(nil))
+    case asset(name: SyntaxViewModifierArgumentType)
     /// `Image(systemName: "gear")`
-    case sfSymbol(name: Parameter<String>)
+    case sfSymbol(name: SyntaxViewModifierArgumentType)
     /// `Image(decorative:name:bundle:)`
-    case decorative(name: Parameter<String>, bundle: Parameter<Bundle?> = .literal(nil))
+    case decorative(name: SyntaxViewModifierArgumentType)
     /// `Image(uiImage:)`
-    case uiImage(image: Parameter<UIImage>)
+    case uiImage(image: SyntaxViewModifierArgumentType)
+    
+    static let layer: CurrentStep.Layer = .image
 
-    var toStitch: (Layer?, [ValueOrEdge])? {
+    func createCustomValueEvents() throws -> [ASTCustomInputValue] {
         switch self {
-
-        case .asset(let name, _),
-             .decorative(let name, _):
-            switch name {
-            case .literal(let lit):
-                return (.image,
-                        [ .value(.init(.image, .string(.init(lit)))) ])
-            case .expression(let expr):
-                return (.image, [ .edge(expr) ])
-            }
-
-        case .sfSymbol(let name):
-            switch name {
-            case .literal(let lit):
-                return (.image,
-                        [ .value(.init(.sfSymbol, .string(.init(lit)))) ])
-            case .expression(let expr):
-                return (.image, [ .edge(expr) ])
-            }
-
-        case .uiImage(let image):
-            switch image {
-            case .literal(let ui):
-                return (.image,
-                        [ .value(.init(.image, .asyncMedia(nil))) ])
-            case .expression(let expr):
-                return (.image, [ .edge(expr) ])
-            }
+            
+        case .asset(let arg),
+                .decorative(let arg),
+                .uiImage(let arg):
+            let portValues = try arg.derivePortValues()
+            return [
+                .init(input: .image,
+                      values: portValues)
+            ]
+            
+        case .sfSymbol(let arg):
+            let portValues = try arg.derivePortValues()
+            return [
+                .init(input: .sfSymbol,
+                      values: portValues)
+            ]
         }
     }
 
     // Factory that infers the correct overload from a `FunctionCallExprSyntax`
-    static func from(_ node: FunctionCallExprSyntax) -> ImageViewConstructor? {
-        let args = node.arguments
+    static func from(_ args: [SyntaxViewArgumentData]) -> ImageViewConstructor? {
         guard let first = args.first else { return nil }
 
         // 1. Image(systemName:)
-        if first.label?.text == "systemName" {
-            return .sfSymbol(name: first.asParameterString())
+        if first.label == "systemName" {
+            return .sfSymbol(name: first.value)
         }
 
         // 2. Image("asset"[, bundle:])
         if first.label == nil {
-            let bundle: Parameter<Bundle?> = .literal(nil)
-            return .asset(name: first.asParameterString(), bundle: bundle)
+//            let bundle: Parameter<Bundle?> = .literal(nil)
+            return .asset(name: first.value)
         }
 
         // 3. Image(decorative: "name"[, bundle:])
-        if first.label?.text == "decorative" {
-            let bundle: Parameter<Bundle?> = .literal(nil)
-            return .decorative(name: first.asParameterString(), bundle: bundle)
+        if first.label == "decorative" {
+            return .decorative(name: first.value)
         }
 
         // 4. Image(uiImage:)
-        if first.label?.text == "uiImage" {
-            return .uiImage(image: .expression(first.expression))
+        if first.label == "uiImage" {
+            return .uiImage(image: first.value)
         }
 
         return nil
@@ -277,53 +271,54 @@ enum HStackViewConstructor: Equatable, FromSwiftUIViewToStitch {
     /// `init(alignment: VerticalAlignment = .center, spacing: CGFloat? = nil, @ViewBuilder content: () -> Content)`
     /// We model that with a single enum case whose associated values carry whatever the
     /// call site provided—using `.center` and `nil` when the developer omitted them.
-    case parameters(alignment: Parameter<VerticalAlignment> = .literal(.center),
-                    spacing:   Parameter<CGFloat?>          = .literal(nil))
+    case parameters(alignment: SyntaxViewModifierArgumentType,
+                    spacing:   SyntaxViewModifierArgumentType)
 
-    // MARK: Stitch mapping
-    var toStitch: (Layer?, [ValueOrEdge])? {
-        var list: [ValueOrEdge] = [
-            .value(.init(.orientation, .orientation(.horizontal)))
-        ]
-
-        guard case let .parameters(alignment, spacing) = self else { return nil }
-
-        // Alignment
-        switch alignment {
-        case .literal(let a) where a != .center:
-            list.append(.value(.init(.layerGroupAlignment,
-                                     // TODO: if `a.toAnchoring` fails, return `SwiftUISyntaxError.unsupportedPortValueTypeDecoding(argument)` ?
-                                     .anchoring(a.toAnchoring))))
-        case .expression(let expr):
-            list.append(.edge(expr))
-        default: break
-        }
-
-        // Spacing
-        switch spacing {
-        case .literal(let s?) :
-            list.append(.value(.init(.spacing, .spacing(.number(s)))))
-        case .expression(let expr):
-            list.append(.edge(expr))
-        default: break
-        }
-
-        return (.group, list)
-    }
+    static let layer: CurrentStep.Layer = .group
+    
+//    // MARK: Stitch mapping
+//    var toStitch: (Layer?, [ValueOrEdge])? {
+//        var list: [ValueOrEdge] = [
+//            .value(.init(.orientation, .orientation(.horizontal)))
+//        ]
+//
+//        guard case let .parameters(alignment, spacing) = self else { return nil }
+//
+//        // Alignment
+//        switch alignment {
+//        case .literal(let a) where a != .center:
+//            list.append(.value(.init(.layerGroupAlignment,
+//                                     // TODO: if `a.toAnchoring` fails, return `SwiftUISyntaxError.unsupportedPortValueTypeDecoding(argument)` ?
+//                                     .anchoring(a.toAnchoring))))
+//        case .expression(let expr):
+//            list.append(.edge(expr))
+//        default: break
+//        }
+//
+//        // Spacing
+//        switch spacing {
+//        case .literal(let s?) :
+//            list.append(.value(.init(.spacing, .spacing(.number(s)))))
+//        case .expression(let expr):
+//            list.append(.edge(expr))
+//        default: break
+//        }
+//
+//        return (.group, list)
+//    }
 
     // MARK: Parse from SwiftSyntax
-    static func from(_ node: FunctionCallExprSyntax) -> HStackViewConstructor? {
-        let args = node.arguments
-
+    static func from(_ args: [SyntaxViewArgumentData]) -> HStackViewConstructor? {
         // defaults
         var alignment: Parameter<VerticalAlignment> = .literal(.center)
         var spacing:   Parameter<CGFloat?>          = .literal(nil)
 
         // iterate through labelled args
         for arg in args {
-            switch arg.label?.text {
+            switch arg.label {
             case "alignment":
-                if let lit = arg.vertAlignLiteral {
+                
+                if let lit = arg.value.vert {
                     alignment = .literal(lit)
                 } else {
                     alignment = .expression(arg.expression)
@@ -344,668 +339,668 @@ enum HStackViewConstructor: Equatable, FromSwiftUIViewToStitch {
     }
 }
 
-// TODO: a lot of this logic overlaps with HStackViewConstructor; only difference is `HorizontalAlignment` instead of `VerticalAlignment`
-enum VStackViewConstructor: Equatable, FromSwiftUIViewToStitch {
-    /// SwiftUI exposes just one public initializer:
-    /// `init(alignment: HorizontalAlignment = .center, spacing: CGFloat? = nil, @ViewBuilder content: () -> Content)`
-    case parameters(alignment: Parameter<HorizontalAlignment> = .literal(.center),
-                    spacing:   Parameter<CGFloat?>            = .literal(nil))
-
-    // MARK: Stitch mapping
-    var toStitch: (Layer?, [ValueOrEdge])? {
-        var list: [ValueOrEdge] = [
-            .value(.init(.orientation, .orientation(.vertical)))
-        ]
-
-        guard case let .parameters(alignment, spacing) = self else { return nil }
-
-        switch alignment {
-        case .literal(let a) where a != .center:
-            list.append(.value(.init(.layerGroupAlignment,
-                                     .anchoring(a.toAnchoring))))
-        case .expression(let expr):
-            list.append(.edge(expr))
-        default: break
-        }
-
-        switch spacing {
-        case .literal(let s?):
-            list.append(.value(.init(.spacing, .spacing(.number(s)))))
-        case .expression(let expr):
-            list.append(.edge(expr))
-        default: break
-        }
-
-        return (.group, list)
-    }
-
-    // MARK: Parse from SwiftSyntax
-    static func from(_ node: FunctionCallExprSyntax) -> VStackViewConstructor? {
-        let args = node.arguments
-        var alignment: Parameter<HorizontalAlignment> = .literal(.center)
-        var spacing:   Parameter<CGFloat?>            = .literal(nil)
-
-        for arg in args {
-            switch arg.label?.text {
-            case "alignment":
-                if let lit = arg.horizAlignLiteral {
-                    alignment = .literal(lit)
-                } else {
-                    alignment = .expression(arg.expression)
-                }
-            case "spacing":
-                if let num = arg.cgFloatValue {
-                    spacing = .literal(num)
-                } else {
-                    spacing = .expression(arg.expression)
-                }
-            default:
-                break
-            }
-        }
-
-        return .parameters(alignment: alignment, spacing: spacing)
-    }
-}
-
-// ── Helper: random-access a TupleExprElementListSyntax by Int index ────────────
-extension LabeledExprListSyntax {
-    subscript(safe index: Int) -> LabeledExprSyntax? {
-        guard index >= 0 && index < count else { return nil }
-        return self[self.index(startIndex, offsetBy: index)]
-    }
-}
-
-enum LazyHStackViewConstructor: Equatable, FromSwiftUIViewToStitch {
-    case parameters(alignment: Parameter<VerticalAlignment> = .literal(.center),
-                    spacing:   Parameter<CGFloat?>          = .literal(nil))
-
-    var toStitch: (Layer?, [ValueOrEdge])? {
-        switch self {
-        case .parameters(let alignment, let spacing):
-            return HStackViewConstructor
-                .parameters(alignment: alignment, spacing: spacing)
-                .toStitch
-        }
-    }
-
-    static func from(_ node: FunctionCallExprSyntax) -> LazyHStackViewConstructor? {
-        // Re‑use HStack parser then wrap
-        guard let base = HStackViewConstructor.from(node) else { return nil }
-        switch base {
-        case .parameters(let a, let s): return .parameters(alignment: a, spacing: s)
-        }
-    }
-}
-
-enum LazyVStackViewConstructor: Equatable, FromSwiftUIViewToStitch {
-    case parameters(alignment: Parameter<HorizontalAlignment> = .literal(.center),
-                    spacing:   Parameter<CGFloat?>            = .literal(nil))
-
-    var toStitch: (Layer?, [ValueOrEdge])? {
-        switch self {
-        case .parameters(let alignment, let spacing):
-            return VStackViewConstructor
-                .parameters(alignment: alignment, spacing: spacing)
-                .toStitch
-        }
-    }
-
-    static func from(_ node: FunctionCallExprSyntax) -> LazyVStackViewConstructor? {
-        guard let base = VStackViewConstructor.from(node) else { return nil }
-        switch base {
-        case .parameters(let a, let s): return .parameters(alignment: a, spacing: s)
-        }
-    }
-}
-
-// MARK: - ZStack -----------------------------------------------------------
-
-// MARK: - TextField --------------------------------------------------------
-
-enum TextFieldViewConstructor: Equatable, FromSwiftUIViewToStitch {
-    /// Simplified model:
-    /// `TextField(_ titleKey: LocalizedStringKey, text: Binding<String>)`
-    /// or `TextField(_ title: String, text: Binding<String>)`
-    case parameters(title: Parameter<String?> = .literal(nil),
-                    binding: ExprSyntax)          // always an expression edge
-
-    // MARK: Stitch mapping
-    ///
-    /// • `title`  →  .placeholder   (omit if nil)
-    /// • `binding`→  .text          (literal constant → value, otherwise edge)
-    var toStitch: (Layer?, [ValueOrEdge])? {
-        guard case let .parameters(title, bindingExpr) = self else { return nil }
-        var list: [ValueOrEdge] = []
-        
-        // ----- title / placeholder ---------------------------------------
-        switch title {
-        case .literal(let str?):
-            list.append(.value(.init(.placeholderText,
-                                     .string(.init(str)))))
-        case .expression(let expr):
-            list.append(.edge(expr))
-        default:
-            break    // .literal(nil)  → no placeholder
-        }
-        
-        // ----- binding / text -------------------------------------------
-        if let constLiteral = bindingExpr.stringLiteralFromConstantBinding() {
-            list.append(.value(.init(.text,
-                                     .string(.init(constLiteral)))))
-        } else {
-            list.append(.edge(bindingExpr))
-        }
-        
-        return (.textField, list)
-    }
-
-    static func from(_ node: FunctionCallExprSyntax) -> Self? {
-        let args = node.arguments
-
-        // need at least title + binding
-        guard let first = args[safe: 0],
-              let second = args[safe: 1] else { return nil }
-
-        // First argument can be unlabeled placeholder string/localised key
-        var title: Parameter<String?> = .literal(nil)
-        if first.label == nil,
-           let lit = first.expression.as(StringLiteralExprSyntax.self) {
-            title = .literal(lit.decoded())
-        } else if first.label == nil {
-            title = .expression(first.expression)
-        }
-
-        // Second arg must be `text:` binding
-        guard second.label?.text == "text" else { return nil }
-
-        return .parameters(title: title,
-                           binding: second.expression)
-    }
-}
-
-enum ZStackViewConstructor: Equatable, FromSwiftUIViewToStitch {
-    /// SwiftUI: `init(alignment: Alignment = .center, content:)`
-    case parameters(alignment: Parameter<Alignment> = .literal(.center))
-
-    // Orientation is implicit overlap; we won’t emit orientation value.
-    var toStitch: (Layer?, [ValueOrEdge])? {
-        var list: [ValueOrEdge] = []
-
-        guard case let .parameters(alignment) = self else { return nil }
-
-        switch alignment {
-        case .literal(let a) where a != .center:
-            list.append(.value(.init(.layerGroupAlignment,
-                                     .anchoring(a.toAnchoring))))
-        case .expression(let expr):
-            list.append(.edge(expr))
-        default:
-            break
-        }
-
-        return (.group, list)
-    }
-
-    static func from(_ node: FunctionCallExprSyntax) -> ZStackViewConstructor? {
-        var alignment: Parameter<Alignment> = .literal(.center)
-
-        for arg in node.arguments {
-            if arg.label?.text == "alignment" {
-                if let alignLit = arg.alignmentLiteral {
-                    alignment = .literal(alignLit)
-                } else {
-                    alignment = .expression(arg.expression)
-                }
-            }
-        }
-
-        return .parameters(alignment: alignment)
-    }
-}
-
-// MARK: - Circle & Rectangle (no‑arg views) -------------------------------
-
-enum CircleViewConstructor: Equatable, FromSwiftUIViewToStitch {
-    case plain                                    // Circle()
-
-    var toStitch: (Layer?, [ValueOrEdge])? {
-        (.oval, [])                             // no args, nothing to edge
-    }
-
-    static func from(_ node: FunctionCallExprSyntax) -> Self? {
-        node.arguments.isEmpty ? .plain : nil
-    }
-}
-
-enum EllipseViewConstructor: Equatable, FromSwiftUIViewToStitch {
-    case plain                                  // Ellipse()
-
-    var toStitch: (Layer?, [ValueOrEdge])? {
-        (.oval, [])                             // same mapping as Circle
-    }
-
-    static func from(_ node: FunctionCallExprSyntax) -> Self? {
-        node.arguments.isEmpty ? .plain : nil
-    }
-}
-
-enum RectangleViewConstructor: Equatable, FromSwiftUIViewToStitch {
-    case plain                                    // Rectangle()
-
-    var toStitch: (Layer?, [ValueOrEdge])? {
-        (.rectangle, [])                          // no args
-    }
-
-    static func from(_ node: FunctionCallExprSyntax) -> Self? {
-        node.arguments.isEmpty ? .plain : nil
-    }
-}
-
-// MARK: - RoundedRectangle -------------------------------------------------
-
-enum RoundedRectangleViewConstructor: Equatable, FromSwiftUIViewToStitch {
-    /// RoundedRectangle(cornerRadius:style:)
-    case cornerRadius(radius: Parameter<CGFloat>,
-                      style:  Parameter<RoundedCornerStyle> = .literal(.continuous))
-    
-    /// RoundedRectangle(cornerSize:style:)
-    case cornerSize(size: Parameter<CGSize>,
-                    style: Parameter<RoundedCornerStyle> = .literal(.continuous))
-    
-    // MARK: Stitch mapping
-    ///
-    /// • RoundedRectangle(cornerRadius:) → Layer.rectangle + cornerRadius
-    /// • RoundedRectangle(cornerSize:)   → Layer.rectangle + cornerSize
-    ///
-    /// (We ignore the `style` for now; it can be added later.)
-    var toStitch: (Layer?, [ValueOrEdge])? {
-        switch self
-        {
-        // ── cornerRadius(radius:style:) ───────────────────────────────
-        case .cornerRadius(let radius, _):
-            switch radius {
-            case .literal(let r):
-                return (
-                    .rectangle,
-                    [ .value(.init(.cornerRadius, .number(r))) ]
-                )
-            case .expression(let expr):
-                return (
-                    .rectangle,
-                    [ .edge(expr) ]
-                )
-            }
-
-        // ── cornerSize(size:style:) ───────────────────────────────────
-        case .cornerSize(let size, _):
-            switch size {
-            case .literal(let s):
-                return (
-                    .rectangle,
-//                    [ .value(.init(.cornerSize, .size(s))) ]
-                    [ .value(.init(.cornerRadius, .number(s.width))) ]
-                )
-            case .expression(let expr):
-                return (
-                    .rectangle,
-                    [ .edge(expr) ]
-                )
-            }
-        }
-    }
-    
-    static func from(_ node: FunctionCallExprSyntax) -> Self? {
-        let args = node.arguments
-        guard let first = args.first else { return nil }
-        
-        if first.label?.text == "cornerRadius" {
-            let style: Parameter<RoundedCornerStyle> = .literal(.continuous)
-            return .cornerRadius(radius: first.asParameterCGFloat(), style: style)
-        }
-        if first.label?.text == "cornerSize" {
-            let style: Parameter<RoundedCornerStyle> = .literal(.continuous)
-            return .cornerSize(size: first.asParameterCGSize(), style: style)
-        }
-        return nil
-    }
-}
-
-// MARK: - ScrollView -------------------------------------------------------
-
-enum ScrollViewViewConstructor: Equatable, FromSwiftUIViewToStitch {
-    /// ScrollView(axes:showIndicators:)
-    case parameters(axes: Parameter<Axis.Set> = .literal(.vertical),
-                    showsIndicators: Parameter<Bool> = .literal(true))
-    
-    // MARK: Stitch mapping
-    ///
-    /// • Always returns `(.scroll, …)`
-    /// • `.horizontal`   →  scrollXEnabled = true
-    /// • `.vertical`     →  scrollYEnabled = true   (default if no arg)
-    /// • `[.horizontal, .vertical]` or `.all`
-    ///                    →  both scrollXEnabled & scrollYEnabled = true
-    /// • Any expression  →  single `.edge(expr)` (caller decides)
-    var toStitch: (Layer?, [ValueOrEdge])? {
-        guard case let .parameters(axes, _) = self else { return nil }
-        var list: [ValueOrEdge] = []
-        
-        switch axes {
-        case .literal(let set):
-            // Axis.Set is an OptionSet; test for membership.
-            if set.contains(.horizontal) {
-                list.append(.value(.init(.scrollXEnabled, .bool(true))))
-            }
-            if set.contains(.vertical) {
-                list.append(.value(.init(.scrollYEnabled, .bool(true))))
-            }
-            if set == [.horizontal, .vertical] {
-                // Already handled by the contains checks, nothing extra
-            }
-            // If neither bit is set (shouldn’t happen), default to vertical
-            if list.isEmpty {
-                list.append(.value(.init(.scrollYEnabled, .bool(true))))
-            }
-            
-        case .expression(let expr):
-            // Try to evaluate at compile‑time
-            if let litSet = expr.axisSetLiteral() {
-                if litSet.contains(.horizontal) {
-                    list.append(.value(.init(.scrollXEnabled, .bool(true))))
-                }
-                if litSet.contains(.vertical) || litSet.isEmpty {
-                    list.append(.value(.init(.scrollYEnabled, .bool(true))))
-                }
-            } else {
-                // Unresolved at compile‑time → forward as edge
-                list.append(.edge(expr))
-            }
-        }
-        
-        return (
-            nil, // ScrollView does not technically correspond to a Stitch Layer
-            list
-        )
-    }
-    
-    static func from(_ node: FunctionCallExprSyntax) -> Self? {
-        let args = node.arguments
-        var axes: Parameter<Axis.Set> = .literal(.vertical)
-        var indicators: Parameter<Bool> = .literal(true)
-        
-        for arg in args {
-            switch arg.label?.text {
-            case nil:      // unnamed first parameter can be Axis.Set
-                axes = arg.asParameterAxisSet()
-            case "showsIndicators":
-                indicators = arg.asParameterBool()
-            default:
-                break
-            }
-        }
-        return .parameters(axes: axes, showsIndicators: indicators)
-    }
-}
-
-
-// MARK: - Gradients --------------------------------------------------------
-
-enum AngularGradientViewConstructor: Equatable, FromSwiftUIViewToStitch {
-    /// AngularGradient(colors:center:startAngle:endAngle:)
-    case parameters(colors: Parameter<[Color]>,
-                    center: Parameter<UnitPoint>,
-                    startAngle: Parameter<CGFloat>,
-                    endAngle:   Parameter<CGFloat>)
-    
-    // MARK: Stitch mapping
-    ///
-    /// SwiftUI                      → Stitch
-    /// ---------------------------------------------------------
-    /// colors[0]                    → .startColor
-    /// colors[1]                    → .endColor
-    /// center                       → .centerAnchor
-    /// startAngle                   → .startAngle
-    /// endAngle                     → .endAngle
-    var toStitch: (Layer?, [ValueOrEdge])? {
-        guard case let .parameters(colors, center, startAngle, endAngle) = self else { return nil }
-        var list: [ValueOrEdge] = []
-        
-        // ----- colors ---------------------------------------------------
-        switch colors {
-        case .literal(let arr) where arr.count >= 2:
-            list.append(.value(.init(.startColor, .color(.init(arr[0])))))
-            list.append(.value(.init(.endColor,   .color(.init(arr[1])))))
-        case .expression(let expr):
-            list.append(.edge(expr))        // expression supplies [Color]
-        default:
-            break
-        }
-        
-        // ----- center / centerAnchor -----------------------------------
-        switch center {
-        case .literal(let p):
-            list.append(.value(.init(.centerAnchor, .anchoring(p.toAnchoring))))
-        case .expression(let expr):
-            list.append(.edge(expr))
-        }
-        
-        // ----- startAngle ----------------------------------------------
-        switch startAngle {
-        case .literal(let deg):
-            list.append(.value(.init(.startAngle, .number(deg))))
-        case .expression(let expr):
-            list.append(.edge(expr))
-        }
-        
-        // ----- endAngle -------------------------------------------------
-        switch endAngle {
-        case .literal(let deg):
-            list.append(.value(.init(.endAngle, .number(deg))))
-        case .expression(let expr):
-            list.append(.edge(expr))
-        }
-        
-        return (.angularGradient, list)
-    }
-    
-    static func from(_ node: FunctionCallExprSyntax) -> Self? {
-        let args = node.arguments
-        guard let colorsArg = args[safe: 0],
-              let centerArg = args[safe: 1],
-              let startArg  = args[safe: 2],
-              let endArg    = args[safe: 3] else { return nil }
-
-        // colors
-        let colors: Parameter<[Color]>
-        if let arr = colorsArg.expression.literalArray({ $0.colorLiteral }),
-           arr.count >= 2 {
-            colors = .literal(arr)
-        } else {
-            colors = .expression(colorsArg.expression)
-        }
-
-        // center
-        let center: Parameter<UnitPoint> = centerArg.unitPointLiteral
-            .map(Parameter.literal) ?? .expression(centerArg.expression)
-
-        // angles
-        func angleParam(_ a: LabeledExprSyntax) -> Parameter<CGFloat> {
-            if let deg = a.angleDegreesLiteral { return .literal(deg) }
-            if let num = a.cgFloatValue       { return .literal(num) }
-            return .expression(a.expression)
-        }
-
-        return .parameters(colors: colors,
-                           center: center,
-                           startAngle: angleParam(startArg),
-                           endAngle:   angleParam(endArg))
-    }
-}
-
-enum LinearGradientViewConstructor: Equatable, FromSwiftUIViewToStitch {
-    /// LinearGradient(colors:startPoint:endPoint:)
-    case parameters(colors: Parameter<[Color]>,
-                    startPoint: Parameter<UnitPoint>,
-                    endPoint: Parameter<UnitPoint>)
-
-    // MARK: Stitch mapping
-    ///
-    /// SwiftUI                      → Stitch
-    /// ---------------------------------------------------------
-    /// colors[0]                    → .startColor   (Color)
-    /// colors[1]                    → .endColor     (Color)
-    /// startPoint (UnitPoint)       → .startAnchor  (Anchoring)
-    /// endPoint   (UnitPoint)       → .endAnchor    (Anchoring)
-    ///
-    /// Expression arguments become `.edge(expr)`.
-    var toStitch: (Layer?, [ValueOrEdge])? {
-        guard case let .parameters(colors, startPoint, endPoint) = self else { return nil }
-        var list: [ValueOrEdge] = []
-
-        // ---- colors ----------------------------------------------------
-        switch colors {
-        case .literal(let arr) where arr.count >= 2:
-            list.append(.value(.init(.startColor, .color(.init(arr[0])))))
-            list.append(.value(.init(.endColor,   .color(.init(arr[1])))))
-        case .expression(let expr):
-            list.append(.edge(expr))         // upstream produces [Color]
-        default:
-            break
-        }
-
-        // ---- startPoint / startAnchor ---------------------------------
-        switch startPoint {
-        case .literal(let p):
-            list.append(.value(.init(.startAnchor, .anchoring(p.toAnchoring))))
-        case .expression(let expr):
-            list.append(.edge(expr))
-        }
-
-        // ---- endPoint / endAnchor -------------------------------------
-        switch endPoint {
-        case .literal(let p):
-            list.append(.value(.init(.endAnchor, .anchoring(p.toAnchoring))))
-        case .expression(let expr):
-            list.append(.edge(expr))
-        }
-
-        return (.linearGradient, list)
-    }
-
-    static func from(_ node: FunctionCallExprSyntax) -> Self? {
-        let args = node.arguments
-        guard let colorsArg = args[safe: 0],
-              let startArg  = args[safe: 1],
-              let endArg    = args[safe: 2] else { return nil }
-
-        // colors
-        let colors: Parameter<[Color]>
-        if let arr = colorsArg.expression.literalArray({ $0.colorLiteral }),
-           arr.count >= 2 {
-            colors = .literal(arr)
-        } else {
-            colors = .expression(colorsArg.expression)
-        }
-
-        // points
-        let startPt: Parameter<UnitPoint> = startArg.unitPointLiteral
-            .map(Parameter.literal) ?? .expression(startArg.expression)
-        let endPt: Parameter<UnitPoint> = endArg.unitPointLiteral
-            .map(Parameter.literal) ?? .expression(endArg.expression)
-
-        return .parameters(colors: colors, startPoint: startPt, endPoint: endPt)
-    }
-}
-
-enum RadialGradientViewConstructor: Equatable, FromSwiftUIViewToStitch {
-    /// RadialGradient(colors:center:startRadius:endRadius:)
-    case parameters(colors: Parameter<[Color]>,
-                    center: Parameter<UnitPoint>,
-                    startRadius: Parameter<CGFloat>,
-                    endRadius: Parameter<CGFloat>)
-
-    // MARK: Stitch mapping
-    ///
-    ///  SwiftUI            → Stitch
-    ///  ---------------------------------------------------------
-    ///  center             → .startAnchor          (Anchoring)
-    ///  colors[0]          → .startColor           (Color)
-    ///  colors[1]          → .endColor             (Color)
-    ///  startRadius        → .startRadius          (Number)
-    ///  endRadius          → .endRadius            (Number)
-    ///
-    ///  If any argument is an expression we emit an `.edge(expr)` instead.
-    var toStitch: (Layer?, [ValueOrEdge])? {
-        guard case let .parameters(colors, center, startRadius, endRadius) = self else { return nil }
-        var list: [ValueOrEdge] = []
-
-        // -------- colors -------------------------------------------------
-        switch colors {
-        case .literal(let arr) where arr.count >= 2:
-            list.append(.value(.init(.startColor, .color(.init(arr[0])))))
-            list.append(.value(.init(.endColor,   .color(.init(arr[1])))))
-        case .expression(let expr):
-            list.append(.edge(expr))           // upstream node outputs [Color]
-        default:
-            break
-        }
-
-        // -------- center / startAnchor ----------------------------------
-        switch center {
-        case .literal(let pt):
-            list.append(.value(.init(.startAnchor, .anchoring(pt.toAnchoring))))
-        case .expression(let expr):
-            list.append(.edge(expr))
-        }
-
-        // -------- startRadius -------------------------------------------
-        switch startRadius {
-        case .literal(let r):
-            list.append(.value(.init(.startRadius, .number(r))))
-        case .expression(let expr):
-            list.append(.edge(expr))
-        }
-
-        // -------- endRadius ---------------------------------------------
-        switch endRadius {
-        case .literal(let r):
-            list.append(.value(.init(.endRadius, .number(r))))
-        case .expression(let expr):
-            list.append(.edge(expr))
-        }
-
-        return (.radialGradient, list)
-    }
-
-    static func from(_ node: FunctionCallExprSyntax) -> Self? {
-        let args = node.arguments
-        guard args.count >= 4 else { return nil }
-
-        // ----- colors ---------------------------------------------------
-        let colors: Parameter<[Color]>
-        if let arr = args[safe: 0]!.expression.literalArray({ $0.colorLiteral }),
-           arr.count >= 2 {
-            colors = .literal(arr)
-        } else {
-            colors = .expression(args[safe: 0]!.expression)
-        }
-
-        // ----- center (UnitPoint) --------------------------------------
-        let centerArg = args[safe: 1]!
-        let center: Parameter<UnitPoint> = centerArg.unitPointLiteral
-            .map(Parameter.literal) ?? .expression(centerArg.expression)
-
-        // ----- startRadius / endRadius ---------------------------------
-        func radiusParam(_ arg: LabeledExprSyntax) -> Parameter<CGFloat> {
-            if let num = arg.cgFloatValue { return .literal(num) }
-            return .expression(arg.expression)
-        }
-        let startR = radiusParam(args[safe: 2]!)
-        let endR   = radiusParam(args[safe: 3]!)
-
-        return .parameters(colors: colors,
-                           center: center,
-                           startRadius: startR,
-                           endRadius:   endR)
-    }
-}
+//// TODO: a lot of this logic overlaps with HStackViewConstructor; only difference is `HorizontalAlignment` instead of `VerticalAlignment`
+//enum VStackViewConstructor: Equatable, FromSwiftUIViewToStitch {
+//    /// SwiftUI exposes just one public initializer:
+//    /// `init(alignment: HorizontalAlignment = .center, spacing: CGFloat? = nil, @ViewBuilder content: () -> Content)`
+//    case parameters(alignment: Parameter<HorizontalAlignment> = .literal(.center),
+//                    spacing:   Parameter<CGFloat?>            = .literal(nil))
+//
+//    // MARK: Stitch mapping
+//    var toStitch: (Layer?, [ValueOrEdge])? {
+//        var list: [ValueOrEdge] = [
+//            .value(.init(.orientation, .orientation(.vertical)))
+//        ]
+//
+//        guard case let .parameters(alignment, spacing) = self else { return nil }
+//
+//        switch alignment {
+//        case .literal(let a) where a != .center:
+//            list.append(.value(.init(.layerGroupAlignment,
+//                                     .anchoring(a.toAnchoring))))
+//        case .expression(let expr):
+//            list.append(.edge(expr))
+//        default: break
+//        }
+//
+//        switch spacing {
+//        case .literal(let s?):
+//            list.append(.value(.init(.spacing, .spacing(.number(s)))))
+//        case .expression(let expr):
+//            list.append(.edge(expr))
+//        default: break
+//        }
+//
+//        return (.group, list)
+//    }
+//
+//    // MARK: Parse from SwiftSyntax
+//    static func from(_ node: FunctionCallExprSyntax) -> VStackViewConstructor? {
+//        let args = node.arguments
+//        var alignment: Parameter<HorizontalAlignment> = .literal(.center)
+//        var spacing:   Parameter<CGFloat?>            = .literal(nil)
+//
+//        for arg in args {
+//            switch arg.label?.text {
+//            case "alignment":
+//                if let lit = arg.horizAlignLiteral {
+//                    alignment = .literal(lit)
+//                } else {
+//                    alignment = .expression(arg.expression)
+//                }
+//            case "spacing":
+//                if let num = arg.cgFloatValue {
+//                    spacing = .literal(num)
+//                } else {
+//                    spacing = .expression(arg.expression)
+//                }
+//            default:
+//                break
+//            }
+//        }
+//
+//        return .parameters(alignment: alignment, spacing: spacing)
+//    }
+//}
+//
+//// ── Helper: random-access a TupleExprElementListSyntax by Int index ────────────
+//extension LabeledExprListSyntax {
+//    subscript(safe index: Int) -> LabeledExprSyntax? {
+//        guard index >= 0 && index < count else { return nil }
+//        return self[self.index(startIndex, offsetBy: index)]
+//    }
+//}
+//
+//enum LazyHStackViewConstructor: Equatable, FromSwiftUIViewToStitch {
+//    case parameters(alignment: Parameter<VerticalAlignment> = .literal(.center),
+//                    spacing:   Parameter<CGFloat?>          = .literal(nil))
+//
+//    var toStitch: (Layer?, [ValueOrEdge])? {
+//        switch self {
+//        case .parameters(let alignment, let spacing):
+//            return HStackViewConstructor
+//                .parameters(alignment: alignment, spacing: spacing)
+//                .toStitch
+//        }
+//    }
+//
+//    static func from(_ node: FunctionCallExprSyntax) -> LazyHStackViewConstructor? {
+//        // Re‑use HStack parser then wrap
+//        guard let base = HStackViewConstructor.from(node) else { return nil }
+//        switch base {
+//        case .parameters(let a, let s): return .parameters(alignment: a, spacing: s)
+//        }
+//    }
+//}
+//
+//enum LazyVStackViewConstructor: Equatable, FromSwiftUIViewToStitch {
+//    case parameters(alignment: Parameter<HorizontalAlignment> = .literal(.center),
+//                    spacing:   Parameter<CGFloat?>            = .literal(nil))
+//
+//    var toStitch: (Layer?, [ValueOrEdge])? {
+//        switch self {
+//        case .parameters(let alignment, let spacing):
+//            return VStackViewConstructor
+//                .parameters(alignment: alignment, spacing: spacing)
+//                .toStitch
+//        }
+//    }
+//
+//    static func from(_ node: FunctionCallExprSyntax) -> LazyVStackViewConstructor? {
+//        guard let base = VStackViewConstructor.from(node) else { return nil }
+//        switch base {
+//        case .parameters(let a, let s): return .parameters(alignment: a, spacing: s)
+//        }
+//    }
+//}
+//
+//// MARK: - ZStack -----------------------------------------------------------
+//
+//// MARK: - TextField --------------------------------------------------------
+//
+//enum TextFieldViewConstructor: Equatable, FromSwiftUIViewToStitch {
+//    /// Simplified model:
+//    /// `TextField(_ titleKey: LocalizedStringKey, text: Binding<String>)`
+//    /// or `TextField(_ title: String, text: Binding<String>)`
+//    case parameters(title: Parameter<String?> = .literal(nil),
+//                    binding: ExprSyntax)          // always an expression edge
+//
+//    // MARK: Stitch mapping
+//    ///
+//    /// • `title`  →  .placeholder   (omit if nil)
+//    /// • `binding`→  .text          (literal constant → value, otherwise edge)
+//    var toStitch: (Layer?, [ValueOrEdge])? {
+//        guard case let .parameters(title, bindingExpr) = self else { return nil }
+//        var list: [ValueOrEdge] = []
+//        
+//        // ----- title / placeholder ---------------------------------------
+//        switch title {
+//        case .literal(let str?):
+//            list.append(.value(.init(.placeholderText,
+//                                     .string(.init(str)))))
+//        case .expression(let expr):
+//            list.append(.edge(expr))
+//        default:
+//            break    // .literal(nil)  → no placeholder
+//        }
+//        
+//        // ----- binding / text -------------------------------------------
+//        if let constLiteral = bindingExpr.stringLiteralFromConstantBinding() {
+//            list.append(.value(.init(.text,
+//                                     .string(.init(constLiteral)))))
+//        } else {
+//            list.append(.edge(bindingExpr))
+//        }
+//        
+//        return (.textField, list)
+//    }
+//
+//    static func from(_ node: FunctionCallExprSyntax) -> Self? {
+//        let args = node.arguments
+//
+//        // need at least title + binding
+//        guard let first = args[safe: 0],
+//              let second = args[safe: 1] else { return nil }
+//
+//        // First argument can be unlabeled placeholder string/localised key
+//        var title: Parameter<String?> = .literal(nil)
+//        if first.label == nil,
+//           let lit = first.expression.as(StringLiteralExprSyntax.self) {
+//            title = .literal(lit.decoded())
+//        } else if first.label == nil {
+//            title = .expression(first.expression)
+//        }
+//
+//        // Second arg must be `text:` binding
+//        guard second.label?.text == "text" else { return nil }
+//
+//        return .parameters(title: title,
+//                           binding: second.expression)
+//    }
+//}
+//
+//enum ZStackViewConstructor: Equatable, FromSwiftUIViewToStitch {
+//    /// SwiftUI: `init(alignment: Alignment = .center, content:)`
+//    case parameters(alignment: Parameter<Alignment> = .literal(.center))
+//
+//    // Orientation is implicit overlap; we won’t emit orientation value.
+//    var toStitch: (Layer?, [ValueOrEdge])? {
+//        var list: [ValueOrEdge] = []
+//
+//        guard case let .parameters(alignment) = self else { return nil }
+//
+//        switch alignment {
+//        case .literal(let a) where a != .center:
+//            list.append(.value(.init(.layerGroupAlignment,
+//                                     .anchoring(a.toAnchoring))))
+//        case .expression(let expr):
+//            list.append(.edge(expr))
+//        default:
+//            break
+//        }
+//
+//        return (.group, list)
+//    }
+//
+//    static func from(_ node: FunctionCallExprSyntax) -> ZStackViewConstructor? {
+//        var alignment: Parameter<Alignment> = .literal(.center)
+//
+//        for arg in node.arguments {
+//            if arg.label?.text == "alignment" {
+//                if let alignLit = arg.alignmentLiteral {
+//                    alignment = .literal(alignLit)
+//                } else {
+//                    alignment = .expression(arg.expression)
+//                }
+//            }
+//        }
+//
+//        return .parameters(alignment: alignment)
+//    }
+//}
+//
+//// MARK: - Circle & Rectangle (no‑arg views) -------------------------------
+//
+//enum CircleViewConstructor: Equatable, FromSwiftUIViewToStitch {
+//    case plain                                    // Circle()
+//
+//    var toStitch: (Layer?, [ValueOrEdge])? {
+//        (.oval, [])                             // no args, nothing to edge
+//    }
+//
+//    static func from(_ node: FunctionCallExprSyntax) -> Self? {
+//        node.arguments.isEmpty ? .plain : nil
+//    }
+//}
+//
+//enum EllipseViewConstructor: Equatable, FromSwiftUIViewToStitch {
+//    case plain                                  // Ellipse()
+//
+//    var toStitch: (Layer?, [ValueOrEdge])? {
+//        (.oval, [])                             // same mapping as Circle
+//    }
+//
+//    static func from(_ node: FunctionCallExprSyntax) -> Self? {
+//        node.arguments.isEmpty ? .plain : nil
+//    }
+//}
+//
+//enum RectangleViewConstructor: Equatable, FromSwiftUIViewToStitch {
+//    case plain                                    // Rectangle()
+//
+//    var toStitch: (Layer?, [ValueOrEdge])? {
+//        (.rectangle, [])                          // no args
+//    }
+//
+//    static func from(_ node: FunctionCallExprSyntax) -> Self? {
+//        node.arguments.isEmpty ? .plain : nil
+//    }
+//}
+//
+//// MARK: - RoundedRectangle -------------------------------------------------
+//
+//enum RoundedRectangleViewConstructor: Equatable, FromSwiftUIViewToStitch {
+//    /// RoundedRectangle(cornerRadius:style:)
+//    case cornerRadius(radius: Parameter<CGFloat>,
+//                      style:  Parameter<RoundedCornerStyle> = .literal(.continuous))
+//    
+//    /// RoundedRectangle(cornerSize:style:)
+//    case cornerSize(size: Parameter<CGSize>,
+//                    style: Parameter<RoundedCornerStyle> = .literal(.continuous))
+//    
+//    // MARK: Stitch mapping
+//    ///
+//    /// • RoundedRectangle(cornerRadius:) → Layer.rectangle + cornerRadius
+//    /// • RoundedRectangle(cornerSize:)   → Layer.rectangle + cornerSize
+//    ///
+//    /// (We ignore the `style` for now; it can be added later.)
+//    var toStitch: (Layer?, [ValueOrEdge])? {
+//        switch self
+//        {
+//        // ── cornerRadius(radius:style:) ───────────────────────────────
+//        case .cornerRadius(let radius, _):
+//            switch radius {
+//            case .literal(let r):
+//                return (
+//                    .rectangle,
+//                    [ .value(.init(.cornerRadius, .number(r))) ]
+//                )
+//            case .expression(let expr):
+//                return (
+//                    .rectangle,
+//                    [ .edge(expr) ]
+//                )
+//            }
+//
+//        // ── cornerSize(size:style:) ───────────────────────────────────
+//        case .cornerSize(let size, _):
+//            switch size {
+//            case .literal(let s):
+//                return (
+//                    .rectangle,
+////                    [ .value(.init(.cornerSize, .size(s))) ]
+//                    [ .value(.init(.cornerRadius, .number(s.width))) ]
+//                )
+//            case .expression(let expr):
+//                return (
+//                    .rectangle,
+//                    [ .edge(expr) ]
+//                )
+//            }
+//        }
+//    }
+//    
+//    static func from(_ node: FunctionCallExprSyntax) -> Self? {
+//        let args = node.arguments
+//        guard let first = args.first else { return nil }
+//        
+//        if first.label?.text == "cornerRadius" {
+//            let style: Parameter<RoundedCornerStyle> = .literal(.continuous)
+//            return .cornerRadius(radius: first.asParameterCGFloat(), style: style)
+//        }
+//        if first.label?.text == "cornerSize" {
+//            let style: Parameter<RoundedCornerStyle> = .literal(.continuous)
+//            return .cornerSize(size: first.asParameterCGSize(), style: style)
+//        }
+//        return nil
+//    }
+//}
+//
+//// MARK: - ScrollView -------------------------------------------------------
+//
+//enum ScrollViewViewConstructor: Equatable, FromSwiftUIViewToStitch {
+//    /// ScrollView(axes:showIndicators:)
+//    case parameters(axes: Parameter<Axis.Set> = .literal(.vertical),
+//                    showsIndicators: Parameter<Bool> = .literal(true))
+//    
+//    // MARK: Stitch mapping
+//    ///
+//    /// • Always returns `(.scroll, …)`
+//    /// • `.horizontal`   →  scrollXEnabled = true
+//    /// • `.vertical`     →  scrollYEnabled = true   (default if no arg)
+//    /// • `[.horizontal, .vertical]` or `.all`
+//    ///                    →  both scrollXEnabled & scrollYEnabled = true
+//    /// • Any expression  →  single `.edge(expr)` (caller decides)
+//    var toStitch: (Layer?, [ValueOrEdge])? {
+//        guard case let .parameters(axes, _) = self else { return nil }
+//        var list: [ValueOrEdge] = []
+//        
+//        switch axes {
+//        case .literal(let set):
+//            // Axis.Set is an OptionSet; test for membership.
+//            if set.contains(.horizontal) {
+//                list.append(.value(.init(.scrollXEnabled, .bool(true))))
+//            }
+//            if set.contains(.vertical) {
+//                list.append(.value(.init(.scrollYEnabled, .bool(true))))
+//            }
+//            if set == [.horizontal, .vertical] {
+//                // Already handled by the contains checks, nothing extra
+//            }
+//            // If neither bit is set (shouldn’t happen), default to vertical
+//            if list.isEmpty {
+//                list.append(.value(.init(.scrollYEnabled, .bool(true))))
+//            }
+//            
+//        case .expression(let expr):
+//            // Try to evaluate at compile‑time
+//            if let litSet = expr.axisSetLiteral() {
+//                if litSet.contains(.horizontal) {
+//                    list.append(.value(.init(.scrollXEnabled, .bool(true))))
+//                }
+//                if litSet.contains(.vertical) || litSet.isEmpty {
+//                    list.append(.value(.init(.scrollYEnabled, .bool(true))))
+//                }
+//            } else {
+//                // Unresolved at compile‑time → forward as edge
+//                list.append(.edge(expr))
+//            }
+//        }
+//        
+//        return (
+//            nil, // ScrollView does not technically correspond to a Stitch Layer
+//            list
+//        )
+//    }
+//    
+//    static func from(_ node: FunctionCallExprSyntax) -> Self? {
+//        let args = node.arguments
+//        var axes: Parameter<Axis.Set> = .literal(.vertical)
+//        var indicators: Parameter<Bool> = .literal(true)
+//        
+//        for arg in args {
+//            switch arg.label?.text {
+//            case nil:      // unnamed first parameter can be Axis.Set
+//                axes = arg.asParameterAxisSet()
+//            case "showsIndicators":
+//                indicators = arg.asParameterBool()
+//            default:
+//                break
+//            }
+//        }
+//        return .parameters(axes: axes, showsIndicators: indicators)
+//    }
+//}
+//
+//
+//// MARK: - Gradients --------------------------------------------------------
+//
+//enum AngularGradientViewConstructor: Equatable, FromSwiftUIViewToStitch {
+//    /// AngularGradient(colors:center:startAngle:endAngle:)
+//    case parameters(colors: Parameter<[Color]>,
+//                    center: Parameter<UnitPoint>,
+//                    startAngle: Parameter<CGFloat>,
+//                    endAngle:   Parameter<CGFloat>)
+//    
+//    // MARK: Stitch mapping
+//    ///
+//    /// SwiftUI                      → Stitch
+//    /// ---------------------------------------------------------
+//    /// colors[0]                    → .startColor
+//    /// colors[1]                    → .endColor
+//    /// center                       → .centerAnchor
+//    /// startAngle                   → .startAngle
+//    /// endAngle                     → .endAngle
+//    var toStitch: (Layer?, [ValueOrEdge])? {
+//        guard case let .parameters(colors, center, startAngle, endAngle) = self else { return nil }
+//        var list: [ValueOrEdge] = []
+//        
+//        // ----- colors ---------------------------------------------------
+//        switch colors {
+//        case .literal(let arr) where arr.count >= 2:
+//            list.append(.value(.init(.startColor, .color(.init(arr[0])))))
+//            list.append(.value(.init(.endColor,   .color(.init(arr[1])))))
+//        case .expression(let expr):
+//            list.append(.edge(expr))        // expression supplies [Color]
+//        default:
+//            break
+//        }
+//        
+//        // ----- center / centerAnchor -----------------------------------
+//        switch center {
+//        case .literal(let p):
+//            list.append(.value(.init(.centerAnchor, .anchoring(p.toAnchoring))))
+//        case .expression(let expr):
+//            list.append(.edge(expr))
+//        }
+//        
+//        // ----- startAngle ----------------------------------------------
+//        switch startAngle {
+//        case .literal(let deg):
+//            list.append(.value(.init(.startAngle, .number(deg))))
+//        case .expression(let expr):
+//            list.append(.edge(expr))
+//        }
+//        
+//        // ----- endAngle -------------------------------------------------
+//        switch endAngle {
+//        case .literal(let deg):
+//            list.append(.value(.init(.endAngle, .number(deg))))
+//        case .expression(let expr):
+//            list.append(.edge(expr))
+//        }
+//        
+//        return (.angularGradient, list)
+//    }
+//    
+//    static func from(_ node: FunctionCallExprSyntax) -> Self? {
+//        let args = node.arguments
+//        guard let colorsArg = args[safe: 0],
+//              let centerArg = args[safe: 1],
+//              let startArg  = args[safe: 2],
+//              let endArg    = args[safe: 3] else { return nil }
+//
+//        // colors
+//        let colors: Parameter<[Color]>
+//        if let arr = colorsArg.expression.literalArray({ $0.colorLiteral }),
+//           arr.count >= 2 {
+//            colors = .literal(arr)
+//        } else {
+//            colors = .expression(colorsArg.expression)
+//        }
+//
+//        // center
+//        let center: Parameter<UnitPoint> = centerArg.unitPointLiteral
+//            .map(Parameter.literal) ?? .expression(centerArg.expression)
+//
+//        // angles
+//        func angleParam(_ a: LabeledExprSyntax) -> Parameter<CGFloat> {
+//            if let deg = a.angleDegreesLiteral { return .literal(deg) }
+//            if let num = a.cgFloatValue       { return .literal(num) }
+//            return .expression(a.expression)
+//        }
+//
+//        return .parameters(colors: colors,
+//                           center: center,
+//                           startAngle: angleParam(startArg),
+//                           endAngle:   angleParam(endArg))
+//    }
+//}
+//
+//enum LinearGradientViewConstructor: Equatable, FromSwiftUIViewToStitch {
+//    /// LinearGradient(colors:startPoint:endPoint:)
+//    case parameters(colors: Parameter<[Color]>,
+//                    startPoint: Parameter<UnitPoint>,
+//                    endPoint: Parameter<UnitPoint>)
+//
+//    // MARK: Stitch mapping
+//    ///
+//    /// SwiftUI                      → Stitch
+//    /// ---------------------------------------------------------
+//    /// colors[0]                    → .startColor   (Color)
+//    /// colors[1]                    → .endColor     (Color)
+//    /// startPoint (UnitPoint)       → .startAnchor  (Anchoring)
+//    /// endPoint   (UnitPoint)       → .endAnchor    (Anchoring)
+//    ///
+//    /// Expression arguments become `.edge(expr)`.
+//    var toStitch: (Layer?, [ValueOrEdge])? {
+//        guard case let .parameters(colors, startPoint, endPoint) = self else { return nil }
+//        var list: [ValueOrEdge] = []
+//
+//        // ---- colors ----------------------------------------------------
+//        switch colors {
+//        case .literal(let arr) where arr.count >= 2:
+//            list.append(.value(.init(.startColor, .color(.init(arr[0])))))
+//            list.append(.value(.init(.endColor,   .color(.init(arr[1])))))
+//        case .expression(let expr):
+//            list.append(.edge(expr))         // upstream produces [Color]
+//        default:
+//            break
+//        }
+//
+//        // ---- startPoint / startAnchor ---------------------------------
+//        switch startPoint {
+//        case .literal(let p):
+//            list.append(.value(.init(.startAnchor, .anchoring(p.toAnchoring))))
+//        case .expression(let expr):
+//            list.append(.edge(expr))
+//        }
+//
+//        // ---- endPoint / endAnchor -------------------------------------
+//        switch endPoint {
+//        case .literal(let p):
+//            list.append(.value(.init(.endAnchor, .anchoring(p.toAnchoring))))
+//        case .expression(let expr):
+//            list.append(.edge(expr))
+//        }
+//
+//        return (.linearGradient, list)
+//    }
+//
+//    static func from(_ node: FunctionCallExprSyntax) -> Self? {
+//        let args = node.arguments
+//        guard let colorsArg = args[safe: 0],
+//              let startArg  = args[safe: 1],
+//              let endArg    = args[safe: 2] else { return nil }
+//
+//        // colors
+//        let colors: Parameter<[Color]>
+//        if let arr = colorsArg.expression.literalArray({ $0.colorLiteral }),
+//           arr.count >= 2 {
+//            colors = .literal(arr)
+//        } else {
+//            colors = .expression(colorsArg.expression)
+//        }
+//
+//        // points
+//        let startPt: Parameter<UnitPoint> = startArg.unitPointLiteral
+//            .map(Parameter.literal) ?? .expression(startArg.expression)
+//        let endPt: Parameter<UnitPoint> = endArg.unitPointLiteral
+//            .map(Parameter.literal) ?? .expression(endArg.expression)
+//
+//        return .parameters(colors: colors, startPoint: startPt, endPoint: endPt)
+//    }
+//}
+//
+//enum RadialGradientViewConstructor: Equatable, FromSwiftUIViewToStitch {
+//    /// RadialGradient(colors:center:startRadius:endRadius:)
+//    case parameters(colors: Parameter<[Color]>,
+//                    center: Parameter<UnitPoint>,
+//                    startRadius: Parameter<CGFloat>,
+//                    endRadius: Parameter<CGFloat>)
+//
+//    // MARK: Stitch mapping
+//    ///
+//    ///  SwiftUI            → Stitch
+//    ///  ---------------------------------------------------------
+//    ///  center             → .startAnchor          (Anchoring)
+//    ///  colors[0]          → .startColor           (Color)
+//    ///  colors[1]          → .endColor             (Color)
+//    ///  startRadius        → .startRadius          (Number)
+//    ///  endRadius          → .endRadius            (Number)
+//    ///
+//    ///  If any argument is an expression we emit an `.edge(expr)` instead.
+//    var toStitch: (Layer?, [ValueOrEdge])? {
+//        guard case let .parameters(colors, center, startRadius, endRadius) = self else { return nil }
+//        var list: [ValueOrEdge] = []
+//
+//        // -------- colors -------------------------------------------------
+//        switch colors {
+//        case .literal(let arr) where arr.count >= 2:
+//            list.append(.value(.init(.startColor, .color(.init(arr[0])))))
+//            list.append(.value(.init(.endColor,   .color(.init(arr[1])))))
+//        case .expression(let expr):
+//            list.append(.edge(expr))           // upstream node outputs [Color]
+//        default:
+//            break
+//        }
+//
+//        // -------- center / startAnchor ----------------------------------
+//        switch center {
+//        case .literal(let pt):
+//            list.append(.value(.init(.startAnchor, .anchoring(pt.toAnchoring))))
+//        case .expression(let expr):
+//            list.append(.edge(expr))
+//        }
+//
+//        // -------- startRadius -------------------------------------------
+//        switch startRadius {
+//        case .literal(let r):
+//            list.append(.value(.init(.startRadius, .number(r))))
+//        case .expression(let expr):
+//            list.append(.edge(expr))
+//        }
+//
+//        // -------- endRadius ---------------------------------------------
+//        switch endRadius {
+//        case .literal(let r):
+//            list.append(.value(.init(.endRadius, .number(r))))
+//        case .expression(let expr):
+//            list.append(.edge(expr))
+//        }
+//
+//        return (.radialGradient, list)
+//    }
+//
+//    static func from(_ node: FunctionCallExprSyntax) -> Self? {
+//        let args = node.arguments
+//        guard args.count >= 4 else { return nil }
+//
+//        // ----- colors ---------------------------------------------------
+//        let colors: Parameter<[Color]>
+//        if let arr = args[safe: 0]!.expression.literalArray({ $0.colorLiteral }),
+//           arr.count >= 2 {
+//            colors = .literal(arr)
+//        } else {
+//            colors = .expression(args[safe: 0]!.expression)
+//        }
+//
+//        // ----- center (UnitPoint) --------------------------------------
+//        let centerArg = args[safe: 1]!
+//        let center: Parameter<UnitPoint> = centerArg.unitPointLiteral
+//            .map(Parameter.literal) ?? .expression(centerArg.expression)
+//
+//        // ----- startRadius / endRadius ---------------------------------
+//        func radiusParam(_ arg: LabeledExprSyntax) -> Parameter<CGFloat> {
+//            if let num = arg.cgFloatValue { return .literal(num) }
+//            return .expression(arg.expression)
+//        }
+//        let startR = radiusParam(args[safe: 2]!)
+//        let endR   = radiusParam(args[safe: 3]!)
+//
+//        return .parameters(colors: colors,
+//                           center: center,
+//                           startRadius: startR,
+//                           endRadius:   endR)
+//    }
+//}

--- a/Stitch/Graph/StitchAI/Mapping/Declarative/DeclarativeViewConstructors.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Declarative/DeclarativeViewConstructors.swift
@@ -25,7 +25,7 @@ protocol FromSwiftUIViewToStitch: Encodable {
     
     static func from(_ args: [SyntaxViewArgumentData]) -> T?
     
-    static var layer: CurrentStep.Layer { get }
+    var layer: CurrentStep.Layer { get }
     
     func createCustomValueEvents() throws -> [ASTCustomInputValue]
 }
@@ -88,7 +88,7 @@ enum TextViewConstructor: Equatable, FromSwiftUIViewToStitch {
 }
 
 extension TextViewConstructor {
-    static let layer: CurrentStep.Layer = .text
+    var layer: CurrentStep.Layer { .text }
     
     var arg: SyntaxViewModifierArgumentType {
         switch self {
@@ -157,7 +157,15 @@ enum ImageViewConstructor: Equatable, FromSwiftUIViewToStitch {
     /// `Image(uiImage:)`
     case uiImage(image: SyntaxViewModifierArgumentType)
     
-    static let layer: CurrentStep.Layer = .image
+    var layer: CurrentStep.Layer {
+        switch self {
+        case .sfSymbol:
+            return .sfSymbol
+            
+        default:
+            return .image
+        }
+    }
 
     func createCustomValueEvents() throws -> [ASTCustomInputValue] {
         switch self {
@@ -233,7 +241,7 @@ enum HStackViewConstructor: Equatable, FromSwiftUIViewToStitch {
     case parameters(alignment: SyntaxViewModifierArgumentType?,
                     spacing:   SyntaxViewModifierArgumentType?)
 
-    static let layer: CurrentStep.Layer = .group
+    var layer: CurrentStep.Layer { .group }
     
     func createCustomValueEvents() throws -> [ASTCustomInputValue] {
         var list: [ASTCustomInputValue] = [

--- a/Stitch/Graph/StitchAI/Mapping/Declarative/DeclarativeViewConstructors.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Declarative/DeclarativeViewConstructors.swift
@@ -14,7 +14,7 @@ import SwiftParser
 
 
 
-protocol FromSwiftUIViewToStitch {
+protocol FromSwiftUIViewToStitch: Encodable {
     associatedtype T
     
     // nil if ViewConstructor could not be turned into Stitch concepts
@@ -59,7 +59,7 @@ protocol FromSwiftUIViewToStitch {
 
 
 // TODO: can we just the `FromSwiftUIViewToStitch` protocol instead? But tricky, since `FromSwiftUIViewToStitch` has an associated i.e. generic type, which would bubble up elsewhere.
-enum ViewConstructor: Equatable {
+enum ViewConstructor: Equatable, Encodable {
     case text(TextViewConstructor)
     case image(ImageViewConstructor)
     case hStack(HStackViewConstructor)

--- a/Stitch/Graph/StitchAI/Mapping/Declarative/DeclarativeViewConstructorsDemoView.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Declarative/DeclarativeViewConstructorsDemoView.swift
@@ -1,316 +1,316 @@
+////
+////  DeclarativeViewConstructorsDemoView.swift
+////  Stitch
+////
+////  Created by Christian J Clampitt on 7/12/25.
+////
 //
-//  DeclarativeViewConstructorsDemoView.swift
-//  Stitch
+//import SwiftUI
+//import SwiftSyntax
+//import SwiftParser
 //
-//  Created by Christian J Clampitt on 7/12/25.
 //
-
-import SwiftUI
-import SwiftSyntax
-import SwiftParser
-
-
-// MARK: - Proof‑of‑Concept Visitor ----------------------------------------
+//// MARK: - Proof‑of‑Concept Visitor ----------------------------------------
+////
+////  This visitor is *stand-alone* and confined to this file so you can
+////  experiment without touching the real parsing pipeline elsewhere.
+////
 //
-//  This visitor is *stand-alone* and confined to this file so you can
-//  experiment without touching the real parsing pipeline elsewhere.
+///// A lightweight record of each Text / Image call we find.
+//struct POCViewCall {
+//    enum Kind {
+//        case text(TextViewConstructor)
+//        case image(ImageViewConstructor)
+//        case hStack(HStackViewConstructor)
+//        case vStack(VStackViewConstructor)
+//        case lazyHStack(LazyHStackViewConstructor)
+//        case lazyVStack(LazyVStackViewConstructor)
+//        case circle(CircleViewConstructor)
+//        case ellipse(EllipseViewConstructor)
+//        case rectangle(RectangleViewConstructor)
+//        case roundedRectangle(RoundedRectangleViewConstructor)
+//        case scrollView(ScrollViewViewConstructor)
+//        case zStack(ZStackViewConstructor)
+//        case textField(TextFieldViewConstructor)
+//        case angularGradient(AngularGradientViewConstructor)
+//        case linearGradient(LinearGradientViewConstructor)
+//        case radialGradient(RadialGradientViewConstructor)
+//    }
+//    let kind: Kind
+//    let node: FunctionCallExprSyntax       // handy for debugging / source‑ranges
+//}
 //
-
-/// A lightweight record of each Text / Image call we find.
-struct POCViewCall {
-    enum Kind {
-        case text(TextViewConstructor)
-        case image(ImageViewConstructor)
-        case hStack(HStackViewConstructor)
-        case vStack(VStackViewConstructor)
-        case lazyHStack(LazyHStackViewConstructor)
-        case lazyVStack(LazyVStackViewConstructor)
-        case circle(CircleViewConstructor)
-        case ellipse(EllipseViewConstructor)
-        case rectangle(RectangleViewConstructor)
-        case roundedRectangle(RoundedRectangleViewConstructor)
-        case scrollView(ScrollViewViewConstructor)
-        case zStack(ZStackViewConstructor)
-        case textField(TextFieldViewConstructor)
-        case angularGradient(AngularGradientViewConstructor)
-        case linearGradient(LinearGradientViewConstructor)
-        case radialGradient(RadialGradientViewConstructor)
-    }
-    let kind: Kind
-    let node: FunctionCallExprSyntax       // handy for debugging / source‑ranges
-}
-
-/// Walks any Swift source and classifies Text / Image constructors
-/// into the strongly‑typed enums defined above.
-final class POCConstructorVisitor: SyntaxVisitor {
-
-    private(set) var calls: [POCViewCall] = []
-
-    // We only care about function calls.
-    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
-
-        guard let calleeIdent = node.calledExpression.as(DeclReferenceExprSyntax.self)?
-            .baseName.text
-        else { return .skipChildren }
-        
-        print("POCVisitor: visiting \(calleeIdent) – args: \(node.arguments.count)")
-
-        switch calleeIdent {
-
-        case "Text":
-            if let ctor = TextViewConstructor.from(node) {
-                calls.append(.init(kind: .text(ctor), node: node))
-            }
-
-        case "Image":
-            if let ctor = ImageViewConstructor.from(node) {
-                calls.append(.init(kind: .image(ctor), node: node))
-            }
-
-        case "HStack":
-            if let ctor = HStackViewConstructor.from(node) {
-                calls.append(.init(kind: .hStack(ctor), node: node))
-            }
-
-        case "VStack":
-            if let ctor = VStackViewConstructor.from(node) {
-                calls.append(.init(kind: .vStack(ctor), node: node))
-            }
-
-        case "LazyHStack":
-            if let ctor = LazyHStackViewConstructor.from(node) {
-                calls.append(.init(kind: .lazyHStack(ctor), node: node))
-            }
-
-        case "LazyVStack":
-            if let ctor = LazyVStackViewConstructor.from(node) {
-                calls.append(.init(kind: .lazyVStack(ctor), node: node))
-            }
-
-        case "Circle":
-            if let ctor = CircleViewConstructor.from(node) {
-                calls.append(.init(kind: .circle(ctor), node: node))
-            }
-
-        case "Ellipse":
-            if let ctor = EllipseViewConstructor.from(node) {
-                calls.append(.init(kind: .ellipse(ctor), node: node))
-            }
-
-        case "Rectangle":
-            if let ctor = RectangleViewConstructor.from(node) {
-                calls.append(.init(kind: .rectangle(ctor), node: node))
-            }
-
-        case "RoundedRectangle":
-            if let ctor = RoundedRectangleViewConstructor.from(node) {
-                calls.append(.init(kind: .roundedRectangle(ctor), node: node))
-            }
-
-        case "ScrollView":
-            if let ctor = ScrollViewViewConstructor.from(node) {
-                calls.append(.init(kind: .scrollView(ctor), node: node))
-            }
-
-        case "ZStack":
-            if let ctor = ZStackViewConstructor.from(node) {
-                calls.append(.init(kind: .zStack(ctor), node: node))
-            }
-
-        case "TextField":
-            if let ctor = TextFieldViewConstructor.from(node) {
-                calls.append(.init(kind: .textField(ctor), node: node))
-            }
-
-        case "AngularGradient":
-            if let ctor = AngularGradientViewConstructor.from(node) {
-                calls.append(.init(kind: .angularGradient(ctor), node: node))
-            }
-        case "LinearGradient":
-            if let ctor = LinearGradientViewConstructor.from(node) {
-                calls.append(.init(kind: .linearGradient(ctor), node: node))
-            }
-        case "RadialGradient":
-            if let ctor = RadialGradientViewConstructor.from(node) {
-                calls.append(.init(kind: .radialGradient(ctor), node: node))
-            }
-
-        default:
-            break
-        }
-        return .visitChildren
-    }
-}
-
-// MARK: - Tiny helpers -----------------------------------------------------
-
-extension StringLiteralExprSyntax {
-    /// Returns the runtime value of a simple one‑segment string literal.
-    func decoded() -> String {
-        guard case .stringSegment(let seg)? = segments.first else { return description }
-        // remove the surrounding quotes and unescape \" \\ \n \t
-        return seg.content.text
-            .replacingOccurrences(of: #"\""#, with: "\"")
-            .replacingOccurrences(of: #"\\n"#, with: "\n")
-            .replacingOccurrences(of: #"\\t"#, with: "\t")
-            .replacingOccurrences(of: #"\\\\"#, with: "\\")
-    }
-}
-
-// MARK: - SwiftUI Preview --------------------------------------------------
-
-import SwiftUI
-
-/// A quick SwiftUI preview that shows how the proof‑of‑concept visitor
-/// classifies a handful of Text / Image constructor calls.
-struct ConstructorDemoView: View {
-    
-    static let sampleSource = """
-        Text("Hello")
-        Text(verbatim: "Raw verbatim value")
-        Text(LocalizedStringKey("greeting_key"))
-        Text(AttributedString("Fancy attributed"))
-
-        Image(systemName: "gear")
-        Image("logo")
-        Image("photo", bundle: .main)
-        Image(decorative: "decor", bundle: nil)
-
-        HStack
-        HStack(alignment: .top)
-        HStack(spacing: 20)
-        HStack(alignment: .bottom, spacing: 10)
-
-        VStack // { Text("B") }
-        VStack(alignment: .leading) // { Text("B") }
-        VStack(spacing: 12) // { Text("B") }
-        VStack(alignment: .trailing, spacing: 6) // { Text("B") }
-
-        LazyHStack
-        LazyHStack(alignment: .top)
-        LazyHStack(spacing: 8)
-
-        LazyVStack // { Text("D") }
-        LazyVStack(alignment: .leading)
-        LazyVStack(spacing: 4)
-        LazyVStack(spacing: mySpacingVariable)
-        LazyVStack(spacing: 2 + 6)
-        Circle()
-        Ellipse()
-        Rectangle()
-        RoundedRectangle(cornerRadius: 12)
-        ScrollView(.horizontal, showsIndicators: false)
-        ScrollView(.vertical)
-        ScrollView([.vertical, .horizontal])
-        ZStack
-        ZStack(alignment: .topLeading)
-        TextField("Email", text: emailBinding)
-        AngularGradient(colors: [.red, .blue],
-                        center: .center,
-                        angle: .degrees(0))
-        LinearGradient(colors: [.green, .yellow],
-                       startPoint: .leading,
-                       endPoint: .trailing)
-        RadialGradient(colors: [.purple, .pink],
-                       center: .center,
-                       startRadius: 0,
-                       endRadius: 100)
-    """
-
-    // One row of the demo table
-    struct DemoRow: Identifiable {
-        let id = UUID()
-        let code: String
-        let overload: String
-        let stitch: String
-    }
-
-    // MARK: - Rows
-    @State private var rows: [DemoRow] = ConstructorDemoView.buildRows()
-    
-    private static func buildRows() -> [DemoRow] {
-        let tree = Parser.parse(source: Self.sampleSource)
-        let visitor = POCConstructorVisitor(viewMode: .fixedUp)
-        visitor.walk(tree)
-
-        return visitor.calls.map { call in
-            let code = call.node.description.trimmingCharacters(in: .whitespacesAndNewlines)
-
-            let overload: String
-            let stitch: String
-
-            let (prefix, ctor): (String, any FromSwiftUIViewToStitch)
-
-            switch call.kind {
-            case .text(let c):             (prefix, ctor) = ("Text", c)
-            case .image(let c):            (prefix, ctor) = ("Image", c)
-            case .hStack(let c):           (prefix, ctor) = ("HStack", c)
-            case .vStack(let c):           (prefix, ctor) = ("VStack", c)
-            case .lazyHStack(let c):       (prefix, ctor) = ("LazyHStack", c)
-            case .lazyVStack(let c):       (prefix, ctor) = ("LazyVStack", c)
-            case .circle(let c):           (prefix, ctor) = ("Circle", c)
-            case .ellipse(let c):          (prefix, ctor) = ("Ellipse", c)
-            case .rectangle(let c):        (prefix, ctor) = ("Rectangle", c)
-            case .roundedRectangle(let c): (prefix, ctor) = ("RoundedRectangle", c)
-            case .scrollView(let c):       (prefix, ctor) = ("ScrollView", c)
-            case .zStack(let c):           (prefix, ctor) = ("ZStack", c)
-            case .textField(let c):        (prefix, ctor) = ("TextField", c)
-            case .angularGradient(let c):  (prefix, ctor) = ("AngularGradient", c)
-            case .linearGradient(let c):   (prefix, ctor) = ("LinearGradient", c)
-            case .radialGradient(let c):   (prefix, ctor) = ("RadialGradient", c)
-            }
-
-            overload = "\(prefix).\(ctor)"
-            if let (layer, values) = ctor.toStitch {
-                let detail = values.map { ve -> String in
-                    switch ve {
-                    case .value(let cv):
-                        return "\(cv.input)=\(cv.value.display)"
-                    case .edge(let expr):
-                        return "edge<\(expr.description)>"
-                    }
-                }.joined(separator: ", ")
-                stitch = "Layer: \(String(describing: layer))  { \(detail) }"
-            } else {
-                stitch = "—"
-            }
-
-            return DemoRow(code: code, overload: overload, stitch: stitch)
-        }
-    }
-
-    var body: some View {
-        VStack(alignment: .leading) {
-            Text("SwiftUI → Overload → Stitch mapping")
-                .font(.headline)
-                .padding(.bottom, 4)
-
-            Button("Run conversions again") {
-                rows = ConstructorDemoView.buildRows()
-            }
-            .padding(.bottom, 4)
-
-            List(rows) { row in
-                logInView("ConstructorDemoView: row: \(row)")
-                HStack(alignment: .top, spacing: 8) {
-                    Text(row.code)
-                        .monospaced()
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .textSelection(.enabled)
-
-                    Text(row.overload)
-                        .monospaced()
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .textSelection(.enabled)
-
-                    Text(row.stitch)
-                        .monospaced()
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .textSelection(.enabled)
-                }
-            }
-        }
-        .padding()
-        .border(.red, width: 4)
-    }
-}
+///// Walks any Swift source and classifies Text / Image constructors
+///// into the strongly‑typed enums defined above.
+//final class POCConstructorVisitor: SyntaxVisitor {
+//
+//    private(set) var calls: [POCViewCall] = []
+//
+//    // We only care about function calls.
+//    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+//
+//        guard let calleeIdent = node.calledExpression.as(DeclReferenceExprSyntax.self)?
+//            .baseName.text
+//        else { return .skipChildren }
+//        
+//        print("POCVisitor: visiting \(calleeIdent) – args: \(node.arguments.count)")
+//
+//        switch calleeIdent {
+//
+//        case "Text":
+//            if let ctor = TextViewConstructor.from(node) {
+//                calls.append(.init(kind: .text(ctor), node: node))
+//            }
+//
+//        case "Image":
+//            if let ctor = ImageViewConstructor.from(node) {
+//                calls.append(.init(kind: .image(ctor), node: node))
+//            }
+//
+//        case "HStack":
+//            if let ctor = HStackViewConstructor.from(node) {
+//                calls.append(.init(kind: .hStack(ctor), node: node))
+//            }
+//
+//        case "VStack":
+//            if let ctor = VStackViewConstructor.from(node) {
+//                calls.append(.init(kind: .vStack(ctor), node: node))
+//            }
+//
+//        case "LazyHStack":
+//            if let ctor = LazyHStackViewConstructor.from(node) {
+//                calls.append(.init(kind: .lazyHStack(ctor), node: node))
+//            }
+//
+//        case "LazyVStack":
+//            if let ctor = LazyVStackViewConstructor.from(node) {
+//                calls.append(.init(kind: .lazyVStack(ctor), node: node))
+//            }
+//
+//        case "Circle":
+//            if let ctor = CircleViewConstructor.from(node) {
+//                calls.append(.init(kind: .circle(ctor), node: node))
+//            }
+//
+//        case "Ellipse":
+//            if let ctor = EllipseViewConstructor.from(node) {
+//                calls.append(.init(kind: .ellipse(ctor), node: node))
+//            }
+//
+//        case "Rectangle":
+//            if let ctor = RectangleViewConstructor.from(node) {
+//                calls.append(.init(kind: .rectangle(ctor), node: node))
+//            }
+//
+//        case "RoundedRectangle":
+//            if let ctor = RoundedRectangleViewConstructor.from(node) {
+//                calls.append(.init(kind: .roundedRectangle(ctor), node: node))
+//            }
+//
+//        case "ScrollView":
+//            if let ctor = ScrollViewViewConstructor.from(node) {
+//                calls.append(.init(kind: .scrollView(ctor), node: node))
+//            }
+//
+//        case "ZStack":
+//            if let ctor = ZStackViewConstructor.from(node) {
+//                calls.append(.init(kind: .zStack(ctor), node: node))
+//            }
+//
+//        case "TextField":
+//            if let ctor = TextFieldViewConstructor.from(node) {
+//                calls.append(.init(kind: .textField(ctor), node: node))
+//            }
+//
+//        case "AngularGradient":
+//            if let ctor = AngularGradientViewConstructor.from(node) {
+//                calls.append(.init(kind: .angularGradient(ctor), node: node))
+//            }
+//        case "LinearGradient":
+//            if let ctor = LinearGradientViewConstructor.from(node) {
+//                calls.append(.init(kind: .linearGradient(ctor), node: node))
+//            }
+//        case "RadialGradient":
+//            if let ctor = RadialGradientViewConstructor.from(node) {
+//                calls.append(.init(kind: .radialGradient(ctor), node: node))
+//            }
+//
+//        default:
+//            break
+//        }
+//        return .visitChildren
+//    }
+//}
+//
+//// MARK: - Tiny helpers -----------------------------------------------------
+//
+//extension StringLiteralExprSyntax {
+//    /// Returns the runtime value of a simple one‑segment string literal.
+//    func decoded() -> String {
+//        guard case .stringSegment(let seg)? = segments.first else { return description }
+//        // remove the surrounding quotes and unescape \" \\ \n \t
+//        return seg.content.text
+//            .replacingOccurrences(of: #"\""#, with: "\"")
+//            .replacingOccurrences(of: #"\\n"#, with: "\n")
+//            .replacingOccurrences(of: #"\\t"#, with: "\t")
+//            .replacingOccurrences(of: #"\\\\"#, with: "\\")
+//    }
+//}
+//
+//// MARK: - SwiftUI Preview --------------------------------------------------
+//
+//import SwiftUI
+//
+///// A quick SwiftUI preview that shows how the proof‑of‑concept visitor
+///// classifies a handful of Text / Image constructor calls.
+//struct ConstructorDemoView: View {
+//    
+//    static let sampleSource = """
+//        Text("Hello")
+//        Text(verbatim: "Raw verbatim value")
+//        Text(LocalizedStringKey("greeting_key"))
+//        Text(AttributedString("Fancy attributed"))
+//
+//        Image(systemName: "gear")
+//        Image("logo")
+//        Image("photo", bundle: .main)
+//        Image(decorative: "decor", bundle: nil)
+//
+//        HStack
+//        HStack(alignment: .top)
+//        HStack(spacing: 20)
+//        HStack(alignment: .bottom, spacing: 10)
+//
+//        VStack // { Text("B") }
+//        VStack(alignment: .leading) // { Text("B") }
+//        VStack(spacing: 12) // { Text("B") }
+//        VStack(alignment: .trailing, spacing: 6) // { Text("B") }
+//
+//        LazyHStack
+//        LazyHStack(alignment: .top)
+//        LazyHStack(spacing: 8)
+//
+//        LazyVStack // { Text("D") }
+//        LazyVStack(alignment: .leading)
+//        LazyVStack(spacing: 4)
+//        LazyVStack(spacing: mySpacingVariable)
+//        LazyVStack(spacing: 2 + 6)
+//        Circle()
+//        Ellipse()
+//        Rectangle()
+//        RoundedRectangle(cornerRadius: 12)
+//        ScrollView(.horizontal, showsIndicators: false)
+//        ScrollView(.vertical)
+//        ScrollView([.vertical, .horizontal])
+//        ZStack
+//        ZStack(alignment: .topLeading)
+//        TextField("Email", text: emailBinding)
+//        AngularGradient(colors: [.red, .blue],
+//                        center: .center,
+//                        angle: .degrees(0))
+//        LinearGradient(colors: [.green, .yellow],
+//                       startPoint: .leading,
+//                       endPoint: .trailing)
+//        RadialGradient(colors: [.purple, .pink],
+//                       center: .center,
+//                       startRadius: 0,
+//                       endRadius: 100)
+//    """
+//
+//    // One row of the demo table
+//    struct DemoRow: Identifiable {
+//        let id = UUID()
+//        let code: String
+//        let overload: String
+//        let stitch: String
+//    }
+//
+//    // MARK: - Rows
+//    @State private var rows: [DemoRow] = ConstructorDemoView.buildRows()
+//    
+//    private static func buildRows() -> [DemoRow] {
+//        let tree = Parser.parse(source: Self.sampleSource)
+//        let visitor = POCConstructorVisitor(viewMode: .fixedUp)
+//        visitor.walk(tree)
+//
+//        return visitor.calls.map { call in
+//            let code = call.node.description.trimmingCharacters(in: .whitespacesAndNewlines)
+//
+//            let overload: String
+//            let stitch: String
+//
+//            let (prefix, ctor): (String, any FromSwiftUIViewToStitch)
+//
+//            switch call.kind {
+//            case .text(let c):             (prefix, ctor) = ("Text", c)
+//            case .image(let c):            (prefix, ctor) = ("Image", c)
+//            case .hStack(let c):           (prefix, ctor) = ("HStack", c)
+//            case .vStack(let c):           (prefix, ctor) = ("VStack", c)
+//            case .lazyHStack(let c):       (prefix, ctor) = ("LazyHStack", c)
+//            case .lazyVStack(let c):       (prefix, ctor) = ("LazyVStack", c)
+//            case .circle(let c):           (prefix, ctor) = ("Circle", c)
+//            case .ellipse(let c):          (prefix, ctor) = ("Ellipse", c)
+//            case .rectangle(let c):        (prefix, ctor) = ("Rectangle", c)
+//            case .roundedRectangle(let c): (prefix, ctor) = ("RoundedRectangle", c)
+//            case .scrollView(let c):       (prefix, ctor) = ("ScrollView", c)
+//            case .zStack(let c):           (prefix, ctor) = ("ZStack", c)
+//            case .textField(let c):        (prefix, ctor) = ("TextField", c)
+//            case .angularGradient(let c):  (prefix, ctor) = ("AngularGradient", c)
+//            case .linearGradient(let c):   (prefix, ctor) = ("LinearGradient", c)
+//            case .radialGradient(let c):   (prefix, ctor) = ("RadialGradient", c)
+//            }
+//
+//            overload = "\(prefix).\(ctor)"
+//            if let (layer, values) = ctor.toStitch {
+//                let detail = values.map { ve -> String in
+//                    switch ve {
+//                    case .value(let cv):
+//                        return "\(cv.input)=\(cv.value.display)"
+//                    case .edge(let expr):
+//                        return "edge<\(expr.description)>"
+//                    }
+//                }.joined(separator: ", ")
+//                stitch = "Layer: \(String(describing: layer))  { \(detail) }"
+//            } else {
+//                stitch = "—"
+//            }
+//
+//            return DemoRow(code: code, overload: overload, stitch: stitch)
+//        }
+//    }
+//
+//    var body: some View {
+//        VStack(alignment: .leading) {
+//            Text("SwiftUI → Overload → Stitch mapping")
+//                .font(.headline)
+//                .padding(.bottom, 4)
+//
+//            Button("Run conversions again") {
+//                rows = ConstructorDemoView.buildRows()
+//            }
+//            .padding(.bottom, 4)
+//
+//            List(rows) { row in
+//                logInView("ConstructorDemoView: row: \(row)")
+//                HStack(alignment: .top, spacing: 8) {
+//                    Text(row.code)
+//                        .monospaced()
+//                        .frame(maxWidth: .infinity, alignment: .leading)
+//                        .textSelection(.enabled)
+//
+//                    Text(row.overload)
+//                        .monospaced()
+//                        .frame(maxWidth: .infinity, alignment: .leading)
+//                        .textSelection(.enabled)
+//
+//                    Text(row.stitch)
+//                        .monospaced()
+//                        .frame(maxWidth: .infinity, alignment: .leading)
+//                        .textSelection(.enabled)
+//                }
+//            }
+//        }
+//        .padding()
+//        .border(.red, width: 4)
+//    }
+//}

--- a/Stitch/Graph/StitchAI/Mapping/Declarative/Parameter.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Declarative/Parameter.swift
@@ -9,33 +9,7 @@ import SwiftUI
 import SwiftSyntax
 import SwiftParser
 
-
-// MARK: - Parameter wrapper: literal vs. arbitrary expression ---------
-
-/// A constructor argument that was either a compile‑time literal (`"logo"`,
-/// `.center`, `12`) or an arbitrary Swift expression (`myGap`, `foo()`, etc.).
-//enum Parameter<Value: Equatable>: Equatable {
-//    case literal(Value)
-//    case expression(ExprSyntax)
-//
-//    /// Convenience for pattern‑matching in `toStitch`.
-//    var literal: Value? {
-//        if case .literal(let v) = self { return v }
-//        return nil
-//    }
-//}
-
-//enum ValueOrEdge: Equatable {
-//    case value(CustomInputValue)
-//    case edge(ExprSyntax)
-//}
-
 struct ASTCustomInputValue: Equatable, Hashable {
     let input: CurrentStep.LayerInputPort
     let value: CurrentStep.PortValue
-    
-//    init(_ input: LayerInputPort,  _ value: PortValue) {
-//        self.input = input
-//        self.value = value
-//    }
 }

--- a/Stitch/Graph/StitchAI/Mapping/Declarative/Parameter.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Declarative/Parameter.swift
@@ -14,28 +14,28 @@ import SwiftParser
 
 /// A constructor argument that was either a compile‑time literal (`"logo"`,
 /// `.center`, `12`) or an arbitrary Swift expression (`myGap`, `foo()`, etc.).
-enum Parameter<Value: Equatable>: Equatable {
-    case literal(Value)
-    case expression(ExprSyntax)
+//enum Parameter<Value: Equatable>: Equatable {
+//    case literal(Value)
+//    case expression(ExprSyntax)
+//
+//    /// Convenience for pattern‑matching in `toStitch`.
+//    var literal: Value? {
+//        if case .literal(let v) = self { return v }
+//        return nil
+//    }
+//}
 
-    /// Convenience for pattern‑matching in `toStitch`.
-    var literal: Value? {
-        if case .literal(let v) = self { return v }
-        return nil
-    }
-}
+//enum ValueOrEdge: Equatable {
+//    case value(CustomInputValue)
+//    case edge(ExprSyntax)
+//}
 
-enum ValueOrEdge: Equatable {
-    case value(CustomInputValue)
-    case edge(ExprSyntax)
-}
-
-struct CustomInputValue: Equatable, Hashable {
-    let input: LayerInputPort
-    let value: PortValue
+struct ASTCustomInputValue: Equatable, Hashable {
+    let input: CurrentStep.LayerInputPort
+    let values: [CurrentStep.PortValue]
     
-    init(_ input: LayerInputPort,  _ value: PortValue) {
-        self.input = input
-        self.value = value
-    }
+//    init(_ input: LayerInputPort,  _ value: PortValue) {
+//        self.input = input
+//        self.value = value
+//    }
 }

--- a/Stitch/Graph/StitchAI/Mapping/Declarative/Parameter.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Declarative/Parameter.swift
@@ -32,7 +32,7 @@ import SwiftParser
 
 struct ASTCustomInputValue: Equatable, Hashable {
     let input: CurrentStep.LayerInputPort
-    let values: [CurrentStep.PortValue]
+    let value: CurrentStep.PortValue
     
 //    init(_ input: LayerInputPort,  _ value: PortValue) {
 //        self.input = input

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxUtils.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxUtils.swift
@@ -61,53 +61,14 @@ func formatSyntaxView(_ node: SyntaxView, indent: String = "") -> String {
         result += "\n\(indent)    constructor: nil,"
     }
     
+    let argsString = (try? node.constructorArguments.encodeToPrintableString()) ?? ""
+    let modifiersString = (try? node.modifiers.encodeToPrintableString()) ?? ""
+    
     // Format arguments
-    result += "\n\(indent)    constructorArguments: ["
-    if !node.constructorArguments.isEmpty {
-        for (i, arg) in node.constructorArguments.enumerated() {
-            let label = "\(arg.label ?? "none")"
-            let valuesDesc = arg.value //values.map { "(\($0.value), \(describe($0.syntaxKind)))" }.joined(separator: ", ")
-            result += "\n\(indent)        (label: \(label), values: [\(valuesDesc)])"
-            if i < node.constructorArguments.count - 1 {
-                result += ","
-            }
-        }
-        result += "\n\(indent)    ],"
-    } else {
-        result += "],"
-    }
+    result += "\n\(indent)    constructorArguments: \n\(argsString)"
     
     // Format modifiers
-    result += "\n\(indent)    modifiers: ["
-    if !node.modifiers.isEmpty {
-        for (i, modifier) in node.modifiers.enumerated() {
-            result += "\n\(indent)        SyntaxViewModifier("
-            result += "\n\(indent)            name: \(modifier.name.rawValue),"
-            // value field removed
-            // Format modifier arguments
-            result += "\n\(indent)            arguments: ["
-            if !modifier.arguments.isEmpty {
-                for (j, arg) in modifier.arguments.enumerated() {
-                    let labelDesc = arg.label == nil ? "" : "\"\(arg.label!)\""
-                    let valueDesc = describe(arg.value)
-                    result += "\n\(indent)                (label: \(labelDesc), value: \(valueDesc))"
-                    if j < modifier.arguments.count - 1 {
-                        result += ","
-                    }
-                }
-                result += "\n\(indent)            ]"
-            } else {
-                result += "]"
-            }
-            result += "\n\(indent)        )"
-            if i < node.modifiers.count - 1 {
-                result += ","
-            }
-        }
-        result += "\n\(indent)    ],"
-    } else {
-        result += "],"
-    }
+    result += "\n\(indent)    modifiers: \n\(modifiersString)"
     
     // Format children recursively
     result += "\n\(indent)    children: ["

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxView.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxView.swift
@@ -19,7 +19,7 @@ struct SyntaxView: Equatable {
     
     // arguments to the View's construct,
     // e.g. ("systemName", "star.fill") for Image(systemName: "star.fill")
-    var constructorArguments: [SyntaxViewArgumentData]
+    var constructorArguments: ViewConstructorType?
     
     // representation of SwiftUI view modifiers, including name and arguments
     // e.g. `.padding()`, `.opacity(0.5)`, `.frame(width: 100, height: 200)`
@@ -28,4 +28,9 @@ struct SyntaxView: Equatable {
     var children: [SyntaxView]
     
     var id: UUID  // Unique identifier for the node
+}
+
+enum ViewConstructorType: Equatable, Sendable {
+    case trackedConstructor(ViewConstructor)
+    case other([SyntaxViewArgumentData])
 }

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxView.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxView.swift
@@ -30,7 +30,18 @@ struct SyntaxView: Equatable {
     var id: UUID  // Unique identifier for the node
 }
 
-enum ViewConstructorType: Equatable, Sendable {
+enum ViewConstructorType: Equatable, Sendable, Encodable {
     case trackedConstructor(ViewConstructor)
     case other([SyntaxViewArgumentData])
+}
+
+extension ViewConstructorType {
+    var defaultArgs: [SyntaxViewArgumentData]? {
+        switch self {
+        case .trackedConstructor:
+            return nil
+        case .other(let array):
+            return array
+        }
+    }
 }

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
@@ -10,7 +10,7 @@ import SwiftSyntax
 import SwiftParser
 
 
-struct SyntaxViewModifier: Equatable, Sendable {
+struct SyntaxViewModifier: Equatable, Sendable, Encodable {
 
     // representation of a SwiftUI view modifier name
     let name: SyntaxViewModifierName
@@ -33,17 +33,17 @@ struct SyntaxViewModifier: Equatable, Sendable {
  )
  ```
  */
-struct SyntaxViewArgumentData: Equatable, Hashable, Sendable {
+struct SyntaxViewArgumentData: Equatable, Hashable, Sendable, Encodable {
     let label: String? //SyntaxViewModifierArgumentLabel
     let value: SyntaxViewModifierArgumentType
 }
 
-struct SyntaxViewSimpleData: Hashable, Sendable {
+struct SyntaxViewSimpleData: Hashable, Sendable, Encodable {
     let value: String
     let syntaxKind: SyntaxArgumentLiteralKind
 }
 
-struct SyntaxViewModifierComplexType: Equatable, Hashable, Sendable {
+struct SyntaxViewModifierComplexType: Equatable, Hashable, Sendable, Encodable {
     let typeName: String
     
     let arguments: [SyntaxViewArgumentData]
@@ -61,7 +61,7 @@ struct SyntaxViewModifierComplexType: Equatable, Hashable, Sendable {
     )
  ```
  */
-indirect enum SyntaxViewModifierArgumentType: Equatable, Hashable, Sendable {
+indirect enum SyntaxViewModifierArgumentType: Equatable, Hashable, Sendable, Encodable {
     
     // e.g. .opacity(5.0)
     case simple(SyntaxViewSimpleData)
@@ -113,7 +113,7 @@ extension SyntaxViewModifierArgumentType {
 
 // Note: easier to debug: looks better in debugger and print statements than `MemberAccessExprSyntax`, which contains other data and types we don't need
 // for e.g. "Color.yellow" or ".yellow"
-struct SyntaxViewMemberAccess: Equatable, Hashable, Sendable {
+struct SyntaxViewMemberAccess: Equatable, Hashable, Sendable, Encodable {
     let base: String? // e.g. "Color" in "Color.yellow"; or nil in ".yellow"
     let property: String // e.g. "yellow" in "Color.yellow" or ".yellow"
 }

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
@@ -10,13 +10,13 @@ import SwiftSyntax
 import SwiftParser
 
 
-struct SyntaxViewModifier: Equatable, Hashable, Sendable {
+struct SyntaxViewModifier: Equatable, Sendable {
 
     // representation of a SwiftUI view modifier name
     let name: SyntaxViewModifierName
     
     // representation of argument(s) to SwiftUI view modifer
-    var arguments: [SyntaxViewArgumentData]
+    var arguments: ViewConstructorType
 }
 
 

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewName.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewName.swift
@@ -60,8 +60,7 @@ extension SyntaxViewName {
     
     var isSupported: Bool {
         (try? self.deriveLayerData(id: .init(),
-                                   viewConstructor: nil,
-                                   args: [],
+                                   args: nil,
                                    modifiers: [],
                                    childrenLayers: [])) != nil
     }

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
@@ -45,9 +45,7 @@ extension SyntaxView {
         do {
             let layerDataResult = try self.name.deriveLayerData(
                 id: self.id,
-                viewConstructor: self.constructor,
                 args: self.constructorArguments,
-//                args: [],
                 modifiers: self.modifiers,
                 childrenLayers: childResults.actions)
             

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
@@ -1018,3 +1018,10 @@ enum SyntaxArgumentConstructorContext {
     case viewConstructor(SyntaxViewName, CurrentStep.LayerInputPort)
     case viewModifier(CurrentStep.LayerInputPort)
 }
+
+extension SyntaxViewModifierArgumentType {
+    func derivePortValues() throws -> [CurrentStep.PortValue] {
+        try SyntaxViewName.derivePortValues(from: self,
+                                            context: nil)
+    }
+}

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
@@ -14,6 +14,11 @@ struct LayerDerivationResult {
     let silentErrors: [SwiftUISyntaxError]
 }
 
+struct LayerInputValuesDerivationResult {
+    let inputValues: [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue]
+    let silentErrors: [SwiftUISyntaxError]
+}
+
 extension SyntaxViewModifierName {
     // May or may not correspond to SwiftUI view modifier's own default argument,
     // e.g. `.clipped`'s default argument is for antialiasing, not whether the view is clipped or not (which is what Stitch's clipped layer-input is about).
@@ -367,8 +372,7 @@ extension SyntaxViewName {
     
     /// Leaf-level mapping for **this** node only
     func deriveLayerData(id: UUID,
-                         viewConstructor: ViewConstructor?,
-                         args: [SyntaxViewArgumentData],
+                         args: ViewConstructorType?,
                          modifiers: [SyntaxViewModifier],
                          childrenLayers: [CurrentAIPatchBuilderResponseFormat.LayerData]) throws -> LayerDerivationResult {
         var silentErrors = [SwiftUISyntaxError]()
@@ -376,52 +380,18 @@ extension SyntaxViewName {
         // ── Base mapping from SyntaxViewName → Layer ────────────────────────
         var (layerType, layerData) = try self
             .deriveLayerAndCustomValuesFromName(id: id,
-                                                args: args,
+                                                args: args?.defaultArgs ?? [],
                                                 childrenLayers: childrenLayers)
-                
-        var customInputValuesFromViewConstructor = [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue]()
+           
+        if let viewConstructor = args {
+            let customInputValuesFromViewConstructor = try self
+                .deriveInputValuesData(argsType: viewConstructor,
+                                       id: id,
+                                       layerType: layerType)
 
-        // Handle constructor-arguments
-        // Try to access the SyntaxView.ViewConstructor, if we have one
-        if let customInputValues = try viewConstructor?.value
-            .createCustomValueEvents() {
-            customInputValuesFromViewConstructor = try customInputValues.map { astInputValue in
-                try CurrentAIPatchBuilderResponseFormat
-                    .CustomLayerInputValue(id: id,
-                                           input: astInputValue.input,
-                                           value: astInputValue.value)
-            }
+            layerData.custom_layer_input_values += customInputValuesFromViewConstructor.inputValues
+            silentErrors += customInputValuesFromViewConstructor.silentErrors
         }
-        
-        // Else fall back to legacy style:
-        else {
-            customInputValuesFromViewConstructor = try args.flatMap { arg in
-                do {
-                    
-                    return try self
-                        .deriveCustomValuesFromConstructorArgument(id: id,
-                                                                   layerType: layerType,
-                                                                   arg: arg)
-                } catch let error as SwiftUISyntaxError {
-                    silentErrors.append(error)
-                    return []
-                } catch {
-                    throw error
-                }
-            }
-        }
-        
-        
-        
-        // TODO: remove and rely on ScrollViewConstructor instead
-        if args.isEmpty && self == .scrollView {
-            customInputValuesFromViewConstructor += [
-                try .init(id: id,
-                          input: .scrollYEnabled,
-                          value: .bool(true))
-            ]
-        }
-        
         
         // Handle modifiers
         let customInputValuesFromViewModifiers = try modifiers.compactMap { modifier in
@@ -437,8 +407,6 @@ extension SyntaxViewName {
                 throw error
             }
         }
-        
-        layerData.custom_layer_input_values += customInputValuesFromViewConstructor
         
         // Parse view modifier events
         for modifierEvent in customInputValuesFromViewModifiers {
@@ -460,6 +428,57 @@ extension SyntaxViewName {
         
         return .init(layerData: layerData,
                      silentErrors: silentErrors)
+    }
+    
+    func deriveInputValuesData(argsType: ViewConstructorType,
+                               id: UUID,
+                               layerType: CurrentStep.Layer) throws -> LayerInputValuesDerivationResult {
+        var silentErrors = [SwiftUISyntaxError]()
+        
+        switch argsType {
+        case .trackedConstructor(let viewConstructor):
+            // Handle constructor-arguments
+            // Try to access the SyntaxView.ViewConstructor, if we have one
+            let customInputValues = try viewConstructor.value
+                .createCustomValueEvents()
+            
+            let values = try customInputValues.map { astInputValue in
+                try CurrentAIPatchBuilderResponseFormat
+                    .CustomLayerInputValue(id: id,
+                                           input: astInputValue.input,
+                                           value: astInputValue.value)
+            }
+            return .init(inputValues: values,
+                         silentErrors: silentErrors)
+            
+        case .other(let args):
+            // Else fall back to legacy style:
+            var values = try args.flatMap { arg -> [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue] in
+                do {
+                    return try self
+                        .deriveCustomValuesFromConstructorArgument(id: id,
+                                                                   layerType: layerType,
+                                                                   arg: arg)
+                } catch let error as SwiftUISyntaxError {
+                    silentErrors.append(error)
+                    return []
+                } catch {
+                    throw error
+                }
+            }
+
+            // TODO: remove and rely on ScrollViewConstructor instead
+            if args.isEmpty && self == .scrollView {
+                values += [
+                    try .init(id: id,
+                              input: .scrollYEnabled,
+                              value: .bool(true))
+                ]
+            }
+            
+            return .init(inputValues: values,
+                         silentErrors: silentErrors)
+        }
     }
     
     func deriveLayerAndCustomValuesFromName(
@@ -684,7 +703,7 @@ extension SyntaxViewName {
             
         case .simple(let port):
             guard let newValue = try Self.deriveCustomValue(
-                from: modifier.arguments,
+                from: modifier.arguments.defaultArgs ?? [],
                 modifierName: modifier.name,
                 id: id,
                 port: port,
@@ -705,8 +724,8 @@ extension SyntaxViewName {
             return .layerInputValues(newValues)
             
         case .layerId:
-            guard let rawValue = modifier.arguments.first?.value.simpleValue else {
-                throw SwiftUISyntaxError.unsupportedLayerIdParsing(modifier.arguments)
+            guard let rawValue = modifier.arguments.defaultArgs?.first?.value.simpleValue else {
+                throw SwiftUISyntaxError.unsupportedLayerIdParsing(modifier.arguments.defaultArgs ?? [])
             }
             // Remove escape characters from any quoted substrings
             let unescaped = rawValue.replacingOccurrences(of: "\\\"", with: "\"")
@@ -937,7 +956,7 @@ extension SyntaxViewName {
                                                                     modifier: SyntaxViewModifier) throws -> [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue] {
         var customValues = [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue]()
         
-        guard let angleArgument = modifier.arguments[safe: 0],
+        guard let angleArgument = modifier.arguments.defaultArgs?[safe: 0],
               // TODO: JULY 2: could be degrees OR radians; Stitch currently only supports degrees
               angleArgument.value.complexValue?.typeName.contains(".degrees") ?? false else {
             
@@ -953,7 +972,7 @@ extension SyntaxViewName {
         }
         
         // i.e. viewModifier was .rotation3DEffect, since it had an `axis:` argument
-        if let axisArgument = modifier.arguments[safe: 1],
+        if let axisArgument = modifier.arguments.defaultArgs?[safe: 1],
            axisArgument.label == "axis" {
             let axisPortValues = try Self.derivePortValues(from: axisArgument.value,
                                                            context: nil)  // we can ignore context here

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
@@ -378,15 +378,19 @@ extension SyntaxViewName {
             .deriveLayerAndCustomValuesFromName(id: id,
                                                 args: args,
                                                 childrenLayers: childrenLayers)
-
-        
-        // Handle constructor-arguments
-        
+                
         var customInputValuesFromViewConstructor = [CurrentAIPatchBuilderResponseFormat.CustomLayerInputValue]()
 
+        // Handle constructor-arguments
         // Try to access the SyntaxView.ViewConstructor, if we have one
-        if let customInputValues = try viewConstructor?.getCustomValueEvents(id: id) {
-            customInputValuesFromViewConstructor = customInputValues
+        if let customInputValues = try viewConstructor?.value
+            .createCustomValueEvents() {
+            customInputValuesFromViewConstructor = try customInputValues.map { astInputValue in
+                try CurrentAIPatchBuilderResponseFormat
+                    .CustomLayerInputValue(id: id,
+                                           input: astInputValue.input,
+                                           value: astInputValue.value)
+            }
         }
         
         // Else fall back to legacy style:

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToCode/StitchSyntaxToCode.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToCode/StitchSyntaxToCode.swift
@@ -13,79 +13,79 @@ import SwiftParser
 // MARK: - ViewNode to SwiftUI Code
 
 /// Converts a ViewNode to SwiftUI code string
-func swiftUICode(from node: SyntaxView, indentation: String = "") -> String {
-    var code = ""
-    
-    // Start with the view name
-    code += node.name.rawValue
-    
-    // Add arguments in parentheses if there are any
-    if !node.constructorArguments.isEmpty {
-        code += "("
-        
-        // Add each argument
-        let args = node.constructorArguments.enumerated().map { index, arg -> String in
-            // If there's a label, include it followed by a colon
-            let label = arg.label == nil ? "" : "\(arg.label!): "
-            let values = arg.value //.map { $0.value }.joined(separator: ", ")
-            return "\(label)\(values)"
-        }.joined(separator: ", ")
-        
-        code += args
-        code += ")"
-    } else {
-        // Empty parentheses for initializers without arguments
-        if node.children.isEmpty {
-            code += "()"
-        }
-    }
-    
-    // Add modifiers
-    for modifier in node.modifiers {
-        code += "\n\(indentation)    ."
-        code += modifier.name.rawValue
-        
-        // Handle the modifier value or arguments
-        if !modifier.arguments.isEmpty {
-            // Complex modifier with labeled arguments
-            code += "("
-            
-            let args = modifier.arguments.enumerated().map { index, arg -> String in
-                let label = arg.label == nil ? "" : "\(arg.label!): "
-                return "\(label)\(arg.value)"
-            }.joined(separator: ", ")
-            
-            code += args
-            code += ")"
-        }
-            else {
-            // Modifier with no arguments (like .padding() with no arguments)
-            code += "()"
-        }
-    }
-    
-    // Add children in a closure if there are any
-    if !node.children.isEmpty {
-        if node.constructorArguments.isEmpty {
-            code += " {"
-        } else {
-            code += "{" // Add space before brace for views with arguments
-        }
-        
-        // Add each child with increased indentation
-        for child in node.children {
-            code += "\n\(indentation)    \(swiftUICode(from: child, indentation: indentation + "    "))"
-        }
-        
-        code += "\n\(indentation)}"
-    }
-    
-    return code
-}
-
-// Example usage function to test the conversion
-func testViewNodeToSwiftUI(viewNode: SyntaxView) {
-    let code = swiftUICode(from: viewNode)
-    print("Generated SwiftUI code:\n\n\(code)\n")
-}
+//func swiftUICode(from node: SyntaxView, indentation: String = "") -> String {
+//    var code = ""
+//    
+//    // Start with the view name
+//    code += node.name.rawValue
+//    
+//    // Add arguments in parentheses if there are any
+//    if !node.constructorArguments.isEmpty {
+//        code += "("
+//        
+//        // Add each argument
+//        let args = node.constructorArguments.enumerated().map { index, arg -> String in
+//            // If there's a label, include it followed by a colon
+//            let label = arg.label == nil ? "" : "\(arg.label!): "
+//            let values = arg.value //.map { $0.value }.joined(separator: ", ")
+//            return "\(label)\(values)"
+//        }.joined(separator: ", ")
+//        
+//        code += args
+//        code += ")"
+//    } else {
+//        // Empty parentheses for initializers without arguments
+//        if node.children.isEmpty {
+//            code += "()"
+//        }
+//    }
+//    
+//    // Add modifiers
+//    for modifier in node.modifiers {
+//        code += "\n\(indentation)    ."
+//        code += modifier.name.rawValue
+//        
+//        // Handle the modifier value or arguments
+//        if !modifier.arguments.isEmpty {
+//            // Complex modifier with labeled arguments
+//            code += "("
+//            
+//            let args = modifier.arguments.enumerated().map { index, arg -> String in
+//                let label = arg.label == nil ? "" : "\(arg.label!): "
+//                return "\(label)\(arg.value)"
+//            }.joined(separator: ", ")
+//            
+//            code += args
+//            code += ")"
+//        }
+//            else {
+//            // Modifier with no arguments (like .padding() with no arguments)
+//            code += "()"
+//        }
+//    }
+//    
+//    // Add children in a closure if there are any
+//    if !node.children.isEmpty {
+//        if node.constructorArguments.isEmpty {
+//            code += " {"
+//        } else {
+//            code += "{" // Add space before brace for views with arguments
+//        }
+//        
+//        // Add each child with increased indentation
+//        for child in node.children {
+//            code += "\n\(indentation)    \(swiftUICode(from: child, indentation: indentation + "    "))"
+//        }
+//        
+//        code += "\n\(indentation)}"
+//    }
+//    
+//    return code
+//}
+//
+//// Example usage function to test the conversion
+//func testViewNodeToSwiftUI(viewNode: SyntaxView) {
+//    let code = swiftUICode(from: viewNode)
+//    print("Generated SwiftUI code:\n\n\(code)\n")
+//}
 


### PR DESCRIPTION
This PR both simplifies and improves the new view constructor derivation logic. By leveraging existing processes, we are able to simplify view constructor logic to be nothing more than an enum of various existing overloads. Allowing existing helpers to parse argument data.