### PR TITLE
Smarter encoding of StitchSpacing for AI V0

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -1113,6 +1113,7 @@
 		ECEA600E28E611AD002D7F4F /* NodeTypeChangedHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEA600D28E611AD002D7F4F /* NodeTypeChangedHelpers.swift */; };
 		ECEACE8C2A8587C3007ACDE2 /* StitchFPS.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEACE8B2A8587C3007ACDE2 /* StitchFPS.swift */; };
 		ECEAFE61270E1E0D007DF78D /* OperationEvaluationHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEAFE60270E1E0D007DF78D /* OperationEvaluationHelpers.swift */; };
+		ECEB1B162E59233200C80553 /* StitchAISpacing_V0.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEB1B152E59233200C80553 /* StitchAISpacing_V0.swift */; };
 		ECEC4A442CE2FB900062ACAF /* StateChangeToStepAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEC4A432CE2FB900062ACAF /* StateChangeToStepAction.swift */; };
 		ECEC4A462CE3BEAF0062ACAF /* StepActionToStateChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEC4A452CE3BEAF0062ACAF /* StepActionToStateChange.swift */; };
 		ECEC7E0826CCBEAC008A39C1 /* ClassicAnimationCurve.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEC7E0726CCBEAC008A39C1 /* ClassicAnimationCurve.swift */; };
@@ -2266,6 +2267,7 @@
 		ECEA600D28E611AD002D7F4F /* NodeTypeChangedHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeTypeChangedHelpers.swift; sourceTree = "<group>"; };
 		ECEACE8B2A8587C3007ACDE2 /* StitchFPS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StitchFPS.swift; sourceTree = "<group>"; };
 		ECEAFE60270E1E0D007DF78D /* OperationEvaluationHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationEvaluationHelpers.swift; sourceTree = "<group>"; };
+		ECEB1B152E59233200C80553 /* StitchAISpacing_V0.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StitchAISpacing_V0.swift; sourceTree = "<group>"; };
 		ECEC4A432CE2FB900062ACAF /* StateChangeToStepAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateChangeToStepAction.swift; sourceTree = "<group>"; };
 		ECEC4A452CE3BEAF0062ACAF /* StepActionToStateChange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepActionToStateChange.swift; sourceTree = "<group>"; };
 		ECEC7E0726CCBEAC008A39C1 /* ClassicAnimationCurve.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassicAnimationCurve.swift; sourceTree = "<group>"; };
@@ -2583,6 +2585,7 @@
 				B5136F512DED5C0A007F12D0 /* StitchAIColor_V0.swift */,
 				B5136F4F2DED5BC0007F12D0 /* StitchAISize_V0.swift */,
 				B5136F4A2DED27B7007F12D0 /* StitchAIPortValue_V0.swift */,
+				ECEB1B152E59233200C80553 /* StitchAISpacing_V0.swift */,
 				B5136F442DED2642007F12D0 /* StitchAIPosition_V0.swift */,
 			);
 			path = Value;
@@ -6433,6 +6436,7 @@
 				B55500CC2C1BA3F60081C3F1 /* PortEdgeUI.swift in Sources */,
 				B539C2EA2B92BF3D00C6CEC3 /* DocumentEncodable.swift in Sources */,
 				B5D34C8B2DF51F70007405BF /* AIGraphDescriptionSystemPrompt_V0.swift in Sources */,
+				ECEB1B162E59233200C80553 /* StitchAISpacing_V0.swift in Sources */,
 				B5368D132A886C1900FE3489 /* InteractionLayer.swift in Sources */,
 				ECF6394F2E4DA912005E766E /* OpenAIConfigurationPicker.swift in Sources */,
 				B500F3682DE6BF1600904992 /* StitchDocsPopoverView.swift in Sources */,

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/Value/StitchAIPortValue_V0.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/Value/StitchAIPortValue_V0.swift
@@ -190,7 +190,7 @@ extension StitchAIPortValue_V0.PortValue {
         case .contentMode(let x):
             return x
         case .spacing(let x):
-            return x
+            return StitchAISpacing_V0.StitchAISpacing(value: x)
         case .padding(let x):
             return x
         case .sizingScenario(let x):

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/Value/StitchAISpacing_V0.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/Value/StitchAISpacing_V0.swift
@@ -1,0 +1,92 @@
+//
+//  StitchAISpacing_V0.swift
+//  Stitch
+//
+//  Created by Christian J Clampitt on 8/22/25.
+//
+
+import Foundation
+import SwiftUI
+import StitchSchemaKit
+
+enum StitchAISpacing_V0: StitchSchemaVersionable {
+    // MARK: - ensure versions are correct
+    static let version = StitchAISchemaVersion._V0
+    typealias StitchSpacing = StitchSpacing_V31.StitchSpacing
+    typealias PreviousInstance = Self.StitchAISpacing
+    // MARK: - end
+    
+    struct StitchAISpacing: StitchAIStringConvertable {
+        var value: StitchSpacing
+    }
+}
+
+extension StitchAISpacing_V0.StitchAISpacing: StitchVersionedCodable {
+    public init(previousInstance: StitchAISpacing_V0.StitchAISpacing) {
+        fatalError()
+    }
+}
+
+// This is an extension of SSK V31's StitchSpacing
+extension StitchAISpacing_V0.StitchSpacing: StitchAIValueStringConvertable {
+    public var description: String {
+        self.display
+    }
+    
+    var encodableString: String {
+        self.description
+    }
+    
+    public init?(_ description: String) {
+        guard let result = Self.fromUserEdit(edit: description) else {
+            return nil
+        }
+        
+        self = result
+    }
+    
+    
+    var display: String {
+        switch self {
+        case .number(let x):
+            return GlobalFormatter.string(for: x) ?? x.description
+        case .between:
+            return "Between"
+        case .evenly:
+            return "Evenly"
+        }
+    }
+    
+    static func fromUserEdit(edit: String) -> StitchSpacing_V31.StitchSpacing? {
+        if edit.lowercased() == .EVENLY_SPACING_STRING {
+            return .evenly
+        } else if edit.lowercased() == .BETWEEN_SPACING_STRING {
+            return .between
+        } else if let number = toNumber(edit) {
+            return .number(number)
+        } else {
+            return nil
+        }
+    }
+}
+
+// This extends the AI-specific wrapper type on SSK V33's StitchSpacing type
+extension StitchAISpacing_V0.StitchAISpacing: StitchAIValueStringConvertable, CustomStringConvertible {
+    var description: String {
+        self.value.display
+    }
+    
+    var encodableString: String {
+        self.description
+    }
+    
+    public init?(_ description: String) {
+        guard let result = StitchAISpacing_V0.StitchSpacing.fromUserEdit(edit: description) else {
+            return nil
+        }
+        
+        self.value = result
+    }
+    
+    
+}

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V1/Value/StitchAISpacing_V1.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V1/Value/StitchAISpacing_V1.swift
@@ -28,6 +28,7 @@ extension StitchAISpacing_V1.StitchAISpacing: StitchVersionedCodable {
     }
 }
 
+// This is an extension of SSK V33's StitchSpacing
 extension StitchSpacing: StitchAIValueStringConvertable {
     var encodableString: String {
         self.display
@@ -42,6 +43,7 @@ extension StitchSpacing: StitchAIValueStringConvertable {
     }
 }
 
+// This extends the AI-specific wrapper type on SSK V33's StitchSpacing type
 extension StitchAISpacing_V1.StitchAISpacing: StitchAIValueStringConvertable, CustomStringConvertible {
     var description: String {
         self.value.display

--- a/Stitch/Graph/StitchAI/PromptGenerator/AICodeEditSystemPromptGenerator.swift
+++ b/Stitch/Graph/StitchAI/PromptGenerator/AICodeEditSystemPromptGenerator.swift
@@ -54,7 +54,7 @@ ScrollView([.vertical]) {
 .layerId("1D822183-260F-4997-9AB5-C896B00C013C")
 ```
 
-And instead use a `ZStack`:
+Instead, use a `ZStack`:
 
 ```swift
 ZStack {

--- a/Stitch/Graph/StitchAI/PromptGenerator/AICodeGenSystemPromptGenerator.swift
+++ b/Stitch/Graph/StitchAI/PromptGenerator/AICodeGenSystemPromptGenerator.swift
@@ -444,7 +444,7 @@ For example, we SHOULD NOT define a method like `private func dialButton(title: 
 struct ContentView: View {
 
     var body: some View {
-        VStack(spacing: 16) {
+        VStack([PortValueDescription(value_type: "spacing", value: "16")]) {
             dialButton(title: "love")
         }
         .layerId("9012A3B4-C5D6-45E7-F8A9-0123A456789B")
@@ -466,7 +466,7 @@ Instead, define the dialButton inline and NOT as a separate `some View`-returnin
 struct ContentView: View {
 
     var body: some View {
-        VStack(spacing: 16) {
+        VStack([PortValueDescription(value_type: "spacing", value: "16")]) {
             Text("love")
         }
         .layerId("9012A3B4-C5D6-45E7-F8A9-0123A456789B")


### PR DESCRIPTION
We no longer encode StitchSpacing like this: 

<img width="362" height="230" alt="Screenshot 2025-08-22 at 4 01 45 PM" src="https://github.com/user-attachments/assets/999a2365-3b74-44af-8251-51147142c12b" />
