### PR TITLE
Fixed inputs encoding for image gen request

### DIFF
--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AICodeGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AICodeGenRequest.swift
@@ -13,7 +13,7 @@ struct AICodeGenFromGraphRequest: StitchAIGraphBuilderRequestable {
     let id: UUID
     let userPrompt: String             // User's input prompt
     let config: OpenAIRequestConfig // Request configuration settings
-    let body: AICodeGenFromGraphRequestBody_V0.AICodeGenFromGraphRequestBody
+    let body: AICodeGenRequestBody_V0.AICodeGenRequestBody
     static let willStream: Bool = false
     
     @MainActor
@@ -29,9 +29,9 @@ struct AICodeGenFromGraphRequest: StitchAIGraphBuilderRequestable {
         self.config = config
         
         // Construct http payload
-        self.body = try AICodeGenFromGraphRequestBody_V0
-            .AICodeGenFromGraphRequestBody(currentGraphData: currentGraphData,
-                                           systemPrompt: systemPrompt)
+        self.body = try AICodeGenRequestBody_V0
+            .AICodeGenRequestBody(currentGraphData: currentGraphData,
+                                  systemPrompt: systemPrompt)
     }
     
     func createCode(document: StitchDocumentViewModel,
@@ -78,7 +78,7 @@ struct AICodeGenFromImageRequest: StitchAIGraphBuilderRequestable {
     let id: UUID
     let userPrompt: String             // User's input prompt
     let config: OpenAIRequestConfig // Request configuration settings
-    let body: AICodeGenFromImageRequestBody_V0.AICodeGenFromImageRequestBody
+    let body: AICodeGenRequestBody_V0.AICodeGenRequestBody
     static let willStream: Bool = false
     
     init(prompt: String,
@@ -93,8 +93,8 @@ struct AICodeGenFromImageRequest: StitchAIGraphBuilderRequestable {
         self.config = config
         
         // Construct http payload
-        self.body = try AICodeGenFromImageRequestBody_V0
-            .AICodeGenFromImageRequestBody(currentGraphData: currentGraphData,
+        self.body = try AICodeGenRequestBody_V0
+            .AICodeGenRequestBody(currentGraphData: currentGraphData,
                                            systemPrompt: systemPrompt)
     }
     
@@ -112,8 +112,6 @@ struct AICodeGenFromImageRequest: StitchAIGraphBuilderRequestable {
                            resultType: StitchAIRequestBuilder_V0.SourceCodeResponse.self)
         logToServerIfRelease("Initial code:\n\(decodedSwiftUICode.source_code)")
         
-        let newCodeToolMessage = try msgFromSourceCodeRequest.createNewToolMessage()
-        
         return (decodedSwiftUICode.source_code, msgFromSourceCodeRequest)
     }
 }
@@ -122,7 +120,6 @@ extension StitchAIGraphBuilderRequestable {
     @MainActor
     func getRequestTask(userPrompt: String,
                         document: StitchDocumentViewModel) throws -> Task<Result<AIGraphData_V0.GraphData, any Error>, Never> {
-        let currentGraphData = try CurrentAIGraphData.GraphData(from: document.visibleGraph.createSchema())
         let systemPrompt = try StitchAIManager.stitchAIGraphBuilderSystem(graph: document.visibleGraph,
                                                                           requestType: Self.type)
         let request = self

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AICodeGen/AICodeGenRequestBody_V0.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AICodeGen/AICodeGenRequestBody_V0.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum AICodeGenFromGraphRequestBody_V0 {
+enum AICodeGenRequestBody_V0 {
     //    static let systemMarkdownLocation = "AIGraphBuilderSystemPrompt_V0"
     
     //    static func getSystemPrompt() throws -> String {
@@ -21,62 +21,53 @@ enum AICodeGenFromGraphRequestBody_V0 {
     //        return systemPrompt
     //    }
     
-    // https://platform.openai.com/docs/api-reference/making-requests
-    struct AICodeGenFromGraphRequestBody: StitchAIRequestableFunctionBody {
+    struct AICodeGenRequestBody: StitchAIRequestableFunctionBody {
         let model: String = "o4-mini-2025-04-16"
         let n: Int = 1
         let temperature: Double = 1.0
         let messages: [OpenAIMessage]
-        let tools = StitchAIRequestBuilder_V0.StitchAIRequestType.userPrompt.allOpenAIFunctions
-        let tool_choice = StitchAIRequestBuilder_V0.StitchAIRequestBuilderFunction.codeBuilder.function
+        let tools: [OpenAIFunction]
+        let tool_choice: OpenAIFunction
         let stream: Bool = false
-        
-        init(currentGraphData: CurrentAIGraphData.GraphData,
-             systemPrompt: String) throws {
-            let codeGenAssistantPrompt = try StitchAIManager.aiCodeGenSystemPromptGenerator(requestType: .userPrompt)
-            
-            let inputsString = try currentGraphData.encodeToPrintableString()
-            
-            print("AICodeGenRequestBody: incoming graph data:\n\((try? currentGraphData.encodeToPrintableString()) ?? "")")
-            
-            self.messages = [
-                .init(role: .system,
-                      content: systemPrompt),
-                .init(role: .system,
-                      content: codeGenAssistantPrompt),
-                .init(role: .user,
-                      content: inputsString)
-            ]
-        }
     }
 }
 
-enum AICodeGenFromImageRequestBody_V0 {
-    struct AICodeGenFromImageRequestBody: StitchAIRequestableFunctionBody {
-        let model: String = "o4-mini-2025-04-16"
-        let n: Int = 1
-        let temperature: Double = 1.0
-        let messages: [OpenAIMessage]
-        let tools = StitchAIRequestBuilder_V0.StitchAIRequestType.imagePrompt.allOpenAIFunctions
-        let tool_choice = StitchAIRequestBuilder_V0.StitchAIRequestBuilderFunction.codeBuilderFromImage.function
-        let stream: Bool = false
+extension AICodeGenRequestBody_V0.AICodeGenRequestBody {
+    init(currentGraphData: CurrentAIGraphData.GraphData,
+         systemPrompt: String) throws {
+        self.tools = StitchAIRequestBuilder_V0.StitchAIRequestType.userPrompt.allOpenAIFunctions
+        self.tool_choice = StitchAIRequestBuilder_V0.StitchAIRequestBuilderFunction.codeBuilder.function
         
-        init(currentGraphData: CurrentAIGraphData.GraphData,
-             systemPrompt: String) throws {
-            let codeGenAssistantPrompt = try StitchAIManager.aiCodeGenSystemPromptGenerator(requestType: .imagePrompt)
-            
-            let inputsString = try currentGraphData.encodeToPrintableString()
-            
-            print("AICodeGenRequestBody: incoming graph data:\n\((try? currentGraphData.encodeToPrintableString()) ?? "")")
-            
-            self.messages = [
-                .init(role: .system,
-                      content: systemPrompt),
-                .init(role: .system,
-                      content: codeGenAssistantPrompt),
-                .init(role: .user,
-                      content: inputsString)
-            ]
-        }
+        let codeGenAssistantPrompt = try StitchAIManager.aiCodeGenSystemPromptGenerator(requestType: .userPrompt)
+        
+        let inputsString = try currentGraphData.encodeToPrintableString()
+        
+        print("AICodeGenRequestBody: incoming graph data:\n\((try? currentGraphData.encodeToPrintableString()) ?? "")")
+        
+        self.messages = [
+            .init(role: .system,
+                  content: systemPrompt),
+            .init(role: .system,
+                  content: codeGenAssistantPrompt),
+            .init(role: .user,
+                  content: inputsString)
+        ]
+    }
+   
+    init(userPrompt: String,
+         systemPrompt: String) throws {
+        self.tools = StitchAIRequestBuilder_V0.StitchAIRequestType.imagePrompt.allOpenAIFunctions
+        self.tool_choice = StitchAIRequestBuilder_V0.StitchAIRequestBuilderFunction.codeBuilderFromImage.function
+        
+        let codeGenAssistantPrompt = try StitchAIManager.aiCodeGenSystemPromptGenerator(requestType: .imagePrompt)
+        
+        self.messages = [
+            .init(role: .system,
+                  content: systemPrompt),
+            .init(role: .system,
+                  content: codeGenAssistantPrompt),
+            .init(role: .user,
+                  content: userPrompt)
+        ]
     }
 }


### PR DESCRIPTION
We were passing an incorrect parameter for the body struct of image gen. Should have been the user prompt, now fixed.

Also removed redundant data structures here.
