### PR TITLE
Explicitly blacklist overlay and background view modifiers

### DIFF
--- a/Stitch/Graph/StitchAI/PromptGenerator/AICodeGenSystemPromptGenerator.swift
+++ b/Stitch/Graph/StitchAI/PromptGenerator/AICodeGenSystemPromptGenerator.swift
@@ -392,6 +392,8 @@ You are ONLY permitted to use these view modifiers. Do not attempt to use view m
 Stitch doesn't support usage of the following view modifiers:
 * `gesture`: only `simultaneousGesture` is allowed.
 * `animation`: instead use native animation patch nodes like "classicAnimation || Patch" or "springAnimation || Patch"
+* `overlay`: instead, use a ZStack
+* `background`: instead, use a ZStack 
 
 ### Other Disallowed Behavior
 In most scenarios, you should not need to replicate functionality that would involve usage of class objects or usage of libraries other than SwiftUI. Native patch nodes largely handle these scenarios for you. Each listed scenario must use native patch nodes.


### PR DESCRIPTION
Add explicit blacklisting for overlay and background view modifiers i system prompt.