### PR TITLE
Mapping and inverse-mapping: font-related view modifiers

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -631,6 +631,7 @@
 		EC5043A52874CDDB00590D07 /* RGBA.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5043A42874CDDB00590D07 /* RGBA.swift */; };
 		EC519E372BACC0ED005C6131 /* MathExpressionSubmenuButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC519E362BACC0ED005C6131 /* MathExpressionSubmenuButtonView.swift */; };
 		EC51AA7926B307E3007919D6 /* groupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC51AA7826B307E3007919D6 /* groupTests.swift */; };
+		EC5251E12E3B0B2800E1AAC1 /* FontCodeExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5251E02E3B0B2800E1AAC1 /* FontCodeExamples.swift */; };
 		EC5263032B59D83600EE1E52 /* HandleStitchAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5263022B59D83600EE1E52 /* HandleStitchAction.swift */; };
 		EC53C0EE2D543A32002ECAEB /* LayerInspectorRowButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC53C0ED2D543A32002ECAEB /* LayerInspectorRowButton.swift */; };
 		EC53F3BA287E25D60021095B /* SineNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC53F3B9287E25D60021095B /* SineNode.swift */; };
@@ -1791,6 +1792,7 @@
 		EC5043A42874CDDB00590D07 /* RGBA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RGBA.swift; sourceTree = "<group>"; };
 		EC519E362BACC0ED005C6131 /* MathExpressionSubmenuButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MathExpressionSubmenuButtonView.swift; sourceTree = "<group>"; };
 		EC51AA7826B307E3007919D6 /* groupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = groupTests.swift; sourceTree = "<group>"; };
+		EC5251E02E3B0B2800E1AAC1 /* FontCodeExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontCodeExamples.swift; sourceTree = "<group>"; };
 		EC5263022B59D83600EE1E52 /* HandleStitchAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandleStitchAction.swift; sourceTree = "<group>"; };
 		EC53C0ED2D543A32002ECAEB /* LayerInspectorRowButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerInspectorRowButton.swift; sourceTree = "<group>"; };
 		EC53F3B9287E25D60021095B /* SineNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SineNode.swift; sourceTree = "<group>"; };
@@ -5110,6 +5112,7 @@
 			children = (
 				ECC734732E0DE95A00AC266C /* CodeExamples.swift */,
 				EC7062B22E14BFC50017A9F0 /* ScrollViewCodeExamples.swift */,
+				EC5251E02E3B0B2800E1AAC1 /* FontCodeExamples.swift */,
 				EC7062C22E15E78C0017A9F0 /* VarBodyCodeExamples.swift */,
 				EC7062C42E15E8120017A9F0 /* MultiparameterViewModifierCodeExamples.swift */,
 				EC1FF4622E171BD500B0D8FC /* ViewModifierCodeExamples.swift */,
@@ -6753,6 +6756,7 @@
 				EC0E1AFE2D4B2288004AAA37 /* LLMValueParsingUtils.swift in Sources */,
 				EC4914A229359AC300D74344 /* TextEndsWithNode.swift in Sources */,
 				B59660982C1A498800BE75D7 /* StitchMLModel.swift in Sources */,
+				EC5251E12E3B0B2800E1AAC1 /* FontCodeExamples.swift in Sources */,
 				ECC2BCD72B9B73C900D5F942 /* SidebarListItemGestureRecognizerView.swift in Sources */,
 				EC560E0B293A758600350046 /* LoopCountNode.swift in Sources */,
 				EC91B56429AE7891006E823D /* NodesOnlyView.swift in Sources */,

--- a/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/CodeExamples.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/CodeExamples.swift
@@ -37,6 +37,24 @@ extension MappingExamples {
         ColorCodeExamples.colorAsValue,
         ColorCodeExamples.colorAsView,
         
+        // Font Modifiers
+        FontCodeExamples.systemFontBody,
+        FontCodeExamples.systemFontHeadline,
+        FontCodeExamples.systemFontLargeTitle,
+        FontCodeExamples.customSystemFont,
+        FontCodeExamples.customSystemFontWithWeight,
+        FontCodeExamples.customSystemFontWithDesign,
+        FontCodeExamples.customSystemFontComplete,
+        FontCodeExamples.fontWeightBold,
+        FontCodeExamples.fontWeightLight,
+        FontCodeExamples.fontDesignRounded,
+        FontCodeExamples.fontDesignMonospaced,
+        FontCodeExamples.fontDesignSerif,
+        FontCodeExamples.combinedFontModifiers,
+        FontCodeExamples.fontWithColorAndWeight,
+        FontCodeExamples.stackWithDifferentFonts,
+        FontCodeExamples.fontInScrollView,
+        
         // ScrollView
         ScrollViewCodeExamples.scrollViewVStack,
         ScrollViewCodeExamples.scrollViewHStack,

--- a/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/FontCodeExamples.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/FontCodeExamples.swift
@@ -1,0 +1,277 @@
+//
+//  FontCodeExamples.swift
+//  Stitch
+//
+//  Created by Christian J Clampitt on 7/31/25.
+//
+
+import Foundation
+import SwiftUI
+
+struct FontCodeExamples {
+    
+    // MARK: - Basic Font Modifier Examples
+    
+    static let systemFontBody = MappingCodeExample(
+        title: "System Font - Body",
+        code:
+"""
+Text("Hello World")
+    .font(.body)
+"""
+    )
+    
+    static let systemFontHeadline = MappingCodeExample(
+        title: "System Font - Headline",
+        code:
+"""
+Text("Important Title")
+    .font(.headline)
+"""
+    )
+    
+    static let systemFontLargeTitle = MappingCodeExample(
+        title: "System Font - Large Title",
+        code:
+"""
+Text("Big Header")
+    .font(.largeTitle)
+"""
+    )
+    
+    static let systemFontCaption = MappingCodeExample(
+        title: "System Font - Caption",
+        code:
+"""
+Text("Small note")
+    .font(.caption)
+"""
+    )
+    
+    // MARK: - Custom System Font Examples
+    
+    static let customSystemFont = MappingCodeExample(
+        title: "Custom System Font",
+        code:
+"""
+Text("Custom Font")
+    .font(.system(size: 24))
+"""
+    )
+    
+    static let customSystemFontWithWeight = MappingCodeExample(
+        title: "Custom System Font with Weight",
+        code:
+"""
+Text("Bold Text")
+    .font(.system(size: 18, weight: .bold))
+"""
+    )
+    
+    static let customSystemFontWithDesign = MappingCodeExample(
+        title: "Custom System Font with Design",
+        code:
+"""
+Text("Rounded Font")
+    .font(.system(size: 20, design: .rounded))
+"""
+    )
+    
+    static let customSystemFontComplete = MappingCodeExample(
+        title: "Custom System Font - Complete",
+        code:
+"""
+Text("Complete Example")
+    .font(.system(size: 22, weight: .semibold, design: .serif))
+"""
+    )
+    
+    // MARK: - Font Weight Modifier Examples
+    
+    static let fontWeightRegular = MappingCodeExample(
+        title: "Font Weight - Regular",
+        code:
+"""
+Text("Regular Weight")
+    .fontWeight(.regular)
+"""
+    )
+    
+    static let fontWeightBold = MappingCodeExample(
+        title: "Font Weight - Bold",
+        code:
+"""
+Text("Bold Weight")
+    .fontWeight(.bold)
+"""
+    )
+    
+    static let fontWeightLight = MappingCodeExample(
+        title: "Font Weight - Light",
+        code:
+"""
+Text("Light Weight")
+    .fontWeight(.light)
+"""
+    )
+    
+    static let fontWeightHeavy = MappingCodeExample(
+        title: "Font Weight - Heavy",
+        code:
+"""
+Text("Heavy Weight")
+    .fontWeight(.heavy)
+"""
+    )
+    
+    // MARK: - Font Design Modifier Examples
+    
+    static let fontDesignDefault = MappingCodeExample(
+        title: "Font Design - Default",
+        code:
+"""
+Text("Default Design")
+    .fontDesign(.default)
+"""
+    )
+    
+    static let fontDesignRounded = MappingCodeExample(
+        title: "Font Design - Rounded",
+        code:
+"""
+Text("Rounded Design")
+    .fontDesign(.rounded)
+"""
+    )
+    
+    static let fontDesignMonospaced = MappingCodeExample(
+        title: "Font Design - Monospaced",
+        code:
+"""
+Text("Monospaced Design")
+    .fontDesign(.monospaced)
+"""
+    )
+    
+    static let fontDesignSerif = MappingCodeExample(
+        title: "Font Design - Serif",
+        code:
+"""
+Text("Serif Design")
+    .fontDesign(.serif)
+"""
+    )
+    
+    // MARK: - Combined Font Modifier Examples
+    
+    static let combinedFontModifiers = MappingCodeExample(
+        title: "Combined Font Modifiers",
+        code:
+"""
+Text("Combined Styling")
+    .font(.title2)
+    .fontWeight(.medium)
+    .fontDesign(.rounded)
+"""
+    )
+    
+    static let fontWithColorAndWeight = MappingCodeExample(
+        title: "Font with Color and Weight",
+        code:
+"""
+Text("Styled Text")
+    .font(.headline)
+    .fontWeight(.bold)
+    .foregroundColor(.blue)
+"""
+    )
+    
+    static let multilineTextWithFont = MappingCodeExample(
+        title: "Multiline Text with Font",
+        code:
+"""
+Text("This is a longer text that demonstrates font styling across multiple lines")
+    .font(.body)
+    .fontWeight(.regular)
+    .fontDesign(.default)
+"""
+    )
+    
+    // MARK: - Edge Case Examples
+    
+    static let emptyTextWithFont = MappingCodeExample(
+        title: "Empty Text with Font",
+        code:
+"""
+Text("")
+    .font(.body)
+    .fontWeight(.bold)
+"""
+    )
+    
+    static let textWithMultipleWeights = MappingCodeExample(
+        title: "Text with Multiple Font Weights (Last Wins)",
+        code:
+"""
+Text("Weight Override")
+    .fontWeight(.light)
+    .fontWeight(.bold)
+"""
+    )
+    
+    static let textWithMultipleDesigns = MappingCodeExample(
+        title: "Text with Multiple Font Designs (Last Wins)",
+        code:
+"""
+Text("Design Override")
+    .fontDesign(.serif)
+    .fontDesign(.rounded)
+"""
+    )
+    
+    // MARK: - Complex Layout Examples
+    
+    static let stackWithDifferentFonts = MappingCodeExample(
+        title: "Stack with Different Fonts",
+        code:
+"""
+VStack {
+    Text("Title")
+        .font(.largeTitle)
+        .fontWeight(.bold)
+    
+    Text("Subtitle")
+        .font(.title2)
+        .fontWeight(.medium)
+    
+    Text("Body text with more details")
+        .font(.body)
+        .fontDesign(.default)
+    
+    Text("Caption or note")
+        .font(.caption)
+        .fontWeight(.light)
+        .foregroundColor(.gray)
+}
+"""
+    )
+    
+    static let fontInScrollView = MappingCodeExample(
+        title: "Font Styling in ScrollView",
+        code:
+"""
+ScrollView {
+    VStack(spacing: 16) {
+        Text("Header")
+            .font(.title)
+            .fontWeight(.bold)
+            .fontDesign(.rounded)
+        
+        Text("Content")
+            .font(.body)
+            .fontDesign(.default)
+    }
+}
+"""
+    )
+}

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayerInputPort.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayerInputPort.swift
@@ -224,7 +224,7 @@ extension SyntaxViewModifierName {
         case .background:
             throw SwiftUISyntaxError.unsupportedViewModifier(self)
         case .font:
-            throw SwiftUISyntaxError.unsupportedViewModifier(self)
+            return .simple(.textFont)
         case .multilineTextAlignment:
             throw SwiftUISyntaxError.unsupportedViewModifier(self)
             
@@ -252,12 +252,13 @@ extension SyntaxViewModifierName {
         
             // TODO: this is a text case
         case .bold,
-                .fontDesign,
-                .fontWeight,
                 .monospacedDigit,
                 .monospaced:
-//            return .textFont
             throw SwiftUISyntaxError.unsupportedViewModifier(self)
+        case .fontDesign:
+            return .simple(.textFont)
+        case .fontWeight:
+            return .simple(.textFont)
             
             // MARK: Could be implemented someday?
         case .textCase,

--- a/Stitch/Graph/StitchAI/Mapping/VPLToCode/VPLToCode.swift
+++ b/Stitch/Graph/StitchAI/Mapping/VPLToCode/VPLToCode.swift
@@ -478,6 +478,12 @@ func renderStrictViewModifier(_ modifier: StrictViewModifier) -> String {
         }
     case .clipped(_):
         return ".clipped()"
+    case .font(let m):
+        return ".font(\(renderArg(m.font)))"
+    case .fontDesign(let m):
+        return ".fontDesign(\(renderArg(m.design)))"
+    case .fontWeight(let m):
+        return ".fontWeight(\(renderArg(m.weight)))"
     }
 }
 
@@ -892,9 +898,103 @@ func makeViewModifierConstructor(from port: LayerInputPort,
             return .clipped(ClippedViewModifier())
         }
         return nil
+    case .textFont:
+        if let stitchFont = value.getTextFont {
+            return decomposeFontToModifiers(stitchFont)
+        }
+        return nil
+    case .fontSize:
+        if let number = value.getNumber {
+            // FontSize alone can't create a complete font modifier,
+            // it needs to be combined with textFont for full functionality
+            // For now, we'll create a basic font modifier with default font
+            let sizeArg = SyntaxViewModifierArgumentType.simple(
+                SyntaxViewSimpleData(value: ".system(size: \(number))", syntaxKind: .string)
+            )
+            return .font(FontViewModifier(font: sizeArg))
+        }
+        return nil
     default:
         return nil
     }
+}
+
+/// Decomposes a StitchFont into the best SwiftUI modifier representation
+/// Uses Approach 3 (Hybrid): intelligent decomposition for better SwiftUI code
+///
+/// Precedence Rules:
+/// 1. .font() takes precedence when we can map to standard SwiftUI system fonts
+/// 2. Fallback to .system(size:, weight:, design:) for complex combinations
+/// 3. Individual .fontDesign() and .fontWeight() modifiers are handled separately during parsing
+func decomposeFontToModifiers(_ stitchFont: StitchFont) -> StrictViewModifier? {
+    // Strategy: Create the most appropriate SwiftUI font modifier based on the StitchFont
+    // We'll prioritize .font() for system fonts with common sizes
+    
+    let fontChoice = stitchFont.fontChoice
+    let fontWeight = stitchFont.fontWeight
+    
+    // Try to map to a standard SwiftUI system font first
+    if let systemFont = mapStitchFontToSwiftUISystemFont(fontChoice, fontWeight) {
+        let fontArg = SyntaxViewModifierArgumentType.memberAccess(
+            SyntaxViewMemberAccess(base: nil, property: String(systemFont.dropFirst())) // Remove leading dot
+        )
+        return .font(FontViewModifier(font: fontArg))
+    }
+    
+    // Fallback: Create .fontDesign() and .fontWeight() modifiers separately
+    // This provides more granular control and is more idiomatic for complex fonts
+    
+    // For now, create a composite font modifier
+    // Future enhancement: return multiple modifiers
+    let designString = mapStitchFontChoiceToSwiftUIDesign(fontChoice)
+    let weightString = mapStitchFontWeightToSwiftUIWeight(fontWeight)
+    
+    // Create a combined font specification directly as syntax
+    let combinedFont = ".system(size: 17, weight: \(weightString), design: \(designString))"
+    let fontArg = SyntaxViewModifierArgumentType.simple(
+        SyntaxViewSimpleData(value: combinedFont, syntaxKind: .memberAccess)
+    )
+    
+    return .font(FontViewModifier(font: fontArg))
+}
+
+// MARK: - StitchFont to SwiftUI Mapping Functions
+
+func mapStitchFontToSwiftUISystemFont(_ fontChoice: StitchFontChoice, _ fontWeight: StitchFontWeight) -> String? {
+    // Map common combinations to standard SwiftUI system fonts
+    switch (fontChoice, fontWeight) {
+    case (.sf, .SF_regular):
+        return ".body"
+    case (.sf, .SF_bold):
+        return ".headline"  // headline is bold by default
+    case (.sf, .SF_light):
+        return ".subheadline"
+    default:
+        return nil  // Use fallback approach
+    }
+}
+
+func mapStitchFontChoiceToSwiftUIDesign(_ fontChoice: StitchFontChoice) -> String {
+    switch fontChoice {
+    case .sf:
+        return ".default"
+    case .sfMono:
+        return ".monospaced"
+    case .sfRounded:
+        return ".rounded"
+    case .newYorkSerif:
+        return ".serif"
+    }
+}
+
+func mapStitchFontWeightToSwiftUIWeight(_ weight: StitchFontWeight) -> String {
+    // Extract the actual weight from the prefixed enum case
+    let weightString = String(describing: weight)
+    if let underscoreIndex = weightString.lastIndex(of: "_") {
+        let actualWeight = String(weightString[weightString.index(after: underscoreIndex)...])
+        return ".\(actualWeight)"
+    }
+    return ".regular"  // fallback
 }
 
 /// Renders a typed view-modifier constructor back into SwiftUI source code.
@@ -957,6 +1057,12 @@ func renderViewModifierConstructor(_ modifier: StrictViewModifier) -> String {
         }
     case .clipped(_):
         return ".clipped()"
+    case .font(let m):
+        return ".font(\(renderArg(m.font)))"
+    case .fontDesign(let m):
+        return ".fontDesign(\(renderArg(m.design)))"
+    case .fontWeight(let m):
+        return ".fontWeight(\(renderArg(m.weight)))"
     }
 }
 
@@ -1102,6 +1208,9 @@ func generateViewModifiersForLayerData(_ layerData: AIGraphData_V0.LayerData, id
         case .offset: return .offsetInGroup
         case .padding: return .padding
         case .clipped: return .isClipped
+        case .font: return .textFont
+        case .fontDesign: return .textFont
+        case .fontWeight: return .textFont
         }
     })
     


### PR DESCRIPTION
font-related view modifiers show up in our attempt to turn a dial screenshot into a UI, so though it would be good to support them.

Stitch's fonts are quite a bit different than the modifiers that SwiftUI offers, so we use some rules and heuristics. Good enough for now.

<img width="1440" height="900" alt="Screenshot 2025-07-30 at 7 43 06 PM" src="https://github.com/user-attachments/assets/ec7b576a-488a-4d5c-9401-fff52d751af3" />
<img width="1440" height="900" alt="Screenshot 2025-07-30 at 7 42 28 PM" src="https://github.com/user-attachments/assets/3761deab-9af2-4c69-8e34-285c3df9ef06" />
<img width="1440" height="900" alt="Screenshot 2025-07-30 at 7 42 06 PM" src="https://github.com/user-attachments/assets/d07fa147-5472-4a4d-80df-2cf306892f0d" />
<img width="1440" height="900" alt="Screenshot 2025-07-30 at 7 32 11 PM" src="https://github.com/user-attachments/assets/29217570-292d-4206-9ac4-04fe4e1cb1e9" />
