### PR TITLE
UX for drag-and-drop an image for AI request

### DIFF
--- a/Stitch/Graph/Menu/InsertNodeMenu/Model/InsertNodeMenuState.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/Model/InsertNodeMenuState.swift
@@ -54,6 +54,10 @@ struct InsertNodeMenuState: Hashable {
     
     var isAutoHiding: Bool = false
     
+    // Image for OpenAI Vision API when user drops an image
+    var droppedImage: UIImage?
+    var droppedImageBase64: String?
+    
     static let startingActiveSelection = allSearchOptions.first
     // TODO: needs to be dynamic, since we now must load in custom components
     

--- a/Stitch/Graph/Menu/InsertNodeMenu/Util/InsertNodeMenuActions.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/Util/InsertNodeMenuActions.swift
@@ -9,6 +9,37 @@ import Foundation
 import SwiftUI
 import StitchSchemaKit
 
+/// Action for handling image drops when insert node menu is open
+struct HandleInsertNodeMenuImageDrop: StitchDocumentEvent {
+    let image: UIImage
+    
+    func handle(state: StitchDocumentViewModel) {
+        log("HandleInsertNodeMenuImageDrop: image received for AI Vision API")
+        
+        // Store the image in the insert node menu state
+        state.insertNodeMenuState.droppedImage = image
+        
+        // Convert to base64 for API usage
+        let base64Result = convertImageToBase64String(uiImage: image)
+        if case .success(let base64String) = base64Result {
+            state.insertNodeMenuState.droppedImageBase64 = base64String
+            log("Successfully converted dropped image to base64 for Vision API")
+        } else {
+            log("Failed to convert dropped image to base64")
+            state.insertNodeMenuState.droppedImageBase64 = nil
+        }
+    }
+}
+
+/// Action for clearing the dropped image
+struct ClearInsertNodeMenuImage: StitchDocumentEvent {
+    func handle(state: StitchDocumentViewModel) {
+        state.insertNodeMenuState.droppedImage = nil
+        state.insertNodeMenuState.droppedImageBase64 = nil
+        log("Cleared dropped image from insert node menu")
+    }
+}
+
 /// Toggles state to show the menu for inserting a new patch or layer node to the graph.
 
 // i.e. user toggled the insert-node-menu via

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenu.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenu.swift
@@ -13,6 +13,9 @@ import TipKit
 
 let INSERT_NODE_MENU_ADD_NODE_BUTTON_COLOR: Color = Color(uiColor: UIColor(hex: "F3F3F3")!)
 
+// Height of the image thumbnail row when visible (matches InsertNodeMenuWithModalBackground)
+let INSERT_NODE_MENU_IMAGE_THUMBNAIL_HEIGHT: CGFloat = 56
+
 // let INSERT_NODE_MENU_WIDTH: CGFloat = 700
 let INSERT_NODE_MENU_WIDTH: CGFloat = 639
 
@@ -156,6 +159,7 @@ struct InsertNodeMenuView: View {
                     .padding(.horizontal, 16)
                     .padding(.vertical, 8)
                 }
+                .frame(height: INSERT_NODE_MENU_IMAGE_THUMBNAIL_HEIGHT)
                 // .background(theme.themeData.graphBackground.opacity(0.1))
                 .transition(.opacity.combined(with: .move(edge: .top)))
             }

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenu.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenu.swift
@@ -124,6 +124,41 @@ struct InsertNodeMenuView: View {
                                     launchTip: self.launchTip,
                                     queryString: $queryString,
                                     userSubmitted: userSubmitted)
+            
+            // Show dropped image thumbnail if available
+            if let droppedImage = insertNodeMenuState.droppedImage {
+                HStack {
+                    HStack(spacing: 8) {
+                        Image(uiImage: droppedImage)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 40, height: 40)
+                            .cornerRadius(8)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .stroke(theme.themeData.edgeColor.opacity(0.3), lineWidth: 1)
+                            )
+                        
+                        Text("Image attached for AI Vision")
+                            .font(.caption)
+                            .foregroundColor(theme.themeData.edgeColor)
+                        
+                        Spacer()
+                        
+                        Button(action: {
+                            dispatch(ClearInsertNodeMenuImage())
+                        }) {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundColor(theme.themeData.edgeColor.opacity(0.6))
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+                }
+                // .background(theme.themeData.graphBackground.opacity(0.1))
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
 
             if !isGeneratingAINode {
                 HStack(spacing: .zero) {

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWithModalBackground.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWithModalBackground.swift
@@ -44,9 +44,14 @@ struct InsertNodeMenuWithModalBackground: View {
     }
     
     var menuYOffset: CGFloat {
-        isLoadingAIRequest
-        ? (-menuHeight/2 + INSERT_NODE_MENU_SEARCH_BAR_HEIGHT/2)
-        : 0
+        guard isLoadingAIRequest else { return 0 }
+        
+        // Calculate visible height when collapsed (search bar + optional image thumbnail)
+        let visibleHeight = INSERT_NODE_MENU_SEARCH_BAR_HEIGHT + 
+                           (insertNodeMenuState.droppedImage != nil ? INSERT_NODE_MENU_IMAGE_THUMBNAIL_HEIGHT : 0)
+        
+        // Offset to keep visible content centered
+        return -menuHeight/2 + visibleHeight/2
     }
     
     var body: some View {

--- a/Stitch/Graph/StitchAI/GraphPrompting/API/OpenAIRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/OpenAIRequest.swift
@@ -238,6 +238,10 @@ extension StitchAIManager {
         document.insertNodeMenuState.show = false
         document.aiManager?.cancelCurrentRequest()
         
+        // Clear any dropped image from the insert menu
+        document.insertNodeMenuState.droppedImage = nil
+        document.insertNodeMenuState.droppedImageBase64 = nil
+        
         log("Storing user prompt and request id")
         document.llmRecording.promptForTrainingDataOrCompletedRequest = request.userPrompt
         document.llmRecording.requestIdFromCompletedRequest = request.id

--- a/Stitch/Graph/Util/GraphUIActions.swift
+++ b/Stitch/Graph/Util/GraphUIActions.swift
@@ -181,20 +181,12 @@ struct SubmitUserPromptToOpenAI: StitchStoreEvent {
         do {
             let swiftUICodeOfGraph = try document.visibleGraph.createSwiftUICode()
                         
-            // Check if we have an image to include
-            let testImage: UIImage? = UIImage(named: "TEST_IMAGE_7")
+            // Check if user dropped an image into the insert menu
             var base64ImageData: String? = nil
-
-//            // TODO: introduce UX for image
-//            if let image = testImage {
-//                let base64Result = convertImageToBase64String(uiImage: image)
-//                if case .success(let base64String) = base64Result {
-//                    base64ImageData = base64String
-//                    print("Successfully converted image to base64 for Vision API")
-//                } else {
-//                    print("Failed to convert image to base64, proceeding without image")
-//                }
-//            }
+            if let droppedImageBase64 = document.insertNodeMenuState.droppedImageBase64 {
+                base64ImageData = droppedImageBase64
+                print("Using dropped image for Vision API")
+            }
             
             // Use vision-capable request that can handle both text and images
             let requestTask = try AICodeGenWithImageRequest(


### PR DESCRIPTION
Note: 
- regular drag-and-drop of an image file for media patch node import also still works
- there seems to be an issue where the AI image does not disappear right away; need to debug further...