### PR TITLE
Implements code mapping to patch data for faster AI requests

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -359,6 +359,10 @@
 		B5F5FD432B37564500BBD9A2 /* WhatToTest.en-US.txt in Resources */ = {isa = PBXBuildFile; fileRef = B5F5FD422B37564500BBD9A2 /* WhatToTest.en-US.txt */; };
 		B5F88D6A2D2D6D8B00B5A45A /* StitchProjectOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F88D692D2D6D8500B5A45A /* StitchProjectOverlayView.swift */; };
 		B5F8D6A82C224A6600B99E5C /* LayerNodeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F8D6A72C224A6600B99E5C /* LayerNodeData.swift */; };
+		B5F8EEE12E3C2A0A009432C5 /* CodeToStitchPatchData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F8EEE02E3C2A00009432C5 /* CodeToStitchPatchData.swift */; };
+		B5F8EEE32E3C2A33009432C5 /* CodeToStitchLayerData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F8EEE22E3C2A2E009432C5 /* CodeToStitchLayerData.swift */; };
+		B5F8EEE52E3C2A42009432C5 /* CodeToStitchUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F8EEE42E3C2A3E009432C5 /* CodeToStitchUtil.swift */; };
+		B5F8EEE72E3C2B60009432C5 /* CodeToStitchModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F8EEE62E3C2B59009432C5 /* CodeToStitchModel.swift */; };
 		B5F9EB9B28D3848A00112799 /* FileManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F9EB9A28D3848A00112799 /* FileManagerTests.swift */; };
 		B5F9EB9E28D3927F00112799 /* MockFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F9EB9D28D3927F00112799 /* MockFileManager.swift */; };
 		B5FBE3C42C4195B3006DA0A7 /* DirectoryWatcher in Frameworks */ = {isa = PBXBuildFile; productRef = B5FBE3C32C4195B3006DA0A7 /* DirectoryWatcher */; };
@@ -1525,6 +1529,10 @@
 		B5F5FD422B37564500BBD9A2 /* WhatToTest.en-US.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "WhatToTest.en-US.txt"; sourceTree = "<group>"; };
 		B5F88D692D2D6D8500B5A45A /* StitchProjectOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StitchProjectOverlayView.swift; sourceTree = "<group>"; };
 		B5F8D6A72C224A6600B99E5C /* LayerNodeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerNodeData.swift; sourceTree = "<group>"; };
+		B5F8EEE02E3C2A00009432C5 /* CodeToStitchPatchData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeToStitchPatchData.swift; sourceTree = "<group>"; };
+		B5F8EEE22E3C2A2E009432C5 /* CodeToStitchLayerData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeToStitchLayerData.swift; sourceTree = "<group>"; };
+		B5F8EEE42E3C2A3E009432C5 /* CodeToStitchUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeToStitchUtil.swift; sourceTree = "<group>"; };
+		B5F8EEE62E3C2B59009432C5 /* CodeToStitchModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeToStitchModel.swift; sourceTree = "<group>"; };
 		B5F9EB9A28D3848A00112799 /* FileManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManagerTests.swift; sourceTree = "<group>"; };
 		B5F9EB9D28D3927F00112799 /* MockFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFileManager.swift; sourceTree = "<group>"; };
 		B5FE64B229641ACD004EB04B /* AsyncMediaImpureEvalResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncMediaImpureEvalResult.swift; sourceTree = "<group>"; };
@@ -5353,7 +5361,11 @@
 		ECB238C72E0A112300D55A25 /* CodeToSyntax */ = {
 			isa = PBXGroup;
 			children = (
+				B5F8EEE62E3C2B59009432C5 /* CodeToStitchModel.swift */,
 				EC66D03C2E07123F00355ED8 /* CodeToStitchSyntax.swift */,
+				B5F8EEE02E3C2A00009432C5 /* CodeToStitchPatchData.swift */,
+				B5F8EEE22E3C2A2E009432C5 /* CodeToStitchLayerData.swift */,
+				B5F8EEE42E3C2A3E009432C5 /* CodeToStitchUtil.swift */,
 				ECC6992E2E16EBA000D8D509 /* VarBodyParser */,
 			);
 			path = CodeToSyntax;
@@ -5831,6 +5843,7 @@
 				E4AB307C29B4F42F000A66B0 /* YOLOv3Tiny.mlmodel in Sources */,
 				ECD7FA8D29D73E2D0073ACAC /* ComponentActions.swift in Sources */,
 				EC2BBF042947BBC2005BCCDB /* ColorFillLayerNode.swift in Sources */,
+				B5F8EEE32E3C2A33009432C5 /* CodeToStitchLayerData.swift in Sources */,
 				EC1587432DE1287000A9C50A /* HardcodedLayerInputSizes.swift in Sources */,
 				B550C22F28D0404300F40B80 /* MiddlewareService.swift in Sources */,
 				EC83D89A2926E42400255311 /* GraphUICursorSelectionActions.swift in Sources */,
@@ -5987,6 +6000,7 @@
 				B548533729371E3900C43828 /* RealityView.swift in Sources */,
 				EC16587D2B6AF03F00FE4AE6 /* EdgeEditingState.swift in Sources */,
 				ECFCBE57284055710087585C /* GraphMovementObserver.swift in Sources */,
+				B5F8EEE52E3C2A42009432C5 /* CodeToStitchUtil.swift in Sources */,
 				EC00D80526FAC4E50024AAF6 /* GraphActions.swift in Sources */,
 				EC5734312B75BA0E00D93A78 /* ReduxHelpers.swift in Sources */,
 				B5410608286D66F3000688CA /* NodeUtils.swift in Sources */,
@@ -6445,6 +6459,7 @@
 				ECD50AC6285D34790009B564 /* ShortcutViewUtils.swift in Sources */,
 				ECD2124B294D089A00672A3E /* LocationNode.swift in Sources */,
 				ECB7B5D32A72DD9400E2D30B /* NodePageData.swift in Sources */,
+				B5F8EEE12E3C2A0A009432C5 /* CodeToStitchPatchData.swift in Sources */,
 				ECF0B0E828774FA7001D7CFC /* LessThanOrEqualNode.swift in Sources */,
 				B5221F682D397735009FF89A /* StitchEntityType.swift in Sources */,
 				EC733DC42639E24C00DD4EC1 /* LayerNodeViewModel.swift in Sources */,
@@ -6454,6 +6469,7 @@
 				ECBD32FF2988A36F00C778BE /* PureEvaluation.swift in Sources */,
 				2084200C25AD1C4F00E26728 /* LoopLengths.swift in Sources */,
 				ECDBD8AB27A1D21C00F8DC91 /* FullScreenGestureRecognizerView.swift in Sources */,
+				B5F8EEE72E3C2B60009432C5 /* CodeToStitchModel.swift in Sources */,
 				EC035BEA2E385E050002E109 /* VPLToCode.swift in Sources */,
 				EC8605AE269DF344007B8ED3 /* ValueAtIndexNode.swift in Sources */,
 				EC8967042B4E230A0066879B /* StraightLine.swift in Sources */,

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V1/Node/NodeType_V1.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V1/Node/NodeType_V1.swift
@@ -238,8 +238,12 @@ extension StitchAIPortValue_V1.NodeType {
             
             // Remap ID if from AI result
             guard let newId = idMap.get(xString) else {
-                fatalErrorIfDebug()
-                return .assignedLayer(nil)
+                // Try to decode UUID if no map
+                guard let uuid = UUID(xString) else {
+                    fatalErrorIfDebug()
+                    return .assignedLayer(nil)
+                }
+                return .assignedLayer(.init(uuid))
             }
             return .assignedLayer(.init(newId))
             

--- a/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/deriveSyntaxFromLayerInput.swift
@@ -13,15 +13,6 @@ enum SwiftUISyntaxError: Error, Sendable {
     case viewNodeNotFound
     case couldNotParseVarBody
     
-    case unsupportedViewModifier(SyntaxViewModifierName)
-    
-    // e.g. `.cornerRadius()`, when that view modifier *requires* an explicit number argument
-    case unsupportedViewModifierCall(SyntaxViewModifierName)
-    
-    case unsupportedConstructorArgument(CurrentAIGraphData.Layer, String?, SyntaxViewModifierArgumentFlatType?)
-    
-    case unsupportedViewModifierForLayer(SyntaxViewModifierName, CurrentAIGraphData.Layer)
-    
     // Decoding from string
     case unsupportedSyntaxArgumentKind(String)
     case unsupportedSyntaxArgument(String?)
@@ -32,13 +23,24 @@ enum SwiftUISyntaxError: Error, Sendable {
     case unsupportedPortValueTypeDecoding(SyntaxViewModifierArgumentType)
     case unsupportedConstructorForPortValueDecoding(StrictViewConstructor)
     
+    // MARK: - Layer decoding errors
     case unsupportedLayer(SyntaxViewName)
 //    case unsupportedConstructorArgument(SyntaxViewArgumentData)
     case unsupportedSyntaxFromLayerInput(CurrentAIGraphData.LayerInputPort)
     case unsupportedSyntaxViewLayer(CurrentAIGraphData.Layer)
-    case unexpectedPatch(CurrentAIGraphData.Patch)
-    
     case unsupportedLayerIdParsing([SyntaxViewArgumentData])
+    case unsupportedViewModifierForLayer(SyntaxViewModifierName, CurrentAIGraphData.Layer)
+    case unsupportedViewModifier(SyntaxViewModifierName)
+    // e.g. `.cornerRadius()`, when that view modifier *requires* an explicit number argument
+    case unsupportedViewModifierCall(SyntaxViewModifierName)
+    // e.g. `.cornerRadius()`, when that view modifier *requires* an explicit number argument
+    case unsupportedConstructorArgument(CurrentAIGraphData.Layer, String?, SyntaxViewModifierArgumentFlatType?)
+    case unexpectedUpstreamLayerCoordinate
+    case unexpectedStateMutatorFound(SwiftParserStateMutation)
+    
+    // Patch decoding errors
+    case unexpectedPatch(CurrentAIGraphData.Patch)
+    case unsupportedStateInPatchInputParsing(SwiftParserPatchData)
     
     case incorrectParsing(message: String)
     case groupLayerDecodingFailed

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchLayerData.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchLayerData.swift
@@ -1,0 +1,225 @@
+//
+//  CodeToStitchLayerData.swift
+//  Stitch
+//
+//  Created by Elliot Boschwitz on 7/31/25.
+//
+
+import SwiftSyntax
+import SwiftParser
+import SwiftSyntaxBuilder
+import SwiftUI
+
+extension SwiftUIViewVisitor {
+    func visitLayerData(identifierExpr: DeclReferenceExprSyntax,
+                        node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+        // This might be a view initialization like Text("Hello")
+        let viewName = identifierExpr.baseName.text
+        
+        guard let nameType = SyntaxNameType.from(viewName) else {
+//                fatalErrorIfDebug("No view discovered for: \(viewName)")
+            log("No concept discovered for: \(viewName)")
+            
+            // Tracks for later silent failures
+            self.caughtErrors.append(.unsupportedSyntaxViewName(viewName))
+            
+            return .skipChildren
+        }
+        
+        log("Found view initialization: \(viewName)")
+        
+        // Parse args, catching arguments we don't yet support
+        let args = self.parseArguments(from: node)
+        
+        switch nameType {
+        case .view(let syntaxViewName):
+            // Create a new ViewNode for this view
+            let viewNode = SyntaxView(
+                name: syntaxViewName,
+                // This is creat
+                constructorArguments: args,
+                modifiers: [],
+                children: [],
+                id: UUID()
+                //                errors: self.caughtErrors
+            )
+            
+            log("Created new ViewNode for \(viewName)")
+            
+            // Set as root or add as child to current node (context-aware)
+            if viewStack.isEmpty {
+                log("Setting as root ViewNode: \(viewName)")
+                viewStack.append(viewNode)
+                currentNodeIndex = 0
+                rootViewNode = viewNode
+
+                log("Current node index set to: \(String(describing: currentNodeIndex))")
+            } else {
+                // Check if this view initialization should be treated as a child
+                // Only apply context-aware logic for top-level view statements that could be children
+                let currentContext = contextStack.last ?? .root
+                log("Current parsing context: \(currentContext)")
+                
+                switch currentContext {
+                case .closure(let parentViewName):
+                    // We're inside a closure of a container view - this IS a legitimate child
+                    if let currentNode = currentViewNode {
+                        log("Adding \(viewName) as child to \(currentNode.name.rawValue) (inside closure)")
+                        var updatedCurrentNode = currentNode
+                        updatedCurrentNode.children.append(viewNode)
+                        updateCurrentViewNode(updatedCurrentNode)
+                        
+                        // Push the new node onto the stack and update current node index
+                        viewStack.append(viewNode)
+                        currentNodeIndex = viewStack.count - 1
+                                                    
+                        log("Pushed \(viewName) onto stack, new index: \(String(describing: currentNodeIndex))")
+                    } else {
+                        log("⚠️ Error: No current node to add child to")
+                    }
+                    
+                case .arguments, .root:
+                    // We're parsing function arguments - this might be a modifier argument
+                    // Check if this is actually being used as a modifier argument
+                    if isWithinModifierArguments(node) {
+                        log("Found view \(viewName) in modifier argument context - allowing normal processing")
+                        // For modifier arguments, we still need to process the view normally
+                        // but we don't add it as a child to any parent view
+                        // Just add it to the stack temporarily so it can be processed
+                        viewStack.append(viewNode)
+                        currentNodeIndex = viewStack.count - 1
+                    } else {
+                        log("⚠️ Found view \(viewName) in argument context - skipping child addition")
+                        log("This view should be handled as an argument, not as a child")
+                        // Don't add to viewStack - this prevents it from being treated as a child
+                    }
+                }
+            }
+            
+            return .visitChildren
+            
+        case .value:
+            // No view here, just continue
+            return .skipChildren
+        }
+    }
+
+    
+    // Helper to get current ViewNode
+    var currentViewNode: SyntaxView? {
+        guard let index = currentNodeIndex, index < viewStack.count else { return nil }
+        return viewStack[index]
+    }
+    
+    /// Returns the modifier name if `node` is a *view modifier* call
+    /// (i.e. a `FunctionCallExprSyntax` whose `calledExpression` is a
+    /// `MemberAccessExprSyntax` **with a non‑nil base**).
+    /// Helper/static calls that appear only as *arguments* – such as
+    /// `.degrees(90)` or `.black` – have `base == nil`, so they are
+    /// filtered out.
+    func modifierNameIfViewModifier(_ node: FunctionCallExprSyntax) -> String? {
+        guard
+            // Must look like `.something`  (i.e. a MemberAccessExpr)
+            let member = node.calledExpression.as(MemberAccessExprSyntax.self),
+            let base   = member.base            // no base ⇒ e.g. `.degrees(90)` helper
+        else {
+            return nil
+        }
+        
+        /// Walks the `base` chain and returns `true` iff we eventually hit a
+        /// `FunctionCallExprSyntax` (e.g. `Rectangle()` or `Color.red`), meaning
+        /// the member access is **chained onto a view instance**.  Static helper
+        /// calls such as `Double.random(in:)` terminate in an `IdentifierExpr`
+        /// (“Double”) and therefore return `false`.
+        func isChainedToView(_ syntax: SyntaxProtocol) -> Bool {
+            if syntax.is(FunctionCallExprSyntax.self) { return true }
+            if let m = syntax.as(MemberAccessExprSyntax.self), let inner = m.base {
+                return isChainedToView(inner)
+            }
+            return false
+        }
+
+        return isChainedToView(base) ? member.declName.baseName.text : nil
+    }
+    
+    /// Check if this function call is within the arguments of a modifier
+    /// This helps distinguish between legitimate child views and modifier arguments
+    private func isWithinModifierArguments(_ node: FunctionCallExprSyntax) -> Bool {
+        // Walk up the parent chain to see if we're inside a modifier's argument list
+        var currentNode: Syntax? = node.parent
+        
+        while let parent = currentNode {
+            // If we find a FunctionCallExprSyntax that is a modifier, and we're in its arguments
+            if let functionCall = parent.as(FunctionCallExprSyntax.self),
+               modifierNameIfViewModifier(functionCall) != nil {
+                // We're inside a modifier's argument list
+                return true
+            }
+            currentNode = parent.parent
+        }
+        
+        return false
+    }
+    
+    /// Propagate a mutation at `index` upward through `viewStack`
+    /// so that every ancestor’s `children` array is updated
+    /// and `rootViewNode` stays in sync.
+    private func bubbleChangeUp(from index: Int) {
+        var childIndex = index
+        while childIndex > 0 {
+            let parentIndex = childIndex - 1
+            var parent = viewStack[parentIndex]
+            let child = viewStack[childIndex]
+            
+            if let match = parent.children.firstIndex(where: { $0.id == child.id }) {
+                parent.children[match] = child
+                viewStack[parentIndex] = parent
+            } else {
+                // Shouldn’t happen, but avoid infinite loop
+                break
+            }
+            childIndex = parentIndex
+        }
+        if !viewStack.isEmpty {
+            rootViewNode = viewStack[0]
+        }
+    }
+
+    // Helper to update currentViewNode properly
+    private func updateCurrentViewNode(_ newNode: SyntaxView) {
+        guard let index = currentNodeIndex, index < viewStack.count else { return }
+        viewStack[index] = newNode
+        bubbleChangeUp(from: index)
+    }
+    
+    // Helper to add a modifier to the current view node
+    private func addModifier(_ modifier: SyntaxViewModifier) {
+        let modName = modifier.name.rawValue
+        log("addModifier → \(modName) to current index \(String(describing: currentNodeIndex))")
+        guard let index = currentNodeIndex, index < viewStack.count else {
+            log("⚠️ Cannot add modifier: no current view node")
+            return
+        }
+        
+        var node = viewStack[index]
+        log("Adding modifier \(modName) to \(node.name.rawValue)")
+        node.modifiers.append(modifier)
+        viewStack[index] = node
+        // Bubble the change up to keep all ancestors current
+        bubbleChangeUp(from: index)
+        log("✅ After adding modifier - modifiers count: \(node.modifiers.count)")
+        log("addModifier → completed. Node \(node.name.rawValue) now has \(node.modifiers.count) modifier(s).")
+    }
+
+    /// Handles standard modifiers with generic argument parsing
+    func handleStandardModifier(node: FunctionCallExprSyntax,
+                                        modifierName: SyntaxViewModifierName) {
+        let modifierArguments = self.parseArguments(from: node)
+        
+        let modifier = SyntaxViewModifier(
+            name: modifierName,
+            arguments: modifierArguments
+        )
+        addModifier(modifier)
+    }
+}

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchModel.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchModel.swift
@@ -1,0 +1,62 @@
+//
+//  CodeToStitchModel.swift
+//  Stitch
+//
+//  Created by Elliot Boschwitz on 7/31/25.
+//
+
+import SwiftSyntax
+import SwiftParser
+import SwiftSyntaxBuilder
+import SwiftUI
+
+struct SwiftUIViewParserResult {
+    let rootView: SyntaxView?
+    let bindingDeclarations: [String : SwiftParserInitializerType]
+    let caughtErrors: [SwiftUISyntaxError]
+}
+
+enum SwiftParserPatternBindingArg {
+    case value(SyntaxViewModifierArgumentType)
+    case binding(DeclReferenceExprSyntax)
+    case subscriptRef(SwiftParserSubscript)
+}
+
+struct SwiftParserPatchData {
+    // TODO: must be decoded
+    let id = UUID().uuidString
+    
+    var patchName: String
+    var args: [SwiftParserPatternBindingArg]
+}
+
+struct SwiftParserSubscript: Sendable {
+    // The name of the variable
+    var subscriptType: SwiftParserSubscriptType
+    var portIndex: Int
+}
+
+enum SwiftParserInitializerType {
+    // creates some patch node from a declared function
+    case patchNode(SwiftParserPatchData)
+    
+    // access an index of some node's outputs
+    case subscriptRef(SwiftParserSubscript)
+    
+    // initializes state
+//    case stateVarName
+    
+    // mutates some existing state
+    case stateMutation(SwiftParserStateMutation)
+}
+
+enum SwiftParserStateMutation: Sendable {
+    case declrRef(String)
+    case subscriptRef(SwiftParserSubscript)
+}
+
+// Subscripts can be used on references or nodes themselves
+enum SwiftParserSubscriptType {
+    case ref(String)
+    case patchNode(SwiftParserPatchData)
+}

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchPatchData.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchPatchData.swift
@@ -1,0 +1,267 @@
+//
+//  CodeToStitchPatchData.swift
+//  Stitch
+//
+//  Created by Elliot Boschwitz on 7/31/25.
+//
+
+import SwiftSyntax
+import SwiftParser
+import SwiftSyntaxBuilder
+import SwiftUI
+
+extension SwiftUIViewVisitor {
+    func visitPatchData(_ node: FunctionCallExprSyntax) -> SwiftParserPatchData? {
+        guard
+            let subscriptExpr = node.calledExpression.as(SubscriptCallExprSyntax.self),
+            let baseIdent = subscriptExpr.calledExpression.as(DeclReferenceExprSyntax.self),
+            baseIdent.baseName.text == "NATIVE_STITCH_PATCH_FUNCTIONS",
+            let firstArg = subscriptExpr.arguments.first,
+            let stringLit = firstArg.expression.as(StringLiteralExprSyntax.self)
+        else {
+            return nil
+        }
+        
+        guard let patchNode = stringLit.segments.first?.description else {
+            return nil
+        }
+        
+        guard let elements = node.arguments.first?.expression.as(ArrayExprSyntax.self)?.elements else {
+            fatalErrorIfDebug()
+            return nil
+        }
+        
+        let patchNodeArgs = elements.compactMap { arg -> SwiftParserPatternBindingArg? in
+            // ArrayExpr → might hold a PortValueDescription literal
+            if let arrayElem = arg.expression.as(ArrayExprSyntax.self),
+               let innerFirstElem = arrayElem.elements.first?.expression {
+                
+                guard let argData = self.parseArgumentType(from: innerFirstElem) else {
+                    fatalError()
+                }
+                
+                return .value(argData)
+            }
+            
+            else if let declrRefSyntax = arg.expression.as(DeclReferenceExprSyntax.self) {
+                print("Input param that points to some reference: \(declrRefSyntax)")
+                return .binding(declrRefSyntax)
+            }
+            
+            else if let subscriptCallExpr = arg.expression.as(SubscriptCallExprSyntax.self) {
+                let subscriptData = self.visitSubscriptData(subscriptCallExpr: subscriptCallExpr)
+                return .subscriptRef(subscriptData)
+            }
+            
+            else {
+                fatalError()
+            }
+        }
+        
+        return .init(patchName: patchNode,
+                     args: patchNodeArgs)
+    }
+    
+    func visitSubscriptData(subscriptCallExpr: SubscriptCallExprSyntax) -> SwiftParserSubscript {
+        // Subscript reference to some existing outputs
+        let subscriptRef = self.deriveSubscriptData(subscriptCallExpr: subscriptCallExpr)
+        
+        // Check for function expressions here too, needed for deriving patch data
+        if let patchFn = subscriptCallExpr.calledExpression.as(FunctionCallExprSyntax.self) {
+            // Assumed to be patch node
+            guard let patchNode = self.visitPatchData(patchFn) else {
+                fatalError()
+            }
+            
+            return .init(subscriptType: .patchNode(patchNode),
+                         portIndex: subscriptRef.portIndex)
+        }
+        
+        else {
+            return subscriptRef
+        }
+    }
+}
+
+extension SwiftParserPatchData {
+    func createStitchData(varName: String,
+                          varNameIdMap: inout [String : String]) -> CurrentAIGraphData.NativePatchNode {
+        guard let patchName = CurrentAIGraphData.StitchAIPatchOrLayer.init(value: .init(self.patchName)) else {
+            fatalError()
+        }
+        
+//        let nodeIdString = String(varName.split(separator: "_")[safe: 1] ?? "")
+//        let decodedId = UUID(uuidString: nodeIdString) ?? .init()
+        varNameIdMap.updateValue(self.id, forKey: varName)
+        
+        let newPatchNode = CurrentAIGraphData
+            .NativePatchNode(node_id: self.id,
+                             node_name: patchName)
+        return newPatchNode
+    }
+}
+
+extension SwiftParserPatchData {
+    static func derivePatchUpstreamCoordinate(upstreamRefData: SwiftParserSubscript,
+                                              varNameIdMap: [String : String]) -> AIGraphData_V0.NodeIndexedCoordinate {
+        let upstreamPortIndex = upstreamRefData.portIndex
+        let upstreamNodeId: String
+        
+        // Get upstream node ID
+        switch upstreamRefData.subscriptType {
+        case .patchNode(let patchNodeData):
+            upstreamNodeId = patchNodeData.id
+            
+        case .ref(let refName):
+            guard let _upstreamNodeId = varNameIdMap.get(refName) else {
+                fatalError()
+            }
+            
+            upstreamNodeId = _upstreamNodeId
+        }
+        
+        return .init(node_id: upstreamNodeId,
+                     port_index: upstreamPortIndex)
+    }
+}
+
+extension SwiftUIViewVisitor {
+    func deriveSubscriptData(subscriptCallExpr: SubscriptCallExprSyntax) -> SwiftParserSubscript {
+        guard let labeledExpr = subscriptCallExpr.arguments.first?.expression.as(IntegerLiteralExprSyntax.self),
+              let portIndex = Int(labeledExpr.literal.text) else {
+            fatalError()
+        }
+        
+        // Patch declarations can call here too
+        if let funcExpr = subscriptCallExpr.calledExpression.as(FunctionCallExprSyntax.self) {
+            guard let patchNode = self.visitPatchData(funcExpr) else {
+                fatalError()
+            }
+            
+            let subscriptRef = SwiftParserSubscript(subscriptType: .patchNode(patchNode),
+                                                    portIndex: portIndex)
+            
+            return subscriptRef
+        }
+        
+        // Output port index access of some patch node in the form of index access of a patch fn's output values
+        else if let declRef = subscriptCallExpr.calledExpression.as(DeclReferenceExprSyntax.self) {
+            
+            let outputPortData = SwiftParserSubscript(subscriptType: .ref(declRef.baseName.text),
+                                                      portIndex: portIndex)
+            
+            return outputPortData
+        }
+        
+        else {
+            fatalError()
+        }
+    }
+}
+
+extension SwiftParserInitializerType {
+    func parseStitchActions(varName: String,
+                            varNameIdMap: [String : String],
+                            varNameOutputPortMap: [String : SwiftParserSubscript],
+    customPatchInputValues: inout [CurrentAIGraphData.CustomPatchInputValue],
+                            patchConnections: inout [CurrentAIGraphData.PatchConnection],
+                            viewStatePatchConnections: inout [String : AIGraphData_V0.NodeIndexedCoordinate]) throws {
+        switch self {
+        case .patchNode(let patchNodeData):
+            for (portIndex, arg) in patchNodeData.args.enumerated() {
+                switch arg {
+                case .binding(let declRefSyntax):
+                    // Get edge data
+                    let refName = declRefSyntax.baseName.text
+                                            
+                    guard let upstreamRefData = varNameOutputPortMap.get(refName) else {
+                        fatalError()
+                    }
+                    
+                    let usptreamCoordinate = SwiftParserPatchData
+                        .derivePatchUpstreamCoordinate(upstreamRefData: upstreamRefData,
+                                                       varNameIdMap: varNameIdMap)
+                    
+                    patchConnections.append(
+                        .init(src_port: usptreamCoordinate,
+                              dest_port: .init(node_id: patchNodeData.id,                          port_index: portIndex))
+                    )
+                    
+                case .value(let argType):
+                    let portDataList = try argType.derivePortValues()
+                    
+                    for portData in portDataList {
+                        switch portData {
+                        case .value(let portValue):
+                            customPatchInputValues.append(
+                                .init(patch_input_coordinate: .init(
+                                    node_id: patchNodeData.id,
+                                    port_index: portIndex),
+                                      value: portValue.value,
+                                      value_type: portValue.value_type)
+                            )
+                            
+                        case .stateRef:
+                            fatalErrorIfDebug("State variables should never be passed into patch nodes")
+                            throw SwiftUISyntaxError.unsupportedStateInPatchInputParsing(patchNodeData)
+                        }
+                    }
+                    
+                case .subscriptRef(let subscriptRef):
+                    // Recursively call subscript data
+                    let subscriptInitializer = SwiftParserInitializerType.subscriptRef(subscriptRef)
+                    try subscriptInitializer
+                        .parseStitchActions(varName: varName,
+                                            varNameIdMap: varNameIdMap,
+                                            varNameOutputPortMap: varNameOutputPortMap,
+                                            customPatchInputValues: &customPatchInputValues,
+                                            patchConnections: &patchConnections,
+                                            viewStatePatchConnections: &viewStatePatchConnections)
+                }
+            }
+            
+        case .stateMutation(let mutationData):
+            let subscriptData: SwiftParserSubscript
+            
+            // Find subscript data which must exist for view state mutation
+            switch mutationData {
+            case .subscriptRef(let _subscriptData):
+                subscriptData = _subscriptData
+                
+            case .declrRef(let ref):
+                guard let refData = varNameOutputPortMap.get(ref) else {
+                    throw SwiftUISyntaxError.unexpectedStateMutatorFound(mutationData)
+                }
+                
+                subscriptData = refData
+            }
+            
+            // Track upstream patch coordinate to some TBD layer input
+            let usptreamCoordinate = SwiftParserPatchData
+                .derivePatchUpstreamCoordinate(upstreamRefData: subscriptData,
+                                               varNameIdMap: varNameIdMap)
+            
+            viewStatePatchConnections.updateValue(usptreamCoordinate,
+                                                  forKey: varName)
+            
+        case .subscriptRef(let subscriptData):
+            switch subscriptData.subscriptType {
+            case .patchNode(let patchNodeData):
+                let initializerData = SwiftParserInitializerType.patchNode(patchNodeData)
+                
+                // Recursively parse patch node data
+                try initializerData
+                    .parseStitchActions(varName: varName,
+                                        varNameIdMap: varNameIdMap,
+                                        varNameOutputPortMap: varNameOutputPortMap,
+                                        customPatchInputValues: &customPatchInputValues,
+                                        patchConnections: &patchConnections,
+                                        viewStatePatchConnections: &viewStatePatchConnections)
+                
+            case .ref:
+                // Ignore here
+                return
+            }
+        }
+    }
+}

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
@@ -11,40 +11,6 @@ import SwiftSyntax
 import SwiftParser
 import SwiftSyntaxBuilder
 
-
-// MARK: - SwiftUI Code to ViewNode
-
-struct SwiftUIViewParserResult {
-    let rootView: SyntaxView?
-    let bindingDeclarations: [String : SwiftParserInitializerType]
-    let caughtErrors: [SwiftUISyntaxError]
-}
-
-extension SwiftUIViewVisitor {
-    /// Parses SwiftUI code into a ViewNode structure
-    static func parseSwiftUICode(_ swiftUICode: String) -> SwiftUIViewParserResult {
-        print("\n==== PARSING CODE ====\n\(swiftUICode)\n=====================\n")
-        
-        // Fall back to the original visitor-based approach for now
-        // but add our own post-processing for modifiers
-        let sourceFile = Parser.parse(source: swiftUICode)
-        
-//#if DEV_DEBUG
-//        print("\n==== DEBUG: SOURCE FILE STRUCTURE ====\n")
-//        dump(sourceFile)
-//        print("\n==== END DEBUG DUMP ====\n")
-//#endif
-        
-        // Create a visitor that will extract the view structure
-        let visitor = SwiftUIViewVisitor(viewMode: .sourceAccurate)
-        visitor.walk(sourceFile)
-                
-        return .init(rootView: visitor.rootViewNode,
-                     bindingDeclarations: visitor.bindingDeclarations,
-                     caughtErrors: visitor.caughtErrors)
-    }
-}
-
 /// SwiftSyntax visitor that extracts ViewNode structure from SwiftUI code
 final class SwiftUIViewVisitor: SyntaxVisitor {
     var rootViewNode: SyntaxView?
@@ -52,33 +18,21 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
     // Top-level declarations of patch data
     var bindingDeclarations = [String : SwiftParserInitializerType]()
     
-    private var currentNodeIndex: Int? // Index into the view stack
-    private var viewStack: [SyntaxView] = []
+    var currentNodeIndex: Int? // Index into the view stack
+    var viewStack: [SyntaxView] = []
     private var idCounter = 0
     
     // Context tracking for proper child vs argument parsing
-    private enum ParsingContext {
+    enum ParsingContext {
         case root
         case closure(parentView: SyntaxViewName)
         case arguments
     }
-    private var contextStack: [ParsingContext] = [.root]
+    
+    var contextStack: [ParsingContext] = [.root]
     
     // Tracks decoding errors
     var caughtErrors: [SwiftUISyntaxError] = []
-    
-    // Debug logging for tracing the parsing process
-    private func log(_ message: String) {
-//#if DEV_DEBUG
-//        print("[SwiftUIParser] \(message)")
-//#endif
-    }
-    
-    private func dbg(_ message: String) {
-//    #if DEV_DEBUG
-//        print("🔍 [ModifierDebug] \(message)")
-//    #endif
-    }
     
     override func visit(_ node: PatternBindingSyntax) -> SyntaxVisitorContinueKind {
         
@@ -137,7 +91,7 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
             // here because the base view may not have been pushed onto the stack yet.
             // Instead, we defer actual attachment to `visitPost(_:)`, which runs after the
             // base `FunctionCallExprSyntax` has been visited.
-            dbg("visit → encountered potential modifier .\(memberAccessExpr.declName.baseName.text) – deferring to visitPost")
+            log("visit → encountered potential modifier .\(memberAccessExpr.declName.baseName.text) – deferring to visitPost")
         }
         
         return .visitChildren
@@ -270,7 +224,7 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
         // ─────────────────────────────────────────────────────────────
         // Handle view‑modifier calls *after* the base view has been visited
         else if let modifierName = modifierNameIfViewModifier(node) {
-            dbg("visitPost → handling view modifier '\(modifierName)'")
+            log("visitPost → handling view modifier '\(modifierName)'")
             
             if let syntaxViewModifierName = SyntaxViewModifierName(rawValue: modifierName) {
                     handleStandardModifier(node: node, modifierName: syntaxViewModifierName)
@@ -279,7 +233,7 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
                 // we are at the end of the modifier chain; pop the base view.
                 if node.parent?.as(MemberAccessExprSyntax.self) == nil {
                     if let popped = viewStack.popLast() {
-                        dbg("visitPost → popped view \(popped.name.rawValue) after completing modifier chain")
+                        log("visitPost → popped view \(popped.name.rawValue) after completing modifier chain")
                     }
                     currentNodeIndex = viewStack.isEmpty ? nil : viewStack.count - 1
                 }
@@ -291,682 +245,27 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
     }
 }
 
-
-// TODO: move utils
 extension SwiftUIViewVisitor {
-    // Parse arguments from function call
-    func parseArguments(from node: FunctionCallExprSyntax) -> ViewConstructorType {
-        // Default handling for other modifiers
-        let arguments = node.arguments.compactMap { (argument) -> SyntaxViewArgumentData? in
-            self.parseArgument(argument)
-        }
+    /// Parses SwiftUI code into a ViewNode structure
+    static func parseSwiftUICode(_ swiftUICode: String) -> SwiftUIViewParserResult {
+        print("\n==== PARSING CODE ====\n\(swiftUICode)\n=====================\n")
         
-        dbg("parseArguments → for \(node.calledExpression.trimmedDescription)  |  \(arguments.count) arg(s): \(arguments)")
+        // Fall back to the original visitor-based approach for now
+        // but add our own post-processing for modifiers
+        let sourceFile = Parser.parse(source: swiftUICode)
         
-        guard let knownViewConstructor = createKnownViewConstructor(
-            from: node,
-            arguments: arguments) else {
-            return .other(arguments)
-        }
+//#if DEV_DEBUG
+//        print("\n==== DEBUG: SOURCE FILE STRUCTURE ====\n")
+//        dump(sourceFile)
+//        print("\n==== END DEBUG DUMP ====\n")
+//#endif
         
-        return .trackedConstructor(knownViewConstructor)
-    }
-    
-    func parseArgument(_ argument: LabeledExprSyntax) -> SyntaxViewArgumentData? {
-        let label = argument.label?.text
-        
-        let expression = argument.expression
-        
-        guard let value = self.parseArgumentType(from: expression) else {
-            return nil
-        }
-        
-        return .init(label: label,
-                     value: value)
-    }
-    
-    func parseFnArgumentType(_ funcExpr: FunctionCallExprSyntax) -> SyntaxViewModifierComplexType {
-        // Recursively create argument data
-        let complexTypeArgs = funcExpr.arguments
-            .compactMap { expr in
-                self.parseArgument(expr)
-            }
-        
-        let complexType = SyntaxViewModifierComplexType(
-            typeName: funcExpr.calledExpression.trimmedDescription,
-            arguments: complexTypeArgs)
-        
-        return complexType
-    }
-    
-    /// Handles conditional logic for determining a type of syntax argument.
-    func parseArgumentType(from expression: SwiftSyntax.ExprSyntax) -> SyntaxViewModifierArgumentType? {
-        // Handles compelx types, like PortValueDescription
-        if let funcExpr = expression.as(FunctionCallExprSyntax.self) {
-            let complexType = self.parseFnArgumentType(funcExpr)
-            return .complex(complexType)
-        }
-        
-        // Recursively handle arguments in tuple case
-        else if let tupleExpr = expression.as(TupleExprSyntax.self) {
-            let tupleArgs = tupleExpr.elements.compactMap(self.parseArgument(_:))
-            return .tuple(tupleArgs)
-        }
-        
-        // Recursively handle arguments in array case
-        else if let arrayExpr = expression.as(ArrayExprSyntax.self) {
-            let arrayArgs = arrayExpr.elements.compactMap {
-                self.parseArgumentType(from: $0.expression)
-            }
-            return .array(arrayArgs)
-        }
-        
-        else if let memberAccessExpr = expression.as(MemberAccessExprSyntax.self) {
-            return .memberAccess(SyntaxViewMemberAccess(
-                base: memberAccessExpr.base?.trimmedDescription,
-                property: memberAccessExpr.declName.baseName.trimmedDescription))
-            
-        }
-        
-        else if let dictExpr = expression.as(DictionaryExprSyntax.self) {
-            // Break down children
-            let dictChildren = dictExpr.content.children(viewMode: .sourceAccurate)
-            let recursedChildren = dictChildren.compactMap { dictElem -> SyntaxViewArgumentData? in
-                guard let dictElem = dictElem.as(DictionaryElementSyntax.self),
-                      // get value data recursively
-                      let value = self.parseArgumentType(from: dictElem.value) else {
-                    return nil
-                }
+        // Create a visitor that will extract the view structure
+        let visitor = SwiftUIViewVisitor(viewMode: .sourceAccurate)
+        visitor.walk(sourceFile)
                 
-                let label = dictElem.key.trimmedDescription
-                return SyntaxViewArgumentData(label: label, value: value)
-            }
-            
-            // Testing tuple type for now, should be the same stuff
-            return .tuple(recursedChildren)
-        }
-        
-        // Tracks references to state
-        else if let declrRefExpr = expression.as(DeclReferenceExprSyntax.self) {
-            return .stateAccess(declrRefExpr.trimmedDescription)
-        }
-        
-        guard let syntaxKind = SyntaxArgumentKind.fromExpression(expression) else {
-            self.caughtErrors.append(.unsupportedSyntaxArgumentKind(expression.trimmedDescription))
-            return nil
-        }
-        
-        switch syntaxKind {
-        case .literal(let syntaxArgumentLiteralKind):
-            // Simple case
-            let data = SyntaxViewSimpleData(
-                value: expression.trimmedDescription,
-                syntaxKind: syntaxArgumentLiteralKind
-            )
-            return .simple(data)
-            
-        default:
-            // No support for variables or expressions here
-            return nil
-        }
-    }
-    
-}
-
-
-// TODO: move layer helpers
-
-extension SwiftUIViewVisitor {
-    func visitLayerData(identifierExpr: DeclReferenceExprSyntax,
-                        node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
-        // This might be a view initialization like Text("Hello")
-        let viewName = identifierExpr.baseName.text
-        
-        guard let nameType = SyntaxNameType.from(viewName) else {
-//                fatalErrorIfDebug("No view discovered for: \(viewName)")
-            log("No concept discovered for: \(viewName)")
-            
-            // Tracks for later silent failures
-            self.caughtErrors.append(.unsupportedSyntaxViewName(viewName))
-            
-            return .skipChildren
-        }
-        
-        log("Found view initialization: \(viewName)")
-        
-        // Parse args, catching arguments we don't yet support
-        let args = self.parseArguments(from: node)
-        
-        switch nameType {
-        case .view(let syntaxViewName):
-            // Create a new ViewNode for this view
-            let viewNode = SyntaxView(
-                name: syntaxViewName,
-                // This is creat
-                constructorArguments: args,
-                modifiers: [],
-                children: [],
-                id: UUID()
-                //                errors: self.caughtErrors
-            )
-            
-            log("Created new ViewNode for \(viewName)")
-            
-            // Set as root or add as child to current node (context-aware)
-            if viewStack.isEmpty {
-                log("Setting as root ViewNode: \(viewName)")
-                viewStack.append(viewNode)
-                currentNodeIndex = 0
-                rootViewNode = viewNode
-
-                log("Current node index set to: \(String(describing: currentNodeIndex))")
-            } else {
-                // Check if this view initialization should be treated as a child
-                // Only apply context-aware logic for top-level view statements that could be children
-                let currentContext = contextStack.last ?? .root
-                log("Current parsing context: \(currentContext)")
-                
-                switch currentContext {
-                case .closure(let parentViewName):
-                    // We're inside a closure of a container view - this IS a legitimate child
-                    if let currentNode = currentViewNode {
-                        log("Adding \(viewName) as child to \(currentNode.name.rawValue) (inside closure)")
-                        var updatedCurrentNode = currentNode
-                        updatedCurrentNode.children.append(viewNode)
-                        updateCurrentViewNode(updatedCurrentNode)
-                        
-                        // Push the new node onto the stack and update current node index
-                        viewStack.append(viewNode)
-                        currentNodeIndex = viewStack.count - 1
-                                                    
-                        log("Pushed \(viewName) onto stack, new index: \(String(describing: currentNodeIndex))")
-                    } else {
-                        log("⚠️ Error: No current node to add child to")
-                    }
-                    
-                case .arguments, .root:
-                    // We're parsing function arguments - this might be a modifier argument
-                    // Check if this is actually being used as a modifier argument
-                    if isWithinModifierArguments(node) {
-                        log("Found view \(viewName) in modifier argument context - allowing normal processing")
-                        // For modifier arguments, we still need to process the view normally
-                        // but we don't add it as a child to any parent view
-                        // Just add it to the stack temporarily so it can be processed
-                        viewStack.append(viewNode)
-                        currentNodeIndex = viewStack.count - 1
-                    } else {
-                        log("⚠️ Found view \(viewName) in argument context - skipping child addition")
-                        log("This view should be handled as an argument, not as a child")
-                        // Don't add to viewStack - this prevents it from being treated as a child
-                    }
-                }
-            }
-            
-            return .visitChildren
-            
-        case .value:
-            // No view here, just continue
-            return .skipChildren
-        }
-    }
-
-    
-    // Helper to get current ViewNode
-    private var currentViewNode: SyntaxView? {
-        guard let index = currentNodeIndex, index < viewStack.count else { return nil }
-        return viewStack[index]
-    }
-    
-    /// Returns the modifier name if `node` is a *view modifier* call
-    /// (i.e. a `FunctionCallExprSyntax` whose `calledExpression` is a
-    /// `MemberAccessExprSyntax` **with a non‑nil base**).
-    /// Helper/static calls that appear only as *arguments* – such as
-    /// `.degrees(90)` or `.black` – have `base == nil`, so they are
-    /// filtered out.
-    private func modifierNameIfViewModifier(_ node: FunctionCallExprSyntax) -> String? {
-        guard
-            // Must look like `.something`  (i.e. a MemberAccessExpr)
-            let member = node.calledExpression.as(MemberAccessExprSyntax.self),
-            let base   = member.base            // no base ⇒ e.g. `.degrees(90)` helper
-        else {
-            return nil
-        }
-        
-        /// Walks the `base` chain and returns `true` iff we eventually hit a
-        /// `FunctionCallExprSyntax` (e.g. `Rectangle()` or `Color.red`), meaning
-        /// the member access is **chained onto a view instance**.  Static helper
-        /// calls such as `Double.random(in:)` terminate in an `IdentifierExpr`
-        /// (“Double”) and therefore return `false`.
-        func isChainedToView(_ syntax: SyntaxProtocol) -> Bool {
-            if syntax.is(FunctionCallExprSyntax.self) { return true }
-            if let m = syntax.as(MemberAccessExprSyntax.self), let inner = m.base {
-                return isChainedToView(inner)
-            }
-            return false
-        }
-
-        return isChainedToView(base) ? member.declName.baseName.text : nil
-    }
-    
-    /// Check if this function call is within the arguments of a modifier
-    /// This helps distinguish between legitimate child views and modifier arguments
-    private func isWithinModifierArguments(_ node: FunctionCallExprSyntax) -> Bool {
-        // Walk up the parent chain to see if we're inside a modifier's argument list
-        var currentNode: Syntax? = node.parent
-        
-        while let parent = currentNode {
-            // If we find a FunctionCallExprSyntax that is a modifier, and we're in its arguments
-            if let functionCall = parent.as(FunctionCallExprSyntax.self),
-               modifierNameIfViewModifier(functionCall) != nil {
-                // We're inside a modifier's argument list
-                return true
-            }
-            currentNode = parent.parent
-        }
-        
-        return false
-    }
-    
-    /// Propagate a mutation at `index` upward through `viewStack`
-    /// so that every ancestor’s `children` array is updated
-    /// and `rootViewNode` stays in sync.
-    private func bubbleChangeUp(from index: Int) {
-        var childIndex = index
-        while childIndex > 0 {
-            let parentIndex = childIndex - 1
-            var parent = viewStack[parentIndex]
-            let child = viewStack[childIndex]
-            
-            if let match = parent.children.firstIndex(where: { $0.id == child.id }) {
-                parent.children[match] = child
-                viewStack[parentIndex] = parent
-            } else {
-                // Shouldn’t happen, but avoid infinite loop
-                break
-            }
-            childIndex = parentIndex
-        }
-        if !viewStack.isEmpty {
-            rootViewNode = viewStack[0]
-        }
-    }
-
-    // Helper to update currentViewNode properly
-    private func updateCurrentViewNode(_ newNode: SyntaxView) {
-        guard let index = currentNodeIndex, index < viewStack.count else { return }
-        viewStack[index] = newNode
-        bubbleChangeUp(from: index)
-    }
-    
-    // Helper to add a modifier to the current view node
-    private func addModifier(_ modifier: SyntaxViewModifier) {
-        let modName = modifier.name.rawValue
-        dbg("addModifier → \(modName) to current index \(String(describing: currentNodeIndex))")
-        guard let index = currentNodeIndex, index < viewStack.count else {
-            log("⚠️ Cannot add modifier: no current view node")
-            return
-        }
-        
-        var node = viewStack[index]
-        log("Adding modifier \(modName) to \(node.name.rawValue)")
-        node.modifiers.append(modifier)
-        viewStack[index] = node
-        // Bubble the change up to keep all ancestors current
-        bubbleChangeUp(from: index)
-        log("✅ After adding modifier - modifiers count: \(node.modifiers.count)")
-        dbg("addModifier → completed. Node \(node.name.rawValue) now has \(node.modifiers.count) modifier(s).")
-    }
-
-    /// Handles standard modifiers with generic argument parsing
-    private func handleStandardModifier(node: FunctionCallExprSyntax,
-                                        modifierName: SyntaxViewModifierName) {
-        let modifierArguments = self.parseArguments(from: node)
-        
-        let modifier = SyntaxViewModifier(
-            name: modifierName,
-            arguments: modifierArguments
-        )
-        addModifier(modifier)
-    }
-}
-
-//// Example usage function to test the parsing
-//func testSwiftUIToViewNode(swiftUICode: String) {
-//    if let viewNode = SwiftUIViewVisitor.parseSwiftUICode(swiftUICode) {
-//        print("\n==== PARSED VIEWNODE RESULT ====\n")
-//        print("Name: \(viewNode.name.rawValue)")
-//        print("Arguments: \(viewNode.constructorArguments)")
-//        print("Modifiers (\(viewNode.modifiers.count)):")
-//        for (index, modifier) in viewNode.modifiers.enumerated() {
-//            print("  [\(index)] \(modifier.name.rawValue))")
-//            if !modifier.arguments.isEmpty {
-//                print("    Arguments:")
-//                for arg in modifier.arguments {
-//                    print("      \(arg.label): \(arg.value)")
-//                }
-//            }
-//        }
-//        print("Children: \(viewNode.children.count)")
-//        print("============================\n")
-//    } else {
-//        print("Failed to parse SwiftUI code")
-//    }
-//}
-//
-//// Run a simple test with a Text view that has modifiers
-//func runModifierParsingTest() {
-//    print("\n==== TESTING MODIFIER PARSING ====\n")
-//
-//    let testCode = "Text(\"Hello\").foregroundColor(.blue).padding()"
-//    print("Test code: \(testCode)")
-//
-//    testSwiftUIToViewNode(swiftUICode: testCode)
-//
-//    print("\n==== TEST COMPLETE ====\n")
-//}
-
-
-// TODO: move
-
-extension SwiftUIViewVisitor {
-    func visitPatchData(_ node: FunctionCallExprSyntax) -> SwiftParserPatchData? {
-        guard
-            let subscriptExpr = node.calledExpression.as(SubscriptCallExprSyntax.self),
-            let baseIdent = subscriptExpr.calledExpression.as(DeclReferenceExprSyntax.self),
-            baseIdent.baseName.text == "NATIVE_STITCH_PATCH_FUNCTIONS",
-            let firstArg = subscriptExpr.arguments.first,
-            let stringLit = firstArg.expression.as(StringLiteralExprSyntax.self)
-        else {
-            return nil
-        }
-        
-        guard let patchNode = stringLit.segments.first?.description else {
-            return nil
-        }
-        
-        guard let elements = node.arguments.first?.expression.as(ArrayExprSyntax.self)?.elements else {
-            fatalErrorIfDebug()
-            return nil
-        }
-        
-        let patchNodeArgs = elements.compactMap { arg -> SwiftParserPatternBindingArg? in
-            // ArrayExpr → might hold a PortValueDescription literal
-            if let arrayElem = arg.expression.as(ArrayExprSyntax.self),
-               let innerFirstElem = arrayElem.elements.first?.expression {
-                
-                guard let argData = self.parseArgumentType(from: innerFirstElem) else {
-                    fatalError()
-                }
-                
-                return .value(argData)
-            }
-            
-            else if let declrRefSyntax = arg.expression.as(DeclReferenceExprSyntax.self) {
-                print("Input param that points to some reference: \(declrRefSyntax)")
-                return .binding(declrRefSyntax)
-            }
-            
-            else if let subscriptCallExpr = arg.expression.as(SubscriptCallExprSyntax.self) {
-                let subscriptData = self.visitSubscriptData(subscriptCallExpr: subscriptCallExpr)
-                return .subscriptRef(subscriptData)
-            }
-            
-            else {
-                fatalError()
-            }
-        }
-        
-        return .init(patchName: patchNode,
-                     args: patchNodeArgs)
-    }
-    
-    func visitSubscriptData(subscriptCallExpr: SubscriptCallExprSyntax) -> SwiftParserSubscript {
-        // Subscript reference to some existing outputs
-        let subscriptRef = self.deriveSubscriptData(subscriptCallExpr: subscriptCallExpr)
-        
-        // Check for function expressions here too, needed for deriving patch data
-        if let patchFn = subscriptCallExpr.calledExpression.as(FunctionCallExprSyntax.self) {
-            // Assumed to be patch node
-            guard let patchNode = self.visitPatchData(patchFn) else {
-                fatalError()
-            }
-            
-            return .init(subscriptType: .patchNode(patchNode),
-                         portIndex: subscriptRef.portIndex)
-        }
-        
-        else {
-            return subscriptRef
-        }
-    }
-}
-
-enum SwiftParserPatternBindingArg {
-    case value(SyntaxViewModifierArgumentType)
-    case binding(DeclReferenceExprSyntax)
-    case subscriptRef(SwiftParserSubscript)
-}
-
-struct SwiftParserPatchData {
-    // TODO: must be decoded
-    let id = UUID().uuidString
-    
-    var patchName: String
-    var args: [SwiftParserPatternBindingArg]
-}
-
-struct SwiftParserSubscript: Sendable {
-    // The name of the variable
-    var subscriptType: SwiftParserSubscriptType
-    var portIndex: Int
-}
-
-enum SwiftParserInitializerType {
-    // creates some patch node from a declared function
-    case patchNode(SwiftParserPatchData)
-    
-    // access an index of some node's outputs
-    case subscriptRef(SwiftParserSubscript)
-    
-    // initializes state
-//    case stateVarName
-    
-    // mutates some existing state
-    case stateMutation(SwiftParserStateMutation)
-}
-
-enum SwiftParserStateMutation: Sendable {
-    case declrRef(String)
-    case subscriptRef(SwiftParserSubscript)
-}
-
-// Subscripts can be used on references or nodes themselves
-enum SwiftParserSubscriptType {
-    case ref(String)
-    case patchNode(SwiftParserPatchData)
-}
-
-extension SwiftParserPatchData {
-    func createStitchData(varName: String,
-                          varNameIdMap: inout [String : String]) -> CurrentAIGraphData.NativePatchNode {
-        guard let patchName = CurrentAIGraphData.StitchAIPatchOrLayer.init(value: .init(self.patchName)) else {
-            fatalError()
-        }
-        
-//        let nodeIdString = String(varName.split(separator: "_")[safe: 1] ?? "")
-//        let decodedId = UUID(uuidString: nodeIdString) ?? .init()
-        varNameIdMap.updateValue(self.id, forKey: varName)
-        
-        let newPatchNode = CurrentAIGraphData
-            .NativePatchNode(node_id: self.id,
-                             node_name: patchName)
-        return newPatchNode
-    }
-}
-
-// TODO: move
-extension SwiftParserPatchData {
-    static func derivePatchUpstreamCoordinate(upstreamRefData: SwiftParserSubscript,
-                                              varNameIdMap: [String : String]) -> AIGraphData_V0.NodeIndexedCoordinate {
-        let upstreamPortIndex = upstreamRefData.portIndex
-        let upstreamNodeId: String
-        
-        // Get upstream node ID
-        switch upstreamRefData.subscriptType {
-        case .patchNode(let patchNodeData):
-            upstreamNodeId = patchNodeData.id
-            
-        case .ref(let refName):
-            guard let _upstreamNodeId = varNameIdMap.get(refName) else {
-                fatalError()
-            }
-            
-            upstreamNodeId = _upstreamNodeId
-        }
-        
-        return .init(node_id: upstreamNodeId,
-                     port_index: upstreamPortIndex)
-    }
-}
-
-// TODO: move
-extension SwiftUIViewVisitor {
-    func deriveSubscriptData(subscriptCallExpr: SubscriptCallExprSyntax) -> SwiftParserSubscript {
-        guard let labeledExpr = subscriptCallExpr.arguments.first?.expression.as(IntegerLiteralExprSyntax.self),
-              let portIndex = Int(labeledExpr.literal.text) else {
-            fatalError()
-        }
-        
-        // Patch declarations can call here too
-        if let funcExpr = subscriptCallExpr.calledExpression.as(FunctionCallExprSyntax.self) {
-            guard let patchNode = self.visitPatchData(funcExpr) else {
-                fatalError()
-            }
-            
-            let subscriptRef = SwiftParserSubscript(subscriptType: .patchNode(patchNode),
-                                                    portIndex: portIndex)
-            
-            return subscriptRef
-        }
-        
-        // Output port index access of some patch node in the form of index access of a patch fn's output values
-        else if let declRef = subscriptCallExpr.calledExpression.as(DeclReferenceExprSyntax.self) {
-            
-            let outputPortData = SwiftParserSubscript(subscriptType: .ref(declRef.baseName.text),
-                                                      portIndex: portIndex)
-            
-            return outputPortData
-        }
-        
-        else {
-            fatalError()
-        }
-    }
-}
-
-extension SwiftParserInitializerType {
-    func parseStitchActions(varName: String,
-                            varNameIdMap: [String : String],
-                            varNameOutputPortMap: [String : SwiftParserSubscript],
-    customPatchInputValues: inout [CurrentAIGraphData.CustomPatchInputValue],
-                            patchConnections: inout [CurrentAIGraphData.PatchConnection],
-                            viewStatePatchConnections: inout [String : AIGraphData_V0.NodeIndexedCoordinate]) throws {
-        switch self {
-        case .patchNode(let patchNodeData):
-            for (portIndex, arg) in patchNodeData.args.enumerated() {
-                switch arg {
-                case .binding(let declRefSyntax):
-                    // Get edge data
-                    let refName = declRefSyntax.baseName.text
-                                            
-                    guard let upstreamRefData = varNameOutputPortMap.get(refName) else {
-                        fatalError()
-                    }
-                    
-                    let usptreamCoordinate = SwiftParserPatchData
-                        .derivePatchUpstreamCoordinate(upstreamRefData: upstreamRefData,
-                                                       varNameIdMap: varNameIdMap)
-                    
-                    patchConnections.append(
-                        .init(src_port: usptreamCoordinate,
-                              dest_port: .init(node_id: patchNodeData.id,                          port_index: portIndex))
-                    )
-                    
-                case .value(let argType):
-                    let portDataList = try argType.derivePortValues()
-                    
-                    for portData in portDataList {
-                        switch portData {
-                        case .value(let portValue):
-                            customPatchInputValues.append(
-                                .init(patch_input_coordinate: .init(
-                                    node_id: patchNodeData.id,
-                                    port_index: portIndex),
-                                      value: portValue.value,
-                                      value_type: portValue.value_type)
-                            )
-                            
-                        case .stateRef:
-                            fatalErrorIfDebug("State variables should never be passed into patch nodes")
-                            throw SwiftUISyntaxError.unsupportedStateInPatchInputParsing(patchNodeData)
-                        }
-                    }
-                    
-                case .subscriptRef(let subscriptRef):
-                    // Recursively call subscript data
-                    let subscriptInitializer = SwiftParserInitializerType.subscriptRef(subscriptRef)
-                    try subscriptInitializer
-                        .parseStitchActions(varName: varName,
-                                            varNameIdMap: varNameIdMap,
-                                            varNameOutputPortMap: varNameOutputPortMap,
-                                            customPatchInputValues: &customPatchInputValues,
-                                            patchConnections: &patchConnections,
-                                            viewStatePatchConnections: &viewStatePatchConnections)
-                }
-            }
-            
-        case .stateMutation(let mutationData):
-            let subscriptData: SwiftParserSubscript
-            
-            // Find subscript data which must exist for view state mutation
-            switch mutationData {
-            case .subscriptRef(let _subscriptData):
-                subscriptData = _subscriptData
-                
-            case .declrRef(let ref):
-                guard let refData = varNameOutputPortMap.get(ref) else {
-                    throw SwiftUISyntaxError.unexpectedStateMutatorFound(mutationData)
-                }
-                
-                subscriptData = refData
-            }
-            
-            // Track upstream patch coordinate to some TBD layer input
-            let usptreamCoordinate = SwiftParserPatchData
-                .derivePatchUpstreamCoordinate(upstreamRefData: subscriptData,
-                                               varNameIdMap: varNameIdMap)
-            
-            viewStatePatchConnections.updateValue(usptreamCoordinate,
-                                                  forKey: varName)
-            
-        case .subscriptRef(let subscriptData):
-            switch subscriptData.subscriptType {
-            case .patchNode(let patchNodeData):
-                let initializerData = SwiftParserInitializerType.patchNode(patchNodeData)
-                
-                // Recursively parse patch node data
-                try initializerData
-                    .parseStitchActions(varName: varName,
-                                        varNameIdMap: varNameIdMap,
-                                        varNameOutputPortMap: varNameOutputPortMap,
-                                        customPatchInputValues: &customPatchInputValues,
-                                        patchConnections: &patchConnections,
-                                        viewStatePatchConnections: &viewStatePatchConnections)
-                
-            case .ref:
-                // Ignore here
-                return
-            }
-        }
+        return .init(rootView: visitor.rootViewNode,
+                     bindingDeclarations: visitor.bindingDeclarations,
+                     caughtErrors: visitor.caughtErrors)
     }
 }

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
@@ -16,6 +16,7 @@ import SwiftSyntaxBuilder
 
 struct SwiftUIViewParserResult {
     let rootView: SyntaxView?
+    let bindingDeclarations: [String : SwiftParserInitializerType]
     let caughtErrors: [SwiftUISyntaxError]
 }
 
@@ -39,6 +40,7 @@ extension SwiftUIViewVisitor {
         visitor.walk(sourceFile)
                 
         return .init(rootView: visitor.rootViewNode,
+                     bindingDeclarations: visitor.bindingDeclarations,
                      caughtErrors: visitor.caughtErrors)
     }
 }
@@ -46,6 +48,10 @@ extension SwiftUIViewVisitor {
 /// SwiftSyntax visitor that extracts ViewNode structure from SwiftUI code
 final class SwiftUIViewVisitor: SyntaxVisitor {
     var rootViewNode: SyntaxView?
+    
+    // Top-level declarations of patch data
+    var bindingDeclarations = [String : SwiftParserInitializerType]()
+    
     private var currentNodeIndex: Int? // Index into the view stack
     private var viewStack: [SyntaxView] = []
     private var idCounter = 0
@@ -73,6 +79,437 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
 //        print("🔍 [ModifierDebug] \(message)")
 //    #endif
     }
+    
+    override func visit(_ node: PatternBindingSyntax) -> SyntaxVisitorContinueKind {
+        
+        guard let identifierPattern = node.pattern.as(IdentifierPatternSyntax.self) else {
+            return .visitChildren
+        }
+              
+        let currentLHS = identifierPattern.identifier.text
+        
+        // Record the name that's being bound (`let added = …`)
+        guard let initializer = node.initializer else {
+            return .visitChildren
+        }
+        
+        // Patch node declaration cases
+        if let funcExpr = initializer.value.as(FunctionCallExprSyntax.self) {
+            // Assumed to be patch node
+            guard let patchNode = self.visitPatchData(funcExpr) else {
+                fatalError()
+            }
+            
+            self.bindingDeclarations
+                .updateValue(.patchNode(patchNode), forKey: currentLHS)
+        }
+        
+        // Subscript callers used to access some node outputs
+        else if let subscriptCallExpr = initializer.value.as(SubscriptCallExprSyntax.self) {
+            // Subscript reference to some existing outputs
+            let subscriptData = self.visitSubscriptData(subscriptCallExpr: subscriptCallExpr)
+            self.bindingDeclarations
+                .updateValue(.subscriptRef(subscriptData),
+                             forKey: currentLHS)
+        }
+
+        else {
+            log("SwiftUIViewVisitor: unknown data at PatternBindingSyntax: \(node)")
+//            fatalError()
+        }
+        
+        return .visitChildren
+    }
+    
+    // Visit function call expressions (which represent view initializations and modifiers)
+    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+        log("Visiting function call: \(node.description)")
+        log("Current stack depth: \(viewStack.count), current index: \(String(describing: currentNodeIndex))")
+        
+        if let identifierExpr = node.calledExpression.as(DeclReferenceExprSyntax.self) {
+            log("LAYER DATA")
+            
+            return self.visitLayerData(identifierExpr: identifierExpr,
+                                       node: node)
+            
+        } else if let memberAccessExpr = node.calledExpression.as(MemberAccessExprSyntax.self) {
+            // Detected a modifier call (e.g. .padding()).  We *do not* attach the modifier
+            // here because the base view may not have been pushed onto the stack yet.
+            // Instead, we defer actual attachment to `visitPost(_:)`, which runs after the
+            // base `FunctionCallExprSyntax` has been visited.
+            dbg("visit → encountered potential modifier .\(memberAccessExpr.declName.baseName.text) – deferring to visitPost")
+        }
+        
+        return .visitChildren
+    }
+    
+    // Tracks assignments to @State variables
+    override func visit(_ node: SequenceExprSyntax) -> SyntaxVisitorContinueKind {
+        let elements = Array(node.elements)
+
+        guard elements.count == 3 else {
+            fatalError()
+        }
+        
+        guard let assignmentExpr = elements[1].as(AssignmentExprSyntax.self),
+              assignmentExpr.trimmedDescription == "=" else {
+            return .skipChildren
+        }
+        
+        guard let refExpr = elements[0].as(DeclReferenceExprSyntax.self) else {
+            return .skipChildren
+        }
+        
+        let assinmentElem = elements[2]
+        
+        if let subscriptExpr = assinmentElem.as(SubscriptCallExprSyntax.self) {
+            let subscriptRef = self.deriveSubscriptData(subscriptCallExpr: subscriptExpr)
+            self.bindingDeclarations
+                .updateValue(.stateMutation(.subscriptRef(subscriptRef)),
+                             forKey: refExpr.baseName.trimmedDescription)
+        }
+        
+        else if let declRefExpr = assinmentElem.as(DeclReferenceExprSyntax.self) {
+            let declLabel = declRefExpr.baseName.trimmedDescription
+            self.bindingDeclarations
+                .updateValue(.stateMutation(.declrRef(declLabel)),
+                             forKey: refExpr.baseName.trimmedDescription)
+            
+        }
+        
+        return .visitChildren
+    }
+    
+    // Handle closure expressions (for container views like VStack, HStack, ZStack)
+    override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
+        log("Entering closure expression")
+        
+        // Check if we're inside a container view that can have children
+        if let currentView = currentViewNode, currentView.name.canHaveChildren {
+            log("Entering closure for container view: \(currentView.name.rawValue)")
+            contextStack.append(.closure(parentView: currentView.name))
+        } else {
+            log("Entering closure in non-container context (likely function arguments)")
+            contextStack.append(.arguments)
+        }
+        
+        return .visitChildren
+    }
+    
+    override func visitPost(_ node: ClosureExprSyntax) {
+        log("Exiting closure expression")
+        
+        // Pop the context we pushed when entering the closure
+        if contextStack.count > 1 {
+            let poppedContext = contextStack.removeLast()
+            log("Popped context: \(poppedContext)")
+        }
+    }
+    
+    // MARK: - SyntaxVisitor Overrides
+    
+    // When we finish visiting a node, manage the view stack
+    override func visitPost(_ node: FunctionCallExprSyntax) {
+        log("Visiting post for function call: \(node.description)")
+        
+        // Handle view initializations (constructor calls like `Rectangle()`, `Text("hello")`)
+        if let identExpr = node.calledExpression.as(DeclReferenceExprSyntax.self) {
+            let viewName = identExpr.baseName.text
+            log("Found view initialization: \(viewName)")
+            log("Current context stack: \(contextStack)")
+            log("Node parent type: \(type(of: node.parent))")
+            
+            // If this view call is the *base* of a MemberAccessExpr (e.g. Rectangle() in
+            // Rectangle().frame(...)), we **keep** it on the stack so that the upcoming
+            // modifier call can still access and mutate the current view node.
+            if node.parent?.as(MemberAccessExprSyntax.self) != nil {
+                log("Deferring pop for \(viewName) because it is base of a modifier chain")
+                return
+            }
+            log("ViewStack before adjustment - count: \(viewStack.count), current node index: \(String(describing: currentNodeIndex))")
+            
+            // Debug the current stack state
+            if !viewStack.isEmpty {
+                log("Current stack state:")
+                for (index, stackNode) in viewStack.enumerated() {
+                    log("  [\(index)] \(stackNode.name.rawValue) with \(stackNode.modifiers.count) modifiers")
+                }
+            }
+            
+            // We're exiting a view initialization
+            if let lastNode = viewStack.last,
+               let nameType = SyntaxNameType.from(viewName),
+               // Ensure a view here instead of a value
+               nameType.isView {
+                // Before removing the node, make sure we capture any modifiers that were added
+                log("Node being popped: \(lastNode.name.rawValue) with \(lastNode.modifiers.count) modifiers")
+                
+                // Remove the last node
+                viewStack.removeLast()
+                
+                // Update current node index to point to the new last node
+                currentNodeIndex = viewStack.count > 0 ? viewStack.count - 1 : nil
+                
+                log("Stack after pop - depth: \(viewStack.count), new current index: \(String(describing: currentNodeIndex))")
+                
+                // Debug the root node state
+                if let root = rootViewNode {
+                    log("Root node: \(root.name.rawValue) with \(root.modifiers.count) modifiers and \(root.children.count) children")
+                    if !root.children.isEmpty {
+                        for (index, child) in root.children.enumerated() {
+                            log("  Root child[\(index)]: \(child.name.rawValue) with \(child.modifiers.count) modifiers")
+                        }
+                    }
+                }
+            } else {
+                log("View stack empty, nothing to pop")
+            }
+        }
+        
+ 
+        // ─────────────────────────────────────────────────────────────
+        // Handle view‑modifier calls *after* the base view has been visited
+        else if let modifierName = modifierNameIfViewModifier(node) {
+            dbg("visitPost → handling view modifier '\(modifierName)'")
+            
+            if let syntaxViewModifierName = SyntaxViewModifierName(rawValue: modifierName) {
+                    handleStandardModifier(node: node, modifierName: syntaxViewModifierName)
+                
+                // If this FunctionCallExpr is not nested inside *another* MemberAccessExpr,
+                // we are at the end of the modifier chain; pop the base view.
+                if node.parent?.as(MemberAccessExprSyntax.self) == nil {
+                    if let popped = viewStack.popLast() {
+                        dbg("visitPost → popped view \(popped.name.rawValue) after completing modifier chain")
+                    }
+                    currentNodeIndex = viewStack.isEmpty ? nil : viewStack.count - 1
+                }
+            } else {
+                print("visitPost error: unable to parse view modifier name: \(modifierName)")
+                self.caughtErrors.append(.unsupportedSyntaxViewModifierName(modifierName))
+            }
+        }
+    }
+}
+
+
+// TODO: move utils
+extension SwiftUIViewVisitor {
+    // Parse arguments from function call
+    func parseArguments(from node: FunctionCallExprSyntax) -> ViewConstructorType {
+        // Default handling for other modifiers
+        let arguments = node.arguments.compactMap { (argument) -> SyntaxViewArgumentData? in
+            self.parseArgument(argument)
+        }
+        
+        dbg("parseArguments → for \(node.calledExpression.trimmedDescription)  |  \(arguments.count) arg(s): \(arguments)")
+        
+        guard let knownViewConstructor = createKnownViewConstructor(
+            from: node,
+            arguments: arguments) else {
+            return .other(arguments)
+        }
+        
+        return .trackedConstructor(knownViewConstructor)
+    }
+    
+    func parseArgument(_ argument: LabeledExprSyntax) -> SyntaxViewArgumentData? {
+        let label = argument.label?.text
+        
+        let expression = argument.expression
+        
+        guard let value = self.parseArgumentType(from: expression) else {
+            return nil
+        }
+        
+        return .init(label: label,
+                     value: value)
+    }
+    
+    func parseFnArgumentType(_ funcExpr: FunctionCallExprSyntax) -> SyntaxViewModifierComplexType {
+        // Recursively create argument data
+        let complexTypeArgs = funcExpr.arguments
+            .compactMap { expr in
+                self.parseArgument(expr)
+            }
+        
+        let complexType = SyntaxViewModifierComplexType(
+            typeName: funcExpr.calledExpression.trimmedDescription,
+            arguments: complexTypeArgs)
+        
+        return complexType
+    }
+    
+    /// Handles conditional logic for determining a type of syntax argument.
+    func parseArgumentType(from expression: SwiftSyntax.ExprSyntax) -> SyntaxViewModifierArgumentType? {
+        // Handles compelx types, like PortValueDescription
+        if let funcExpr = expression.as(FunctionCallExprSyntax.self) {
+            let complexType = self.parseFnArgumentType(funcExpr)
+            return .complex(complexType)
+        }
+        
+        // Recursively handle arguments in tuple case
+        else if let tupleExpr = expression.as(TupleExprSyntax.self) {
+            let tupleArgs = tupleExpr.elements.compactMap(self.parseArgument(_:))
+            return .tuple(tupleArgs)
+        }
+        
+        // Recursively handle arguments in array case
+        else if let arrayExpr = expression.as(ArrayExprSyntax.self) {
+            let arrayArgs = arrayExpr.elements.compactMap {
+                self.parseArgumentType(from: $0.expression)
+            }
+            return .array(arrayArgs)
+        }
+        
+        else if let memberAccessExpr = expression.as(MemberAccessExprSyntax.self) {
+            return .memberAccess(SyntaxViewMemberAccess(
+                base: memberAccessExpr.base?.trimmedDescription,
+                property: memberAccessExpr.declName.baseName.trimmedDescription))
+            
+        }
+        
+        else if let dictExpr = expression.as(DictionaryExprSyntax.self) {
+            // Break down children
+            let dictChildren = dictExpr.content.children(viewMode: .sourceAccurate)
+            let recursedChildren = dictChildren.compactMap { dictElem -> SyntaxViewArgumentData? in
+                guard let dictElem = dictElem.as(DictionaryElementSyntax.self),
+                      // get value data recursively
+                      let value = self.parseArgumentType(from: dictElem.value) else {
+                    return nil
+                }
+                
+                let label = dictElem.key.trimmedDescription
+                return SyntaxViewArgumentData(label: label, value: value)
+            }
+            
+            // Testing tuple type for now, should be the same stuff
+            return .tuple(recursedChildren)
+        }
+        
+        // Tracks references to state
+        else if let declrRefExpr = expression.as(DeclReferenceExprSyntax.self) {
+            return .stateAccess(declrRefExpr.trimmedDescription)
+        }
+        
+        guard let syntaxKind = SyntaxArgumentKind.fromExpression(expression) else {
+            self.caughtErrors.append(.unsupportedSyntaxArgumentKind(expression.trimmedDescription))
+            return nil
+        }
+        
+        switch syntaxKind {
+        case .literal(let syntaxArgumentLiteralKind):
+            // Simple case
+            let data = SyntaxViewSimpleData(
+                value: expression.trimmedDescription,
+                syntaxKind: syntaxArgumentLiteralKind
+            )
+            return .simple(data)
+            
+        default:
+            // No support for variables or expressions here
+            return nil
+        }
+    }
+    
+}
+
+
+// TODO: move layer helpers
+
+extension SwiftUIViewVisitor {
+    func visitLayerData(identifierExpr: DeclReferenceExprSyntax,
+                        node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+        // This might be a view initialization like Text("Hello")
+        let viewName = identifierExpr.baseName.text
+        
+        guard let nameType = SyntaxNameType.from(viewName) else {
+//                fatalErrorIfDebug("No view discovered for: \(viewName)")
+            log("No concept discovered for: \(viewName)")
+            
+            // Tracks for later silent failures
+            self.caughtErrors.append(.unsupportedSyntaxViewName(viewName))
+            
+            return .skipChildren
+        }
+        
+        log("Found view initialization: \(viewName)")
+        
+        // Parse args, catching arguments we don't yet support
+        let args = self.parseArguments(from: node)
+        
+        switch nameType {
+        case .view(let syntaxViewName):
+            // Create a new ViewNode for this view
+            let viewNode = SyntaxView(
+                name: syntaxViewName,
+                // This is creat
+                constructorArguments: args,
+                modifiers: [],
+                children: [],
+                id: UUID()
+                //                errors: self.caughtErrors
+            )
+            
+            log("Created new ViewNode for \(viewName)")
+            
+            // Set as root or add as child to current node (context-aware)
+            if viewStack.isEmpty {
+                log("Setting as root ViewNode: \(viewName)")
+                viewStack.append(viewNode)
+                currentNodeIndex = 0
+                rootViewNode = viewNode
+
+                log("Current node index set to: \(String(describing: currentNodeIndex))")
+            } else {
+                // Check if this view initialization should be treated as a child
+                // Only apply context-aware logic for top-level view statements that could be children
+                let currentContext = contextStack.last ?? .root
+                log("Current parsing context: \(currentContext)")
+                
+                switch currentContext {
+                case .closure(let parentViewName):
+                    // We're inside a closure of a container view - this IS a legitimate child
+                    if let currentNode = currentViewNode {
+                        log("Adding \(viewName) as child to \(currentNode.name.rawValue) (inside closure)")
+                        var updatedCurrentNode = currentNode
+                        updatedCurrentNode.children.append(viewNode)
+                        updateCurrentViewNode(updatedCurrentNode)
+                        
+                        // Push the new node onto the stack and update current node index
+                        viewStack.append(viewNode)
+                        currentNodeIndex = viewStack.count - 1
+                                                    
+                        log("Pushed \(viewName) onto stack, new index: \(String(describing: currentNodeIndex))")
+                    } else {
+                        log("⚠️ Error: No current node to add child to")
+                    }
+                    
+                case .arguments, .root:
+                    // We're parsing function arguments - this might be a modifier argument
+                    // Check if this is actually being used as a modifier argument
+                    if isWithinModifierArguments(node) {
+                        log("Found view \(viewName) in modifier argument context - allowing normal processing")
+                        // For modifier arguments, we still need to process the view normally
+                        // but we don't add it as a child to any parent view
+                        // Just add it to the stack temporarily so it can be processed
+                        viewStack.append(viewNode)
+                        currentNodeIndex = viewStack.count - 1
+                    } else {
+                        log("⚠️ Found view \(viewName) in argument context - skipping child addition")
+                        log("This view should be handled as an argument, not as a child")
+                        // Don't add to viewStack - this prevents it from being treated as a child
+                    }
+                }
+            }
+            
+            return .visitChildren
+            
+        case .value:
+            // No view here, just continue
+            return .skipChildren
+        }
+    }
+
     
     // Helper to get current ViewNode
     private var currentViewNode: SyntaxView? {
@@ -179,248 +616,7 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
         log("✅ After adding modifier - modifiers count: \(node.modifiers.count)")
         dbg("addModifier → completed. Node \(node.name.rawValue) now has \(node.modifiers.count) modifier(s).")
     }
-        
-    // Visit function call expressions (which represent view initializations and modifiers)
-    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
-        log("Visiting function call: \(node.description)")
-        log("Current stack depth: \(viewStack.count), current index: \(String(describing: currentNodeIndex))")
-        
-        if let identifierExpr = node.calledExpression.as(DeclReferenceExprSyntax.self) {
-            // This might be a view initialization like Text("Hello")
-            let viewName = identifierExpr.baseName.text
-            
-            guard let nameType = SyntaxNameType.from(viewName) else {
-//                fatalErrorIfDebug("No view discovered for: \(viewName)")
-                log("No concept discovered for: \(viewName)")
-                
-                // Tracks for later silent failures
-                self.caughtErrors.append(.unsupportedSyntaxViewName(viewName))
-                
-                return .skipChildren
-            }
-            
-            log("Found view initialization: \(viewName)")
-            
-            // Parse args, catching arguments we don't yet support
-            let args = self.parseArguments(from: node)
-            
-            switch nameType {
-            case .view(let syntaxViewName):
-                // Create a new ViewNode for this view
-                let viewNode = SyntaxView(
-                    name: syntaxViewName,
-                    // This is creat
-                    constructorArguments: args,
-                    modifiers: [],
-                    children: [],
-                    id: UUID()
-                    //                errors: self.caughtErrors
-                )
-                
-                log("Created new ViewNode for \(viewName)")
-                
-                // Set as root or add as child to current node (context-aware)
-                if viewStack.isEmpty {
-                    log("Setting as root ViewNode: \(viewName)")
-                    viewStack.append(viewNode)
-                    currentNodeIndex = 0
-                    rootViewNode = viewNode
 
-                    log("Current node index set to: \(String(describing: currentNodeIndex))")
-                } else {
-                    // Check if this view initialization should be treated as a child
-                    // Only apply context-aware logic for top-level view statements that could be children
-                    let currentContext = contextStack.last ?? .root
-                    log("Current parsing context: \(currentContext)")
-                    
-                    switch currentContext {
-                    case .closure(let parentViewName):
-                        // We're inside a closure of a container view - this IS a legitimate child
-                        if let currentNode = currentViewNode {
-                            log("Adding \(viewName) as child to \(currentNode.name.rawValue) (inside closure)")
-                            var updatedCurrentNode = currentNode
-                            updatedCurrentNode.children.append(viewNode)
-                            updateCurrentViewNode(updatedCurrentNode)
-                            
-                            // Push the new node onto the stack and update current node index
-                            viewStack.append(viewNode)
-                            currentNodeIndex = viewStack.count - 1
-                                                        
-                            log("Pushed \(viewName) onto stack, new index: \(String(describing: currentNodeIndex))")
-                        } else {
-                            log("⚠️ Error: No current node to add child to")
-                        }
-                        
-                    case .arguments, .root:
-                        // We're parsing function arguments - this might be a modifier argument
-                        // Check if this is actually being used as a modifier argument
-                        if isWithinModifierArguments(node) {
-                            log("Found view \(viewName) in modifier argument context - allowing normal processing")
-                            // For modifier arguments, we still need to process the view normally
-                            // but we don't add it as a child to any parent view
-                            // Just add it to the stack temporarily so it can be processed
-                            viewStack.append(viewNode)
-                            currentNodeIndex = viewStack.count - 1
-                        } else {
-                            log("⚠️ Found view \(viewName) in argument context - skipping child addition")
-                            log("This view should be handled as an argument, not as a child")
-                            // Don't add to viewStack - this prevents it from being treated as a child
-                        }
-                    }
-                }
-                
-            case .value:
-                // No view here, just continue
-                return .skipChildren
-            }
-            
-        } else if let memberAccessExpr = node.calledExpression.as(MemberAccessExprSyntax.self) {
-            // Detected a modifier call (e.g. .padding()).  We *do not* attach the modifier
-            // here because the base view may not have been pushed onto the stack yet.
-            // Instead, we defer actual attachment to `visitPost(_:)`, which runs after the
-            // base `FunctionCallExprSyntax` has been visited.
-            dbg("visit → encountered potential modifier .\(memberAccessExpr.declName.baseName.text) – deferring to visitPost")
-        }
-        
-        return .visitChildren
-    }
-
-    // Parse arguments from function call
-    func parseArguments(from node: FunctionCallExprSyntax) -> ViewConstructorType {
-        // Default handling for other modifiers
-        let arguments = node.arguments.compactMap { (argument) -> SyntaxViewArgumentData? in
-            self.parseArgument(argument)
-        }
-        
-        dbg("parseArguments → for \(node.calledExpression.trimmedDescription)  |  \(arguments.count) arg(s): \(arguments)")
-        
-        guard let knownViewConstructor = createKnownViewConstructor(
-            from: node,
-            arguments: arguments) else {
-            return .other(arguments)
-        }
-        
-        return .trackedConstructor(knownViewConstructor)
-    }
-    
-    func parseArgument(_ argument: LabeledExprSyntax) -> SyntaxViewArgumentData? {
-        let label = argument.label?.text
-        
-        let expression = argument.expression
-        
-        guard let value = self.parseArgumentType(from: expression) else {
-            return nil
-        }
-        
-        return .init(label: label,
-                     value: value)
-    }
-    
-    /// Handles conditional logic for determining a type of syntax argument.
-    func parseArgumentType(from expression: SwiftSyntax.ExprSyntax) -> SyntaxViewModifierArgumentType? {
-        // Handles compelx types, like PortValueDescription
-        if let funcExpr = expression.as(FunctionCallExprSyntax.self) {
-            // Recursively create argument data
-            let complexTypeArgs = funcExpr.arguments
-                .compactMap { expr in
-                    self.parseArgument(expr)
-                }
-            
-            let complexType = SyntaxViewModifierComplexType(
-                typeName: funcExpr.calledExpression.trimmedDescription,
-                arguments: complexTypeArgs)
-            
-            return .complex(complexType)
-        }
-        
-        // Recursively handle arguments in tuple case
-        else if let tupleExpr = expression.as(TupleExprSyntax.self) {
-            let tupleArgs = tupleExpr.elements.compactMap(self.parseArgument(_:))
-            return .tuple(tupleArgs)
-        }
-        
-        // Recursively handle arguments in array case
-        else if let arrayExpr = expression.as(ArrayExprSyntax.self) {
-            let arrayArgs = arrayExpr.elements.compactMap {
-                self.parseArgumentType(from: $0.expression)
-            }
-            return .array(arrayArgs)
-        }
-        
-        else if let memberAccessExpr = expression.as(MemberAccessExprSyntax.self) {
-            return .memberAccess(SyntaxViewMemberAccess(
-                base: memberAccessExpr.base?.trimmedDescription,
-                property: memberAccessExpr.declName.baseName.trimmedDescription))
-            
-        }
-        
-        else if let dictExpr = expression.as(DictionaryExprSyntax.self) {
-            // Break down children
-            let dictChildren = dictExpr.content.children(viewMode: .sourceAccurate)
-            let recursedChildren = dictChildren.compactMap { dictElem -> SyntaxViewArgumentData? in
-                guard let dictElem = dictElem.as(DictionaryElementSyntax.self),
-                      // get value data recursively
-                      let value = self.parseArgumentType(from: dictElem.value) else {
-                    return nil
-                }
-                
-                let label = dictElem.key.trimmedDescription
-                return SyntaxViewArgumentData(label: label, value: value)
-            }
-            
-            // Testing tuple type for now, should be the same stuff
-            return .tuple(recursedChildren)
-        }
-        
-        guard let syntaxKind = SyntaxArgumentKind.fromExpression(expression) else {
-            self.caughtErrors.append(.unsupportedSyntaxArgumentKind(expression.trimmedDescription))
-            return nil
-        }
-        
-        switch syntaxKind {
-        case .literal(let syntaxArgumentLiteralKind):
-            // Simple case
-            let data = SyntaxViewSimpleData(
-                value: expression.trimmedDescription,
-                syntaxKind: syntaxArgumentLiteralKind
-            )
-            return .simple(data)
-            
-        default:
-            // No support for variables or expressions here
-            return nil
-        }
-    }
-    
-    // Handle closure expressions (for container views like VStack, HStack, ZStack)
-    override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
-        log("Entering closure expression")
-        
-        // Check if we're inside a container view that can have children
-        if let currentView = currentViewNode, currentView.name.canHaveChildren {
-            log("Entering closure for container view: \(currentView.name.rawValue)")
-            contextStack.append(.closure(parentView: currentView.name))
-        } else {
-            log("Entering closure in non-container context (likely function arguments)")
-            contextStack.append(.arguments)
-        }
-        
-        return .visitChildren
-    }
-    
-    override func visitPost(_ node: ClosureExprSyntax) {
-        log("Exiting closure expression")
-        
-        // Pop the context we pushed when entering the closure
-        if contextStack.count > 1 {
-            let poppedContext = contextStack.removeLast()
-            log("Popped context: \(poppedContext)")
-        }
-    }
-    
-    // MARK: - Modifier Handling
-
-    
     /// Handles standard modifiers with generic argument parsing
     private func handleStandardModifier(node: FunctionCallExprSyntax,
                                         modifierName: SyntaxViewModifierName) {
@@ -431,90 +627,6 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
             arguments: modifierArguments
         )
         addModifier(modifier)
-    }
-    
-    // MARK: - SyntaxVisitor Overrides
-    
-    // When we finish visiting a node, manage the view stack
-    override func visitPost(_ node: FunctionCallExprSyntax) {
-        log("Visiting post for function call: \(node.description)")
-        
-        // Handle view initializations (constructor calls like `Rectangle()`, `Text("hello")`)
-        if let identExpr = node.calledExpression.as(DeclReferenceExprSyntax.self) {
-            let viewName = identExpr.baseName.text
-            log("Found view initialization: \(viewName)")
-            log("Current context stack: \(contextStack)")
-            log("Node parent type: \(type(of: node.parent))")
-            
-            // If this view call is the *base* of a MemberAccessExpr (e.g. Rectangle() in
-            // Rectangle().frame(...)), we **keep** it on the stack so that the upcoming
-            // modifier call can still access and mutate the current view node.
-            if node.parent?.as(MemberAccessExprSyntax.self) != nil {
-                log("Deferring pop for \(viewName) because it is base of a modifier chain")
-                return
-            }
-            log("ViewStack before adjustment - count: \(viewStack.count), current node index: \(String(describing: currentNodeIndex))")
-            
-            // Debug the current stack state
-            if !viewStack.isEmpty {
-                log("Current stack state:")
-                for (index, stackNode) in viewStack.enumerated() {
-                    log("  [\(index)] \(stackNode.name.rawValue) with \(stackNode.modifiers.count) modifiers")
-                }
-            }
-            
-            // We're exiting a view initialization
-            if let lastNode = viewStack.last,
-               let nameType = SyntaxNameType.from(viewName),
-               // Ensure a view here instead of a value
-               nameType.isView {
-                // Before removing the node, make sure we capture any modifiers that were added
-                log("Node being popped: \(lastNode.name.rawValue) with \(lastNode.modifiers.count) modifiers")
-                
-                // Remove the last node
-                viewStack.removeLast()
-                
-                // Update current node index to point to the new last node
-                currentNodeIndex = viewStack.count > 0 ? viewStack.count - 1 : nil
-                
-                log("Stack after pop - depth: \(viewStack.count), new current index: \(String(describing: currentNodeIndex))")
-                
-                // Debug the root node state
-                if let root = rootViewNode {
-                    log("Root node: \(root.name.rawValue) with \(root.modifiers.count) modifiers and \(root.children.count) children")
-                    if !root.children.isEmpty {
-                        for (index, child) in root.children.enumerated() {
-                            log("  Root child[\(index)]: \(child.name.rawValue) with \(child.modifiers.count) modifiers")
-                        }
-                    }
-                }
-            } else {
-                log("View stack empty, nothing to pop")
-            }
-        }
-        
- 
-        // ─────────────────────────────────────────────────────────────
-        // Handle view‑modifier calls *after* the base view has been visited
-        else if let modifierName = modifierNameIfViewModifier(node) {
-            dbg("visitPost → handling view modifier '\(modifierName)'")
-            
-            if let syntaxViewModifierName = SyntaxViewModifierName(rawValue: modifierName) {
-                    handleStandardModifier(node: node, modifierName: syntaxViewModifierName)
-                
-                // If this FunctionCallExpr is not nested inside *another* MemberAccessExpr,
-                // we are at the end of the modifier chain; pop the base view.
-                if node.parent?.as(MemberAccessExprSyntax.self) == nil {
-                    if let popped = viewStack.popLast() {
-                        dbg("visitPost → popped view \(popped.name.rawValue) after completing modifier chain")
-                    }
-                    currentNodeIndex = viewStack.isEmpty ? nil : viewStack.count - 1
-                }
-            } else {
-                print("visitPost error: unable to parse view modifier name: \(modifierName)")
-                self.caughtErrors.append(.unsupportedSyntaxViewModifierName(modifierName))
-            }
-        }
     }
 }
 
@@ -552,3 +664,309 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
 //
 //    print("\n==== TEST COMPLETE ====\n")
 //}
+
+
+// TODO: move
+
+extension SwiftUIViewVisitor {
+    func visitPatchData(_ node: FunctionCallExprSyntax) -> SwiftParserPatchData? {
+        guard
+            let subscriptExpr = node.calledExpression.as(SubscriptCallExprSyntax.self),
+            let baseIdent = subscriptExpr.calledExpression.as(DeclReferenceExprSyntax.self),
+            baseIdent.baseName.text == "NATIVE_STITCH_PATCH_FUNCTIONS",
+            let firstArg = subscriptExpr.arguments.first,
+            let stringLit = firstArg.expression.as(StringLiteralExprSyntax.self)
+        else {
+            return nil
+        }
+        
+        guard let patchNode = stringLit.segments.first?.description else {
+            return nil
+        }
+        
+        guard let elements = node.arguments.first?.expression.as(ArrayExprSyntax.self)?.elements else {
+            fatalErrorIfDebug()
+            return nil
+        }
+        
+        let patchNodeArgs = elements.compactMap { arg -> SwiftParserPatternBindingArg? in
+            // ArrayExpr → might hold a PortValueDescription literal
+            if let arrayElem = arg.expression.as(ArrayExprSyntax.self),
+               let innerFirstElem = arrayElem.elements.first?.expression {
+                
+                guard let argData = self.parseArgumentType(from: innerFirstElem) else {
+                    fatalError()
+                }
+                
+                return .value(argData)
+            }
+            
+            else if let declrRefSyntax = arg.expression.as(DeclReferenceExprSyntax.self) {
+                print("Input param that points to some reference: \(declrRefSyntax)")
+                return .binding(declrRefSyntax)
+            }
+            
+            else if let subscriptCallExpr = arg.expression.as(SubscriptCallExprSyntax.self) {
+                let subscriptData = self.visitSubscriptData(subscriptCallExpr: subscriptCallExpr)
+                return .subscriptRef(subscriptData)
+            }
+            
+            else {
+                fatalError()
+            }
+        }
+        
+        return .init(patchName: patchNode,
+                     args: patchNodeArgs)
+    }
+    
+    func visitSubscriptData(subscriptCallExpr: SubscriptCallExprSyntax) -> SwiftParserSubscript {
+        // Subscript reference to some existing outputs
+        let subscriptRef = self.deriveSubscriptData(subscriptCallExpr: subscriptCallExpr)
+        
+        // Check for function expressions here too, needed for deriving patch data
+        if let patchFn = subscriptCallExpr.calledExpression.as(FunctionCallExprSyntax.self) {
+            // Assumed to be patch node
+            guard let patchNode = self.visitPatchData(patchFn) else {
+                fatalError()
+            }
+            
+            return .init(subscriptType: .patchNode(patchNode),
+                         portIndex: subscriptRef.portIndex)
+        }
+        
+        else {
+            return subscriptRef
+        }
+    }
+}
+
+enum SwiftParserPatternBindingArg {
+    case value(SyntaxViewModifierArgumentType)
+    case binding(DeclReferenceExprSyntax)
+    case subscriptRef(SwiftParserSubscript)
+}
+
+struct SwiftParserPatchData {
+    // TODO: must be decoded
+    let id = UUID().uuidString
+    
+    var patchName: String
+    var args: [SwiftParserPatternBindingArg]
+}
+
+struct SwiftParserSubscript: Sendable {
+    // The name of the variable
+    var subscriptType: SwiftParserSubscriptType
+    var portIndex: Int
+}
+
+enum SwiftParserInitializerType {
+    // creates some patch node from a declared function
+    case patchNode(SwiftParserPatchData)
+    
+    // access an index of some node's outputs
+    case subscriptRef(SwiftParserSubscript)
+    
+    // initializes state
+//    case stateVarName
+    
+    // mutates some existing state
+    case stateMutation(SwiftParserStateMutation)
+}
+
+enum SwiftParserStateMutation: Sendable {
+    case declrRef(String)
+    case subscriptRef(SwiftParserSubscript)
+}
+
+// Subscripts can be used on references or nodes themselves
+enum SwiftParserSubscriptType {
+    case ref(String)
+    case patchNode(SwiftParserPatchData)
+}
+
+extension SwiftParserPatchData {
+    func createStitchData(varName: String,
+                          varNameIdMap: inout [String : String]) -> CurrentAIGraphData.NativePatchNode {
+        guard let patchName = CurrentAIGraphData.StitchAIPatchOrLayer.init(value: .init(self.patchName)) else {
+            fatalError()
+        }
+        
+//        let nodeIdString = String(varName.split(separator: "_")[safe: 1] ?? "")
+//        let decodedId = UUID(uuidString: nodeIdString) ?? .init()
+        varNameIdMap.updateValue(self.id, forKey: varName)
+        
+        let newPatchNode = CurrentAIGraphData
+            .NativePatchNode(node_id: self.id,
+                             node_name: patchName)
+        return newPatchNode
+    }
+}
+
+// TODO: move
+extension SwiftParserPatchData {
+    static func derivePatchUpstreamCoordinate(upstreamRefData: SwiftParserSubscript,
+                                              varNameIdMap: [String : String]) -> AIGraphData_V0.NodeIndexedCoordinate {
+        let upstreamPortIndex = upstreamRefData.portIndex
+        let upstreamNodeId: String
+        
+        // Get upstream node ID
+        switch upstreamRefData.subscriptType {
+        case .patchNode(let patchNodeData):
+            upstreamNodeId = patchNodeData.id
+            
+        case .ref(let refName):
+            guard let _upstreamNodeId = varNameIdMap.get(refName) else {
+                fatalError()
+            }
+            
+            upstreamNodeId = _upstreamNodeId
+        }
+        
+        return .init(node_id: upstreamNodeId,
+                     port_index: upstreamPortIndex)
+    }
+}
+
+// TODO: move
+extension SwiftUIViewVisitor {
+    func deriveSubscriptData(subscriptCallExpr: SubscriptCallExprSyntax) -> SwiftParserSubscript {
+        guard let labeledExpr = subscriptCallExpr.arguments.first?.expression.as(IntegerLiteralExprSyntax.self),
+              let portIndex = Int(labeledExpr.literal.text) else {
+            fatalError()
+        }
+        
+        // Patch declarations can call here too
+        if let funcExpr = subscriptCallExpr.calledExpression.as(FunctionCallExprSyntax.self) {
+            guard let patchNode = self.visitPatchData(funcExpr) else {
+                fatalError()
+            }
+            
+            let subscriptRef = SwiftParserSubscript(subscriptType: .patchNode(patchNode),
+                                                    portIndex: portIndex)
+            
+            return subscriptRef
+        }
+        
+        // Output port index access of some patch node in the form of index access of a patch fn's output values
+        else if let declRef = subscriptCallExpr.calledExpression.as(DeclReferenceExprSyntax.self) {
+            
+            let outputPortData = SwiftParserSubscript(subscriptType: .ref(declRef.baseName.text),
+                                                      portIndex: portIndex)
+            
+            return outputPortData
+        }
+        
+        else {
+            fatalError()
+        }
+    }
+}
+
+extension SwiftParserInitializerType {
+    func parseStitchActions(varName: String,
+                            varNameIdMap: [String : String],
+                            varNameOutputPortMap: [String : SwiftParserSubscript],
+    customPatchInputValues: inout [CurrentAIGraphData.CustomPatchInputValue],
+                            patchConnections: inout [CurrentAIGraphData.PatchConnection],
+                            viewStatePatchConnections: inout [String : AIGraphData_V0.NodeIndexedCoordinate]) throws {
+        switch self {
+        case .patchNode(let patchNodeData):
+            for (portIndex, arg) in patchNodeData.args.enumerated() {
+                switch arg {
+                case .binding(let declRefSyntax):
+                    // Get edge data
+                    let refName = declRefSyntax.baseName.text
+                                            
+                    guard let upstreamRefData = varNameOutputPortMap.get(refName) else {
+                        fatalError()
+                    }
+                    
+                    let usptreamCoordinate = SwiftParserPatchData
+                        .derivePatchUpstreamCoordinate(upstreamRefData: upstreamRefData,
+                                                       varNameIdMap: varNameIdMap)
+                    
+                    patchConnections.append(
+                        .init(src_port: usptreamCoordinate,
+                              dest_port: .init(node_id: patchNodeData.id,                          port_index: portIndex))
+                    )
+                    
+                case .value(let argType):
+                    let portDataList = try argType.derivePortValues()
+                    
+                    for portData in portDataList {
+                        switch portData {
+                        case .value(let portValue):
+                            customPatchInputValues.append(
+                                .init(patch_input_coordinate: .init(
+                                    node_id: patchNodeData.id,
+                                    port_index: portIndex),
+                                      value: portValue.value,
+                                      value_type: portValue.value_type)
+                            )
+                            
+                        case .stateRef:
+                            fatalErrorIfDebug("State variables should never be passed into patch nodes")
+                            throw SwiftUISyntaxError.unsupportedStateInPatchInputParsing(patchNodeData)
+                        }
+                    }
+                    
+                case .subscriptRef(let subscriptRef):
+                    // Recursively call subscript data
+                    let subscriptInitializer = SwiftParserInitializerType.subscriptRef(subscriptRef)
+                    try subscriptInitializer
+                        .parseStitchActions(varName: varName,
+                                            varNameIdMap: varNameIdMap,
+                                            varNameOutputPortMap: varNameOutputPortMap,
+                                            customPatchInputValues: &customPatchInputValues,
+                                            patchConnections: &patchConnections,
+                                            viewStatePatchConnections: &viewStatePatchConnections)
+                }
+            }
+            
+        case .stateMutation(let mutationData):
+            let subscriptData: SwiftParserSubscript
+            
+            // Find subscript data which must exist for view state mutation
+            switch mutationData {
+            case .subscriptRef(let _subscriptData):
+                subscriptData = _subscriptData
+                
+            case .declrRef(let ref):
+                guard let refData = varNameOutputPortMap.get(ref) else {
+                    throw SwiftUISyntaxError.unexpectedStateMutatorFound(mutationData)
+                }
+                
+                subscriptData = refData
+            }
+            
+            // Track upstream patch coordinate to some TBD layer input
+            let usptreamCoordinate = SwiftParserPatchData
+                .derivePatchUpstreamCoordinate(upstreamRefData: subscriptData,
+                                               varNameIdMap: varNameIdMap)
+            
+            viewStatePatchConnections.updateValue(usptreamCoordinate,
+                                                  forKey: varName)
+            
+        case .subscriptRef(let subscriptData):
+            switch subscriptData.subscriptType {
+            case .patchNode(let patchNodeData):
+                let initializerData = SwiftParserInitializerType.patchNode(patchNodeData)
+                
+                // Recursively parse patch node data
+                try initializerData
+                    .parseStitchActions(varName: varName,
+                                        varNameIdMap: varNameIdMap,
+                                        varNameOutputPortMap: varNameOutputPortMap,
+                                        customPatchInputValues: &customPatchInputValues,
+                                        patchConnections: &patchConnections,
+                                        viewStatePatchConnections: &viewStatePatchConnections)
+                
+            case .ref:
+                // Ignore here
+                return
+            }
+        }
+    }
+}

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchUtil.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchUtil.swift
@@ -1,0 +1,130 @@
+//
+//  CodeToStitchUtil.swift
+//  Stitch
+//
+//  Created by Elliot Boschwitz on 7/31/25.
+//
+
+import SwiftSyntax
+import SwiftParser
+import SwiftSyntaxBuilder
+import SwiftUI
+
+extension SwiftUIViewVisitor {
+    // Parse arguments from function call
+    func parseArguments(from node: FunctionCallExprSyntax) -> ViewConstructorType {
+        // Default handling for other modifiers
+        let arguments = node.arguments.compactMap { (argument) -> SyntaxViewArgumentData? in
+            self.parseArgument(argument)
+        }
+        
+        log("parseArguments → for \(node.calledExpression.trimmedDescription)  |  \(arguments.count) arg(s): \(arguments)")
+        
+        guard let knownViewConstructor = createKnownViewConstructor(
+            from: node,
+            arguments: arguments) else {
+            return .other(arguments)
+        }
+        
+        return .trackedConstructor(knownViewConstructor)
+    }
+    
+    func parseArgument(_ argument: LabeledExprSyntax) -> SyntaxViewArgumentData? {
+        let label = argument.label?.text
+        
+        let expression = argument.expression
+        
+        guard let value = self.parseArgumentType(from: expression) else {
+            return nil
+        }
+        
+        return .init(label: label,
+                     value: value)
+    }
+    
+    func parseFnArgumentType(_ funcExpr: FunctionCallExprSyntax) -> SyntaxViewModifierComplexType {
+        // Recursively create argument data
+        let complexTypeArgs = funcExpr.arguments
+            .compactMap { expr in
+                self.parseArgument(expr)
+            }
+        
+        let complexType = SyntaxViewModifierComplexType(
+            typeName: funcExpr.calledExpression.trimmedDescription,
+            arguments: complexTypeArgs)
+        
+        return complexType
+    }
+    
+    /// Handles conditional logic for determining a type of syntax argument.
+    func parseArgumentType(from expression: SwiftSyntax.ExprSyntax) -> SyntaxViewModifierArgumentType? {
+        // Handles compelx types, like PortValueDescription
+        if let funcExpr = expression.as(FunctionCallExprSyntax.self) {
+            let complexType = self.parseFnArgumentType(funcExpr)
+            return .complex(complexType)
+        }
+        
+        // Recursively handle arguments in tuple case
+        else if let tupleExpr = expression.as(TupleExprSyntax.self) {
+            let tupleArgs = tupleExpr.elements.compactMap(self.parseArgument(_:))
+            return .tuple(tupleArgs)
+        }
+        
+        // Recursively handle arguments in array case
+        else if let arrayExpr = expression.as(ArrayExprSyntax.self) {
+            let arrayArgs = arrayExpr.elements.compactMap {
+                self.parseArgumentType(from: $0.expression)
+            }
+            return .array(arrayArgs)
+        }
+        
+        else if let memberAccessExpr = expression.as(MemberAccessExprSyntax.self) {
+            return .memberAccess(SyntaxViewMemberAccess(
+                base: memberAccessExpr.base?.trimmedDescription,
+                property: memberAccessExpr.declName.baseName.trimmedDescription))
+            
+        }
+        
+        else if let dictExpr = expression.as(DictionaryExprSyntax.self) {
+            // Break down children
+            let dictChildren = dictExpr.content.children(viewMode: .sourceAccurate)
+            let recursedChildren = dictChildren.compactMap { dictElem -> SyntaxViewArgumentData? in
+                guard let dictElem = dictElem.as(DictionaryElementSyntax.self),
+                      // get value data recursively
+                      let value = self.parseArgumentType(from: dictElem.value) else {
+                    return nil
+                }
+                
+                let label = dictElem.key.trimmedDescription
+                return SyntaxViewArgumentData(label: label, value: value)
+            }
+            
+            // Testing tuple type for now, should be the same stuff
+            return .tuple(recursedChildren)
+        }
+        
+        // Tracks references to state
+        else if let declrRefExpr = expression.as(DeclReferenceExprSyntax.self) {
+            return .stateAccess(declrRefExpr.trimmedDescription)
+        }
+        
+        guard let syntaxKind = SyntaxArgumentKind.fromExpression(expression) else {
+            self.caughtErrors.append(.unsupportedSyntaxArgumentKind(expression.trimmedDescription))
+            return nil
+        }
+        
+        switch syntaxKind {
+        case .literal(let syntaxArgumentLiteralKind):
+            // Simple case
+            let data = SyntaxViewSimpleData(
+                value: expression.trimmedDescription,
+                syntaxKind: syntaxArgumentLiteralKind
+            )
+            return .simple(data)
+            
+        default:
+            // No support for variables or expressions here
+            return nil
+        }
+    }
+}

--- a/Stitch/Graph/StitchAI/Mapping/CodeToVPL/Declarative/Parameter.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToVPL/Declarative/Parameter.swift
@@ -9,9 +9,44 @@ import SwiftUI
 import SwiftSyntax
 import SwiftParser
 
-struct ASTCustomInputValue: Equatable, Hashable {
-    let input: CurrentAIGraphData.LayerInputPort
-    let value: CurrentAIGraphData.PortValue
+//struct ASTCustomInputValue: Equatable, Hashable {
+//    let input: CurrentAIGraphData.LayerInputPort
+//    let value: LayerPortDerivationType
+//}
+
+typealias ASTCustomInputValue = LayerPortDerivation
+
+extension LayerPortDerivation {
+    // TODO: remove this init
+    init(id: NodeId,
+         input: LayerInputPort,
+         value: CurrentAIGraphData.PortValue) {
+        self.init(input: input,
+                  value: value)
+    }
+    
+    init(input: LayerInputPort,
+         value: CurrentAIGraphData.PortValue) {
+        self = .init(coordinate: .init(layerInput: input,
+                                       portType: .packed),
+                     inputData: .value(.init(value)))
+    }
+    
+    init(input: LayerInputPort,
+         inputData: LayerPortDerivationType) {
+        self = .init(coordinate: .init(layerInput: input,
+                                       portType: .packed),
+                     inputData: inputData)
+    }
+}
+
+extension Array where Element == LayerPortDerivation {
+    init(_ portTypes: [LayerPortDerivationType], input: LayerInputPort) {
+        self = portTypes.map {
+            LayerPortDerivation.init(input: input,
+                                     inputData: $0)
+        }
+    }
 }
 
 /// A constructor argument that was either a compile‑time literal (`"logo"`,

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxUtils.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxUtils.swift
@@ -38,6 +38,9 @@ private func describe(_ argType: SyntaxViewModifierArgumentType) -> String {
     case .memberAccess(let data):
         return "memberAccess(\(data))"
         
+    case .stateAccess(let x):
+        return "state access: \(x)"
+        
     case .tuple(let args):
         return "tuple(\(args.map(describe(_:)).joined(separator: ", ")))"
         

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
@@ -76,12 +76,15 @@ indirect enum SyntaxViewModifierArgumentType: Equatable, Hashable, Sendable, Enc
     
     // e.g. `.fill(.yellow)` or `Color.yellow`; `ScrollView(.horizontal)`
     case memberAccess(SyntaxViewMemberAccess)
+    
+    case stateAccess(String)
 }
 
 // Non-recursive sub-enum of `SyntaxViewModifierArgumentType` for when we are working in contexts where we have already flattened the nested argument-types like `tuple` and `array`
 enum SyntaxViewModifierArgumentFlatType: Equatable, Hashable, Sendable {
     case simple(SyntaxViewSimpleData)
     case complex(SyntaxViewModifierComplexType)
+    case stateAccess(String)
     case memberAccess(SyntaxViewMemberAccess)
     
     var toSyntaxViewModifierArgumentType: SyntaxViewModifierArgumentType {
@@ -90,6 +93,8 @@ enum SyntaxViewModifierArgumentFlatType: Equatable, Hashable, Sendable {
             return .simple(x)
         case .memberAccess(let x):
             return .memberAccess(x)
+        case .stateAccess(let x):
+            return .stateAccess(x)
         case .complex(let x):
             return .complex(x)
         }
@@ -106,6 +111,8 @@ extension SyntaxViewModifierArgumentType {
             return [.memberAccess(x)]
         case .complex(let x):
             return [.complex(x)]
+        case .stateAccess(let x):
+            return [.stateAccess(x)]
         case .tuple(let xs):
             return xs.flatMap(\.value.toSyntaxViewModifierArgumentFlatType)
         case .array(let xs):
@@ -131,6 +138,8 @@ extension SyntaxViewModifierArgumentType {
         case .complex(let syntaxViewModifierComplexType):
             return syntaxViewModifierComplexType.arguments
                 .flatMap(\.value.allNestedSimpleValues)
+        case .stateAccess(let x):
+            return [x]
         case .tuple(let array):
             return array.flatMap(\.value.allNestedSimpleValues)
         case .array(let array):
@@ -416,6 +425,9 @@ extension SyntaxViewModifierArgumentType {
         
         case .memberAccess(let memberData):
             return AnyEncodable(memberData.property)
+        
+        case .stateAccess(let x):
+            return AnyEncodable(x)
         }
     }
 }

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayerInputPort.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayerInputPort.swift
@@ -109,7 +109,7 @@ enum DerivedLayerInputPortsResult: Equatable, Hashable, Sendable {
 }
 
 enum LayerInputViewModification {
-    case layerInputValues([CurrentAIGraphData.CustomLayerInputValue])
+    case layerInputValues([LayerPortDerivation])
     case layerIdAssignment(String)
 }
 


### PR DESCRIPTION
> **This PR temporarily removes support for custom node types and JS nodes.**

This PR replaces OpenAI patch builder requests with programmatic mapping, reducing the needed OpenAI requests from 3 to 2.

The implementation harnesses existing code parsing, using more overrides to catch syntax expressions used for patch data. Furthermore, it tracks state variable declarations used to bridge patch data to layer views, driving layer connections.