### PR TITLE
Do not show error for `.gesture`-related view modifiers, which are handled elsewhere

### DIFF
--- a/Stitch/Graph/Node/Patch/Type/Loop/LoopNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Loop/LoopNode.swift
@@ -38,20 +38,18 @@ func loopStartEval(inputs: PortValuesList,
     // Origami loopStart node turns an input loops into nil outputs.
     // We default to taking the first value from an input loop,
     // and using that as count.
-    if let number: Double = inputs.first?.first?.getNumber {
-
-        let nodeCount = Int(number)
-
-        // We can't have a loop of length less than 1
-        if nodeCount < 1 {
-            let indicesLoop: PortValues = [.number(0)]
-            return [indicesLoop]
-        }
-
-        let indicesLoop: PortValues = (0..<Int(nodeCount)).map { .number(Double($0))}
+    assertInDebug(inputs.first?.first?.getNumber.isDefined ?? false)
+    
+    let number: Double = inputs.first?.first?.getNumber ?? .zero
+    
+    let nodeCount = Int(number)
+    
+    // We can't have a loop of length less than 1
+    if nodeCount < 1 {
+        let indicesLoop: PortValues = [.number(0)]
         return [indicesLoop]
-    } else {
-        log("loopStartEval: did not have node count")
-        fatalError("loopStartEval")
     }
+    
+    let indicesLoop: PortValues = (0..<Int(nodeCount)).map { .number(Double($0))}
+    return [indicesLoop]
 }

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayerInputPort.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayerInputPort.swift
@@ -373,8 +373,6 @@ extension SyntaxViewModifierName {
             throw SwiftUISyntaxError.unsupportedViewModifier(self)
         case .foregroundStyle:
             throw SwiftUISyntaxError.unsupportedViewModifier(self)
-        case .gesture:
-            throw SwiftUISyntaxError.unsupportedViewModifier(self)
         case .help:
             throw SwiftUISyntaxError.unsupportedViewModifier(self)
         case .highPriorityGesture:
@@ -427,13 +425,9 @@ extension SyntaxViewModifierName {
             throw SwiftUISyntaxError.unsupportedViewModifier(self)
         case .onDrop:
             throw SwiftUISyntaxError.unsupportedViewModifier(self)
-        case .onHover:
-            throw SwiftUISyntaxError.unsupportedViewModifier(self)
-        case .onLongPressGesture:
-            throw SwiftUISyntaxError.unsupportedViewModifier(self)
+
+            
         case .onSubmit:
-            throw SwiftUISyntaxError.unsupportedViewModifier(self)
-        case .onTapGesture:
             throw SwiftUISyntaxError.unsupportedViewModifier(self)
         case .overlay:
             throw SwiftUISyntaxError.unsupportedViewModifier(self)
@@ -459,8 +453,7 @@ extension SyntaxViewModifierName {
             throw SwiftUISyntaxError.unsupportedViewModifier(self)
         case .shadow:
             throw SwiftUISyntaxError.unsupportedViewModifier(self)
-        case .simultaneousGesture:
-            throw SwiftUISyntaxError.unsupportedViewModifier(self)
+        
         case .sliderStyle:
             throw SwiftUISyntaxError.unsupportedViewModifier(self)
         case .smallCaps:
@@ -476,10 +469,26 @@ extension SyntaxViewModifierName {
         case .tableStyle:
             throw SwiftUISyntaxError.unsupportedViewModifier(self)
         
+        // Gestures -- currently these are all handled via the prompt and special Stitch-flavored Swift code
+        case .onHover:
+            // throw SwiftUISyntaxError.unsupportedViewModifier(self)
+            return nil
+        case .onLongPressGesture:
+            // throw SwiftUISyntaxError.unsupportedViewModifier(self)
+            return nil
+        case .gesture:
+            // throw SwiftUISyntaxError.unsupportedViewModifier(self)
+            return nil
+        case .onTapGesture:
+            // throw SwiftUISyntaxError.unsupportedViewModifier(self)
+            return nil
+        case .simultaneousGesture:
+            // throw SwiftUISyntaxError.unsupportedViewModifier(self)
+            return nil
+            
         // Probably never will be implemented?
         case .task:
             throw SwiftUISyntaxError.unsupportedViewModifier(self)
-    
 
         case .toggleStyle:
             throw SwiftUISyntaxError.unsupportedViewModifier(self)


### PR DESCRIPTION
Closes https://github.com/StitchDesign/Stitch--Old/issues/7380

We don't need to show this "error" to the user.