### PR TITLE
Fixed code parsing issue caused by unnecessary state creation

### DIFF
--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchPatchData.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchPatchData.swift
@@ -204,7 +204,8 @@ extension SwiftParserInitializerType {
                     
                     patchConnections.append(
                         .init(src_port: usptreamCoordinate,
-                              dest_port: .init(node_id: patchNodeData.id,                          port_index: portIndex))
+                              dest_port: .init(node_id: patchNodeData.id,
+                                               port_index: portIndex))
                     )
                     
                 case .value(let argType):

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
@@ -104,9 +104,18 @@ extension Dictionary where Key == String, Value == SwiftParserInitializerType {
                     continue
                 }
                 
-            case .stateMutation:
+            case .stateMutation(let mutationData):
                 // Create state with disconnected upstream patch port, feed this into layer data and update all the helpers
                 viewStateVarNames.insert(varName)
+                
+                // Save outputs that are assigned to this variable
+                switch mutationData {
+                case .subscriptRef(let subscriptData):
+                    varNameOutputPortMap.updateValue(subscriptData, forKey: varName)
+                    
+                default:
+                    break
+                }
             }
         }
         


### PR DESCRIPTION
AI code creation can create unnecessary state variables—this would cause a code parsing issue, now fixed here.