### PR TITLE
Canvas creation cleanup for pack/unpacked modes

### DIFF
--- a/Stitch/Graph/Edge/Util/PortActions.swift
+++ b/Stitch/Graph/Edge/Util/PortActions.swift
@@ -150,8 +150,6 @@ extension GraphState {
            !upstreamOutputObserver.allLoopedValues.isEmpty {
             downstreamInputObserver.setValuesInInput(upstreamOutputObserver.allLoopedValues)
         }
-        
-        self.updateTopologicalData()
     }
 
     @MainActor
@@ -159,6 +157,8 @@ extension GraphState {
 
         // Add edge
         self.addEdgeWithoutGraphRecalc(edge: edge)
+        
+        self.updateTopologicalData()
         
         // Then recalculate the graph again, with new edge,
         // starting at the 'from' node downward:

--- a/Stitch/Graph/LayerInspector/LayerPortAddedToCanvas.swift
+++ b/Stitch/Graph/LayerInspector/LayerPortAddedToCanvas.swift
@@ -194,14 +194,6 @@ extension StitchDocumentViewModel {
                                    document: self)
         }
         
-        // If we're not dragging an edge to the inspector, then we cannot swap.
-        if !draggedOutput.isDefined {
-            guard previousPackMode == layerInputType.portType.mode else {
-                log("Tried to add whole layer input to canvas when layer input was in unpack mode")
-                return
-            }
-        }
-        
         // Remove an existing layer fields on the canvas if mode changed on drag
         else if didModeChange {
             switch newPackMode {

--- a/Stitch/Graph/LayerInspector/LayerPortAddedToCanvas.swift
+++ b/Stitch/Graph/LayerInspector/LayerPortAddedToCanvas.swift
@@ -142,28 +142,7 @@ extension GraphState {
 }
 
 
-extension StitchDocumentViewModel {
-//    @MainActor
-//    func addLayerInputToCanvas(node: NodeViewModel,
-//                               layerInput: LayerInputPort,
-//                               
-//                               // We added a layer-input to the canvas via edge-drawing,
-//                               // and need to position the layer-input next to the dragged output.
-//                               draggedOutput: OutputPortUIViewModel?,
-//                               
-//                               // If we added multiple layer inputs to the canvas at one time (via layer multiselect), we offset them
-//                               canvasHeightOffset: Int?,
-//                               
-//                               // For LLM-actions, horizontal offset
-//                               position: CGPoint? = nil) {
-//        self.addCanvasLayerInput(node: node,
-//                                 layerInputType: .init(layerInput: layerInput,
-//                                                       portType: .packed),
-//                                 draggedOutput: draggedOutput,
-//                                 canvasHeightOffset: canvasHeightOffset,
-//                                 position: position)
-//    }
-    
+extension StitchDocumentViewModel {    
     @MainActor
     func addCanvasLayerInput(node: NodeViewModel,
                              layerInputType: LayerInputType,
@@ -266,23 +245,6 @@ extension StitchDocumentViewModel {
         
         graph.propertySidebar.selectedProperty = nil
     }
-    
-//    // If we added this layer-input to the canvas as part of an edge-drag,
-//    // create an edge between the dragged output and the added layer-input
-//    @MainActor
-//    func createEdgeIfLayerInputOrFieldAddedViaOutputDrag(draggedOutput: OutputCoordinate?,
-//                                                         layerInputOrFieldCanvasItem: CanvasItemViewModel) {
-//        
-//        // If we added this layer-input to the canvas as part of an edge-drag,
-//        // create an edge between the dragged output and the added layer-input
-//        if let draggedOutput = draggedOutput {
-//            guard let firstInput = layerInputOrFieldCanvasItem.inputViewModels.first?.nodeIOCoordinate else {
-//                fatalErrorIfDebug()
-//                return
-//            }
-//            self.visibleGraph.addEdgeWithoutGraphRecalc(from: draggedOutput, to: firstInput)
-//        }
-//    }
 }
 
 
@@ -327,104 +289,6 @@ extension StitchDocumentViewModel {
                                  draggedOutput: draggedOutput,
                                  canvasHeightOffset: canvasHeightOffset)
     }
-        
-//        let graph = self.visibleGraph
-//        
-//        guard let node = graph.getNode(nodeId),
-//              let layerNode = node.layerNode else {
-//            fatalErrorIfDebug("LayerInputFieldAddedToCanvas: no node and/or layer node")
-//            return
-//        }
-//                
-//        let portObserver: LayerInputObserver = layerNode[keyPath: layerInput.layerNodeKeyPath]
-//
-//        // TODO: FIX ISSUE WHERE ANCHOR-POINTS (EDGE'S TO) DID NOT UPDATED PROPERLY WHEN SWAPPING OUT INPUT-ON-CANVAS FOR FIELD-ON-CANVAS; and then remove this statement
-//        if draggedOutput.isDefined,
-//           let _ = portObserver.packedCanvasObserverOnlyIfPacked  {
-//            log("addLayerFieldToCanvas: Whole input \(layerInput) already on canvas, exiting early")
-//            return
-//        }
-//        
-//        let previousPackMode = portObserver.mode
-//        
-//        // Not all layer inputs are multifield!
-//        guard let unpackedPort: InputLayerNodeRowData = portObserver._unpackedData.allPorts[safe: fieldIndex] else {
-//            fatalErrorIfDebug("LayerInputFieldAddedToCanvas: no unpacked port for fieldIndex \(fieldIndex)")
-//            return
-//        }
-//                 
-//        // Remove existing layer field first; can happen when we're dragging
-//        if let existingCanvasObserver = unpackedPort.canvasObserver {
-//            log("addLayerFieldToCanvas: Field \(fieldIndex) for input \(layerInput) already on canvas")
-//            graph.deleteCanvasItem(existingCanvasObserver.id,
-//                                   document: self)
-//        }
-        
-//        // TODO: allow this even when it's not from drawing an edge?
-//        // If we already have the input on the canvas, remove that first
-//        if draggedOutput.isDefined,
-//           let existingInputOnCanvas = portObserver.packedCanvasObserverOnlyIfPacked {
-//            log("addLayerFieldToCanvas: Whole input \(layerInput) already on canvas")
-//            graph.deleteCanvasItem(existingInputOnCanvas.id,
-//                                   document: self)
-//        }
-    
-        // MARK: CREATING AND INITIALIZING THE CANVAS ITEM VIEW MODEL ITSELF
-        
-//        // First field-group grabbed since layers don't have differing groups within one input
-//        guard let unpackedPortParentFieldGroupType: FieldGroupType = layerInput
-//            .getDefaultValue(for: layerNode.layer)
-//            .getNodeRowType(nodeIO: .input, layerInputPort: layerInput, isLayerInspector: true)
-//            .fieldGroupTypes
-//            .first else {
-//            fatalErrorIfDebug()
-//            return
-//        }
-        
-//        let activeIndex = self.activeIndex
-        
-//        let canvasPosition = self.getLayerInputOrFieldCanvasInsertionPosition(
-//            draggedOutput: draggedOutput,
-//            canvasHeightOffset: canvasHeightOffset,
-//            position: nil)
-//        
-//        let canvasItem = CanvasItemViewModel(
-//            id: .layerInput(LayerInputCoordinate(node: nodeId,
-//                                                 keyPath: unpackedPort.id)),
-//            position: canvasPosition,
-//            zIndex: graph.highestZIndex + 1,
-//            parentGroupNodeId: self.groupNodeFocused?.groupNodeId,
-//            inputRowObservers: [unpackedPort.rowObserver],
-//            outputRowObservers: [])
-        
-//        canvasItem.assignNodeReferenceAndUpdateFieldGroupsOnRowViewModels(
-//            node,
-//            activeIndex: activeIndex,
-//            unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-//            unpackedPortIndex: fieldIndex,
-//            graph: graph)
-//        
-//        self.createEdgeIfLayerInputOrFieldAddedViaOutputDrag(
-//            draggedOutput: draggedOutput?.id,
-//            layerInputOrFieldCanvasItem: canvasItem)
-//        
-//        unpackedPort.canvasObserver = canvasItem
-//        
-//        
-//        // MARK: Change the pack mode
-//        
-//        let newPackMode = portObserver.mode
-//        if previousPackMode != newPackMode {
-//            portObserver.wasPackModeToggled(document: self)
-//        }
-//        
-//        // MARK: RESET CACHE
-//        
-//        graph.resetLayerInputsCache(layerNode: layerNode,
-//                                    activeIndex: activeIndex) // Why?
-//        
-//        graph.propertySidebar.selectedProperty = nil
-//    }
     
     @MainActor
     func handleLayerInputFieldAddedToCanvas(layerInput: LayerInputPort,

--- a/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
+++ b/Stitch/Graph/Node/Component/StitchComponentViewModel.swift
@@ -185,8 +185,6 @@ extension StitchComponentViewModel {
         self.canvas.assignNodeReferenceAndUpdateFieldGroupsOnRowViewModels(
             node,
             activeIndex: document.activeIndex,
-            unpackedPortParentFieldGroupType: nil,
-            unpackedPortIndex: nil,
             graph: graph)
         
         self.graph.assignReferencesAndUpdateUICaches(document: document,

--- a/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
+++ b/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
@@ -34,7 +34,7 @@ extension LayerInputObserver {
 protocol LayerNodeRowData: AnyObject {
     associatedtype RowObserverable: NodeRowObserver
     
-    @MainActor var rowObserver: RowObserverable { get set }
+    @MainActor var rowObserver: RowObserverable { get }
     @MainActor var canvasObserver: CanvasItemViewModel? { get set }
     @MainActor var inspectorRowViewModel: RowObserverable.RowViewModelType { get set }
 }
@@ -47,7 +47,7 @@ protocol LayerNodeRowData: AnyObject {
 @Observable
 final class InputLayerNodeRowData: LayerNodeRowData, Identifiable {
     let id: LayerInputType
-    var rowObserver: InputNodeRowObserver
+    let rowObserver: InputNodeRowObserver
     var inspectorRowViewModel: InputNodeRowViewModel
     var canvasObserver: CanvasItemViewModel?
     
@@ -147,25 +147,17 @@ final class OutputLayerNodeRowData: LayerNodeRowData, Identifiable {
         self.canvasObserver?.assignNodeReferenceAndUpdateFieldGroupsOnRowViewModels(
             node,
             activeIndex: activeIndex,
-            // Not relevant for output
-            unpackedPortParentFieldGroupType: nil,
-            unpackedPortIndex: nil,
             graph: graph)
                         
         self.inspectorRowViewModel.updateFieldGroupsIfEmptyAndUpdatePortAddress(
             node: node,
-            initialValue: rowDelegate.getActiveValue(activeIndex: activeIndex),
-            // Not relevant for output
-            unpackedPortParentFieldGroupType: nil,
-            unpackedPortIndex: nil)
+            initialValue: rowDelegate.getActiveValue(activeIndex: activeIndex))
     }
 }
 
 extension LayerNodeRowData {
     @MainActor
     func initializeDelegate(_ node: NodeViewModel,
-                            unpackedPortParentFieldGroupType: FieldGroupType?,
-                            unpackedPortIndex: Int?,
                             activeIndex: ActiveIndex,
                             graph: GraphState) {
         
@@ -174,17 +166,13 @@ extension LayerNodeRowData {
         self.canvasObserver?.assignNodeReferenceAndUpdateFieldGroupsOnRowViewModels(
             node,
             activeIndex: activeIndex,
-            unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-            unpackedPortIndex: unpackedPortIndex,
             graph: graph)
         
         let rowDelegate = self.rowObserver
         
         self.inspectorRowViewModel.updateFieldGroupsIfEmptyAndUpdatePortAddress(
             node: node,
-            initialValue: rowDelegate.getActiveValue(activeIndex: activeIndex),
-            unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-            unpackedPortIndex: unpackedPortIndex)
+            initialValue: rowDelegate.getActiveValue(activeIndex: activeIndex))
     }
     
     @MainActor

--- a/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
+++ b/Stitch/Graph/Node/Layer/ViewModel/LayerNodeViewModel.swift
@@ -458,15 +458,6 @@ extension LayerNodeViewModel: SchemaObserver {
                         id: .layerOutput(coordinate),
                         inputRowObservers: [],
                         outputRowObservers: [outputData.rowObserver])
-                    
-                    // updateGraphData should take care of this ?
-//                    outputData.canvasObserver?.assignNodeReferenceAndUpdateFieldGroupsOnRowViewModels(
-//                        node,
-//                        activeIndex: activeIndex,
-//                        // Not relevant
-//                        unpackedPortParentFieldGroupType: nil,
-//                        unpackedPortIndex: nil,
-//                        graph: graph)
                 }
                 return
             }

--- a/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
+++ b/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
@@ -191,8 +191,6 @@ extension PatchNodeViewModel {
         self.canvasObserver.assignNodeReferenceAndUpdateFieldGroupsOnRowViewModels(
             node,
             activeIndex: activeIndex,
-            unpackedPortParentFieldGroupType: nil,
-            unpackedPortIndex: nil,
             graph: graph)
     }
     

--- a/Stitch/Graph/Node/Port/ViewModel/FieldGroup.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/FieldGroup.swift
@@ -25,8 +25,6 @@ struct FieldGroup: Identifiable {
     init(fieldValues: FieldValues,
          type: FieldGroupType,
          groupLabel: String? = nil,
-         unpackedPortParentFieldGroupType: FieldGroupType?,
-         unpackedPortIndex: Int?,
          startingFieldIndex: Int = 0,
          layerInput: LayerInputPort?,
          rowId: NodeRowViewModelId) {
@@ -34,8 +32,6 @@ struct FieldGroup: Identifiable {
         let fieldObservers: [FieldViewModel] = .createFieldViewModels(
             fieldValues: fieldValues,
             fieldGroupType: type,
-            unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-            unpackedPortIndex: unpackedPortIndex,
             startingFieldIndex: startingFieldIndex,
             layerInput: layerInput,
             rowId: rowId)
@@ -140,15 +136,11 @@ extension NodeRowType {
 extension NodeRowViewModel {
     @MainActor
     func createFieldGroups(initialValue: PortValue,
-                           nodeIO: NodeIO, // from node row observer
-                           unpackedPortParentFieldGroupType: FieldGroupType?,
-                           unpackedPortIndex: Int?) -> [FieldGroup] {
+                           nodeIO: NodeIO) -> [FieldGroup] {
         getFieldGroups(
             rowId: self.id,
             value: initialValue,
             nodeIO: nodeIO,
-            unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-            unpackedPortIndex: unpackedPortIndex,
             layerInput: self.id.layerInputPort,
             isLayerInspector: self.isLayerInspector)
     }
@@ -159,8 +151,6 @@ extension NodeRowViewModel {
 func getFieldGroups(rowId: NodeRowViewModelId,
                     value: PortValue,
                     nodeIO: NodeIO,
-                    unpackedPortParentFieldGroupType: FieldGroupType?,
-                    unpackedPortIndex: Int?,
                     layerInput: LayerInputPort?,
                     isLayerInspector: Bool) -> [FieldGroup] {
     
@@ -182,48 +172,36 @@ func getFieldGroups(rowId: NodeRowViewModelId,
     case .size:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .wH,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
     case .size3D:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .wHL,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
     case .position:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .xY,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
     case .point3D:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .xYZ,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
     case .point4D:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .xYZW,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
     case .padding:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .padding,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
@@ -234,23 +212,17 @@ func getFieldGroups(rowId: NodeRowViewModelId,
         return [.init(fieldValues: fieldValuesList[0],
                       type: .xYZ,
                       groupLabel: "Position",
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId),
                 .init(fieldValues: fieldValuesList[1],
                       type: .xYZ,
                       groupLabel: "Scale",
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       startingFieldIndex: 3,
                       layerInput: layerInput,
                       rowId: rowId),
                 .init(fieldValues: fieldValuesList[2],
                       type: .xYZ,
                       groupLabel: "Rotation",
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       startingFieldIndex: 6,
                       layerInput: layerInput,
                       rowId: rowId)]
@@ -260,22 +232,16 @@ func getFieldGroups(rowId: NodeRowViewModelId,
         case .closePath:
             return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                           type: .dropdown,
-                          unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                          unpackedPortIndex: unpackedPortIndex,
                           layerInput: layerInput,
                           rowId: rowId)]
         case .lineTo: // i.e. .moveTo or .lineTo
             return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                           type: .dropdown,
-                          unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                          unpackedPortIndex: unpackedPortIndex,
                           layerInput: layerInput,
                           rowId: rowId),
                     .init(fieldValues: fieldValuesList[safe: 1] ?? [],
                           type: .xY,
                           groupLabel: "Point", // optional
-                          unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                          unpackedPortIndex: unpackedPortIndex,
                           // REQUIRED, else we get two dropdowns
                           startingFieldIndex: 1,
                           layerInput: layerInput,
@@ -285,31 +251,23 @@ func getFieldGroups(rowId: NodeRowViewModelId,
             return .init([
                 .init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .dropdown,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId),
                 .init(fieldValues: fieldValuesList[safe: 1] ?? [],
                       type: .xY,
                       groupLabel: "Point",
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       startingFieldIndex: 1,
                       layerInput: layerInput,
                       rowId: rowId),
                 .init(fieldValues: fieldValuesList[safe: 2] ?? [],
                       type: .xY,
                       groupLabel: "Curve From",
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       startingFieldIndex: 3,
                       layerInput: layerInput,
                       rowId: rowId),
                 .init(fieldValues: fieldValuesList[safe: 3] ?? [],
                       type: .xY,
                       groupLabel: "Curve To",
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       startingFieldIndex: 5,
                       layerInput: layerInput,
                       rowId: rowId)
@@ -317,8 +275,6 @@ func getFieldGroups(rowId: NodeRowViewModelId,
         case .output:
             return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                           type: .readOnly,
-                          unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                          unpackedPortIndex: unpackedPortIndex,
                           layerInput: layerInput,
                           rowId: rowId)]
         }
@@ -326,8 +282,6 @@ func getFieldGroups(rowId: NodeRowViewModelId,
     case .singleDropdown:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .dropdown,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
@@ -335,160 +289,120 @@ func getFieldGroups(rowId: NodeRowViewModelId,
         // TODO: Can keep using .dropdown ?
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .dropdown,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
     case .layerGroupOrientationDropdown:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .layerGroupOrientation,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
     case .layerGroupAlignment:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .layerGroupAlignment,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
     case .textAlignmentPicker:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .textAlignment,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
     case .textVerticalAlignmentPicker:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .textVerticalAlignment,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
     case .textDecoration:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .textDecoration,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
     case .bool:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .bool,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
     case .asyncMedia:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .asyncMedia,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
     case .number:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .number,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
     case .string:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .string,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
     case .layerDimension:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .layerDimension,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
     case .pulse:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .pulse,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
     case .color:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .color,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
     case .json:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .json,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
     case .assignedLayer:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .assignedLayer,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
     case .pinTo:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .pinTo,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
     case .anchoring:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .anchoring,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
     case .readOnly:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .readOnly,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
     case .spacing:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .spacing,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
         
     case .anchorEntity:
         return [.init(fieldValues: fieldValuesForSingleFieldGroup,
                       type: .anchorEntity,
-                      unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                      unpackedPortIndex: unpackedPortIndex,
                       layerInput: layerInput,
                       rowId: rowId)]
     }

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
@@ -156,6 +156,15 @@ extension LayerInputKeyPathType {
             return nil
         }
     }
+    
+    var mode: LayerInputMode {
+        switch self {
+        case .packed:
+            return .packed
+        case .unpacked:
+            return .unpacked
+        }
+    }
 }
 
 extension Int {
@@ -378,27 +387,11 @@ extension LayerInputObserver {
                             graph: GraphState) {
                 
         self._packedData.initializeDelegate(node,
-                                            // Not relevant for packed data
-                                            unpackedPortParentFieldGroupType: nil,
-                                            unpackedPortIndex: nil,
                                             activeIndex: activeIndex,
                                             graph: graph)
-                
-        let layerInput: LayerInputPort = self.port
-                
-        // MARK: first group type grabbed since layers don't have differing groups within one input
-        let unpackedPortParentFieldGroupType = layerInput
-            .getDefaultValue(for: layer)
-            .getNodeRowType(nodeIO: .input,
-                            layerInputPort: layerInput,
-                            isLayerInspector: true)
-            .fieldGroupTypes
-            .first
         
         self._unpackedData.allPorts.enumerated().forEach { fieldIndex, port in
             port.initializeDelegate(node,
-                                    unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                                    unpackedPortIndex: fieldIndex,
                                     activeIndex: activeIndex,
                                     graph: graph)
         }

--- a/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/Layer/LayerInputObserver.swift
@@ -475,11 +475,6 @@ extension LayerInputObserver {
         self.mode == .packed ? self._packedData.canvasObserver : nil
     }
     
-    @MainActor
-    var unpackedCanvasObserversOnlyIfUnpacked: [CanvasItemViewModel]? {
-        self.mode == .unpacked ? self.getAllCanvasObservers() : nil
-    }
-    
     // All row observers for this input; for working with row observer(s) regardless of pack vs unpack
     @MainActor
     var allRowObservers: [InputNodeRowObserver] {

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowObserver/NodeRowObserver.swift
@@ -95,10 +95,7 @@ extension NodeRowViewModel {
         guard !nodeRowTypeChanged else {
             self.cachedFieldGroups = self.createFieldGroups(
                 initialValue: newValue,
-                nodeIO: nodeIO,
-                // Node Row Type change is only when a patch node changes its node type; can't happen for layer nodes
-                unpackedPortParentFieldGroupType: nil,
-                unpackedPortIndex: nil)
+                nodeIO: nodeIO)
             return
         }
         
@@ -138,11 +135,7 @@ extension NodeRowViewModel {
             if willUpdateFieldsCount {
                 self.cachedFieldGroups = self.createFieldGroups(
                     initialValue: newValue,
-                    nodeIO: nodeIO,
-                    // Note: this is only for a patch node whose node-type has changed (?); does not happen with layer nodes, a layer input being packed or unpacked is irrelevant here etc.
-                    // Not relevant?
-                    unpackedPortParentFieldGroupType: nil,
-                    unpackedPortIndex:  nil)
+                    nodeIO: nodeIO)
                 return
             }
             

--- a/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
+++ b/Stitch/Graph/Node/Port/ViewModel/NodeRowViewModel/NodeRowViewModel.swift
@@ -72,13 +72,9 @@ extension NodeRowViewModel {
     @MainActor
     func updateFieldGroupsIfEmptyAndUpdatePortAddress(
         node: NodeViewModel,
-        initialValue: PortValue,
-        unpackedPortParentFieldGroupType: FieldGroupType?,
-        unpackedPortIndex: Int?
+        initialValue: PortValue
     ) {
         self.updateActiveValueAndFieldGroupsCaches(
-            unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-            unpackedPortIndex: unpackedPortIndex,
             initialValue: initialValue)
                 
         // TODO: can this really change across the lifetime of a node row view model ?
@@ -94,9 +90,7 @@ extension NodeRowViewModel {
     }
      
     @MainActor
-    func updateActiveValueAndFieldGroupsCaches(unpackedPortParentFieldGroupType: FieldGroupType?,
-                                               unpackedPortIndex: Int?,
-                                               initialValue: PortValue) {
+    func updateActiveValueAndFieldGroupsCaches(initialValue: PortValue) {
         
         // TODO: confusing? `isEmpty` is a check like "we've never set field groups here", but we have logic down below for "if field groups count changed"; this is all just from re-arranging existing code that was called `initializeXYZ`
         guard self.cachedFieldGroups.isEmpty else {
@@ -109,9 +103,7 @@ extension NodeRowViewModel {
         
         let fields = self.createFieldGroups(
             initialValue: initialValue,
-            nodeIO: Self.nodeIO,
-            unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-            unpackedPortIndex: unpackedPortIndex)
+            nodeIO: Self.nodeIO)
         
         let didFieldsChange = !zip(self.cachedFieldGroups, fields).allSatisfy { $0.id == $1.id }
         

--- a/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/CanvasItemViewModel.swift
@@ -218,8 +218,6 @@ extension CanvasItemViewModel {
     func assignNodeReferenceAndUpdateFieldGroupsOnRowViewModels(
         _ node: NodeViewModel,
         activeIndex: ActiveIndex,
-        unpackedPortParentFieldGroupType: FieldGroupType?,
-        unpackedPortIndex: Int?,
         graph: GraphReader
     ) {
         
@@ -229,9 +227,7 @@ extension CanvasItemViewModel {
             if let rowObserver = graph.getInputRowObserver($0.id.asNodeIOCoordinate) {
                 $0.updateFieldGroupsIfEmptyAndUpdatePortAddress(
                     node: node,
-                    initialValue: rowObserver.getActiveValue(activeIndex: activeIndex),
-                    unpackedPortParentFieldGroupType: unpackedPortParentFieldGroupType,
-                    unpackedPortIndex: unpackedPortIndex)
+                    initialValue: rowObserver.getActiveValue(activeIndex: activeIndex))
             }
         }
         
@@ -239,10 +235,7 @@ extension CanvasItemViewModel {
             if let rowObserver = graph.getOutputRowObserver($0.id.asNodeIOCoordinate) {
                 $0.updateFieldGroupsIfEmptyAndUpdatePortAddress(
                     node: node,
-                    initialValue: rowObserver.getActiveValue(activeIndex: activeIndex),
-                    // Not relevant for output row view models
-                    unpackedPortParentFieldGroupType: nil,
-                    unpackedPortIndex: nil)
+                    initialValue: rowObserver.getActiveValue(activeIndex: activeIndex))
             }
         }
         

--- a/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModel.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModel/NodeViewModel.swift
@@ -686,15 +686,6 @@ extension NodeViewModel {
         
         // TODO: should no longer be necessary ? should be handled by `updateGraphData` call ?
         graph.updateGraphData(document)
-//
-//        // Assign delegates once view models are assigned to node
-//        newInputObserver.initializeDelegate(self, graph: graph)
-//        newInputViewModel.initializeDelegate(
-//            self,
-//            initialValue: newInputObserver.getActiveValue(activeIndex: document.activeIndex),
-//            // Only relevant for layer nodes, which cannot have an input added or removed
-//            unpackedPortParentFieldGroupType: nil,
-//            unpackedPortIndex: nil)
     }
 
     @MainActor

--- a/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
+++ b/Stitch/Graph/Node/ViewModel/NodeViewModelType.swift
@@ -97,9 +97,6 @@ extension NodeViewModelType {
             canvasItemViewModel.assignNodeReferenceAndUpdateFieldGroupsOnRowViewModels(
                 node,
                 activeIndex: activeIndex,
-                // Not relevant
-                unpackedPortParentFieldGroupType: nil,
-                unpackedPortIndex: nil,
                 graph: graph)
             
         case .component(let componentViewModel):

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
@@ -37,7 +37,7 @@ extension StitchDocumentViewModel {
         let migratedNodeName = try newLayer.node_name.value.convert(to: PatchOrLayer.self)
         let existingLayerNode = existingGraph.nodes.get(newId)
         let needsNewNodeCreation = existingLayerNode?.kind.getLayer != migratedNodeName.layer
-
+        
         if needsNewNodeCreation {
             // Creates new layer node view model
             let newLayerNode = graph
@@ -46,10 +46,15 @@ extension StitchDocumentViewModel {
                             highestZIndex: graph.highestZIndex,
                             choice: migratedNodeName,
                             center: self.newCanvasItemInsertionLocation)
+            
             graph.visibleNodesViewModel.nodes.updateValue(newLayerNode,
                                                           forKey: newLayerNode.id)
+
+            // Initialize delegates for later helpers (like edges)
+            newLayerNode.initializeDelegate(graph: graph,
+                                            document: self)
         }
-                
+        
         if let children = newLayer.children {
             for child in children {
                 // Recursive call
@@ -150,8 +155,12 @@ extension CurrentAIGraphData.GraphData {
                             highestZIndex: highestZIndex,
                             choice: .patch(.javascript),
                             center: graphCenter)
-
+            
             graph.visibleNodesViewModel.nodes.updateValue(newNode, forKey: newId)
+            
+            // Initialize delegates for later helpers (like edges)
+            newNode.initializeDelegate(graph: graph,
+                                       document: document)
             
             if let patchNode = newNode.patchNode {
                 let jsSettings = try JavaScriptNodeSettings(
@@ -186,6 +195,10 @@ extension CurrentAIGraphData.GraphData {
                                 center: graphCenter)
                 
                 graph.visibleNodesViewModel.nodes.updateValue(newNode, forKey: newId)
+                
+                // Initialize delegates for later helpers (like edges)
+                newNode.initializeDelegate(graph: graph,
+                                           document: document)
             } else if let existingPatchNode = existingPatchNode {
                 newNode = existingPatchNode
             } else {
@@ -281,22 +294,32 @@ extension CurrentAIGraphData.GraphData {
                                                to: inputCoordinate)
                 
                 // create canvas node
-                guard let fromNodeLocation = document.visibleGraph.getNode(upstreamNodeId)?.nonLayerCanvasItem?.position,
+                guard let node = graph.getNode(upstreamNodeId),
+                      let fromNodeLocation = node.nonLayerCanvasItem?.position,
                       let destinationNode = document.visibleGraph.getNode(inputCoordinate.nodeId),
-                      let layerInput = inputCoordinate.keyPath?.layerInput else {
+                      let layerInputType = inputCoordinate.keyPath else {
                     throw SwiftUISyntaxError.layerEdgeDataFailure(varName)
                 }
+                
+                // Make input mode packed or unpacked depending on coordinate
+//                switch newInputValueSetting.coordinate.portType {
+//                case .packed:
+//                    layerData.mode = .packed
+//                    
+//                case .unpacked:
+//                    layerData.mode = .unpacked
+//                }
 
                 var position = fromNodeLocation
                 position.x += 200
                 
-                document.addLayerInputToCanvas(node: destinationNode,
-                                               layerInput: layerInput,
-                                               draggedOutput: nil,
-                                               canvasHeightOffset: nil,
-                                               position: position)
+                document.addCanvasLayerInput(node: destinationNode,
+                                             layerInputType: layerInputType,
+                                             draggedOutput: nil,
+                                             canvasHeightOffset: nil,
+                                             position: position)
                 
-                graph.edgeAdded(edge: newEdgeData)
+                graph.addEdgeWithoutGraphRecalc(edge: newEdgeData)
             }
         }
         
@@ -312,7 +335,7 @@ extension CurrentAIGraphData.GraphData {
                 from: outputPort,
                 to: inputPort)
             
-            let _ = document.visibleGraph.edgeAdded(edge: edge)
+            let _ = document.visibleGraph.addEdgeWithoutGraphRecalc(edge: edge)
         }
         
         // Delete unused nodes

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
@@ -300,15 +300,6 @@ extension CurrentAIGraphData.GraphData {
                       let layerInputType = inputCoordinate.keyPath else {
                     throw SwiftUISyntaxError.layerEdgeDataFailure(varName)
                 }
-                
-                // Make input mode packed or unpacked depending on coordinate
-//                switch newInputValueSetting.coordinate.portType {
-//                case .packed:
-//                    layerData.mode = .packed
-//                    
-//                case .unpacked:
-//                    layerData.mode = .unpacked
-//                }
 
                 var position = fromNodeLocation
                 position.x += 200

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/StepAction.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/StepAction.swift
@@ -204,7 +204,7 @@ extension StepActionConnectionAdded: StepActionable {
             if let fromNodeLocation = document.visibleGraph.getNode(self.fromNodeId)?.nonLayerCanvasItem?.position,
                let destinationNode = document.visibleGraph.getNode(self.toNodeId),
                destinationNode.kind.isLayer {
-                guard let layerInput = inputPort.keyPath?.layerInput else {
+                guard let layerInputType = inputPort.keyPath else {
                     // fatalErrorIfDebug()
                     return .actionValidationError("expected layer node keypath but got: \(self.port)")
                 }
@@ -212,11 +212,11 @@ extension StepActionConnectionAdded: StepActionable {
                 var position = fromNodeLocation
                 position.x += 200
                 
-                document.addLayerInputToCanvas(node: destinationNode,
-                                               layerInput: layerInput,
-                                               draggedOutput: nil,
-                                               canvasHeightOffset: nil,
-                                               position: position)
+                document.addCanvasLayerInput(node: destinationNode,
+                                             layerInputType: layerInputType,
+                                             draggedOutput: nil,
+                                             canvasHeightOffset: nil,
+                                             position: position)
             }
             
         } catch {

--- a/Stitch/Graph/Util/HardcodedSizes/PseudoScriptForHardcodedSizes.swift
+++ b/Stitch/Graph/Util/HardcodedSizes/PseudoScriptForHardcodedSizes.swift
@@ -192,10 +192,11 @@ extension StitchDocumentViewModel {
             
             // For each input port, attempt to add to canvas
             for input in LayerInputPort.allCases {
-                self.addLayerInputToCanvas(node: nodeVM,
-                                           layerInput: input,
-                                           draggedOutput: nil,
-                                           canvasHeightOffset: nil)
+                self.addCanvasLayerInput(node: nodeVM,
+                                         layerInputType: .init(layerInput: input,
+                                                               portType: .packed),
+                                         draggedOutput: nil,
+                                         canvasHeightOffset: nil)
             }
         }
         

--- a/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
+++ b/Stitch/Graph/ViewModel/VisibleNodesViewModel.swift
@@ -329,9 +329,6 @@ func syncRowViewModels(activeIndex: ActiveIndex, graph: GraphReader) {
             canvasGroup.assignNodeReferenceAndUpdateFieldGroupsOnRowViewModels(
                 node,
                 activeIndex: activeIndex,
-                // Layer inputs can never be inputs for group nodes
-                unpackedPortParentFieldGroupType: nil,
-                unpackedPortIndex: nil,
                 graph: graph)
                             
         case .component(let componentViewModel):


### PR DESCRIPTION
Fixes issues where AI helpers may create a packed or unpacked canvas item, but our current helpers weren't built for handling either/or.

Due to strong code overlap there was an opportunity here to clean up the code, preventing my issue of using the wrong helper from happening again.