### PR TITLE
Use PortValueDescription with reverse mapping by default

### DIFF
--- a/Stitch/Graph/StitchAI/Mapping/ASTExplorerView.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ASTExplorerView.swift
@@ -296,7 +296,7 @@ struct ASTExplorerView: View {
             } ?? []
             
             // Generate SwiftUI code with configurable script wrapper
-            let newSwiftUICode = try fakeDoc.graph.createSwiftUICode(ignoreScript: ignoreScript)
+            let newSwiftUICode = try fakeDoc.graph.createSwiftUICode(ignoreScript: ignoreScript, usePortValueDescription: usePortValueDescription)
             self.regeneratedCode = newSwiftUICode
             
             // Also maintain derivedConstructors for compatibility with existing UI

--- a/Stitch/Graph/StitchAI/Mapping/VPLToCode/LayerVPLToCode.swift
+++ b/Stitch/Graph/StitchAI/Mapping/VPLToCode/LayerVPLToCode.swift
@@ -646,7 +646,7 @@ func graphDataToStrictSyntaxViews(_ graphData: AIGraphData_V0.GraphData) throws 
 
 extension StrictSyntaxView {
     /// Generates complete SwiftUI code string for this view including modifiers and children
-    func toSwiftUICode(usePortValueDescription: Bool = false) -> String {
+    func toSwiftUICode(usePortValueDescription: Bool = true) -> String {
         let constructorString = constructor.swiftUICallString()
         
         // Handle children for container views

--- a/Stitch/Graph/StitchAI/Mapping/VPLToCode/LayerVPLToCode.swift
+++ b/Stitch/Graph/StitchAI/Mapping/VPLToCode/LayerVPLToCode.swift
@@ -660,7 +660,7 @@ extension StrictSyntaxView {
         return viewWithChildren + modifiersString
     }
     
-    private func generateChildrenCode(usePortValueDescription: Bool = false) -> String {
+    private func generateChildrenCode(usePortValueDescription: Bool = true) -> String {
         guard !children.isEmpty else { return "" }
         
         // Check if this is a container view that needs children
@@ -681,7 +681,7 @@ extension StrictSyntaxView {
 }
 
 /// Renders a StrictViewModifier to SwiftUI modifier string
-func renderStrictViewModifier(_ modifier: StrictViewModifier, usePortValueDescription: Bool = false) -> String {
+func renderStrictViewModifier(_ modifier: StrictViewModifier, usePortValueDescription: Bool = true) -> String {
     switch modifier {
     case .opacity(let m):
         return ".opacity(\(renderArg(m.value, usePortValueDescription: usePortValueDescription, valueType: "number")))"
@@ -1013,7 +1013,7 @@ func getPortValueDescriptionType(for modifierName: String, argumentIndex: Int = 
     }
 }
 
-func renderArg(_ arg: SyntaxViewModifierArgumentType, usePortValueDescription: Bool = false, valueType: String = "") -> String {
+func renderArg(_ arg: SyntaxViewModifierArgumentType, usePortValueDescription: Bool = true, valueType: String = "") -> String {
     // Check for special cases that should never use PortValueDescription
     if case .stateAccess(_) = arg {
         // State variables should never be wrapped according to system prompt

--- a/Stitch/Graph/StitchAI/Mapping/VPLToCode/PatchVPLToCode.swift
+++ b/Stitch/Graph/StitchAI/Mapping/VPLToCode/PatchVPLToCode.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 extension GraphState {
     @MainActor
-    func createSwiftUICode(ignoreScript: Bool = false) throws -> String {
+    func createSwiftUICode(ignoreScript: Bool = false, usePortValueDescription: Bool = true) throws -> String {
         let graphEntity = self.createSchema()
         let aiGraph = try AIGraphData_V0.GraphData(from: graphEntity)
         
@@ -32,7 +32,7 @@ extension GraphState {
         
         // Generate complete SwiftUI code from StrictSyntaxView
         let viewCode = syntaxes.map { strictSyntaxView in
-            strictSyntaxView.toSwiftUICode()
+            strictSyntaxView.toSwiftUICode(usePortValueDescription: usePortValueDescription)
         }.joined(separator: "\n\n\t\t")
         
         

--- a/Stitch/Graph/StitchAI/PromptGenerator/AICodeGenSystemPromptGenerator.swift
+++ b/Stitch/Graph/StitchAI/PromptGenerator/AICodeGenSystemPromptGenerator.swift
@@ -76,6 +76,18 @@ Text(PortValueDescription(value: "hello world", value_type: "string"))
     .color([PortValueDescription(value: "#FFFFFF", value_type: "color")])
 ```
 
+Another example:
+
+```swift
+Text("salut").foregroundColor(Color.yellow)
+```
+
+Becomes:
+
+```swift
+Text("salut").foregroundColor([PortValueDescription(value: "#FFFF00FF", value_type: "color")])
+```
+
 This means that for any value declared inside a view's constructor, a view modifier, or anywhere some value is declared, you must use a `[PortValueDescription]` object.
 
 #### Permitted Usage of State in View Modifiers


### PR DESCRIPTION
Switches to using PortValueDescription with reverse mapping as the default approach for better code generation consistency.