### PR TITLE
Re-added JS node support

### DIFF
--- a/Stitch/App/StitchApp.swift
+++ b/Stitch/App/StitchApp.swift
@@ -41,8 +41,8 @@ struct StitchApp: App {
         FirebaseApp.configure()
     }
 
-//#if FAKE_FLAG
-#if DEV_DEBUG
+#if FAKE_FLAG
+//#if DEV_DEBUG
     var body: some Scene {
         WindowGroup {
 //            ConstructorDemoView()

--- a/Stitch/App/StitchApp.swift
+++ b/Stitch/App/StitchApp.swift
@@ -41,8 +41,8 @@ struct StitchApp: App {
         FirebaseApp.configure()
     }
 
-#if FAKE_FLAG
-//#if DEV_DEBUG
+//#if FAKE_FLAG
+#if DEV_DEBUG
     var body: some Scene {
         WindowGroup {
 //            ConstructorDemoView()

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIJsNodeEditRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIJsNodeEditRequest.swift
@@ -7,6 +7,66 @@
 
 import SwiftUI
 
+struct AIJSNodeSettingsFromScritptRequest: StitchAIRequestable {
+    let id = UUID()
+    let config = OpenAIRequestConfig.default
+    let body: AIJSNodeSettingsFromScritptRequestBody
+    let willStream = false
+    
+    init(existingScript: String) {
+        self.body = .init(existingScript: existingScript)
+    }
+    
+    @MainActor
+    func willRequest(document: StitchDocumentViewModel,
+                     canShareData: Bool,
+                     requestTask: Self.RequestTask) {
+        // Nothing to do
+    }
+    
+    static func validateResponse(decodedResult: JavaScriptNodeSettingsAI) throws -> JavaScriptNodeSettings {
+        .init(suggestedTitle: decodedResult.suggested_title,
+              script: decodedResult.script,
+              inputDefinitions: try decodedResult.input_definitions.map(JavaScriptPortDefinition.init),
+              outputDefinitions: try decodedResult.output_definitions.map(JavaScriptPortDefinition.init))
+    }
+    
+    // TODO: support streaming
+    @MainActor
+    func onSuccessfulDecodingChunk(result: JavaScriptNodeSettings,
+                                   currentAttempt: Int) {
+        fatalErrorIfDebug("No JavaScript node support for streaming.")
+    }
+    
+    // TODO: support streaming
+    static func buildResponse(from streamingChunks: [JavaScriptNodeSettings]) throws -> CurrentJavaScriptNodeSettingsAI.JavaScriptNodeSettingsAI {
+        // Unsupported
+        fatalError()
+    }
+}
+
+struct AIJSNodeSettingsFromScritptRequestBody: StitchAIRequestBodyFormattable {
+    let model: String = "gpt-5-mini-2025-08-07"
+    let n: Int = 1
+    let temperature: Double = 1.0
+    let response_format = AIEditJsNodeResponseFormat_V0.AIEditJsNodeResponseFormat()
+    let messages: [OpenAIMessage]
+    let stream = false
+    
+    init(existingScript: String) {
+        let responseFormat = AIEditJsNodeResponseFormat_V0.AIEditJsNodeResponseFormat()
+        let structuredOutputs = responseFormat.json_schema.schema
+        let systemPrompt = AIEditJsNodeSystemPrompt_V0.systemPrompt
+        
+        self.messages = [
+            .init(role: .system,
+                  content: systemPrompt + "Make sure your response follows this schema: \(try! structuredOutputs.encodeToPrintableString())"),
+            .init(role: .user,
+                  content: existingScript)
+        ]
+    }
+}
+
 struct AIEditJSNodeRequest: StitchAIRequestable {
     let id: UUID
     let userPrompt: String             // User's input prompt

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
@@ -193,17 +193,6 @@ extension CurrentAIGraphData.GraphData {
                 newNode.initializeDelegate(graph: graph,
                                            document: document)
             }
-            //            else if let existingPatchNode = existingPatchNode {
-            //                newNode = existingPatchNode
-            //            } else {
-            //                fatalErrorIfDebug()
-            //                continue
-            //            }
-            //
-            //            guard let patchNode = newNode.patchNodeViewModel else {
-            //                fatalErrorIfDebug()
-            //                continue
-            //            }
         }
         
         // Set input values for new nodes

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
@@ -94,18 +94,22 @@ extension CurrentAIGraphData.GraphData {
     @MainActor
     func applyAIGraph(to document: StitchDocumentViewModel,
                       viewStatePatchConnections: [String : AIGraphData_V0.NodeIndexedCoordinate],
-                      requestType: StitchAIRequestBuilder_V0.StitchAIRequestType) throws {
+                      requestType: StitchAIRequestBuilder_V0.StitchAIRequestType) async throws {
         switch requestType {
         case .userPrompt:
             // User prompt-based requests are always assumed to be edit requests, which completely replace existing graph data
-            try self.createAIGraph(document: document)
+            try await self.createAIGraph(document: document)
         }
         
         document.encodeProjectInBackground()
     }
     
     @MainActor
-    func createAIGraph(document: StitchDocumentViewModel) throws {
+    func createAIGraph(document: StitchDocumentViewModel) async throws {
+        guard let aiManager = document.aiManager else {
+            return
+        }
+        
         let graph = document.visibleGraph
         let graphCenter = document.viewPortCenter
         let highestZIndex = document.visibleGraph.highestZIndex
@@ -148,14 +152,18 @@ extension CurrentAIGraphData.GraphData {
                                        document: document)
             
             if let patchNode = newNode.patchNode {
-                let jsSettings = try JavaScriptNodeSettings(
-                    suggestedTitle: newPatch.suggested_title,
-                    script: newPatch.javascript_source_code,
-                    inputDefinitions: newPatch.input_definitions.map(JavaScriptPortDefinition.init),
-                    outputDefinitions: newPatch.output_definitions.map(JavaScriptPortDefinition.init))
+                // Get AI info
+                let jsNodeRequest = AIJSNodeSettingsFromScritptRequest(existingScript: newPatch.sourceCode)
+                
+                let jsSettings = try await jsNodeRequest
+                    .request(document: document,
+                             aiManager: aiManager)
                 
                 patchNode.processNewJavascript(response: jsSettings,
                                                document: document)
+                
+                // Check here
+                assertInDebug(patchNode.javaScriptNodeSettings != nil)
             }
         }
         
@@ -184,14 +192,24 @@ extension CurrentAIGraphData.GraphData {
                 // Initialize delegates for later helpers (like edges)
                 newNode.initializeDelegate(graph: graph,
                                            document: document)
-            } else if let existingPatchNode = existingPatchNode {
-                newNode = existingPatchNode
-            } else {
-                fatalErrorIfDebug()
-                continue
             }
-            
-            guard let patchNode = newNode.patchNodeViewModel else {
+            //            else if let existingPatchNode = existingPatchNode {
+            //                newNode = existingPatchNode
+            //            } else {
+            //                fatalErrorIfDebug()
+            //                continue
+            //            }
+            //
+            //            guard let patchNode = newNode.patchNodeViewModel else {
+            //                fatalErrorIfDebug()
+            //                continue
+            //            }
+        }
+        
+        // Set input values for new nodes
+        for (oldId, newId) in idMap {
+            guard let newNode = graph.nodes.get(newId),
+                  let patchNode = newNode.patchNodeViewModel else {
                 fatalErrorIfDebug()
                 continue
             }

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequest.swift
@@ -134,10 +134,12 @@ extension StitchAICodeCreator {
                     guard let document = document else { return }
                     
                     do {
-                        try graphData
-                            .applyAIGraph(to: document,
-                                          viewStatePatchConnections: actionsResult.graphData .viewStatePatchConnections,
-                                          requestType: Self.type)
+                        Task(priority: .high) {
+                            try await graphData
+                                .applyAIGraph(to: document,
+                                              viewStatePatchConnections: actionsResult.graphData .viewStatePatchConnections,
+                                              requestType: Self.type)
+                        }
                         
 #if STITCH_AI_TESTING || DEBUG || DEV_DEBUG
                         // Display parsing warnings

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIGraphData/AIGraphDataUtil_V0.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIGraphData/AIGraphDataUtil_V0.swift
@@ -39,8 +39,8 @@ extension AIGraphData_V0.GraphData {
             result.updateValue(node, forKey: node.id)
         }
         
-        var jsNodes = [AIGraphData_V0.JsPatchNode]()
-        var nativeNodes = [AIGraphData_V0.NativePatchNode]()
+        var jsNodes = [AIGraphData_V0.PreprocessedJSPatchNode]()
+        var nativeNodes = [AIGraphData_V0.PatchNode]()
         var nodeTypeSettings = [AIGraphData_V0.NativePatchNodeValueTypeSetting]()
         var patchConnections = [AIGraphData_V0.PatchConnection]()
         var customPatchInputs = [AIGraphData_V0.CustomPatchInputValue]()
@@ -54,8 +54,9 @@ extension AIGraphData_V0.GraphData {
             case .patch(let patchNodeEntity):
                 // JS node scenario
                 if let jsData = patchNodeEntity.javaScriptNodeSettings {
-                    jsNodes.append( .init(from: jsData,
-                                          id: patchNodeEntity.id))
+                    jsNodes.append(.init(node_id: patchNodeEntity.id.uuidString,
+                                         funcName: nodeEntity.title.toCamelCase(),
+                                         sourceCode: jsData.script))
                 }
                 
                 // Native node scenario

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIGraphData/AIGraphData_V0.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIGraphData/AIGraphData_V0.swift
@@ -26,8 +26,8 @@ enum AIGraphData_V0 {
     }
     
     struct PatchData: Codable {
-        let javascript_patches: [AIGraphData_V0.JsPatchNode]
-        let native_patches: [AIGraphData_V0.NativePatchNode]
+        let javascript_patches: [AIGraphData_V0.PreprocessedJSPatchNode]
+        let native_patches: [AIGraphData_V0.PatchNode]
         let native_patch_value_type_settings: [AIGraphData_V0.NativePatchNodeValueTypeSetting]
         let patch_connections: [PatchConnection]
         let custom_patch_input_values: [CustomPatchInputValue]
@@ -44,6 +44,12 @@ enum AIGraphData_V0 {
         var custom_layer_input_values: [LayerPortDerivation] = []
     }
     
+    struct PreprocessedJSPatchNode: Codable {
+        let node_id: String
+        let funcName: String
+        let sourceCode: String
+    }
+    
     struct JsPatchNode: Codable {
         let node_id: String
         let javascript_source_code: String
@@ -52,7 +58,7 @@ enum AIGraphData_V0 {
         let output_definitions: [JavaScriptPortDefinitionAI_V1.JavaScriptPortDefinitionAI]
     }
     
-    struct NativePatchNode: Codable {
+    struct PatchNode: Codable {
         let node_id: String
         let node_name: StitchAIPatchOrLayer
     }

--- a/Stitch/Graph/StitchAI/Mapping/ASTExplorerView.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ASTExplorerView.swift
@@ -137,7 +137,7 @@ struct ASTExplorerView: View {
                 }
             }
             .tabViewStyle(.automatic)
-            .onChange(of: selectedTab, initial: true) { _, _ in transform() }
+            .onChange(of: selectedTab) { _, _ in transform() }
             
             if let errorString = errorString {
                 VStack(alignment: .leading) {
@@ -265,12 +265,16 @@ struct ASTExplorerView: View {
             silentlyCaughtErrors += stitchActionsResult.caughtErrors
             
             // Apply AI result to fake document
-            try stitchActionsResult.graphData
-                .createAIGraph(document: fakeDoc)
-            
-            // Generate SwiftUI code with configurable script wrapper
-            let newSwiftUICode = try fakeDoc.graph.createSwiftUICode(ignoreScript: ignoreScript, usePortValueDescription: usePortValueDescription)
-            self.regeneratedCode = newSwiftUICode
+            Task(priority: .high) {
+                try await stitchActionsResult.graphData
+                    .createAIGraph(document: fakeDoc)
+                
+                try await MainActor.run {
+                    // Generate SwiftUI code with configurable script wrapper
+                    let newSwiftUICode = try fakeDoc.graph.createSwiftUICode(ignoreScript: ignoreScript, usePortValueDescription: usePortValueDescription)
+                    self.regeneratedCode = newSwiftUICode
+                }
+            }
         } catch {
             errorString = "\(error)"
         }
@@ -289,7 +293,7 @@ struct ASTExplorerView: View {
                     .font(.system(.body, design: .monospaced))
                     .padding()
                     .border(Color.secondary)
-                    .onChange(of: binding.wrappedValue, initial: true) { _,_  in transform() }
+//                    .onChange(of: binding.wrappedValue) { _,_  in transform() }
             } else {
                 TextEditor(text: .constant(text))
                     .font(.system(.body, design: .monospaced))

--- a/Stitch/Graph/StitchAI/Mapping/ASTExplorerView.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ASTExplorerView.swift
@@ -293,7 +293,6 @@ struct ASTExplorerView: View {
                     .font(.system(.body, design: .monospaced))
                     .padding()
                     .border(Color.secondary)
-//                    .onChange(of: binding.wrappedValue) { _,_  in transform() }
             } else {
                 TextEditor(text: .constant(text))
                     .font(.system(.body, design: .monospaced))

--- a/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/StitchToPatchData.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/StitchToPatchData.swift
@@ -12,6 +12,7 @@ import SwiftUI
 
 struct StitchPatchCodeConversionResult {
     let patchNodeDeclarations: [String]
+    let jsNodeFns: [String: String]
     let varNameIdMap: [String : String]
 }
 
@@ -33,19 +34,36 @@ extension GraphEntity {
                 return nil
             }
             
+            let isJSNode = patchNodeEntity.patch == .javascript
             let varName = patchNodeEntity.patch.rawValue.createUniqueVarName(nodeId: nodeId)
             
             let args: [String] = try patchNodeEntity.inputs.map { $0.portData }
                 .createSwiftUICodeArgs(patchNodeEntityMap: patchNodeEntityDict)
             
+            let fnNameSpace = isJSNode ? "Self.fn_\(varName)" : """
+            NATIVE_STITCH_PATCH_FUNCTIONS["\(patchNodeEntity.patch.aiDisplayTitle)"]
+            """
+            
             let patchDeclaration = """
-                let \(varName) = NATIVE_STITCH_PATCH_FUNCTIONS["\(patchNodeEntity.patch.aiDisplayTitle)"]([
+                let \(varName) = \(fnNameSpace)([
                         \(args.joined(separator: ",\n\t\t"))
                     ])
                 """
             
             varIdNameMap.updateValue(varName, forKey: nodeId)
             return patchDeclaration
+        }
+        
+        // Save scripts for JS nodes
+        let jsNodeFns: [String: String] = patchNodeEntityDict.values.reduce(into: .init()) { result, node in
+            guard let jsSettings = node.javaScriptNodeSettings else {
+                return
+            }
+            
+            let varName = node.patch.rawValue.createUniqueVarName(nodeId: node.id)
+//            let fnName = "fn_\(varName)"
+            
+            result.updateValue(jsSettings.script, forKey: varName)
         }
         
         // Create new script that maps var names to some ID, which we use later to get actual UUID for node
@@ -65,6 +83,7 @@ extension GraphEntity {
         }
         
         return .init(patchNodeDeclarations: patchNodeDeclarations + layerStateAssignments,
+                     jsNodeFns: jsNodeFns,
                      varNameIdMap: varNameIdMap)
     }
 }

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchModel.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchModel.swift
@@ -24,8 +24,13 @@ enum SwiftParserPatternBindingArg {
 
 struct SwiftParserPatchData {
     let id: String
-    var patchName: String
+    var patchType: SwiftParserPatchType
     var args: [SwiftParserPatternBindingArg]
+}
+
+enum SwiftParserPatchType {
+    case native(String)
+    case js(String)
 }
 
 struct SwiftParserSubscript: Sendable {
@@ -48,6 +53,9 @@ indirect enum SwiftParserInitializerType: Sendable {
 
     // mutates some existing state
     case stateMutation(SwiftParserInitializerType)
+    
+    // js nodes
+    case jsNodeScript(String)
 }
 
 // Subscripts can be used on references or nodes themselves

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchPatchData.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchPatchData.swift
@@ -42,15 +42,18 @@ extension SwiftUIViewVisitor {
     func visitPatchData(_ node: FunctionCallExprSyntax,
                         // var names are provided from already created nodes
                         varName: String?) -> SwiftParserPatchData? {
-        let patchNode: String
+        let patchNode: SwiftParserPatchType
         
         if let subscriptExpr = node.calledExpression.as(SubscriptCallExprSyntax.self),
            // Backup check for binding declaration of the patch
            let _patchNode = subscriptExpr.getPatchNodeName() {
-            patchNode = _patchNode
+            patchNode = .native(_patchNode)
         } else if let patchNodeRefName = node.getPatchNodeRefName(),
                   let patchNodeRef = self.bindingDeclarations.get(patchNodeRefName)?.patchNodeRef {
-            patchNode = patchNodeRef
+            patchNode = .native(patchNodeRef)
+        } else if let memberAccess = node.calledExpression.as(MemberAccessExprSyntax.self) {
+            // Assume to be a reference to a JavaScript node
+            patchNode = .js(memberAccess.declName.baseName.text)
         } else {
             return nil
         }
@@ -97,7 +100,7 @@ extension SwiftUIViewVisitor {
         }
         
         return .init(id: id,
-                     patchName: patchNode,
+                     patchType: patchNode,
                      args: patchNodeArgs)
     }
     
@@ -127,9 +130,22 @@ extension SwiftUIViewVisitor {
 
 extension SwiftParserPatchData {
     func createStitchData(varName: String,
-                          varNameIdMap: inout [String : String]) -> CurrentAIGraphData.NativePatchNode {
-        guard let patchName = CurrentAIGraphData.StitchAIPatchOrLayer.init(value: .init(self.patchName)) else {
-            fatalError()
+                          varNameIdMap: inout [String : String],
+                          varNameJsFnMap: inout [String : String]) -> CurrentAIGraphData.PatchNode {
+        let patchName: CurrentAIGraphData.StitchAIPatchOrLayer
+        
+        switch self.patchType {
+        case .native(let nativePatchType):
+            guard let _patchName = CurrentAIGraphData.StitchAIPatchOrLayer.init(value: .init(nativePatchType)) else {
+                fatalError()
+            }
+            patchName = _patchName
+            
+        case .js(let fnName):
+            // Track fn name
+            varNameJsFnMap.updateValue(varName, forKey: fnName)
+            
+            patchName = .init(value: .patch(.javascript))
         }
         
         // Re-use id from Stitch -> Code if node is unchanged
@@ -140,8 +156,8 @@ extension SwiftParserPatchData {
         varNameIdMap.updateValue(id, forKey: varName)
         
         let newPatchNode = CurrentAIGraphData
-            .NativePatchNode(node_id: self.id,
-                             node_name: patchName)
+            .PatchNode(node_id: self.id,
+                       node_name: patchName)
         return newPatchNode
     }
 }
@@ -219,6 +235,8 @@ extension SwiftParserInitializerType {
                             varNamePatchNodeRefMap: [String : String],
                             patchConnections: inout [CurrentAIGraphData.PatchConnection],
                             viewStatePatchConnections: inout [String : AIGraphData_V0.NodeIndexedCoordinate],
+                            preprocessedJSNodes: inout [CurrentAIGraphData.PreprocessedJSPatchNode],
+                            varNameJsFnMap: inout [String: String],
                             subscriptParentInfo: AIGraphData_V0.NodeIndexedCoordinate? = nil) throws {
         switch self {
         case .patchNode(let patchNodeData):
@@ -230,7 +248,8 @@ extension SwiftParserInitializerType {
                                             
                     guard let upstreamRefData = varNameOutputPortMap.get(refName) else {
                         // TODO: this may happen as a result of bad code from ChatGPT
-                        fatalError()
+//                        fatalError()
+                        continue
                     }
                     
                     let usptreamCoordinate = SwiftParserPatchData
@@ -267,6 +286,8 @@ extension SwiftParserInitializerType {
                                                         customPatchInputValues: &customPatchInputValues, varNamePatchNodeRefMap: varNamePatchNodeRefMap,
                                                         patchConnections: &patchConnections,
                                                         viewStatePatchConnections: &viewStatePatchConnections,
+                                                        preprocessedJSNodes: &preprocessedJSNodes,
+                                                        varNameJsFnMap: &varNameJsFnMap,
                                                         subscriptParentInfo: .init(node_id: patchNodeData.id,
                                                                                    port_index: portIndex))
                             } else {
@@ -286,6 +307,8 @@ extension SwiftParserInitializerType {
                                             varNamePatchNodeRefMap: varNamePatchNodeRefMap,
                                             patchConnections: &patchConnections,
                                             viewStatePatchConnections: &viewStatePatchConnections,
+                                            preprocessedJSNodes: &preprocessedJSNodes,
+                                            varNameJsFnMap: &varNameJsFnMap,
                                             subscriptParentInfo: .init(node_id: patchNodeData.id,
                                                                        port_index: portIndex))
                 }
@@ -335,7 +358,9 @@ extension SwiftParserInitializerType {
                                         customPatchInputValues: &customPatchInputValues,
                                         varNamePatchNodeRefMap: varNamePatchNodeRefMap,
                                         patchConnections: &patchConnections,
-                                        viewStatePatchConnections: &viewStatePatchConnections)
+                                        viewStatePatchConnections: &viewStatePatchConnections,
+                                        preprocessedJSNodes: &preprocessedJSNodes,
+                                        varNameJsFnMap: &varNameJsFnMap,)
                 
             case .ref(let refName):
                 // Get edge data
@@ -358,6 +383,21 @@ extension SwiftParserInitializerType {
         case .declrRef:
             // Ignore here
             return
+        
+        case .jsNodeScript(let script):
+            // Must reuse ID
+            guard let varNameForJsFn = varNameJsFnMap.get(varName),
+                  let id = varNameIdMap.get(varNameForJsFn) else {
+                fatalErrorIfDebug()
+                break
+            }
+            
+            // Create JS node
+            let newJSNode = AIGraphData_V0
+                .PreprocessedJSPatchNode(node_id: id,
+                                         funcName: varName,
+                                         sourceCode: script)
+            preprocessedJSNodes.append(newJSNode)
         }
     }
 }

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
@@ -159,6 +159,29 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
         return .visitChildren
     }
     
+    /// Parse for JS nodes.
+    override func visit(_ node: MemberBlockItemSyntax) -> SyntaxVisitorContinueKind {
+        guard let funcDeclSyntax = node.decl.as(FunctionDeclSyntax.self) else {
+            return .visitChildren
+        }
+        
+        if funcDeclSyntax.name.text == "updateLayerInputs" {
+            return .visitChildren
+        }
+        
+        // JS node case
+        else {
+            guard let body = funcDeclSyntax.body else {
+                return .visitChildren
+            }
+            
+            let funcName = funcDeclSyntax.name.text
+            let jsBodyScript = body.description.trimmingOuterBraces()
+            self.bindingDeclarations.updateValue(.jsNodeScript(jsBodyScript), forKey: funcName)
+            return .skipChildren
+        }
+    }
+    
     override func visitPost(_ node: ClosureExprSyntax) {
         // log("Exiting closure expression")
         
@@ -346,5 +369,24 @@ extension SwiftUIViewVisitor {
         }
         
         return count
+    }
+}
+
+// TODO: move
+extension String {
+    func trimmingOuterBraces() -> String {
+        // Trim leading/trailing whitespace and newlines first
+        let trimmed = self.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        guard trimmed.hasPrefix("{"), trimmed.hasSuffix("}") else {
+            // No outer braces, return original
+            return self
+        }
+        
+        // Remove first and last character
+        let start = trimmed.index(after: trimmed.startIndex)
+        let end = trimmed.index(before: trimmed.endIndex)
+        return String(trimmed[start..<end])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
@@ -372,7 +372,6 @@ extension SwiftUIViewVisitor {
     }
 }
 
-// TODO: move
 extension String {
     func trimmingOuterBraces() -> String {
         // Trim leading/trailing whitespace and newlines first

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
@@ -70,12 +70,16 @@ extension Dictionary where Key == String, Value == SwiftParserInitializerType {
         // Tracks @State variable declarations
         var viewStateVarNames = Set<String>()
         
+        // Tracks a variable name for each JS function name
+        var varNameJsFnMap = [String : String]()
+        
         // MARK: data to be returned
         var caughtErrors: [SwiftUISyntaxError] = []
-        var nativePatchNodes = [CurrentAIGraphData.NativePatchNode]()
+        var nativePatchNodes = [CurrentAIGraphData.PatchNode]()
         var nativePatchValueTypeSettings = [CurrentAIGraphData.NativePatchNodeValueTypeSetting]()
         var patchConnections = [CurrentAIGraphData.PatchConnection]()
         var customPatchInputValues = [CurrentAIGraphData.CustomPatchInputValue]()
+        var preprocessedJSNodes = [CurrentAIGraphData.PreprocessedJSPatchNode]()
         
         // Because patch data is decoded before layer data, we don't yet know the destination ports for layer edges, therefore, we just track the source patch to some state variable
         var viewStatePatchConnections = [String : AIGraphData_V0.NodeIndexedCoordinate]()
@@ -88,7 +92,8 @@ extension Dictionary where Key == String, Value == SwiftParserInitializerType {
             case .patchNode(let patchNodeData):
                 let newPatchNode = patchNodeData
                     .createStitchData(varName: varName,
-                                      varNameIdMap: &varNameIdMap)
+                                      varNameIdMap: &varNameIdMap,
+                                      varNameJsFnMap: &varNameJsFnMap)
                 nativePatchNodes.append(newPatchNode)
                 
             case .subscriptRef(let subscriptData):
@@ -100,7 +105,8 @@ extension Dictionary where Key == String, Value == SwiftParserInitializerType {
                     // Track more patch nodes
                     let newPatchNode = patchNodeData
                         .createStitchData(varName: varName,
-                                          varNameIdMap: &varNameIdMap)
+                                          varNameIdMap: &varNameIdMap,
+                                          varNameJsFnMap: &varNameJsFnMap)
                     nativePatchNodes.append(newPatchNode)
                     
                 case .ref:
@@ -127,6 +133,10 @@ extension Dictionary where Key == String, Value == SwiftParserInitializerType {
                     break
                 }
             
+            case .jsNodeScript:
+                // Skipping here
+                break
+                
             case .declrRef:
                 break
             }
@@ -142,11 +152,13 @@ extension Dictionary where Key == String, Value == SwiftParserInitializerType {
                                     customPatchInputValues: &customPatchInputValues,
                                     varNamePatchNodeRefMap: varNamePatchNodeRefMap,
                                     patchConnections: &patchConnections,
-                                    viewStatePatchConnections: &viewStatePatchConnections)
+                                    viewStatePatchConnections: &viewStatePatchConnections,
+                                    preprocessedJSNodes: &preprocessedJSNodes,
+                                    varNameJsFnMap: &varNameJsFnMap)
         }
         
         return .init(actions: AIGraphData_V0
-            .PatchData(javascript_patches: [],
+            .PatchData(javascript_patches: preprocessedJSNodes,
                        native_patches: nativePatchNodes,
                        native_patch_value_type_settings: nativePatchValueTypeSettings,
                        patch_connections: patchConnections,

--- a/Stitch/Graph/StitchAI/Mapping/VPLToCode/PatchVPLToCode.swift
+++ b/Stitch/Graph/StitchAI/Mapping/VPLToCode/PatchVPLToCode.swift
@@ -13,10 +13,11 @@ extension GraphState {
         let graphEntity = self.createSchema()
         let aiGraph = try AIGraphData_V0.GraphData(from: graphEntity)
         
-        let patchNodeDeclarations = try graphEntity
+        let patchData = try graphEntity
             .createBindingDeclarations(nodeIdsInTopologicalOrder: self.nodeIdsInTopologicalOrder,
                                        viewStatePatchConnections: aiGraph.viewStatePatchConnections)
-            .patchNodeDeclarations
+        
+        let patchNodeDeclarations = patchData.patchNodeDeclarations
         
         let stateVarDeclarations = aiGraph.viewStatePatchConnections.keys.map { stateVarName in
             "@State var \(stateVarName): [PortValueDescription] = []"
@@ -62,6 +63,16 @@ extension GraphState {
             return viewCode
         }
         
+        // Create js nodes script
+        let jsNodesScript = patchData.jsNodeFns.map { jsNodeData in
+            """
+            static func fn_\(jsNodeData.key)(_ inputs: [[PortValueDescription]]) -> [[PortValueDescription]] {
+                \(jsNodeData.value)
+            }
+            """
+        }
+            .joined(separator: "\n\n")
+        
         let script = """
 struct ContentView: some View {
     \(stateVarDeclarations)
@@ -73,6 +84,8 @@ struct ContentView: some View {
     func updateLayerInputs() {
         \(patchNodeDeclarations.joined(separator: "\n\t\t"))
     }
+
+    \(jsNodesScript)
 }
 """
         


### PR DESCRIPTION
This PR re-adds JS node support for AI graph requests. JS nodes were removed following full mapping support.

The temporary solution uses sequential HTTP requests for inferring needed JS information given a new JS node. Future changes could streamline this with increased async logic as well as mapping.
