### PR TITLE
Wrap `var body`'s top level views in `VStack` if no single 'root' view (matches SwiftUI's implicit `var body` behavior)

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -572,6 +572,7 @@
 		EC3420DE2AF9C2BE00EBD896 /* CommentBoxDataUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC3420DD2AF9C2BE00EBD896 /* CommentBoxDataUtils.swift */; };
 		EC3420E02AF9C2C700EBD896 /* CommentExpansionBoxUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC3420DF2AF9C2C700EBD896 /* CommentExpansionBoxUtils.swift */; };
 		EC3420E22AF9C2EC00EBD896 /* CommentBoxHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC3420E12AF9C2EC00EBD896 /* CommentBoxHelpers.swift */; };
+		EC34B7FF2E44419F00649A3F /* PreprocessingExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC34B7FE2E44419F00649A3F /* PreprocessingExamples.swift */; };
 		EC35A511297622030014D14A /* JSONShapeCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC35A510297622030014D14A /* JSONShapeCommand.swift */; };
 		EC363D56294282FD0093C473 /* Triangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC363D55294282FD0093C473 /* Triangle.swift */; };
 		EC365A832D7F48E60015B8D7 /* ShadowInspectorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC365A822D7F48E60015B8D7 /* ShadowInspectorRow.swift */; };
@@ -1740,6 +1741,7 @@
 		EC3420DD2AF9C2BE00EBD896 /* CommentBoxDataUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentBoxDataUtils.swift; sourceTree = "<group>"; };
 		EC3420DF2AF9C2C700EBD896 /* CommentExpansionBoxUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentExpansionBoxUtils.swift; sourceTree = "<group>"; };
 		EC3420E12AF9C2EC00EBD896 /* CommentBoxHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentBoxHelpers.swift; sourceTree = "<group>"; };
+		EC34B7FE2E44419F00649A3F /* PreprocessingExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreprocessingExamples.swift; sourceTree = "<group>"; };
 		EC35A510297622030014D14A /* JSONShapeCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONShapeCommand.swift; sourceTree = "<group>"; };
 		EC363D55294282FD0093C473 /* Triangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Triangle.swift; sourceTree = "<group>"; };
 		EC365A822D7F48E60015B8D7 /* ShadowInspectorRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowInspectorRow.swift; sourceTree = "<group>"; };
@@ -5127,6 +5129,7 @@
 			children = (
 				ECC734732E0DE95A00AC266C /* CodeExamples.swift */,
 				EC7062B22E14BFC50017A9F0 /* ScrollViewCodeExamples.swift */,
+				EC34B7FE2E44419F00649A3F /* PreprocessingExamples.swift */,
 				EC5251E02E3B0B2800E1AAC1 /* FontCodeExamples.swift */,
 				EC7062C22E15E78C0017A9F0 /* VarBodyCodeExamples.swift */,
 				EC97004F2E3C80860049202B /* PortValueDescriptionCodeExamples.swift */,
@@ -6820,6 +6823,7 @@
 				EC9486A22AE1ACED00B51AB1 /* LayerHoveredActions.swift in Sources */,
 				ECB6EE9F29314D51003D60C7 /* PatchNodeType.swift in Sources */,
 				EC3420DE2AF9C2BE00EBD896 /* CommentBoxDataUtils.swift in Sources */,
+				EC34B7FF2E44419F00649A3F /* PreprocessingExamples.swift in Sources */,
 				ECC301B329380EBB00C34F10 /* ValueAtPathNode.swift in Sources */,
 				B5EFD5B12D5D896B006A68FB /* StitchAISystemPromptGenerator.swift in Sources */,
 				EC1587452DE1287900A9C50A /* HardcodedPatchByNodeTypeSizes.swift in Sources */,

--- a/Stitch/App/StitchApp.swift
+++ b/Stitch/App/StitchApp.swift
@@ -41,8 +41,8 @@ struct StitchApp: App {
         FirebaseApp.configure()
     }
 
-#if FAKE_FLAG
-//#if DEV_DEBUG
+//#if FAKE_FLAG
+#if DEV_DEBUG
     var body: some Scene {
         WindowGroup {
 //            ConstructorDemoView()

--- a/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/CodeExamples.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/CodeExamples.swift
@@ -102,9 +102,18 @@ extension MappingExamples {
         RotationModifierCodeExamples.rotationEffectPortValueDescriptionVariable,
         RotationModifierCodeExamples.rotation3DEffectPortValueDescriptionMultiAxis,
         
+        // Preprocessing examples - testing our new multiple root view logic
+        PreprocessingCodeExamples.singleRootView,
+        PreprocessingCodeExamples.multipleRootViews,
+        PreprocessingCodeExamples.singleStackWithChildren,
+        PreprocessingCodeExamples.mixedMultipleViews,
+        PreprocessingCodeExamples.phoneKeypadExample,
+        PreprocessingCodeExamples.complexNestedExample,
+        
         //        // // NOT YET SUPPORTED:
         //        RotationModifierCodeExamples.rotationEffectAnchor,
         //        RotationModifierCodeExamples.rotationEffectRadians,
         //        RotationModifierCodeExamples.rotation3DEffectPerspective,
     ]
 }
+

--- a/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/PreprocessingExamples.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/PreprocessingExamples.swift
@@ -1,0 +1,151 @@
+//
+//  PreprocessingExamples.swift
+//  Stitch
+//
+//  Created by Christian J Clampitt on 8/6/25.
+//
+
+import Foundation
+
+
+
+// MARK: - Preprocessing Examples
+
+struct PreprocessingCodeExamples {
+    
+    // Case 1: Single root view - should NOT be wrapped
+    static let singleRootView = MappingCodeExample(
+        title: "Single Root View (No Wrapping)",
+        code: """
+HStack {
+    Rectangle()
+    Ellipse()
+}
+"""
+    )
+    
+    // Case 2: Multiple root views - should be wrapped in VStack
+    static let multipleRootViews = MappingCodeExample(
+        title: "Multiple Root Views (Should Wrap)",
+        code: """
+Rectangle()
+Ellipse()
+"""
+    )
+    
+    // Case 3: Single stack with children - should NOT be wrapped
+    static let singleStackWithChildren = MappingCodeExample(
+        title: "Single Stack With Children (No Wrapping)",
+        code: """
+VStack {
+    Text("Hello")
+    Text("World")
+    Rectangle()
+        .fill(Color.blue)
+}
+"""
+    )
+    
+    // Case 4: Mixed multiple views - should be wrapped
+    static let mixedMultipleViews = MappingCodeExample(
+        title: "Mixed Multiple Views (Should Wrap)",
+        code: """
+HStack {
+    Rectangle()
+    Ellipse()
+}
+
+Text("Between stacks")
+
+VStack {
+    Text("Hello")
+    Text("World")
+}
+"""
+    )
+    
+    // Case 5: Phone keypad example - multiple HStacks and other views
+    static let phoneKeypadExample = MappingCodeExample(
+        title: "Phone Keypad (Multiple Root Views)",
+        code: """
+VStack(alignment: .center) {
+    VStack(alignment: .center) {
+        ZStack(alignment: .center) {
+            Ellipse()
+            VStack {
+                Text("1")
+                Text("")
+            }
+        }
+    }
+}
+
+HStack(alignment: .center) {
+    VStack(alignment: .center) {
+        ZStack(alignment: .center) {
+            Ellipse()
+            VStack {
+                Text("4")
+                Text("GHI")
+            }
+        }
+    }
+    VStack(alignment: .center) {
+        ZStack(alignment: .center) {
+            Ellipse()
+            VStack {
+                Text("5")
+                Text("JKL")
+            }
+        }
+    }
+}
+
+ZStack(alignment: .center) {
+    Rectangle()
+        .fill(Color.green)
+        .cornerRadius(10.0)
+    Image(systemName: "phone.fill")
+        .foregroundColor(Color.white)
+        .scaleEffect(0.5)
+}
+"""
+    )
+    
+    // Case 6: Complex nested example - single root, should NOT wrap
+    static let complexNestedExample = MappingCodeExample(
+        title: "Complex Nested (Single Root)",
+        code: """
+ZStack {
+    VStack {
+        HStack {
+            Rectangle()
+                .fill(Color.red)
+            Ellipse()
+                .fill(Color.blue)
+        }
+        
+        Text("Middle text")
+            .font(.headline)
+        
+        HStack {
+            Button("Left") { }
+            Spacer()
+            Button("Right") { }
+        }
+    }
+    
+    // Overlay content
+    VStack {
+        Spacer()
+        Text("Overlay")
+            .foregroundColor(.white)
+            .padding()
+            .background(Color.black.opacity(0.7))
+            .cornerRadius(8)
+        Spacer()
+    }
+}
+"""
+    )
+}


### PR DESCRIPTION
We ask the LLM to send us a `var body` with a single root view, but sometimes it ignores this, which severely messes up our code-parsing logic.

This is a safer means of recovery and captures what SwiftUI actually does with a `var body` that has more than one top-level view.

We do this as part of "preprocessing" the code received by the LLM -- it's done BEFORE we parse it for `SyntaxView` etc.

<img width="1440" height="900" alt="Screenshot 2025-08-06 at 7 24 54 PM" src="https://github.com/user-attachments/assets/9abab377-f47a-46d4-af55-70fcfa51044b" />

<img width="1440" height="900" alt="Screenshot 2025-08-06 at 7 26 57 PM" src="https://github.com/user-attachments/assets/5b0a2ce4-11c4-451e-a1de-e0b439fb1fa0" />

<img width="1440" height="900" alt="Screenshot 2025-08-06 at 7 27 29 PM" src="https://github.com/user-attachments/assets/e7e7093d-ea14-483f-9237-ed7d6e4338cb" />
