### PR TITLE
Fix inverse mapping for stack alignment

### DIFF
--- a/Stitch/Graph/StitchAI/Mapping/CodeToVPL/Declarative/DeclarativeUtils.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToVPL/Declarative/DeclarativeUtils.swift
@@ -251,7 +251,7 @@ extension SyntaxViewModifierArgumentType {
 extension SyntaxViewMemberAccess {
     // New helper: horizontal alignment literal
     var horizAlignLiteral: HorizontalAlignment? {
-        let ident = self.base
+        let ident = self.property
         switch ident {
         case "leading": return .leading
         case "trailing": return .trailing
@@ -261,7 +261,7 @@ extension SyntaxViewMemberAccess {
     }
         
     var vertAlignLiteral: VerticalAlignment? {
-        let ident = self.base
+        let ident = self.property
         switch ident {
         case "top": return .top
         case "bottom": return .bottom


### PR DESCRIPTION
We now handle stack constructor's alignment parameter.

<img width="1440" height="900" alt="Screenshot 2025-07-30 at 3 55 56 PM" src="https://github.com/user-attachments/assets/6c78c472-5ba9-44d8-bd84-997e83b4f772" />
