### PR TITLE
Turn `x.overlay(y)` into `ZStack { x y }`

### DIFF
--- a/Stitch.xcodeproj/project.pbxproj
+++ b/Stitch.xcodeproj/project.pbxproj
@@ -679,6 +679,7 @@
 		EC5F51E42BFFBB3300D3DAD7 /* PreviewGridData.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5F51E32BFFBB3300D3DAD7 /* PreviewGridData.swift */; };
 		EC5F642D2C29E68500A9E52F /* LayerInspectorPortView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5F642C2C29E68500A9E52F /* LayerInspectorPortView.swift */; };
 		EC5F642F2C29E6A900A9E52F /* LayerInspectorState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5F642E2C29E6A900A9E52F /* LayerInspectorState.swift */; };
+		EC5FB3542E5F8F8200E9D3AC /* OverlayExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5FB3532E5F8F8200E9D3AC /* OverlayExamples.swift */; };
 		EC609DB429352FB800BF60A5 /* NumberExtensionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC609DB329352FB800BF60A5 /* NumberExtensionUtils.swift */; };
 		EC609DB629352FE200BF60A5 /* URLExtensionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC609DB529352FE200BF60A5 /* URLExtensionUtils.swift */; };
 		EC609DBA2935303600BF60A5 /* URLSessionExtensionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC609DB92935303600BF60A5 /* URLSessionExtensionUtils.swift */; };
@@ -1856,6 +1857,7 @@
 		EC5F51E32BFFBB3300D3DAD7 /* PreviewGridData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewGridData.swift; sourceTree = "<group>"; };
 		EC5F642C2C29E68500A9E52F /* LayerInspectorPortView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerInspectorPortView.swift; sourceTree = "<group>"; };
 		EC5F642E2C29E6A900A9E52F /* LayerInspectorState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerInspectorState.swift; sourceTree = "<group>"; };
+		EC5FB3532E5F8F8200E9D3AC /* OverlayExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayExamples.swift; sourceTree = "<group>"; };
 		EC609DB329352FB800BF60A5 /* NumberExtensionUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberExtensionUtils.swift; sourceTree = "<group>"; };
 		EC609DB529352FE200BF60A5 /* URLExtensionUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLExtensionUtils.swift; sourceTree = "<group>"; };
 		EC609DB92935303600BF60A5 /* URLSessionExtensionUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionExtensionUtils.swift; sourceTree = "<group>"; };
@@ -5164,6 +5166,7 @@
 			isa = PBXGroup;
 			children = (
 				ECC734732E0DE95A00AC266C /* CodeExamples.swift */,
+				EC5FB3532E5F8F8200E9D3AC /* OverlayExamples.swift */,
 				ECD4C3BA2E4C23A0001F4C7A /* GridCodeExamples.swift */,
 				EC7062B22E14BFC50017A9F0 /* ScrollViewCodeExamples.swift */,
 				EC34B7FE2E44419F00649A3F /* PreprocessingExamples.swift */,
@@ -6725,6 +6728,7 @@
 				E419F3F72D40337400C169D4 /* EditBeforeSubmitModalView.swift in Sources */,
 				EC2942452BA13E6100D14CD1 /* SidebarItemSelectionActions.swift in Sources */,
 				EC1213D528873BF10012234C /* AnimationEvaluationHelpers.swift in Sources */,
+				EC5FB3542E5F8F8200E9D3AC /* OverlayExamples.swift in Sources */,
 				ECC2BCCF2B9B72E900D5F942 /* SidebarListItemSwipeView.swift in Sources */,
 				EC6914E02DE8CF1600AFF58F /* AITrainingExampleFromExistingGraph.swift in Sources */,
 				ECDAFFF72E200F4400AF71E9 /* DeclarativeUtils.swift in Sources */,

--- a/Stitch/App/StitchApp.swift
+++ b/Stitch/App/StitchApp.swift
@@ -41,8 +41,8 @@ struct StitchApp: App {
         FirebaseApp.configure()
     }
 
-#if FAKE_FLAG
-//#if DEV_DEBUG
+//#if FAKE_FLAG
+#if DEV_DEBUG
     var body: some Scene {
         WindowGroup {
             ASTExplorerView()

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
@@ -11,6 +11,13 @@ import SwiftSyntax
 import SwiftParser
 import SwiftSyntaxBuilder
 
+/// Context for SwiftUI code parsing to control preprocessing behavior
+enum ParseContext {
+    case topLevel        // Normal parsing (apply VStack wrapping for multiple views)
+    case overlayContent  // Overlay closure content (skip VStack wrapping)
+    case scrollContent   // ScrollView or other container content
+}
+
 /// SwiftSyntax visitor that extracts ViewNode structure from SwiftUI code
 final class SwiftUIViewVisitor: SyntaxVisitor {
     // Maps known patch nodes to a variable name
@@ -200,16 +207,16 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
 
 extension SwiftUIViewVisitor {
     /// Parses SwiftUI code into a ViewNode structure
-    static func parseSwiftUICode(_ swiftUICode: String) -> SwiftUIViewParserResult {
+    static func parseSwiftUICode(_ swiftUICode: String, context: ParseContext = .topLevel) -> SwiftUIViewParserResult {
 //        log("\n==== PARSING CODE ====\n\(swiftUICode)\n=====================\n")
         
         var varNameIdMap = [String : String]()
         
         // Preprocess the code to ensure single root view in var body
-        let preprocessedCode = preprocessSwiftUICode(swiftUICode)
+        let preprocessedCode = preprocessSwiftUICode(swiftUICode, context: context)
         
-//        log("DEBUG: swiftUICode: \n\(swiftUICode)")
-//        log("DEBUG: preprocessedCode: \n\(preprocessedCode)")
+        log("DEBUG: swiftUICode: \n\(swiftUICode)")
+        log("DEBUG: preprocessedCode: \n\(preprocessedCode)")
         
         // Fall back to the original visitor-based approach for now
         // but add our own post-processing for modifiers
@@ -231,7 +238,12 @@ extension SwiftUIViewVisitor {
     }
     
     /// Preprocesses SwiftUI code to wrap multiple top-level views in var body with VStack
-    private static func preprocessSwiftUICode(_ code: String) -> String {
+    private static func preprocessSwiftUICode(_ code: String, context: ParseContext) -> String {
+        // Only apply VStack wrapping for top-level parsing context
+        guard context == .topLevel else {
+            return code
+        }
+        
         // Simple approach: if the code doesn't have var body, it's just raw views - wrap them
         if !code.contains("var body") {
             // Count top-level SwiftUI view declarations

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchUtil.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchUtil.swift
@@ -23,11 +23,21 @@ extension SwiftUIViewVisitor {
         guard let knownViewConstructor = createKnownViewConstructor(
             from: node,
             arguments: arguments) else {
-            
+        
             // Append closure arg if exists
-            if let closureBlock = node.trailingClosure?.statements.first?.item.trimmedDescription {
+            if let trailingClosure = node.trailingClosure {
+                let statements = trailingClosure.statements.map { $0.item.trimmedDescription }
+                let joinedStatements = statements.joined(separator: "\n")
+                
+                // Debug logging
+                log("DEBUG: Parsing trailing closure with \(statements.count) statements:")
+                for (index, statement) in statements.enumerated() {
+                    log("  Statement \(index): \(statement)")
+                }
+                log("DEBUG: Final joined trailing closure: \(joinedStatements)")
+                
                 arguments.append(.init(label: nil,
-                                       value: .closure(closureBlock)))
+                                       value: .closure(joinedStatements)))
             }
             
             return .other(arguments)
@@ -65,7 +75,7 @@ extension SwiftUIViewVisitor {
     
     /// Handles conditional logic for determining a type of syntax argument.
     func parseArgumentType(from expression: SwiftSyntax.ExprSyntax) -> SyntaxViewModifierArgumentType? {
-        // Handles compelx types, like PortValueDescription
+        // Handles complex types, like PortValueDescription
         if let funcExpr = expression.as(FunctionCallExprSyntax.self) {
             let complexType = self.parseFnArgumentType(funcExpr)
             return .complex(complexType)
@@ -117,7 +127,9 @@ extension SwiftUIViewVisitor {
         
         // Closures
         else if let closureExpr = expression.as(ClosureExprSyntax.self) {
-            return .closure(closureExpr.statements.first?.item.trimmedDescription ?? "")
+            let statements = closureExpr.statements.map { $0.item.trimmedDescription }
+            let joinedStatements = statements.joined(separator: "\n")
+            return .closure(joinedStatements)
         }
         
         guard let syntaxKind = SyntaxArgumentKind.fromExpression(expression) else {

--- a/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/CodeExamples.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/CodeExamples.swift
@@ -115,6 +115,14 @@ extension MappingExamples {
         PreprocessingCodeExamples.phoneKeypadExample,
         PreprocessingCodeExamples.complexNestedExample,
         
+        // Overlay examples - testing overlay to ZStack transformation
+        OverlayCodeExamples.simpleOverlayFunctionCall,
+        OverlayCodeExamples.simpleOverlayClosure,
+        OverlayCodeExamples.multipleChildrenOverlay,
+        OverlayCodeExamples.vstackOverlay,
+        OverlayCodeExamples.complexOverlayWithModifiers,
+        OverlayCodeExamples.nestedOverlay,
+        
         //        // // NOT YET SUPPORTED:
         //        RotationModifierCodeExamples.rotationEffectAnchor,
         //        RotationModifierCodeExamples.rotationEffectRadians,

--- a/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/CodeExamples.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/CodeExamples.swift
@@ -30,6 +30,15 @@ extension MappingExamples {
     // TODO: break into separate pieces
     static let codeExamples: [MappingCodeExample] = [
         
+        // Overlay examples - testing overlay to ZStack transformation
+        OverlayCodeExamples.simpleOverlayFunctionCall,
+        OverlayCodeExamples.simpleOverlayClosure,
+        OverlayCodeExamples.multipleChildrenOverlay,
+        OverlayCodeExamples.vstackOverlay,
+        OverlayCodeExamples.complexOverlayWithModifiers,
+        OverlayCodeExamples.nestedOverlay,
+        
+        // OLDER
         ViewModifierCodeExamples.colorInitInFillModifier,
         ViewModifierCodeExamples.paddingNoArgsModifier,
         
@@ -114,14 +123,6 @@ extension MappingExamples {
         PreprocessingCodeExamples.mixedMultipleViews,
         PreprocessingCodeExamples.phoneKeypadExample,
         PreprocessingCodeExamples.complexNestedExample,
-        
-        // Overlay examples - testing overlay to ZStack transformation
-        OverlayCodeExamples.simpleOverlayFunctionCall,
-        OverlayCodeExamples.simpleOverlayClosure,
-        OverlayCodeExamples.multipleChildrenOverlay,
-        OverlayCodeExamples.vstackOverlay,
-        OverlayCodeExamples.complexOverlayWithModifiers,
-        OverlayCodeExamples.nestedOverlay,
         
         //        // // NOT YET SUPPORTED:
         //        RotationModifierCodeExamples.rotationEffectAnchor,

--- a/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/OverlayExamples.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/OverlayExamples.swift
@@ -1,0 +1,82 @@
+//
+//  OverlayExamples.swift
+//  Stitch
+//
+//  Created by Christian J Clampitt on 8/27/25.
+//
+
+import Foundation
+import SwiftUI
+
+struct OverlayCodeExamples {
+    
+    static let simpleOverlayFunctionCall = MappingCodeExample(
+        title: "Simple Overlay (Function Call)",
+        code: """
+        Rectangle()
+            .overlay(Ellipse())
+        """
+    )
+    
+    static let simpleOverlayClosure = MappingCodeExample(
+        title: "Simple Overlay (Closure)",
+        code: """
+        Rectangle()
+            .overlay {
+                Ellipse()
+            }
+        """
+    )
+    
+    static let multipleChildrenOverlay = MappingCodeExample(
+        title: "Multiple Children in Overlay",
+        code: """
+        Rectangle()
+            .overlay {
+                Ellipse()
+                Text("Text")
+            }
+        """
+    )
+    
+    static let vstackOverlay = MappingCodeExample(
+        title: "VStack in Overlay",
+        code: """
+        Rectangle()
+            .overlay {
+                VStack {
+                    Ellipse()
+                    Text("Text")
+                }
+            }
+        """
+    )
+    
+    static let complexOverlayWithModifiers = MappingCodeExample(
+        title: "Complex Overlay with Modifiers",
+        code: """
+        Rectangle()
+            .fill(.blue)
+            .overlay {
+                Circle()
+                    .fill(.red)
+                    .frame(width: 50, height: 50)
+            }
+            .padding()
+        """
+    )
+    
+    static let nestedOverlay = MappingCodeExample(
+        title: "Nested Overlay",
+        code: """
+        Rectangle()
+            .overlay {
+                Rectangle()
+                    .fill(.green)
+                    .overlay {
+                        Text("Nested")
+                    }
+            }
+        """
+    )
+}

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxView.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxView.swift
@@ -40,6 +40,47 @@ struct SyntaxView: Equatable, Sendable {
     var id: UUID  // Unique identifier for the node
 }
 
+extension SyntaxView {
+    /// Removes all modifiers of the specified type from this view
+    func removingModifiers(ofType modifierType: SyntaxViewModifierName) -> SyntaxView {
+        var updated = self
+        updated.modifiers = self.modifiers.filter { $0.name != modifierType }
+        return updated
+    }
+    
+    /// Creates a new ZStack containing this view and the specified overlay children
+    func wrappedInZStack(withOverlayChildren overlayChildren: [SyntaxView]) -> SyntaxView {
+        // If no overlay children, return this view unchanged
+        guard !overlayChildren.isEmpty else { return self }
+        
+        var zStackChildren = [self] // Base view first
+        
+        // Add overlay children
+        if overlayChildren.count == 1 {
+            // Single overlay child - add directly
+            zStackChildren.append(overlayChildren[0])
+        } else {
+            // Multiple overlay children - wrap them in their own ZStack
+            let innerZStack = SyntaxView(
+                name: "ZStack",
+                constructorArguments: nil,
+                modifiers: [],
+                children: overlayChildren,
+                id: UUID()
+            )
+            zStackChildren.append(innerZStack)
+        }
+        
+        return SyntaxView(
+            name: "ZStack",
+            constructorArguments: nil,
+            modifiers: [],
+            children: zStackChildren,
+            id: UUID()
+        )
+    }
+}
+
 enum ViewConstructorType: Equatable, Sendable, Encodable {
     case trackedConstructor(StrictViewConstructor)
     case other([SyntaxViewArgumentData])

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
@@ -35,10 +35,10 @@ extension Array where Element == SyntaxViewModifier {
     
     /// Extracts SyntaxViews from overlay modifier arguments (for function call form like .overlay(View))
     func getOverlayArgumentViews(for modifierName: SyntaxViewModifierName) -> [SyntaxView] {
-        return self.compactMap { modifier in
+        return self.flatMap { modifier in
             guard modifier.name == modifierName,
                   let args = modifier.arguments.defaultArgs else {
-                return nil
+                return [SyntaxView]()
             }
             
             // Extract complex type arguments that represent views
@@ -57,7 +57,7 @@ extension Array where Element == SyntaxViewModifier {
                     return nil
                 }
             }
-        }.flatMap { $0 }
+        }
     }
 }
 

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
@@ -32,6 +32,33 @@ extension Array where Element == SyntaxViewModifier {
                 .first
         }
     }
+    
+    /// Extracts SyntaxViews from overlay modifier arguments (for function call form like .overlay(View))
+    func getOverlayArgumentViews(for modifierName: SyntaxViewModifierName) -> [SyntaxView] {
+        return self.compactMap { modifier in
+            guard modifier.name == modifierName,
+                  let args = modifier.arguments.defaultArgs else {
+                return nil
+            }
+            
+            // Extract complex type arguments that represent views
+            return args.compactMap { arg -> SyntaxView? in
+                switch arg.value {
+                case .complex(let complexType):
+                    // Convert complex type argument to SyntaxView
+                    return SyntaxView(
+                        name: complexType.typeName,
+                        constructorArguments: complexType.arguments.isEmpty ? nil : .other(complexType.arguments),
+                        modifiers: [],
+                        children: [],
+                        id: UUID()
+                    )
+                default:
+                    return nil
+                }
+            }
+        }.flatMap { $0 }
+    }
 }
 
 /*

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
@@ -204,7 +204,7 @@ extension Array where Element == String {
     /// Extracts SyntaxView objects from overlay script strings
     func extractOverlaySyntaxViews() -> [SyntaxView] {
         return self.flatMap { script in
-            let result = SwiftUIViewVisitor.parseSwiftUICode(script)
+            let result = SwiftUIViewVisitor.parseSwiftUICode(script, context: .overlayContent)
             return result.viewStack
         }
     }

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
@@ -200,6 +200,14 @@ extension Array where Element == String {
         return .init(actions: actionsResults.flatMap(\.actions),
                      caughtErrors: actionsResults.flatMap(\.caughtErrors))
     }
+    
+    /// Extracts SyntaxView objects from overlay script strings
+    func extractOverlaySyntaxViews() -> [SyntaxView] {
+        return self.flatMap { script in
+            let result = SwiftUIViewVisitor.parseSwiftUICode(script)
+            return result.viewStack
+        }
+    }
 }
 
 extension SyntaxView {
@@ -216,11 +224,28 @@ extension SyntaxView {
         let backgroundModifierScripts = self.modifiers.getClosureScripts(for: .background)
         let overlayModifierScripts = self.modifiers.getClosureScripts(for: .overlay)
         
-        // Recursively get layer data for background and overlay modifiers
+        // Transform view structure if overlay modifiers are present
+        let transformedView: SyntaxView
+        if !overlayModifierScripts.isEmpty {
+            // Extract overlay content as SyntaxView objects
+            let overlayChildren = overlayModifierScripts.extractOverlaySyntaxViews()
+            
+            // Create ZStack with base view (without overlay modifiers) and overlay children
+            let baseViewWithoutOverlay = self.removingModifiers(ofType: .overlay)
+            transformedView = baseViewWithoutOverlay.wrappedInZStack(withOverlayChildren: overlayChildren)
+        } else {
+            transformedView = self
+        }
+        
+        // If we transformed the view, recursively process the ZStack
+        if transformedView.name == "ZStack" && !overlayModifierScripts.isEmpty {
+            return transformedView.deriveStitchActions(bindingDeclarations: bindingDeclarations)
+        }
+        
+        // Continue with original processing for non-overlay cases
+        // Recursively get layer data for background modifiers (overlays are now handled above)
         let backgroundLayerData = backgroundModifierScripts.deriveStitchActions()
-        let overlayLayerData = overlayModifierScripts.deriveStitchActions()
         silentErrors += backgroundLayerData.caughtErrors
-        silentErrors += overlayLayerData.caughtErrors
         
         guard let nameType = SyntaxNameType.from(self.name) else {
             // Check for custom view builder fn
@@ -235,7 +260,7 @@ extension SyntaxView {
             let scriptResult = SwiftUIViewVisitor.parseSwiftUICode(viewBuilderFn)
             let result = scriptResult.deriveStitchActions(bindingDeclarations: scriptResult.bindingDeclarations)
             
-            let actions = overlayLayerData.actions + result.graphData.layer_data_list + backgroundLayerData.actions
+            let actions = result.graphData.layer_data_list + backgroundLayerData.actions
             
             return .init(actions: actions,
                          caughtErrors: result.caughtErrors + silentErrors)
@@ -276,14 +301,14 @@ extension SyntaxView {
                     layerData.children = nil
                 }
         
-                return .init(actions: overlayLayerData.actions + [layerData] + backgroundLayerData.actions,
+                return .init(actions: [layerData] + backgroundLayerData.actions,
                              caughtErrors: silentErrors)
             } catch let error as SwiftUISyntaxError {
                 if error.shouldFailSilently {
                     log("deriveStitchActions: silent failure for unsupported layer concept: \(error)")
                     // Silent error for unsupported layers
                     silentErrors.append(error)
-                    return .init(actions: overlayLayerData.actions + childResults.actions + backgroundLayerData.actions,
+                    return .init(actions: childResults.actions + backgroundLayerData.actions,
                                  caughtErrors: silentErrors)
                 } else {
                     fatalErrorIfDebug(error.localizedDescription)

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
@@ -226,9 +226,23 @@ extension SyntaxView {
         
         // Transform view structure if overlay modifiers are present
         let transformedView: SyntaxView
-        if !overlayModifierScripts.isEmpty {
-            // Extract overlay content as SyntaxView objects
-            let overlayChildren = overlayModifierScripts.extractOverlaySyntaxViews()
+        let hasOverlayClosures = !overlayModifierScripts.isEmpty
+        let overlayArgumentViews = self.modifiers.getOverlayArgumentViews(for: .overlay)
+        let hasOverlayArguments = !overlayArgumentViews.isEmpty
+        
+        if hasOverlayClosures || hasOverlayArguments {
+            // Extract overlay content as SyntaxView objects from both sources
+            var overlayChildren: [SyntaxView] = []
+            
+            // Add children from closure scripts (overlay { ... } form)
+            if hasOverlayClosures {
+                overlayChildren += overlayModifierScripts.extractOverlaySyntaxViews()
+            }
+            
+            // Add children from function arguments (overlay(View) form)
+            if hasOverlayArguments {
+                overlayChildren += overlayArgumentViews
+            }
             
             // Create ZStack with base view (without overlay modifiers) and overlay children
             let baseViewWithoutOverlay = self.removingModifiers(ofType: .overlay)
@@ -238,7 +252,7 @@ extension SyntaxView {
         }
         
         // If we transformed the view, recursively process the ZStack
-        if transformedView.name == "ZStack" && !overlayModifierScripts.isEmpty {
+        if transformedView.name == "ZStack" && (hasOverlayClosures || hasOverlayArguments) {
             return transformedView.deriveStitchActions(bindingDeclarations: bindingDeclarations)
         }
         

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayerInputPort.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayerInputPort.swift
@@ -426,11 +426,13 @@ extension SyntaxViewModifierName {
         case .onDrop:
             throw SwiftUISyntaxError.unsupportedViewModifier(self)
 
-            
         case .onSubmit:
             throw SwiftUISyntaxError.unsupportedViewModifier(self)
+        
+        // TODO: We actually "support" `.overlay`, or allow the LLM to send us code containing `.overlay`
         case .overlay:
             return nil
+            
         case .preferredColorScheme:
             throw SwiftUISyntaxError.unsupportedViewModifier(self)
         case .presentationCornerRadius:

--- a/Stitch/Graph/StitchAI/PromptGenerator/AICodeGenSystemPromptGenerator.swift
+++ b/Stitch/Graph/StitchAI/PromptGenerator/AICodeGenSystemPromptGenerator.swift
@@ -362,7 +362,6 @@ You are ONLY permitted to use these view modifiers. Do not attempt to use view m
 
 #### Disallowed View Modifiers
 
-**NEVER** use `.overlay` or `.background`; use a ZStack instead.
 **NEVER** use `.gesture`; only `simultaneousGesture` is allowed.
 **NEVER** use `.animation`: instead, use native animation patch nodes like "classicAnimation || Patch" or "springAnimation || Patch"
 


### PR DESCRIPTION
Stitch does not support the interface for `.overlay`, but we support the concept via `ZStack`.

If the LLM sends us `.overlay`, we'll turn that into a `ZStack`, which we can actually handle.

<img width="1440" height="900" alt="Screenshot 2025-08-27 at 1 58 33 PM" src="https://github.com/user-attachments/assets/546f1bc2-c4fb-4736-ba82-a459321b1c32" />
<img width="1439" height="520" alt="Screenshot 2025-08-27 at 2 31 25 PM" src="https://github.com/user-attachments/assets/96d74b37-d396-4d15-b6c0-abb078ae3c99" />
<img width="1428" height="617" alt="Screenshot 2025-08-27 at 2 31 08 PM" src="https://github.com/user-attachments/assets/e21a07c6-040b-4940-a9eb-f5e0c7d739b4" />
<img width="1437" height="466" alt="Screenshot 2025-08-27 at 2 30 55 PM" src="https://github.com/user-attachments/assets/95a5177a-0a90-435d-9b8b-0adab1d3e081" />
<img width="1431" height="466" alt="Screenshot 2025-08-27 at 2 30 49 PM" src="https://github.com/user-attachments/assets/4dceb0ce-54cf-48eb-be82-4c2b17a65a41" />
