### PR TITLE
Removed support for Offset in Group connections from AI

### DIFF
--- a/Stitch/Graph/StitchAI/Mapping/CodeToVPL/Declarative/DeclarativeViewConstructors.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToVPL/Declarative/DeclarativeViewConstructors.swift
@@ -1863,7 +1863,7 @@ struct PositionViewModifier: PortValuesPackModifiable {
 }
 
 struct OffsetViewModifier: PortValuesPackModifiable {
-    static let layerInputPort = LayerInputPort.offsetInGroup
+    static let layerInputPort = LayerInputPort.position
     static let nodeType = NodeType.position
     
     let args: [SyntaxViewModifierArgumentType]


### PR DESCRIPTION
Issue here being that usage of the offset view modifier frequently used Offset in Group layer input connections, which is rarely correctly used.
