### PR TITLE
Support `.rotationEffect` view modifier; treat `.rotation3DEffect` view modifier as just for `.rotationZ` layer input (for now)

### DIFF
--- a/Stitch/App/StitchApp.swift
+++ b/Stitch/App/StitchApp.swift
@@ -47,7 +47,14 @@ struct StitchApp: App {
         WindowGroup {
 //            ConstructorDemoView()
 //             VarBodyParserDemoView()
-             ASTExplorerView()
+             
+            ASTExplorerView()
+            
+//                .onAppear {
+//                    let prompt = try! StitchAIManager.aiCodeGenSystemPromptGenerator(requestType: .userPrompt)
+//                    print("PROMPT HERE:")
+//                    print(prompt)
+//                }
         }
     }
 #else

--- a/Stitch/Graph/StitchAI/Mapping/ASTExplorerView.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ASTExplorerView.swift
@@ -85,6 +85,9 @@ struct ASTExplorerView: View {
     
     /// Controls whether regenerated code uses PortValueDescription format
     @State private var usePortValueDescription: Bool = false
+    
+    /// Controls whether to generate raw view code or full SwiftUI file with ContentView wrapper
+    @State private var ignoreScript: Bool = true
 
     init(
 //        initialVisibleStages: Set<Stage> = Set(Stage.allCases)
@@ -123,6 +126,10 @@ struct ASTExplorerView: View {
                 Toggle("Use PortValueDescription", isOn: $usePortValueDescription)
                     .toggleStyle(.switch)
                     .onChange(of: usePortValueDescription) { _, _ in transform() }
+                
+                Toggle("Ignore Script Wrapper", isOn: $ignoreScript)
+                    .toggleStyle(.switch)
+                    .onChange(of: ignoreScript) { _, _ in transform() }
             }
 
             TabView(selection: $selectedTab) {
@@ -288,8 +295,8 @@ struct ASTExplorerView: View {
                 try layerDataToStrictSyntaxView(layerData, idMap: &idMap)
             } ?? []
             
-            // TODO: let us toggle whether we wrap the regenerated SwiftUI code into
-            let newSwiftUICode = try fakeDoc.graph.createSwiftUICode(ignoreScript: true)
+            // Generate SwiftUI code with configurable script wrapper
+            let newSwiftUICode = try fakeDoc.graph.createSwiftUICode(ignoreScript: ignoreScript)
             self.regeneratedCode = newSwiftUICode
             
             // Also maintain derivedConstructors for compatibility with existing UI

--- a/Stitch/Graph/StitchAI/Mapping/ASTExplorerView.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ASTExplorerView.swift
@@ -87,9 +87,10 @@ struct ASTExplorerView: View {
     @State private var usePortValueDescription: Bool = false
 
     init(
-        initialVisibleStages: Set<Stage> = Set(Stage.allCases)
+//        initialVisibleStages: Set<Stage> = Set(Stage.allCases)
 //        initialVisibleStages: Set<Stage> = Set([.originalCode, .parsedSyntax, .derivedActions])
 //        initialVisibleStages: Set<Stage> = Set([.originalCode, .parsedSyntax, .derivedActions, .rebuiltSyntax])
+        initialVisibleStages: Set<Stage> = Set([.originalCode, .derivedActions, .regeneratedCode])
     ) {
         _visibleStages = State(initialValue: initialVisibleStages)
     }
@@ -287,7 +288,8 @@ struct ASTExplorerView: View {
                 try layerDataToStrictSyntaxView(layerData, idMap: &idMap)
             } ?? []
             
-            let newSwiftUICode = try fakeDoc.graph.createSwiftUICode()
+            // TODO: let us toggle whether we wrap the regenerated SwiftUI code into
+            let newSwiftUICode = try fakeDoc.graph.createSwiftUICode(ignoreScript: true)
             self.regeneratedCode = newSwiftUICode
             
             // Also maintain derivedConstructors for compatibility with existing UI

--- a/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/CodeExamples.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/CodeExamples.swift
@@ -96,6 +96,12 @@ extension MappingExamples {
         PortValueDescriptionCodeExamples.rectangleWithBlurPVD,
         PortValueDescriptionCodeExamples.stackWithPortValueDescriptions,
         
+        // Rotation with PortValueDescription examples
+        RotationModifierCodeExamples.rotationEffectPortValueDescription,
+        RotationModifierCodeExamples.rotation3DEffectPortValueDescription,
+        RotationModifierCodeExamples.rotationEffectPortValueDescriptionVariable,
+        RotationModifierCodeExamples.rotation3DEffectPortValueDescriptionMultiAxis,
+        
         //        // // NOT YET SUPPORTED:
         //        RotationModifierCodeExamples.rotationEffectAnchor,
         //        RotationModifierCodeExamples.rotationEffectRadians,

--- a/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/RotationModifierCodeExamples.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/RotationModifierCodeExamples.swift
@@ -59,4 +59,58 @@ struct RotationModifierCodeExamples {
     """
     )
 
+    // MARK: - PortValueDescription Examples
+    
+    static let rotationEffectPortValueDescription = MappingCodeExample(
+        title: "rotationEffect with PortValueDescription",
+        code:
+    """
+    Rectangle()
+        .rotationEffect([PortValueDescription(value: 45, value_type: "number")])
+    """
+    )
+
+    static let rotation3DEffectPortValueDescription = MappingCodeExample(
+        title: "rotation3DEffect with PortValueDescription",
+        code:
+    """
+    Rectangle()
+        .rotation3DEffect(
+            [PortValueDescription(value: 60, value_type: "number")],
+            axis: [
+                PortValueDescription(
+                    value: ["x": 0, "y": 1, "z": 0],
+                    value_type: "3dPoint"
+                )
+            ]
+        )
+    """
+    )
+
+    static let rotationEffectPortValueDescriptionVariable = MappingCodeExample(
+        title: "rotationEffect with PortValueDescription variable",
+        code:
+    """
+    Rectangle()
+        .rotationEffect([PortValueDescription(value: rotationAngle, value_type: "number")])
+    """
+    )
+
+    static let rotation3DEffectPortValueDescriptionMultiAxis = MappingCodeExample(
+        title: "rotation3DEffect with PortValueDescription multi-axis",
+        code:
+    """
+    Text("3D Rotated")
+        .rotation3DEffect(
+            [PortValueDescription(value: 45, value_type: "number")],
+            axis: [
+                PortValueDescription(
+                    value: ["x": 1, "y": 1, "z": 0],
+                    value_type: "3dPoint"
+                )
+            ]
+        )
+    """
+    )
+
 }

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
@@ -769,16 +769,7 @@ extension SyntaxViewName {
                 layerType: layerType)
             
             return .layerInputValues(newValues)
-            
-        case .rotationScenario:
-            // Certain modifiers, e.g. `.rotation3DEffect` correspond to multiple layer-inputs (.rotationX, .rotationY, .rotationZ)
-            let newValues = try Self.deriveCustomValuesFromRotationLayerInputTranslation(
-                id: id,
-                layerType: layerType,
-                modifier: modifier)
-            
-            return .layerInputValues(newValues)
-            
+                        
         case .layerId:
             guard let rawValue = modifier.arguments.defaultArgs?.first?.value.simpleValue else {
                 throw SwiftUISyntaxError.unsupportedLayerIdParsing(modifier.arguments.defaultArgs ?? [])

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayerInputPort.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayerInputPort.swift
@@ -94,7 +94,7 @@ enum DerivedLayerInputPortsResult: Equatable, Hashable, Sendable {
     case simple(CurrentAIGraphData.LayerInputPort)
     
     // Special case: .rotation3DEffect modifier corresponds to *three* different layer inputs; .rotation also requires special parsing of its `.degrees(x)` arguments
-    case rotationScenario
+//    case rotationScenario
     
     // Tracks some layer ID assigned to a view
     case layerId
@@ -160,11 +160,17 @@ extension SyntaxViewModifierName {
             return .simple(.position)
         
         // Rotation is a more complicated scenario which we handle with special logic
-        case .rotationEffect,
-            .rotation3DEffect:
+        case .rotationEffect:
+            return .simple(.rotationZ)
+            
+            // tricky: this view modifier corresponds to
+        case .rotation3DEffect:
             // .rotationEffect is always a z-axis rotation, i.e. .rotationZ
             // .rotation3DEffect is .rotationX or .rotationY or .rotationZ
-            return .rotationScenario
+//            return .rotationScenario
+            
+            // TODO: the .rotation3DEffect view modifier actually corresponds to 3 separate layer inputs (.rotationX, .rotationY, .rotationZ)
+            return .simple(.rotationZ)
                     
         case .blur:
             return .simple(.blurRadius)

--- a/Stitch/Graph/StitchAI/Mapping/VPLToCode/PatchVPLToCode.swift
+++ b/Stitch/Graph/StitchAI/Mapping/VPLToCode/PatchVPLToCode.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 extension GraphState {
     @MainActor
-    func createSwiftUICode() throws -> String {
+    func createSwiftUICode(ignoreScript: Bool = false) throws -> String {
         let graphEntity = self.createSchema()
         let aiGraph = try AIGraphData_V0.GraphData(from: graphEntity)
         
@@ -35,6 +35,10 @@ extension GraphState {
             strictSyntaxView.toSwiftUICode()
         }.joined(separator: "\n\n\t\t")
         
+        
+        if ignoreScript {
+            return viewCode
+        }
         
         let script = """
 struct ContentView: some View {


### PR DESCRIPTION
<img width="1440" height="900" alt="Screenshot 2025-08-04 at 1 55 42 PM" src="https://github.com/user-attachments/assets/045dc4ce-24e1-465f-a8bd-b1b453988bb3" />
<img width="1440" height="900" alt="Screenshot 2025-08-04 at 1 55 36 PM" src="https://github.com/user-attachments/assets/2032cf85-48f0-4b4f-85e5-7b3e5a860706" />
