### PR TITLE
Reverted OpenAI functions implementation

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -4537,10 +4537,10 @@
 		B5F3D0B02DE3CBBA00103676 /* PromptGenerator */ = {
 			isa = PBXGroup;
 			children = (
-				B5675A922E31A94A00269ABB /* AICodeEditSystemPromptGenerator.swift */,
 				B5CD1A282E2AB907009CDF74 /* AIGraphBuilderSystemPromptGenerator.swift */,
 				B5EFD5B02D5D8967006A68FB /* StitchAISystemPromptGenerator.swift */,
 				B5B31CE72E0C6769003EABA2 /* AICodeGenSystemPromptGenerator.swift */,
+				B5675A922E31A94A00269ABB /* AICodeEditSystemPromptGenerator.swift */,
 				B503B0CD2E0D826A004F5EB8 /* AIPatchBuilderSystemPromptGenerator.swift */,
 			);
 			path = PromptGenerator;

--- a/Stitch/App/Serialization/SerializationUtils.swift
+++ b/Stitch/App/Serialization/SerializationUtils.swift
@@ -28,6 +28,10 @@ extension Encodable {
     }
     
     func encodeToString() throws -> String {
+        if let stringValue = self as? String {
+            return stringValue
+        }
+        
         let data = try self.encodeToData()
         return try data.createJsonString()
     }

--- a/Stitch/App/Serialization/SerializationUtils.swift
+++ b/Stitch/App/Serialization/SerializationUtils.swift
@@ -23,6 +23,10 @@ extension Encodable {
     }
     
     func encodeToPrintableString() throws -> String {
+        if let stringValue = self as? String {
+            return stringValue
+        }
+        
         let data = try self.encodeToData()
         return try data.createPrintableJsonString()
     }

--- a/Stitch/Graph/StitchAI/GraphPrompting/API/OpenAIRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/OpenAIRequest.swift
@@ -277,42 +277,33 @@ extension StitchAIRequestable {
 
 extension StitchAIFunctionRequestable {
     /// Called when an OpenAI function expects subsequent functions to call.
-    func requestMessagesForNextFn<ResultType>(returnedFnType: StitchAIRequestBuilder_V0.StitchAIRequestBuilderFunction,
-                                              requestType: StitchAIRequestBuilder_V0.StitchAIRequestType,
-                                              document: StitchDocumentViewModel,
-                                              aiManager: StitchAIManager,
-                                              paramsCallback: @escaping ((ResultType) -> ResultType)) async throws -> [OpenAIMessage] where ResultType: Codable {
-        let result = await aiManager.startOpenAIRequest(self,
-                                                        attempt: 0,
-                                                        lastCapturedError: "",
-                                                        document: document)
-        switch result {
-            
-        case .success(var msg):
-            log("StitchAIRequestable: requestForMessage: success")
-            let supplementarySystemPrompt = OpenAIMessage(
-                role: .system,
-                content: try returnedFnType.getAssistantPrompt(for: requestType)
-            )
-            
-            // Mutate Params given user feedback
-            let decodedParams = try msg
-                .decodeMessage(document: document,
-                               aiManager: aiManager,
-                               resultType: ResultType.self)
-            let newDecodedParams = paramsCallback(decodedParams)
-            msg.tool_calls?[0].function.arguments = try newDecodedParams.encodeToString()
-            
-            // Create tool message for function response
-            let responseToolMsg = try msg.createNewToolMessage()
-            
-            return [supplementarySystemPrompt, msg, responseToolMsg]
-        case .failure(let failure):
-            log("StitchAIRequestable: requestForMessage: failure")
-            logToServerIfRelease("AICodeGenRequest: getRequestTask: request.request: failure: \(failure.localizedDescription)")
-            throw failure
-        }
-    }
+//    func requestMessagesForNextFn<ResultType>(returnedFnType: StitchAIRequestBuilder_V0.StitchAIRequestBuilderFunction,
+//                                              requestType: StitchAIRequestBuilder_V0.StitchAIRequestType,
+//                                              document: StitchDocumentViewModel,
+//                                              aiManager: StitchAIManager) async throws -> [OpenAIMessage] where ResultType: Codable {
+//        let result = await aiManager.startOpenAIRequest(self,
+//                                                        attempt: 0,
+//                                                        lastCapturedError: "",
+//                                                        document: document)
+//        switch result {
+//            
+//        case .success(var msg):
+//            log("StitchAIRequestable: requestForMessage: success")
+//            let supplementarySystemPrompt = OpenAIMessage(
+//                role: .system,
+//                content: try returnedFnType.getAssistantPrompt(for: requestType)
+//            )
+//            
+//            // Create tool message for function response
+//            let responseToolMsg = try msg.createNewToolMessage()
+//            
+//            return [supplementarySystemPrompt, msg, responseToolMsg]
+//        case .failure(let failure):
+//            log("StitchAIRequestable: requestForMessage: failure")
+//            logToServerIfRelease("AICodeGenRequest: getRequestTask: request.request: failure: \(failure.localizedDescription)")
+//            throw failure
+//        }
+//    }
     
     /// Called when last OpenAI function is called.
     func requestMessageForFn(document: StitchDocumentViewModel,

--- a/Stitch/Graph/StitchAI/GraphPrompting/API/OpenAIStreamHelpers.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/OpenAIStreamHelpers.swift
@@ -146,7 +146,7 @@ extension StitchAIManager {
                                 with request: AIRequest,
                                 attempt: Int,
                                 document: StitchDocumentViewModel) async -> Result<AIRequest.RequestResponsePayload, Error> where AIRequest: StitchAIRequestable {
-        if AIRequest.willStream {
+        if request.willStream {
             return await self.openStream(for: urlRequest,
                                    with: request,
                                    attempt: attempt)

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/OpenAIRequestable.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/OpenAIRequestable.swift
@@ -16,7 +16,7 @@ protocol OpenAIRequestable: Encodable {
     var response_format: FormatType { get }
 }
 
-protocol OpenAIResponseFormatable: Encodable {
+protocol OpenAIResponseFormatable: Encodable, Sendable {
     associatedtype JsonSchema: OpenAIJsonSchema
     
     var type: String { get }

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/OpenAISchema/OpenAIStructuredOutputs.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/OpenAISchema/OpenAIStructuredOutputs.swift
@@ -126,7 +126,7 @@ struct OpenAIFunctionPayload: Encodable {
 
 struct OpenAISchema {
     // MARK: OpenAI requires a specific ID format that if unmatched will break requests
-    static let sampleId = "call_BS6GNUPw4tDLPlWBBqvKlr3O"
+//    static let sampleId = "call_BS6GNUPw4tDLPlWBBqvKlr3O"
     
     var type: OpenAISchemaType
     var properties: (any Encodable & Sendable)?

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/OpenAISchema/OpenAIStructuredOutputs.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/OpenAISchema/OpenAIStructuredOutputs.swift
@@ -277,6 +277,17 @@ struct OpenAIRequestBody: Encodable {
     var stream: Bool = false
 }
 
+struct OpenAIStructuredOutputsRequestBody<ResponseFormat: OpenAIResponseFormatable>: Encodable {
+    var model: String = "o4-mini-2025-04-16"
+    var n: Int = 1
+    var temperature: Double = 1.0
+    var response_format: ResponseFormat
+    var messages: [OpenAIMessage]
+    var tools: [OpenAIFunction]?
+    var tool_choice: OpenAIFunction? = nil
+    var stream: Bool = false
+}
+
 //extension OpenAIRequestBody {
 //    /// Sets up request body for OpenAI. Assign a `toolChoice` if you want the response object to be a function.
 //    init(messages: [OpenAIMessage],

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/OpenAISchema/OpenAIStructuredOutputs.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/OpenAISchema/OpenAIStructuredOutputs.swift
@@ -272,27 +272,27 @@ struct OpenAIRequestBody: Encodable {
     var n: Int = 1
     var temperature: Double = 1.0
     var messages: [OpenAIMessage]
-    var tools: [OpenAIFunction] = []
+    var tools: [OpenAIFunction]?
     var tool_choice: OpenAIFunction? = nil
     var stream: Bool = false
 }
 
-extension OpenAIRequestBody {
-    /// Sets up request body for OpenAI. Assign a `toolChoice` if you want the response object to be a function.
-    init(messages: [OpenAIMessage],
-         type: StitchAIRequestBuilder_V0.StitchAIRequestType,
-         functionType: StitchAIRequestBuilder_V0.StitchAIRequestBuilderFunction? = nil) {
-        let tools = type.allOpenAIFunctions
-        
-        if let functionType = functionType {
-            self = .init(messages: messages,
-                         tools: tools,
-                         tool_choice: functionType.function)
-        } else {
-            // Basically runs the unstructured assistant response
-            self = .init(messages: messages,
-                         tools: tools,
-                         tool_choice: .init(type: .none))
-        }
-    }
-}
+//extension OpenAIRequestBody {
+//    /// Sets up request body for OpenAI. Assign a `toolChoice` if you want the response object to be a function.
+//    init(messages: [OpenAIMessage],
+//         type: StitchAIRequestBuilder_V0.StitchAIRequestType,
+//         functionType: StitchAIRequestBuilder_V0.StitchAIRequestBuilderFunction? = nil) {
+//        let tools = type.allOpenAIFunctions
+//        
+//        if let functionType = functionType {
+//            self = .init(messages: messages,
+//                         tools: tools,
+//                         tool_choice: functionType.function)
+//        } else {
+//            // Basically runs the unstructured assistant response
+//            self = .init(messages: messages,
+//                         tools: tools,
+//                         tool_choice: .init(type: .none))
+//        }
+//    }
+//}

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/OpenAISchema/OpenAIStructuredOutputs.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/OpenAISchema/OpenAIStructuredOutputs.swift
@@ -126,7 +126,7 @@ struct OpenAIFunctionPayload: Encodable {
 
 struct OpenAISchema {
     // MARK: OpenAI requires a specific ID format that if unmatched will break requests
-//    static let sampleId = "call_BS6GNUPw4tDLPlWBBqvKlr3O"
+    static let sampleId = "call_BS6GNUPw4tDLPlWBBqvKlr3O"
     
     var type: OpenAISchemaType
     var properties: (any Encodable & Sendable)?

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIGraphCreationRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIGraphCreationRequest.swift
@@ -27,7 +27,7 @@ struct AIGraphCreationRequest: StitchAIRequestable {
     let userPrompt: String             // User's input prompt
     let config: OpenAIRequestConfig // Request configuration settings
     let body: AIGraphCreationRequestBody
-    static let willStream: Bool = true
+    let willStream: Bool = true
     
     /// Initialize a new request with prompt and optional configuration
     @MainActor

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIGraphDescriptionRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIGraphDescriptionRequest.swift
@@ -12,7 +12,7 @@ struct AIGraphDescriptionRequest: StitchAIRequestable {
     let userPrompt: String              // User's input prompt
     let config: OpenAIRequestConfig     // Request configuration settings
     let body: AIGraphDescriptionRequestBody
-    static let willStream: Bool = false
+    let willStream: Bool = false
     
     @MainActor
     init(config: OpenAIRequestConfig = .default,

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIJsNodeEditRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIJsNodeEditRequest.swift
@@ -12,7 +12,7 @@ struct AIEditJSNodeRequest: StitchAIRequestable {
     let userPrompt: String             // User's input prompt
     let config: OpenAIRequestConfig // Request configuration settings
     let body: AIEditJsNodeRequestBody
-    static let willStream: Bool = false
+    let willStream: Bool = false
     
     // Tracks origin node of request
     let nodeId: NodeId

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
@@ -11,9 +11,9 @@ enum AIPatchBuilderRequestError: Error {
     case nodeIdNotFound
 }
 
-struct AIPatchBuilderFunctionInputs: Encodable {
+struct AIPatchBuilderFunctionInputs: Codable {
     let swiftui_source_code: String
-    let layer_data_list: [AIGraphData_V0.LayerData]
+    let layer_data_list: String
 }
 
 struct AIPatchBuilderFunctionInputsSchema: Encodable {

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequest.swift
@@ -85,17 +85,33 @@ struct AICodeGenFromImageRequest: StitchAICodeCreator {
     func createCode(document: StitchDocumentViewModel,
                     aiManager: StitchAIManager,
                     systemPrompt: String) async throws -> String {
-        let imageRequestInputs = AICodeGenFromImageInputs(
-            user_prompt: self.userPrompt,
-            image_data: .init(base64Image: self.base64Image)
-        )
+        
+        // TODO: images aren't being decoded properly from OpenAI, will come back
+        fatalError()
+        
+//        let imageRequestInput = OpenAIUserImageContent(base64Image: self.base64Image)
+//        let userRequestInput = OpenAIUserTextContent(text: self.userPrompt)
+//        let userInputsFull = try [
+//            try imageRequestInput.encodeToString(),
+//            try userRequestInput.encodeToString()
+//        ].encodeToString()
+        
+        var content: [OpenAIMessageContent] = [
+             .text(userPrompt)
+         ]
+        
+        let imageUrl = "data:image/jpeg;base64,\(self.base64Image)"
+         content.append(.image(url: imageUrl, detail: "high"))
+
+         // TODO: AI IMAGE IS WIP
+         let encodedContent = try content.encodeToPrintableString()
         
         let createCodeRequest = try OpenAIChatCompletionRequest(
             id: self.id,
             requestType: Self.type,
             systemPrompt: systemPrompt,
             assistantPrompt: try StitchAIManager.aiCodeGenSystemPromptGenerator(requestType: .imagePrompt),
-            inputs: imageRequestInputs)
+            inputs: encodedContent)
         
         let codeResult = try await createCodeRequest
             .request(document: document,

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequest.swift
@@ -215,37 +215,24 @@ extension StitchAICodeCreator {
         let patchBuilderInputs = AIPatchBuilderFunctionInputs(
             swiftui_source_code: swiftUICode,
             layer_data_list: try layerDataList.encodeToString())
-//        
-//        // Update parameters of patch builder request with updated layer list
-//        patchBuilderToolCall.tool_calls?[0].function.arguments = try patchBuilderInputs.encodeToString()
-//        
-//        let processPatchBuilderMsgs = try OpenAIFunctionRequest
-//            .createChainedFnMessages(toolResponse: patchBuilderToolCall,
-//                                     functionType: .processPatchData,
-//                                     requestType: Self.type,
-//                                     inputsArguments: nil)
-//        
-//        allMessages += processPatchBuilderMsgs
-//        
-//        let processPatchDataRequest = OpenAIFunctionRequest(
-//            id: self.id,
-//            functionType: .processPatchData,
-//            requestType: Self.type,
-//            messages: allMessages)
-//        
-//        let processPatchDataToolCall = try await processPatchDataRequest
-//            .requestMessageForFn(document: document,
-//                                 aiManager: aiManager)
-//        
-//        let patchBuildResult = try processPatchDataToolCall
-//            .decodeMessage(document: document,
-//                           aiManager: aiManager,
-//                           resultType: CurrentAIGraphData.PatchData.self)
-//
-//        logToServerIfRelease("Successful patch builder result: \(try patchBuildResult.encodeToPrintableString())")
-//        let graphData = AIGraphData_V0.GraphData(layer_data_list: layerDataList,
-//                                                 patch_data: patchBuildResult)
-//        return (graphData, allDiscoveredErrors)
+        
+        let patchBuilderRequest = try OpenAIChatCompletionStructuredOutputsRequest(
+            id: self.id,
+            requestType: Self.type,
+            systemPrompt: systemPrompt,
+            assistantPrompt: try StitchAIManager.aiPatchBuilderSystemPromptGenerator(),
+            responseFormat: AIPatchBuilderResponseFormat_V0.AIPatchBuilderResponseFormat(),
+            inputs: patchBuilderInputs)
+        
+        let patchBuilderResult = try await patchBuilderRequest
+            .request(document: document,
+                     aiManager: aiManager)
+        
+        logToServerIfRelease("Successful patch builder result: \(try patchBuilderResult.encodeToPrintableString())")
+        
+        let graphData = AIGraphData_V0.GraphData(layer_data_list: layerDataList,
+                                                 patch_data: patchBuilderResult)
+        return (graphData, allDiscoveredErrors)
     }
 }
 

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequest.swift
@@ -42,13 +42,17 @@ struct AICodeGenFromGraphRequest: StitchAICodeCreator {
         
         log("AICodeGenFromGraphRequest.createCode initial result:\n\(codeResult)")
         
+        let editInputs = StitchAIRequestBuilder_V0.EditCodeParams(
+            source_code: codeResult,
+            user_prompt: userPrompt)
+        
         // Request for code edit
         let codeEditRequest = try OpenAIChatCompletionRequest(
             id: self.id,
             requestType: Self.type,
             systemPrompt: systemPrompt,
             assistantPrompt: try StitchAIManager.aiCodeEditSystemPromptGenerator(requestType: Self.type),
-            inputs: self.userPrompt)
+            inputs: editInputs)
         
         let codeEditResult = try await codeEditRequest
             .request(document: document,
@@ -116,6 +120,8 @@ extension StitchAICodeCreator {
     @MainActor
     func getRequestTask(userPrompt: String,
                         document: StitchDocumentViewModel) throws -> Task<Result<AIGraphData_V0.GraphData, any Error>, Never> {
+        log("getRequestTask: user prompt: \(userPrompt)")
+        
         let systemPrompt = try StitchAIManager.stitchAIGraphBuilderSystem(graph: document.visibleGraph,
                                                                           requestType: Self.type)
         let request = self

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequest.swift
@@ -27,7 +27,7 @@ struct AICodeGenFromGraphRequest: StitchAICodeCreator {
     
     func createCode(document: StitchDocumentViewModel,
                     aiManager: StitchAIManager,
-                    systemPrompt: String) async throws -> OpenAIMessage {
+                    systemPrompt: String) async throws -> (OpenAIMessage, [OpenAIMessage]) {
         var allMessages = [OpenAIMessage(
             role: .system,
             content: systemPrompt
@@ -80,7 +80,7 @@ struct AICodeGenFromGraphRequest: StitchAICodeCreator {
         }
 #endif
         
-        return editToolCall
+        return (editToolCall, allMessages)
     }
 }
 
@@ -106,7 +106,7 @@ struct AICodeGenFromImageRequest: StitchAICodeCreator {
     
     func createCode(document: StitchDocumentViewModel,
                     aiManager: StitchAIManager,
-                    systemPrompt: String) async throws -> OpenAIMessage {
+                    systemPrompt: String) async throws -> (OpenAIMessage, [OpenAIMessage]) {
         fatalError()
 //
 //        let imageRequestInputs = AICodeGenFromImageInputs(
@@ -209,12 +209,7 @@ extension StitchAICodeCreator {
                                 systemPrompt: String) async throws -> (AIGraphData_V0.GraphData, [SwiftUISyntaxError]) {
         log("SUCCESS: userPrompt: \(userPrompt)")
         
-        var allMessages: [OpenAIMessage] = [
-            .init(role: .system,
-                  content: systemPrompt)
-        ]
-        
-        let codeToolCallMsg = try await self
+        var (codeToolCallMsg, allMessages) = try await self
             .createCode(document: document,
                         aiManager: aiManager,
                         systemPrompt: systemPrompt)

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequest.swift
@@ -47,7 +47,7 @@ struct AICodeGenFromGraphRequest: StitchAICodeCreator {
             id: self.id,
             requestType: Self.type,
             systemPrompt: systemPrompt,
-            assistantPrompt: try StitchAIManager.aiCodeGenSystemPromptGenerator(requestType: Self.type),
+            assistantPrompt: try StitchAIManager.aiCodeEditSystemPromptGenerator(requestType: Self.type),
             inputs: self.userPrompt)
         
         let codeEditResult = try await codeEditRequest

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequest.swift
@@ -85,34 +85,23 @@ struct AICodeGenFromImageRequest: StitchAICodeCreator {
     func createCode(document: StitchDocumentViewModel,
                     aiManager: StitchAIManager,
                     systemPrompt: String) async throws -> String {
-        fatalError()
-//
-//        let imageRequestInputs = AICodeGenFromImageInputs(
-//            user_prompt: self.userPrompt,
-//            image_data: .init(base64Image: self.base64Image)
-//        )
-//        
-//        let toolMessages = try OpenAIFunctionRequest.createInitialFnMessages(
-//            functionType: .codeBuilderFromImage,
-//            requestType: Self.type,
-//            inputsArguments: imageRequestInputs,
-//            systemPrompt: systemPrompt)
-//        
-//        let createCodeRequest = OpenAIFunctionRequest(
-//            id: self.id,
-//            functionType: .processCode,
-//            requestType: Self.type,
-//            messages: toolMessages)
-//        
-//        let msgFromCodeCreation = try await createCodeRequest
-//            .requestMessageForFn(document: document, aiManager: aiManager)
-//
-//        let decodedSwiftUICode = try msgFromCodeCreation
-//            .decodeMessage(document: document,
-//                           aiManager: aiManager,
-//                           resultType: StitchAIRequestBuilder_V0.SourceCodeResponse.self)
-//
-//        return decodedSwiftUICode.source_code
+        let imageRequestInputs = AICodeGenFromImageInputs(
+            user_prompt: self.userPrompt,
+            image_data: .init(base64Image: self.base64Image)
+        )
+        
+        let createCodeRequest = try OpenAIChatCompletionRequest(
+            id: self.id,
+            requestType: Self.type,
+            systemPrompt: systemPrompt,
+            assistantPrompt: try StitchAIManager.aiCodeGenSystemPromptGenerator(requestType: .imagePrompt),
+            inputs: imageRequestInputs)
+        
+        let codeResult = try await createCodeRequest
+            .request(document: document,
+                     aiManager: aiManager)
+        
+        return codeResult
     }
 }
 

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequest.swift
@@ -40,18 +40,18 @@ struct AICodeGenFromGraphRequest: StitchAICodeCreator {
             id: self.id,
             functionType: .codeEditor,
             requestType: Self.type,
-            messages: editRequestMessages + [
-                // Add user prompt
-                .init(role: .user,
-                      content: self.userPrompt)
-            ])
+            messages: editRequestMessages)
         
         // Creates code and then creates tool call for edit request
         let editRequestToolCalls = try await editCodeFnRequest
             .requestMessagesForNextFn(returnedFnType: .codeEditor,
                                       requestType: Self.type,
                                       document: document,
-                                      aiManager: aiManager)
+                                      aiManager: aiManager) { params -> StitchAIRequestBuilder_V0.EditCodeParams in
+                var params = params
+                params.user_prompt = self.userPrompt
+                return params
+            }
       
         // Debug only--print SwiftUI code result
 #if !RELEASE

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequest.swift
@@ -34,23 +34,23 @@ struct AICodeGenFromGraphRequest: StitchAICodeCreator {
         )]
         
         // Create tool message for code creation
-        let codeCreateRequestMessages = try OpenAIFunctionRequest
+        let (createCodeToolCall, codeCreateRequestMessages) = try OpenAIFunctionRequest
             .createInitialFnMessages(functionType: .codeBuilder,
                                      requestType: Self.type,
                                      inputsArguments: self.currentGraphData)
         allMessages += codeCreateRequestMessages
         
-        // Request for code creation
-        let codeCreateFnRequest = OpenAIFunctionRequest(
-            id: self.id,
-            functionType: .codeBuilder,
-            requestType: Self.type,
-            messages: allMessages)
-        
-        // Creates function stub for code create
-        let createCodeToolCall = try await codeCreateFnRequest
-            .requestMessageForFn(document: document,
-                                 aiManager: aiManager)
+//        // Request for code creation
+//        let codeCreateFnRequest = OpenAIFunctionRequest(
+//            id: self.id,
+//            functionType: .codeBuilder,
+//            requestType: Self.type,
+//            messages: allMessages)
+//        
+//        // Creates function stub for code create
+//        let createCodeToolCall = try await codeCreateFnRequest
+//            .requestMessageForFn(document: document,
+//                                 aiManager: aiManager)
     
         // Create tool message for code edit
         let codeEditRequestMessages = try OpenAIFunctionRequest

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequest.swift
@@ -85,7 +85,7 @@ struct AICodeGenFromGraphRequest: StitchAICodeCreator {
             .createChainedFnMessages(toolResponse: editToolCall,
                                      functionType: .processCode,
                                      requestType: Self.type,
-                                     inputsArguments: self.userPrompt)
+                                     inputsArguments: nil)
         allMessages += codeProcessingRequestMessages
         
         let processCodeRequest = OpenAIFunctionRequest(

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequestInputs.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequestInputs.swift
@@ -7,15 +7,19 @@
 
 import Foundation
 
-struct AICodeGenFromImageInputs: Codable {
-    let user_prompt: String
-    let image_data: OpenAIUserImageContent
+//struct AICodeGenFromImageInputs: Codable {
+//    let user_prompt: String
+//    let image_data: OpenAIUserImageContent
+//}
+
+struct OpenAIUserTextContent: Encodable {
+    let type = "text"
+    let text: String
 }
 
-struct OpenAIUserImageContent: Codable {
+struct OpenAIUserImageContent: Encodable {
     var type = "image_url"
     var image_url: OpenAIImageUrl
-    var detail = "high"
     
     init(base64Image: String) {
         self.image_url = .init(base64Image: base64Image)
@@ -24,22 +28,53 @@ struct OpenAIUserImageContent: Codable {
 
 struct OpenAIImageUrl {
     let base64Image: String
+    var detail = "high"
 }
 
-extension OpenAIImageUrl: Codable {
+extension OpenAIImageUrl: Encodable {
     enum CodingKeys: String, CodingKey {
         case url
+        case detail
     }
     
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         let urlString = "data:image/jpeg;base64,\(base64Image)"
         try container.encode(urlString, forKey: .url)
+        try container.encode(self.detail, forKey: .detail)
     }
     
-    init(from decoder: any Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let decodedString = try container.decode(String.self, forKey: .url)
-        self.base64Image = String(decodedString.dropFirst("data:image/jpeg;base64,".count))
+//    init(from decoder: any Decoder) throws {
+//        let container = try decoder.container(keyedBy: CodingKeys.self)
+//        let decodedString = try container.decode(String.self, forKey: .url)
+//        self.base64Image = String(decodedString.dropFirst("data:image/jpeg;base64,".count))
+//        self.detail = try container.decode(String.self, forKey: .detail)
+//    }
+}
+
+
+// MARK: - old way
+enum OpenAIMessageContent: Encodable {
+    case text(String)
+    case image(url: String, detail: String)
+    
+    enum CodingKeys: String, CodingKey {
+        case type
+        case text
+        case imageURL = "image_url"
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        
+        switch self {
+        case .text(let text):
+            try container.encode("text", forKey: .type)
+            try container.encode(text, forKey: .text)
+            
+        case .image(let url, let detail):
+            try container.encode("image_url", forKey: .type)
+            try container.encode(["url": url, "detail": detail], forKey: .imageURL)
+        }
     }
 }

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/OpenAIFunctionRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/OpenAIFunctionRequest.swift
@@ -54,7 +54,9 @@ struct OpenAIChatCompletionRequest: StitchAIChatCompletionRequestable {
         self.type = requestType
         self.body = .init(messages: messages)
     }
-    
+}
+
+extension OpenAIChatCompletionRequest {
     @MainActor
     func willRequest(document: StitchDocumentViewModel,
                      canShareData: Bool,

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/OpenAIFunctionRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/OpenAIFunctionRequest.swift
@@ -7,7 +7,28 @@
 
 import SwiftUI
 
-struct OpenAIFunctionRequest: StitchAIFunctionRequestable {
+//struct OpenAIFunctionRequest: StitchAIFunctionRequestable {
+//    let id: UUID
+//    let type: StitchAIRequestBuilder_V0.StitchAIRequestType
+//    let config: OpenAIRequestConfig = .default
+//    let body: OpenAIRequestBody
+//    static let willStream: Bool = false
+//    
+//    // Object for creating actual code creation request
+//    init(id: UUID,
+//         functionType: StitchAIRequestBuilder_V0.StitchAIRequestBuilderFunction,
+//         requestType: StitchAIRequestBuilder_V0.StitchAIRequestType,
+//         messages: [OpenAIMessage]) {
+//        self.id = id
+//        self.type = requestType
+//        self.body = .init(messages: messages,
+//                          type: requestType,
+//                          functionType: functionType)
+//    }
+//}
+
+// TODO: move
+struct OpenAIChatCompletionRequest: StitchAIChatCompletionRequestable {
     let id: UUID
     let type: StitchAIRequestBuilder_V0.StitchAIRequestType
     let config: OpenAIRequestConfig = .default
@@ -16,13 +37,50 @@ struct OpenAIFunctionRequest: StitchAIFunctionRequestable {
     
     // Object for creating actual code creation request
     init(id: UUID,
-         functionType: StitchAIRequestBuilder_V0.StitchAIRequestBuilderFunction,
          requestType: StitchAIRequestBuilder_V0.StitchAIRequestType,
-         messages: [OpenAIMessage]) {
+         systemPrompt: String,
+         assistantPrompt: String,
+         inputs: any Encodable) throws {
+        let messages: [OpenAIMessage] = [
+            .init(role: .system,
+                  content: systemPrompt),
+            .init(role: .system,
+                  content: assistantPrompt),
+            .init(role: .user,
+                  content: try inputs.encodeToString())
+        ]
+        
         self.id = id
         self.type = requestType
-        self.body = .init(messages: messages,
-                          type: requestType,
-                          functionType: functionType)
+        self.body = .init(messages: messages)
+    }
+    
+    @MainActor
+    func willRequest(document: StitchDocumentViewModel,
+                     canShareData: Bool,
+                     requestTask: Self.RequestTask) {
+        // Nothing to do
+    }
+    
+    static func validateResponse(decodedResult: String) throws -> String {
+        // Nothing to do here
+        decodedResult
+    }
+    
+    @MainActor
+    func onSuccessfulRequest(result: String,
+                             aiManager: StitchAIManager,
+                             document: StitchDocumentViewModel) throws {
+        print("AI request successful: \(result)")
+    }
+    
+    @MainActor
+    func onSuccessfulDecodingChunk(result: String,
+                                   currentAttempt: Int) {
+        fatalErrorIfDebug("No JavaScript node support for streaming.")
+    }
+    
+    static func buildResponse(from streamingChunks: [String]) throws -> String {
+        streamingChunks.joined()
     }
 }

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/StitchAIFunctionRequestable.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/StitchAIFunctionRequestable.swift
@@ -41,7 +41,7 @@ protocol StitchAICodeCreator {
     
     func createCode(document: StitchDocumentViewModel,
                     aiManager: StitchAIManager,
-                    systemPrompt: String) async throws -> String
+                    systemPrompt: String) async throws -> OpenAIMessage
 }
 
 extension StitchAIFunctionRequestable {    

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/StitchAIFunctionRequestable.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/StitchAIFunctionRequestable.swift
@@ -41,7 +41,7 @@ protocol StitchAICodeCreator {
     
     func createCode(document: StitchDocumentViewModel,
                     aiManager: StitchAIManager,
-                    systemPrompt: String) async throws -> OpenAIMessage
+                    systemPrompt: String) async throws -> (OpenAIMessage, [OpenAIMessage])
 }
 
 extension StitchAIFunctionRequestable {    
@@ -53,7 +53,7 @@ extension StitchAIFunctionRequestable {
         
         if let systemPrompt = try functionType.getAssistantPrompt(for: requestType) {
             messages.append(OpenAIMessage(
-                role: .system,
+                role: .assistant,
                 content: try functionType.getAssistantPrompt(for: requestType)
             ))
         }

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/StitchAIFunctionRequestable.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/StitchAIFunctionRequestable.swift
@@ -48,41 +48,71 @@ extension StitchAIFunctionRequestable {
     /// Starts new chain of function calling. Call this when no existing funciton messages can be used.
     static func createInitialFnMessages(functionType: StitchAIRequestBuilder_V0.StitchAIRequestBuilderFunction,
                                         requestType: StitchAIRequestBuilder_V0.StitchAIRequestType,
-                                        inputsArguments: any Encodable,
-                                        systemPrompt: String) throws -> [OpenAIMessage] {
-        let systemPromptMsg = OpenAIMessage(
-            role: .system,
-            content: systemPrompt
-        )
+                                        inputsArguments: (any Encodable)?) throws -> [OpenAIMessage] {
+        var messages = [OpenAIMessage]()
         
-        let supplementarySystemPrompt = OpenAIMessage(
-            role: .system,
-            content: try functionType.getAssistantPrompt(for: requestType)
-        )
+        if let systemPrompt = try functionType.getAssistantPrompt(for: requestType) {
+            messages.append(OpenAIMessage(
+                role: .system,
+                content: try functionType.getAssistantPrompt(for: requestType)
+            ))
+        }
 
-        // MARK: OpenAI requires a specific ID format that if unmatched will break requests
-        let toolId = OpenAISchema.sampleId
+        if let inputsArguments = inputsArguments {
+            messages.append(OpenAIMessage(
+                role: .user,
+                content: try inputsArguments.encodeToString()
+            ))
+        }
+//        // MARK: OpenAI requires a specific ID format that if unmatched will break requests
+//        let toolId = OpenAISchema.sampleId
+//        
+//        let msgFromSourceCodeRequest = OpenAIMessage(
+//            role: .assistant,
+//            tool_calls: [
+//                .init(
+//                    id: toolId,
+//                    type: "function",
+//                    function: .init(name: functionType.rawValue,
+//                                    arguments: try inputsArguments.encodeToString())
+//                )
+//            ],
+//            annotations: []
+//        )
+//
+//        let newCodeToolMessage = try msgFromSourceCodeRequest.createNewToolMessage()
         
-        let msgFromSourceCodeRequest = OpenAIMessage(
-            role: .assistant,
-            tool_calls: [
-                .init(
-                    id: toolId,
-                    type: "function",
-                    function: .init(name: functionType.rawValue,
-                                    arguments: try inputsArguments.encodeToString())
-                )
-            ],
-            annotations: []
-        )
-
-        let newCodeToolMessage = try msgFromSourceCodeRequest.createNewToolMessage()
+        return messages
+    }
+    
+    static func createChainedFnMessages(toolResponse: OpenAIMessage,
+                                        functionType: StitchAIRequestBuilder_V0.StitchAIRequestBuilderFunction,
+                                        requestType: StitchAIRequestBuilder_V0.StitchAIRequestType,
+                                        inputsArguments: (any Encodable)?) throws -> [OpenAIMessage] {
+        let toolMsg = try toolResponse.createNewToolMessage()
         
-        return [
-            systemPromptMsg,
-            supplementarySystemPrompt,
-            msgFromSourceCodeRequest,
-            newCodeToolMessage]
+        let fnMessages = try Self.createInitialFnMessages(functionType: functionType,
+                                                          requestType: requestType,
+                                                          inputsArguments: inputsArguments)
+//        // MARK: OpenAI requires a specific ID format that if unmatched will break requests
+//        let toolId = OpenAISchema.sampleId
+//
+//        let msgFromSourceCodeRequest = OpenAIMessage(
+//            role: .assistant,
+//            tool_calls: [
+//                .init(
+//                    id: toolId,
+//                    type: "function",
+//                    function: .init(name: functionType.rawValue,
+//                                    arguments: try inputsArguments.encodeToString())
+//                )
+//            ],
+//            annotations: []
+//        )
+//
+//        let newCodeToolMessage = try msgFromSourceCodeRequest.createNewToolMessage()
+        
+        return [toolResponse, toolMsg] + fnMessages
     }
 }
 

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/StitchAIFunctionRequestable.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/StitchAIFunctionRequestable.swift
@@ -12,7 +12,7 @@ Self.InitialDecodedResult == [OpenAIToolCallResponse], Self.InitialDecodedResult
     var type: StitchAIRequestBuilder_V0.StitchAIRequestType { get }
 }
 
-protocol StitchAIChatCompletionRequestable: StitchAIRequestable where Self.Body == OpenAIRequestBody {
+protocol StitchAIChatCompletionRequestable: StitchAIRequestable {
     var type: StitchAIRequestBuilder_V0.StitchAIRequestType { get }
 }
 

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/StitchAIRequestBuilder.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/StitchAIRequestBuilder.swift
@@ -53,30 +53,30 @@ extension StitchAIRequestBuilder_V0 {
         case imagePrompt
     }
     
-    enum StitchAIRequestBuilderFunction: String {
-        case codeBuilder = "create_swiftui_code"
-        case codeBuilderFromImage = "create_code_from_image"
-        case codeEditor = "edit_swiftui_code"
-        case patchBuilder = "patch_builder"
-        case processCode = "process_code"
-        case processPatchData = "process_patch_data"
-    }
+//    enum StitchAIRequestBuilderFunction: String {
+//        case codeBuilder = "create_swiftui_code"
+//        case codeBuilderFromImage = "create_code_from_image"
+//        case codeEditor = "edit_swiftui_code"
+//        case patchBuilder = "patch_builder"
+//        case processCode = "process_code"
+//        case processPatchData = "process_patch_data"
+//    }
 }
 
 
 extension StitchAIRequestBuilder_V0.StitchAIRequestType {
-    var allFunctions: [StitchAIRequestBuilder_V0.StitchAIRequestBuilderFunction] {
-        switch self {
-        case .userPrompt:
-            return [.codeBuilder, .codeEditor, .processCode, .patchBuilder, .processPatchData]
-        case .imagePrompt:
-            return [.codeBuilderFromImage, .processCode, .patchBuilder, .processPatchData]
-        }
-    }
-    
-    var allOpenAIFunctions: [OpenAIFunction] {
-        self.allFunctions.map(\.function)
-    }
+//    var allFunctions: [StitchAIRequestBuilder_V0.StitchAIRequestBuilderFunction] {
+//        switch self {
+//        case .userPrompt:
+//            return [.codeBuilder, .codeEditor, .processCode, .patchBuilder, .processPatchData]
+//        case .imagePrompt:
+//            return [.codeBuilderFromImage, .processCode, .patchBuilder, .processPatchData]
+//        }
+//    }
+//    
+//    var allOpenAIFunctions: [OpenAIFunction] {
+//        self.allFunctions.map(\.function)
+//    }
     
     var goalDescription: String {
         switch self {
@@ -91,13 +91,13 @@ extension StitchAIRequestBuilder_V0.StitchAIRequestType {
         }
     }
     
-    var listedFunctionsDescriptionForSystemPrompt: String {
-        self.allFunctions.enumerated().map { index, fn in
-            """
-            \(index + 1). `\(fn.rawValue)`: \(fn.functionDescription)
-            """
-        }.joined(separator: "\n")
-    }
+//    var listedFunctionsDescriptionForSystemPrompt: String {
+//        self.allFunctions.enumerated().map { index, fn in
+//            """
+//            \(index + 1). `\(fn.rawValue)`: \(fn.functionDescription)
+//            """
+//        }.joined(separator: "\n")
+//    }
     
     var systemPromptTitle: String {
         switch self {
@@ -118,131 +118,131 @@ extension StitchAIRequestBuilder_V0.StitchAIRequestType {
     }
 }
 
-extension StitchAIRequestBuilder_V0.StitchAIRequestBuilderFunction {
-    var function: OpenAIFunction {
-        switch self {
-        case .codeBuilder:
-            return OpenAIFunction(
-                name: self.rawValue,
-                description: "Generate SwiftUI code from Stitch concepts.",
-                parameters: OpenAISchema(
-                    type: .object,
-                    properties: AIGraphData_V0.GraphDataSchema(),
-                    required: ["layer_data_list", "patch_data"],
-                    description: "Graph data of existing graph."),
-                strict: true
-            )
-            
-        case .codeBuilderFromImage:
-            return OpenAIFunction(
-                name: self.rawValue,
-                description: "Generate SwiftUI code from an image.",
-                parameters: OpenAISchema(
-                    type: .object,
-                    properties: StitchAIRequestBuilder_V0.ImageRequestInputParameters(),
-                    required: ["user_prompt", "image_data"],
-                    description: "Parameters for building SwiftUI view from image."),
-                strict: true
-            )
-        
-        case .codeEditor:
-            return OpenAIFunction(
-                name: self.rawValue,
-                description: "Edit SwiftUI code based on user prompt.",
-                parameters: OpenAISchema(
-                    type: .object,
-                    properties: StitchAIRequestBuilder_V0.EditRequestInputParameters(),
-                    required: ["user_prompt", "source_code"],
-                    description: "SwiftUI source code of existing graph."),
-                strict: true
-            )
-            
-        case .processCode:
-            return OpenAIFunction(
-                name: self.rawValue,
-                description: "Processes some SwiftUI code before Stitch conversion.",
-                parameters: OpenAISchema(
-                    type: .object,
-                    properties: StitchAIRequestBuilder_V0.SourceCodeResponseSchema(),
-                    required: ["source_code"],
-                    description: "SwiftUI source code following user request."),
-                strict: true
-            )
-            
-        case .patchBuilder:
-            return OpenAIFunction(
-                name: self.rawValue,
-                description: "Build Stitch graphs based on layer data and SwiftUI source code.",
-                parameters: OpenAISchema(
-                    type: .object,
-                    properties: AIPatchBuilderFunctionInputsSchema(),
-                    required: ["swiftui_source_code", "layer_data_list"],
-                    description: "Provides SwiftUI source code and Stitch layer data for a function that produces Stitch patch data."),
-                strict: true
-            )
-            
-        case .processPatchData:
-            return OpenAIFunction(
-                name: self.rawValue,
-                description: "Processes patch graph data.",
-                parameters: AIPatchBuilderResponseFormat_V0.PatchBuilderStructuredOutputsDefinitions.PatchData,
-                strict: true
-            )
-        }
-    }
-    
-    var functionDescription: String {
-        switch self {
-        case .codeBuilder:
-            return """
-                **Builds SwiftUI Code from Stitch Data.** You will receive as input structured data about the current Stitch document, and your output must be a SwiftUI app that reflects this prototype.
-                """
-        case .codeBuilderFromImage:
-            return """
-                **Builds SwiftUI Code from an Image.** You will receive as input an uploaded image, and your output must be a SwiftUI app that attempts to replicate the uploaded image.
-                """
-        case .codeEditor:
-            return """
-                **Edits SwiftUI Code.** Based on the SwiftUI source code created from the last step, modify the code based on the user prompt.
-                """
-        case .processCode:
-            return """
-                **Processes SwiftUI source code.** Let's Stitch process code for deriving some data before sending into patch builder.
-                """
-        
-        case .patchBuilder:
-            return """
-                **Creates Stitch structured prototype data.** Convert the SwiftUI source code into Stitch concepts. 
-                """
-            
-        case .processPatchData:
-            return """
-                **Processes patch graph data.** Last step before patch data is combined with already parsed layer data to update a Stitch document.
-                """
-        }
-    }
-    
-    func getAssistantPrompt(for requestType: StitchAIRequestBuilder_V0.StitchAIRequestType) throws -> String? {
-        switch self {
-        case .codeBuilder:
-            return try StitchAIManager.aiCodeGenSystemPromptGenerator(requestType: requestType)
-            
-        case .codeBuilderFromImage:
-            return try StitchAIManager.aiCodeGenSystemPromptGenerator(requestType: requestType)
-            
-        case .codeEditor:
-            return try StitchAIManager.aiCodeEditSystemPromptGenerator(requestType: requestType)
-            
-        case .processCode:
-            // End of function calling, no more subsequent calls to make
-            return nil
-            
-        case .patchBuilder:
-            return try StitchAIManager.aiPatchBuilderSystemPromptGenerator()
-            
-        case .processPatchData:
-            // End of function calling, no more subsequent calls to make
-            return nil
-        }
-    }
-}
+//extension StitchAIRequestBuilder_V0.StitchAIRequestBuilderFunction {
+//    var function: OpenAIFunction {
+//        switch self {
+//        case .codeBuilder:
+//            return OpenAIFunction(
+//                name: self.rawValue,
+//                description: "Generate SwiftUI code from Stitch concepts.",
+//                parameters: OpenAISchema(
+//                    type: .object,
+//                    properties: AIGraphData_V0.GraphDataSchema(),
+//                    required: ["layer_data_list", "patch_data"],
+//                    description: "Graph data of existing graph."),
+//                strict: true
+//            )
+//            
+//        case .codeBuilderFromImage:
+//            return OpenAIFunction(
+//                name: self.rawValue,
+//                description: "Generate SwiftUI code from an image.",
+//                parameters: OpenAISchema(
+//                    type: .object,
+//                    properties: StitchAIRequestBuilder_V0.ImageRequestInputParameters(),
+//                    required: ["user_prompt", "image_data"],
+//                    description: "Parameters for building SwiftUI view from image."),
+//                strict: true
+//            )
+//        
+//        case .codeEditor:
+//            return OpenAIFunction(
+//                name: self.rawValue,
+//                description: "Edit SwiftUI code based on user prompt.",
+//                parameters: OpenAISchema(
+//                    type: .object,
+//                    properties: StitchAIRequestBuilder_V0.EditRequestInputParameters(),
+//                    required: ["user_prompt", "source_code"],
+//                    description: "SwiftUI source code of existing graph."),
+//                strict: true
+//            )
+//            
+//        case .processCode:
+//            return OpenAIFunction(
+//                name: self.rawValue,
+//                description: "Processes some SwiftUI code before Stitch conversion.",
+//                parameters: OpenAISchema(
+//                    type: .object,
+//                    properties: StitchAIRequestBuilder_V0.SourceCodeResponseSchema(),
+//                    required: ["source_code"],
+//                    description: "SwiftUI source code following user request."),
+//                strict: true
+//            )
+//            
+//        case .patchBuilder:
+//            return OpenAIFunction(
+//                name: self.rawValue,
+//                description: "Build Stitch graphs based on layer data and SwiftUI source code.",
+//                parameters: OpenAISchema(
+//                    type: .object,
+//                    properties: AIPatchBuilderFunctionInputsSchema(),
+//                    required: ["swiftui_source_code", "layer_data_list"],
+//                    description: "Provides SwiftUI source code and Stitch layer data for a function that produces Stitch patch data."),
+//                strict: true
+//            )
+//            
+//        case .processPatchData:
+//            return OpenAIFunction(
+//                name: self.rawValue,
+//                description: "Processes patch graph data.",
+//                parameters: AIPatchBuilderResponseFormat_V0.PatchBuilderStructuredOutputsDefinitions.PatchData,
+//                strict: true
+//            )
+//        }
+//    }
+//    
+//    var functionDescription: String {
+//        switch self {
+//        case .codeBuilder:
+//            return """
+//                **Builds SwiftUI Code from Stitch Data.** You will receive as input structured data about the current Stitch document, and your output must be a SwiftUI app that reflects this prototype.
+//                """
+//        case .codeBuilderFromImage:
+//            return """
+//                **Builds SwiftUI Code from an Image.** You will receive as input an uploaded image, and your output must be a SwiftUI app that attempts to replicate the uploaded image.
+//                """
+//        case .codeEditor:
+//            return """
+//                **Edits SwiftUI Code.** Based on the SwiftUI source code created from the last step, modify the code based on the user prompt.
+//                """
+//        case .processCode:
+//            return """
+//                **Processes SwiftUI source code.** Let's Stitch process code for deriving some data before sending into patch builder.
+//                """
+//        
+//        case .patchBuilder:
+//            return """
+//                **Creates Stitch structured prototype data.** Convert the SwiftUI source code into Stitch concepts. 
+//                """
+//            
+//        case .processPatchData:
+//            return """
+//                **Processes patch graph data.** Last step before patch data is combined with already parsed layer data to update a Stitch document.
+//                """
+//        }
+//    }
+//    
+//    func getAssistantPrompt(for requestType: StitchAIRequestBuilder_V0.StitchAIRequestType) throws -> String? {
+//        switch self {
+//        case .codeBuilder:
+//            return try StitchAIManager.aiCodeGenSystemPromptGenerator(requestType: requestType)
+//            
+//        case .codeBuilderFromImage:
+//            return try StitchAIManager.aiCodeGenSystemPromptGenerator(requestType: requestType)
+//            
+//        case .codeEditor:
+//            return try StitchAIManager.aiCodeEditSystemPromptGenerator(requestType: requestType)
+//            
+//        case .processCode:
+//            // End of function calling, no more subsequent calls to make
+//            return nil
+//            
+//        case .patchBuilder:
+//            return try StitchAIManager.aiPatchBuilderSystemPromptGenerator()
+//            
+//        case .processPatchData:
+//            // End of function calling, no more subsequent calls to make
+//            return nil
+//        }
+//    }
+//}

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/StitchAIRequestBuilder.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/StitchAIRequestBuilder.swift
@@ -40,6 +40,11 @@ struct StitchAIRequestBuilder_V0 {
     struct SourceCodeResponse: Codable {
         let source_code: String
     }
+    
+    struct EditCodeParams: Codable {
+        var source_code: String
+        var user_prompt: String
+    }
 }
 
 extension StitchAIRequestBuilder_V0 {

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/StitchAIRequestBuilder.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/StitchAIRequestBuilder.swift
@@ -8,34 +8,34 @@
 import SwiftUI
 
 struct StitchAIRequestBuilder_V0 {
-    struct ImageRequestInputParameters: Encodable {
-        let user_prompt = OpenAISchema(type: .string)
-        let image_data = OpenAISchema(type: .object,
-                                      properties: ImageDataSchema(),
-                                      required: ["type", "image_url", "detail"])
-    }
-    
-    struct EditRequestInputParameters: Encodable {
-        let user_prompt = OpenAISchema(
-            type: .string,
-            description: "Code change request by the user.")
-        
-        let source_code = OpenAISchema(
-            type: .string,
-            description: "SwiftUI source code.")
-    }
-    
-    struct SourceCodeResponseSchema: Encodable {
-        let source_code = OpenAISchema(
-            type: .string,
-            description: "SwiftUI source code.")
-    }
-    
-    struct ImageDataSchema: Encodable {
-        let type = OpenAISchema(type: .string)
-        let image_url = OpenAISchema(type: .string)
-        let detail = OpenAISchema(type: .string)
-    }
+//    struct ImageRequestInputParameters: Encodable {
+//        let user_prompt = OpenAISchema(type: .string)
+//        let image_data = OpenAISchema(type: .object,
+//                                      properties: ImageDataSchema(),
+//                                      required: ["type", "image_url", "detail"])
+//    }
+//    
+//    struct EditRequestInputParameters: Encodable {
+//        let user_prompt = OpenAISchema(
+//            type: .string,
+//            description: "Code change request by the user.")
+//        
+//        let source_code = OpenAISchema(
+//            type: .string,
+//            description: "SwiftUI source code.")
+//    }
+//    
+//    struct SourceCodeResponseSchema: Encodable {
+//        let source_code = OpenAISchema(
+//            type: .string,
+//            description: "SwiftUI source code.")
+//    }
+//    
+//    struct ImageDataSchema: Encodable {
+//        let type = OpenAISchema(type: .string)
+//        let image_url = OpenAISchema(type: .string)
+//        let detail = OpenAISchema(type: .string)
+//    }
     
     struct SourceCodeResponse: Codable {
         let source_code: String

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/StitchAIRequestable.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/StitchAIRequestable.swift
@@ -29,7 +29,7 @@ protocol StitchAIRequestable: Sendable where InitialDecodedResult: Codable, Toke
     var id: UUID { get }
     var config: OpenAIRequestConfig { get } // Request configuration settings
     var body: Body { get }
-    static var willStream: Bool { get }
+    var willStream: Bool { get }
     
     /// Validates a successfully decoded response and outputs a possibly different data structure.
     static func validateResponse(decodedResult: InitialDecodedResult) throws -> FinalDecodedResult

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIGraphData/AIGraphDataUtil_V0.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIGraphData/AIGraphDataUtil_V0.swift
@@ -32,7 +32,7 @@ extension AIGraphData_V0 {
     typealias NodeIOPortType = NodeIOPortType_V33.NodeIOPortType
 }
 
-extension AIGraphData_V0.GraphData {
+extension AIGraphData_V0.CodeCreatorParams {
     init(from graphEntity: AIGraphData_V0.GraphEntity) throws {
         let nodesDict = graphEntity.nodes.reduce(into: [UUID : AIGraphData_V0.NodeEntity]()) { result, node in
             result.updateValue(node, forKey: node.id)
@@ -100,7 +100,7 @@ extension AIGraphData_V0.GraphData {
             .createAIData(nodesDict: nodesDict,
             layerConnections: &layerConnections)
         
-        self = .init(layer_data_list: aiLayerData,
+        self = .init(layer_data_list: try aiLayerData.encodeToString(),
                      patch_data: .init(javascript_patches: jsNodes,
                                        native_patches: nativeNodes,
                                        native_patch_value_type_settings: nodeTypeSettings,

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIGraphData/AIGraphData_V0.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIGraphData/AIGraphData_V0.swift
@@ -9,6 +9,12 @@ import StitchSchemaKit
 import SwiftUI
 
 enum AIGraphData_V0 {
+    struct CodeCreatorParams: Codable {
+        // String because layer data isn't supported for structured params given nesting
+        let layer_data_list: String
+        let patch_data: PatchData
+    }
+    
     struct GraphData: Codable {
         let layer_data_list: [LayerData]
         let patch_data: PatchData

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIPatchBuilder/AIPatchBuilderResponseFormat_V0.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIPatchBuilder/AIPatchBuilderResponseFormat_V0.swift
@@ -9,24 +9,23 @@ import SwiftUI
 import StitchSchemaKit
 
 enum AIPatchBuilderResponseFormat_V0 {
-    // TODO: remove this
-//    struct AIPatchBuilderResponseFormat: OpenAIResponseFormatable {
-//        let type = "json_schema"
-//        let json_schema = AIPatchBuilderJsonSchema()
-//    }    
-//    
-//    struct AIPatchBuilderJsonSchema: OpenAIJsonSchema {
-//        let name = "GraphBuilder"
-//        let schema = PatchBuilderStructuredOutputsPayload()
-//    }
-//    
-//    struct PatchBuilderStructuredOutputsPayload: OpenAISchemaDefinable {
-//        let defs = PatchBuilderStructuredOutputsDefinitions()
-//        let schema = OpenAISchema(type: .object,
-//                                  properties: AIPatchBuilderResponseFormat_V0.GraphBuilderSchema(),
-//                                  required: ["javascript_patches", "native_patches", "native_patch_value_type_settings", "patch_connections", "layer_connections", "custom_patch_input_values"])
-//        let strict = true
-//    }
+    struct AIPatchBuilderResponseFormat: OpenAIResponseFormatable {
+        let type = "json_schema"
+        let json_schema = AIPatchBuilderJsonSchema()
+    }    
+    
+    struct AIPatchBuilderJsonSchema: OpenAIJsonSchema {
+        let name = "GraphBuilder"
+        let schema = PatchBuilderStructuredOutputsPayload()
+    }
+    
+    struct PatchBuilderStructuredOutputsPayload: OpenAISchemaDefinable {
+        let defs = PatchBuilderStructuredOutputsDefinitions()
+        let schema = OpenAISchema(type: .object,
+                                  properties: AIPatchBuilderResponseFormat_V0.GraphBuilderSchema(),
+                                  required: ["javascript_patches", "native_patches", "native_patch_value_type_settings", "patch_connections", "layer_connections", "custom_patch_input_values"])
+        let strict = true
+    }
 
     struct PatchBuilderStructuredOutputsDefinitions: Encodable {
         // Value Types

--- a/Stitch/Graph/StitchAI/PromptGenerator/AICodeEditSystemPromptGenerator.swift
+++ b/Stitch/Graph/StitchAI/PromptGenerator/AICodeEditSystemPromptGenerator.swift
@@ -71,9 +71,7 @@ ZStack {
 ```
 
 # Code Generation Rules
-Adhere to the guidelines specified in this document:
-
-\(try StitchAIManager.aiCodeGenSystemPromptGenerator(requestType: .userPrompt))
+Adhere to the guidelines specified earlier in the system prompt.
 
 # Summary
 Edit the provided source code given the provided user prompt. Adhere to the strict guidelines provided in the above document.

--- a/Stitch/Graph/StitchAI/PromptGenerator/AICodeEditSystemPromptGenerator.swift
+++ b/Stitch/Graph/StitchAI/PromptGenerator/AICodeEditSystemPromptGenerator.swift
@@ -71,7 +71,9 @@ ZStack {
 ```
 
 # Code Generation Rules
-Adhere to the guidelines specified earlier in the system prompt.
+Adhere to the following guideliens:
+
+\(try StitchAIManager.aiCodeGenSystemPromptGenerator(requestType: requestType))
 
 # Summary
 Edit the provided source code given the provided user prompt. Adhere to the strict guidelines provided in the above document.

--- a/Stitch/Graph/StitchAI/PromptGenerator/AICodeEditSystemPromptGenerator.swift
+++ b/Stitch/Graph/StitchAI/PromptGenerator/AICodeEditSystemPromptGenerator.swift
@@ -17,6 +17,8 @@ extension StitchAIManager {
 
 Default to non-destructive functionality--don't remove or edit code unless explicitly requested or required by the user's request.
 
+If, however, the view contains an `EmptyView`, you may remove this view entirely assuming the user didn't request the removal of all views and logic.
+
 Refrain from reusing existing hierarchies when adding something new. Instead, append the view to a top-level `ZStack`, creating the `ZStack` if need be.
 
 For example, if given the request "Add a pink oval" to the subsequent view:

--- a/Stitch/Graph/StitchAI/PromptGenerator/AICodeGenSystemPromptGenerator.swift
+++ b/Stitch/Graph/StitchAI/PromptGenerator/AICodeGenSystemPromptGenerator.swift
@@ -41,6 +41,8 @@ Your SwiftUI code must decouple view from logic as much as possible. Code must b
 * **`updateLayerInputs()` function:** the only caller allowed to update state variables in the view directly. Called on every frame update.
 * **All other view functions:** must be static and represent the behavior of a patch node, detailed later.
 
+**The returned source code must be a valid SwiftUI view containing a `struct ContentView: View` declaraion along with a `var body: some View`.**
+
 Code components **not** allowed in our view are:
 * **Top-level view arguments.** Our view must be able to be invoked without any arguments.
 * **Top-level constants other than layer IDs.** Do not create constants defined at the view level. Instead, use `@State` variables and update them from `updateLayerInputs` function. Define values directly in view if no constant needs to be made.

--- a/Stitch/Graph/StitchAI/PromptGenerator/AIGraphBuilderSystemPromptGenerator.swift
+++ b/Stitch/Graph/StitchAI/PromptGenerator/AIGraphBuilderSystemPromptGenerator.swift
@@ -28,9 +28,6 @@ You are a tool that creates data for prototypes in our app, called Stitch. Stitc
 
 \(requestType.goalDescription)
 
-You will call a series of OpenAI functions in sequential order. The job of these functions is to break down graph building into scoped steps. These functions are:
-\(requestType.listedFunctionsDescriptionForSystemPrompt)
-
 # Stitch Data Glossary
 
 Each function is adhering to a specific set of rules which are designed to restrict the known universe to Stitch-only concepts. Invoked functions should consult this glossary whenever Stitch-specific data is created.

--- a/Stitch/Graph/Util/GraphUIActions.swift
+++ b/Stitch/Graph/Util/GraphUIActions.swift
@@ -179,7 +179,7 @@ struct SubmitUserPromptToOpenAI: StitchStoreEvent {
         
 
         do {
-            let graphData = try AIGraphData_V0.GraphData(from: document.visibleGraph.createSchema())
+            let graphData = try AIGraphData_V0.CodeCreatorParams(from: document.visibleGraph.createSchema())
             
             let requestTask = try AICodeGenFromGraphRequest(
                 prompt: prompt,


### PR DESCRIPTION
This PR reverts the newer functions approach for using chat completions API.

Functions wasn't the ideal choice for our current flow, given that (a) we know each function that needs to be called and (b) there's two hops needed per function invocation.

Heads up—there's a regression with image-based requests, I'll fix ASAP.