### PR TITLE
Use brackets, not curly braces, when turning complex `PortValue` types into SwiftUI code `PortValueDescription`s 

### DIFF
--- a/Stitch/App/StitchApp.swift
+++ b/Stitch/App/StitchApp.swift
@@ -41,8 +41,8 @@ struct StitchApp: App {
         FirebaseApp.configure()
     }
 
-#if FAKE_FLAG
-//#if DEV_DEBUG
+//#if FAKE_FLAG
+#if DEV_DEBUG
     var body: some Scene {
         WindowGroup {
             ASTExplorerView()

--- a/Stitch/Graph/StitchAI/Mapping/VPLToCode/PortValue/PortValueToCode.swift
+++ b/Stitch/Graph/StitchAI/Mapping/VPLToCode/PortValue/PortValueToCode.swift
@@ -73,11 +73,15 @@ extension Array where Element == PortValue {
         }
         
         let valueDesc = PrintablePortValueDescription(firstValue)
-        let string = try valueDesc.jsonWithoutQuotedKeys()
         
-        // gets rid of brackets
-        let trimmedStr = string.dropFirst().dropLast()
-        return "[PortValueDescription(\(trimmedStr))]"
+        // Manually construct the PortValueDescription with proper square bracket formatting
+        let valueJson = try JSONEncoder().encode(valueDesc.value)
+        let valueString = String(data: valueJson, encoding: .utf8) ?? "\"\""
+        
+        // Replace curly braces with square brackets for dictionary values
+        let correctedValueString = valueString.replacingOccurrences(of: "{", with: "[").replacingOccurrences(of: "}", with: "]")
+        
+        return "[PortValueDescription(value: \(correctedValueString), value_type: \"\(valueDesc.value_type.value)\")]"
     }
 }
 
@@ -169,7 +173,7 @@ func extractValueForPortValueDescription(_ arg: SyntaxViewModifierArgumentType) 
         if c.typeName == "CGSize" {
             // Extract width and height for size type
             let dict = (try? c.arguments.createValuesDict()) ?? [:]
-            return "{\(dict.map { "\"\($0.key)\": \"\($0.value)\"" }.joined(separator: ", "))}"
+            return "[\(dict.map { "\"\($0.key)\": \"\($0.value)\"" }.joined(separator: ", "))]"
         }
         return "\"\(c.typeName)(...)\""
         
@@ -184,7 +188,7 @@ func extractValueForPortValueDescription(_ arg: SyntaxViewModifierArgumentType) 
             let value = extractValueForPortValueDescription(field.value)
             return "\"\(label)\": \(value)"
         }.joined(separator: ", ")
-        return "{\(dict)}"
+        return "[\(dict)]"
     case .stateAccess(_):
         // State access should not use PortValueDescription according to system prompt
         fatalErrorIfDebug("/* state access - should not be wrapped */")


### PR DESCRIPTION
<img width="1427" height="759" alt="Screenshot 2025-08-27 at 11 30 33 AM" src="https://github.com/user-attachments/assets/3ba38caf-1743-4b59-a0b6-f06f66804ab9" />
<img width="1434" height="764" alt="Screenshot 2025-08-27 at 11 30 19 AM" src="https://github.com/user-attachments/assets/3afe0304-af63-4878-9ba9-beb2f982ee7b" />
<img width="1433" height="771" alt="Screenshot 2025-08-27 at 11 30 09 AM" src="https://github.com/user-attachments/assets/a95673f4-2d19-4d3c-90c0-cb405b583dd7" />
