### PR TITLE
Fixed issue where SwiftUI views were unordered on AI edit

### DIFF
--- a/Stitch/Graph/Sidebar/Util/LayerGrouping/SidebarLayerData.swift
+++ b/Stitch/Graph/Sidebar/Util/LayerGrouping/SidebarLayerData.swift
@@ -54,3 +54,11 @@ extension SidebarLayerData: StitchNestedListElement {
         UUID()
     }
 }
+
+extension Array where Element == SidebarLayerData {
+    var flattenedIds: [UUID] {
+        self.flatMap {
+            [$0.id] + ($0.children?.flattenedIds ?? [])
+        }
+    }
+}

--- a/Stitch/Graph/StitchAI/Mapping/VPLToCode/LayerVPLToCode.swift
+++ b/Stitch/Graph/StitchAI/Mapping/VPLToCode/LayerVPLToCode.swift
@@ -16,7 +16,7 @@ extension LayerNodeEntity {
     /// Only constructor-surface arguments are considered; **no view modifiers**.
     @MainActor
     func createSwiftUIViewBuilderCode(children: [LayerNodeEntity],
-                                      layerEntityMap: [UUID: LayerNodeEntity],
+                                      orderedLayerEntities: [LayerNodeEntity],
                                       varIdNameMap: [UUID: String]) throws -> String? {
         switch self.layer {
             
@@ -37,7 +37,7 @@ extension LayerNodeEntity {
         case .group:
             return try self
                 .createNestedGroupSwiftUICode(children: children,
-                                              layerEntityMap: layerEntityMap,
+                                              orderedLayerEntities: orderedLayerEntities,
                                               varIdNameMap: varIdNameMap)
             
             
@@ -83,12 +83,12 @@ extension LayerNodeEntity {
     
     @MainActor
     func createNestedGroupSwiftUICode(children: [LayerNodeEntity],
-                                      layerEntityMap: [UUID: LayerNodeEntity],
+                                      orderedLayerEntities: [LayerNodeEntity],
                                       varIdNameMap: [UUID: String]) throws -> String? {
         assertInDebug(self.layer == .group)
         
         let childrenContents = try children
-            .createSwiftUICode(layerEntityMap: layerEntityMap,
+            .createSwiftUICode(orderedLayerEntities: orderedLayerEntities,
                                varIdNameMap: varIdNameMap)
         
         // Check if scroll is enabled
@@ -151,7 +151,7 @@ extension LayerNodeEntity {
             case .grid:
                 // Generate LazyVGrid code
                 return try self.createLazyVGridCode(children: children,
-                                                    layerEntityMap: layerEntityMap,
+                                                    orderedLayerEntities: orderedLayerEntities,
                                                     varIdNameMap: varIdNameMap)
             }
         }
@@ -159,12 +159,12 @@ extension LayerNodeEntity {
     
     @MainActor
     func createLazyVGridCode(children: [LayerNodeEntity],
-                             layerEntityMap: [UUID: LayerNodeEntity],
+                             orderedLayerEntities: [LayerNodeEntity],
                              varIdNameMap: [UUID: String]) throws -> String? {
         assertInDebug(self.layer == .group)
         
         let childrenContents = try children
-            .createSwiftUICode(layerEntityMap: layerEntityMap,
+            .createSwiftUICode(orderedLayerEntities: orderedLayerEntities,
                                varIdNameMap: varIdNameMap)
         
         // Get spacing from the group's spacing port
@@ -205,9 +205,9 @@ extension LayerNodeEntity {
         
     /// Converts layer data from graph to SwiftUI code
     @MainActor
-    func createSwiftUICode(layerEntityMap: [UUID: LayerNodeEntity],
+    func createSwiftUICode(orderedLayerEntities: [LayerNodeEntity],
                            varIdNameMap: [UUID: String]) throws -> String? {
-        let childrenLayerEntities = layerEntityMap.values.filter {
+        let childrenLayerEntities = orderedLayerEntities.filter {
             $0.layerGroupId == self.id
         }
         
@@ -218,7 +218,7 @@ extension LayerNodeEntity {
         if isGroup {
             guard let groupSwiftUICode = try self
                 .createNestedGroupSwiftUICode(children: childrenLayerEntities,
-                                              layerEntityMap: layerEntityMap,
+                                              orderedLayerEntities: orderedLayerEntities,
                                               varIdNameMap: varIdNameMap) else {
                 return nil
             }
@@ -230,7 +230,7 @@ extension LayerNodeEntity {
             // Create the constructor
             guard let constructor = try self
                 .createSwiftUIViewBuilderCode(children: childrenLayerEntities,
-                                              layerEntityMap: layerEntityMap,
+                                              orderedLayerEntities: orderedLayerEntities,
                                               varIdNameMap: varIdNameMap) else {
                 return nil
             }
@@ -250,7 +250,7 @@ extension LayerNodeEntity {
         if isNotGroupButHasChildren {
             // Convert children recursively
             let swiftUICodeForChildren = try childrenLayerEntities.compactMap {
-                try $0.createSwiftUICode(layerEntityMap: layerEntityMap,
+                try $0.createSwiftUICode(orderedLayerEntities: orderedLayerEntities,
                                          varIdNameMap: varIdNameMap)
             }
             
@@ -263,13 +263,13 @@ extension LayerNodeEntity {
 
 extension Array where Element == LayerNodeEntity {
     @MainActor
-    func createSwiftUICode(layerEntityMap: [UUID: LayerNodeEntity],
+    func createSwiftUICode(orderedLayerEntities: [LayerNodeEntity],
                            varIdNameMap: [UUID: String]) throws -> String {
         var droppedLayers: [LayerNodeEntity] = []
         
         let strings = try self.compactMap { layerEntity -> String? in
-            let result = try layerEntity.createSwiftUICode(layerEntityMap: layerEntityMap,
-                                                          varIdNameMap: varIdNameMap)
+            let result = try layerEntity.createSwiftUICode(orderedLayerEntities: orderedLayerEntities,
+                                                           varIdNameMap: varIdNameMap)
             if result == nil {
                 droppedLayers.append(layerEntity)
                 log("DROPPED LAYER: \(layerEntity.layer) with id \(layerEntity.id) - createSwiftUICode returned nil")

--- a/Stitch/Graph/StitchAI/Mapping/VPLToCode/PatchVPLToCode.swift
+++ b/Stitch/Graph/StitchAI/Mapping/VPLToCode/PatchVPLToCode.swift
@@ -31,9 +31,16 @@ extension GraphState {
         
         // log("createSwiftUICode: allLayerEntities: \(allLayerEntities)")
         
-        let layerEntitiesMap = allLayerEntities.reduce(into: [UUID: LayerNodeEntity]()) { result, layerNode in
-            result.updateValue(layerNode, forKey: layerNode.id)
-        }
+        let orderedLayerEntities = graphEntity.orderedSidebarLayers
+            .flattenedIds
+            .compactMap { id -> LayerNodeEntity? in
+                guard let layerEntity = self.nodes.get(id)?.layerNodeViewModel else {
+                    fatalErrorIfDebug()
+                    return nil
+                }
+                
+                return layerEntity.createSchema()
+            }
         
         // Filter for just top layer entities in beginning
         let topLevelLayerEntities = allLayerEntities
@@ -56,7 +63,7 @@ extension GraphState {
         // log("createSwiftUICode: varNameIdMap: \(varNameIdMap)")
         
         let viewCode = try topLevelLayerEntities
-            .createSwiftUICode(layerEntityMap: layerEntitiesMap,
+            .createSwiftUICode(orderedLayerEntities: orderedLayerEntities,
                                varIdNameMap: varNameIdMap)
         
         if ignoreScript {


### PR DESCRIPTION
Issue caused by using unordered nodes dictionary instead of sidebar layer data when creating programmatic code.