### PR TITLE
Removed fatal error that would break on conditionals

### DIFF
--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
@@ -111,7 +111,8 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
         let elements = Array(node.elements)
 
         guard elements.count == 3 else {
-            fatalError()
+            // Comes up from conditionals using `??`, just ignore
+            return .skipChildren
         }
         
         guard let assignmentExpr = elements[1].as(AssignmentExprSyntax.self),


### PR DESCRIPTION
Fixes issue where some code examples like:
```swift
PortValueDescription(value: number, value_type: "string").value.value as? String ?? number
```

Where we use `??` would cause a crash due to unexpected argument count.