### PR TITLE
When `FeatureFlag. USE_SWIFTUI_IMPLEMENTATION` true, apply both position and offset-in-group layer inputs

### DIFF
--- a/Stitch/App/FeatureFlags.swift
+++ b/Stitch/App/FeatureFlags.swift
@@ -14,7 +14,10 @@ struct FeatureFlags {
     static let USE_COMPONENTS = false
     static let USE_AI_MODE = true
     
-    static let USE_AI_IMAGE_REQUEST = true
+    // For changes that move Stitch's implementation details closer to SwiftUI,
+    // but which may not be good to expose to most beta testers quite yet.
+    // TODO: set false for
+    static let USE_SWIFTUI_IMPLEMENTATION: Bool = true
     
     // TODO: SET FALSE BEFORE NEXT RELEASE / just use Stitch AI Reasoning ?
     static let SHOW_AI_TABLE_ROWS_VIEWER = true

--- a/Stitch/App/StitchApp.swift
+++ b/Stitch/App/StitchApp.swift
@@ -41,8 +41,8 @@ struct StitchApp: App {
         FirebaseApp.configure()
     }
 
-//#if FAKE_FLAG
-#if DEV_DEBUG
+#if FAKE_FLAG
+//#if DEV_DEBUG
     var body: some Scene {
         WindowGroup {
 //            ConstructorDemoView()

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonPositionModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonPositionModifier.swift
@@ -83,7 +83,12 @@ struct PreviewCommonPositionModifier: ViewModifier {
         
         if parentIsScrollableGrid {
             content
-        } else {
+        }
+        
+        // An implementation that is a little bit closer to SwiftUI;
+        // really, LayerInputPort.position should correspond to SwiftUI's .position view modifier, etc.;
+        // Helpful for simplifying confusion between .offsetInGroup vs .position
+        else if FeatureFlags.USE_SWIFTUI_IMPLEMENTATION {
             let offset = viewModel.offsetInGroup.getSize?.asCGSize(parentSize) ?? .zero
              
             content
@@ -95,15 +100,15 @@ struct PreviewCommonPositionModifier: ViewModifier {
                 .offset(x: pos.x, y: pos.y)
         }
         
-//        else if parentDisablesPosition {
-//           let offset = viewModel.offsetInGroup.getSize?.asCGSize(parentSize) ?? .zero
-//            content
-//               .offset(x: offset.width, y: offset.height)
-//        } else {
-//            content
-////                .position(x: pos.x, y: pos.y)
-//                .offset(x: pos.x, y: pos.y)
-//        }
+        else if parentDisablesPosition {
+           let offset = viewModel.offsetInGroup.getSize?.asCGSize(parentSize) ?? .zero
+            content
+               .offset(x: offset.width, y: offset.height)
+        } else {
+            content
+//                .position(x: pos.x, y: pos.y)
+                .offset(x: pos.x, y: pos.y)
+        }
         
     }
 }

--- a/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonPositionModifier.swift
+++ b/Stitch/Graph/PrototypePreview/Layer/View/CommonModifier/PreviewCommonPositionModifier.swift
@@ -79,16 +79,31 @@ struct PreviewCommonPositionModifier: ViewModifier {
     
     @ViewBuilder func positioningView(_ content: Content) -> some View {
         // logInView("PreviewCommonPositionModifier: regular: \(viewModel.layer)")
+        
+        
         if parentIsScrollableGrid {
             content
-        } else if parentDisablesPosition {
-           let offset = viewModel.offsetInGroup.getSize?.asCGSize(parentSize) ?? .zero
-            content
-               .offset(x: offset.width, y: offset.height)
         } else {
+            let offset = viewModel.offsetInGroup.getSize?.asCGSize(parentSize) ?? .zero
+             
             content
-//                .position(x: pos.x, y: pos.y)
+            
+            // .offset which is based on the `offsetInGroup` layer input
+                .offset(x: offset.width, y: offset.height)
+            
+            // .offset which is based on the `position` layer input
                 .offset(x: pos.x, y: pos.y)
         }
+        
+//        else if parentDisablesPosition {
+//           let offset = viewModel.offsetInGroup.getSize?.asCGSize(parentSize) ?? .zero
+//            content
+//               .offset(x: offset.width, y: offset.height)
+//        } else {
+//            content
+////                .position(x: pos.x, y: pos.y)
+//                .offset(x: pos.x, y: pos.y)
+//        }
+        
     }
 }


### PR DESCRIPTION
We now apply position layer input even if the layer is in a group with an orientation;
and we also apply offsetInGroup layer input even if layer is not in a group with an orientation.

Gets them closer to SwiftUI's `.position` and `.offset` view modifiers.

Eventually we'll likely want to directly map some layer inputs to SwiftUI's `.position` and `.offset` view modifier.

Another approach would be to inform the model which is the preferred layer input (probably position). 