### PR TITLE
Clear AI uploaded image when node menu opened

### DIFF
--- a/Stitch/Graph/Menu/InsertNodeMenu/Util/InsertNodeMenuActions.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/Util/InsertNodeMenuActions.swift
@@ -77,6 +77,10 @@ extension StitchDocumentViewModel {
 
         if showMenu {
             self.insertNodeMenuState.activeSelection = InsertNodeMenuState.startingActiveSelection
+            
+            // Clear any previously uploaded image when opening the menu
+            self.insertNodeMenuState.droppedImage = nil
+            self.insertNodeMenuState.droppedImageBase64 = nil
         } else {
             // Note: active-selection can be nil when search results give nothing; but should we really set it `nil` when we close the menu ?
 //            self.insertNodeMenuState.activeSelection = nil

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenu.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenu.swift
@@ -157,7 +157,8 @@ struct InsertNodeMenuView: View {
                         .buttonStyle(PlainButtonStyle())
                     }
                     .padding(.horizontal, 16)
-                    .padding(.vertical, 8)
+                    .padding(.top, 4)
+                    .padding(.bottom, 8)
                 }
                 .frame(height: INSERT_NODE_MENU_IMAGE_THUMBNAIL_HEIGHT)
                 // .background(theme.themeData.graphBackground.opacity(0.1))


### PR DESCRIPTION
Fix to properly clear AI uploaded images when the insert node menu is opened