### PR TITLE
Explicitly wrap top-level sidebar layers in a `ZStack` when converting Stitch -> code; avoids SwiftUI `var body`'s implicit `VStack`

### DIFF
--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequest.swift
@@ -205,6 +205,8 @@ extension StitchAICodeCreator {
         let codeParserResult = SwiftUIViewVisitor.parseSwiftUICode(swiftUICode,
                                                                    varNameIdMap: [:])
         
+        logToServerIfRelease("StitchAICodeCreator codeParserResult:\n\(codeParserResult)")
+        
         let actionsResult = try codeParserResult.deriveStitchActions()
         
         print("Derived Stitch layer data:\n\((try? actionsResult.encodeToPrintableString()) ?? "")")

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchLayerData.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchLayerData.swift
@@ -88,6 +88,23 @@ extension SwiftUIViewVisitor {
                         // Just add it to the stack temporarily so it can be processed
                         viewStack.append(viewNode)
                         currentNodeIndex = viewStack.count - 1
+                    } else if currentContext == .root {
+                        // Multiple views at root level - need to wrap in ZStack to match Stitch sidebar behavior
+                        if let existingRoot = rootViewNode {
+                            // Create a ZStack to contain both the existing root and this new view
+                            let zStackNode = SyntaxView(
+                                name: .zStack,
+                                constructorArguments: nil,
+                                modifiers: [],
+                                children: [existingRoot, viewNode],
+                                id: UUID()
+                            )
+                            
+                            // Update viewStack and root
+                            viewStack = [zStackNode]
+                            currentNodeIndex = 0
+                            rootViewNode = zStackNode
+                        }
                     } else {
 //                        log("⚠️ Found view \(viewName) in argument context - skipping child addition")
 //                        log("This view should be handled as an argument, not as a child")

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
@@ -31,7 +31,7 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
     private var idCounter = 0
     
     // Context tracking for proper child vs argument parsing
-    enum ParsingContext {
+    enum ParsingContext: Equatable {
         case root
         case closure(parentView: SyntaxViewName)
         case arguments


### PR DESCRIPTION
In SwiftUI, "top level views" i.e. views with no parent in `var body` are implicitly wrapped in a VStack.

This is the opposite of Stitch, which implicitly wraps top level layers in a ZStack.

To make sure our Swift code matches Stitch behavior, we now wrap top level sidebar layers in a ZStack in the generated-code.

Solves bug where top-level layers were being lost during graph edits.