### PR TITLE
Support `PortValueDescription` with `.font` view modifier

### DIFF
--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/StitchAIRequestBuilder.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/StitchAIRequestBuilder.swift
@@ -92,23 +92,7 @@ extension StitchAIRequestBuilder_V0.StitchAIRequestType {
 //            \(index + 1). `\(fn.rawValue)`: \(fn.functionDescription)
 //            """
 //        }.joined(separator: "\n")
-//    }
-    
-    var systemPromptTitle: String {
-        switch self {
-        case .userPrompt:
-            return "SwiftUI Code Builder from Stitch Graph Data"
-        }
-    }
-    
-    var inputTypeDescription: String {
-        switch self {
-        case .userPrompt:
-            return "existing graph data"
-//        case .imagePrompt:
-//            return "image upload"
-        }
-    }
+//    }    
 }
 
 //extension StitchAIRequestBuilder_V0.StitchAIRequestBuilderFunction {

--- a/Stitch/Graph/StitchAI/Mapping/CodeToVPL/Declarative/DeclarativeViewConstructors.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToVPL/Declarative/DeclarativeViewConstructors.swift
@@ -2215,6 +2215,24 @@ func createFontEvents(from fontArg: SyntaxViewModifierArgumentType) throws -> [A
         }
     }
     
+    // Handle arrays with PortValueDescription or other values
+    // Use derivePortValues to extract the actual values from PortValueDescription
+    if case .array(_) = fontArg {
+        let portValues = try fontArg.derivePortValues()
+        
+        // Check if we got a numeric value from PortValueDescription
+        if let firstValue = portValues.first,
+           case .value(let portValueDescription) = firstValue,
+           let fontSize = portValueDescription.value as? Double {
+            // Create font events with extracted font size and default font
+            let defaultFont = StitchFont(fontChoice: .sf, fontWeight: .SF_regular)
+            return [
+                ASTCustomInputValue(input: .textFont, value: .textFont(defaultFont)),
+                ASTCustomInputValue(input: .fontSize, value: .number(fontSize))
+            ]
+        }
+    }
+    
     // Fallback: treat as generic font and use default mapping
     let defaultFont = StitchFont(fontChoice: .sf, fontWeight: .SF_regular)
     return [ASTCustomInputValue(input: .textFont, value: .textFont(defaultFont))]

--- a/Stitch/Graph/StitchAI/Mapping/CodeToVPL/Declarative/DeclarativeViewConstructors.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToVPL/Declarative/DeclarativeViewConstructors.swift
@@ -2174,7 +2174,7 @@ func createFontEvents(from fontArg: SyntaxViewModifierArgumentType) throws -> [A
         
         return [
             ASTCustomInputValue(input: .textFont, value: .textFont(stitchFont)),
-            ASTCustomInputValue(input: .fontSize, value: .number(fontSize))
+            ASTCustomInputValue(input: .fontSize, value: .layerDimension(.number(fontSize)))
         ]
     }
     
@@ -2210,7 +2210,7 @@ func createFontEvents(from fontArg: SyntaxViewModifierArgumentType) throws -> [A
             let stitchFont = StitchFont(fontChoice: fontChoice, fontWeight: fontWeight)
             return [
                 ASTCustomInputValue(input: .textFont, value: .textFont(stitchFont)),
-                ASTCustomInputValue(input: .fontSize, value: .number(fontSize))
+                ASTCustomInputValue(input: .fontSize, value: .layerDimension(.number(fontSize)))
             ]
         }
     }
@@ -2221,15 +2221,66 @@ func createFontEvents(from fontArg: SyntaxViewModifierArgumentType) throws -> [A
         let portValues = try fontArg.derivePortValues()
         
         // Check if we got a numeric value from PortValueDescription
+        // Handle both value_type: "number" and value_type: "layerDimension"
         if let firstValue = portValues.first,
-           case .value(let portValueDescription) = firstValue,
-           let fontSize = portValueDescription.value as? Double {
-            // Create font events with extracted font size and default font
-            let defaultFont = StitchFont(fontChoice: .sf, fontWeight: .SF_regular)
-            return [
-                ASTCustomInputValue(input: .textFont, value: .textFont(defaultFont)),
-                ASTCustomInputValue(input: .fontSize, value: .number(fontSize))
-            ]
+           case .value(let portValueDescription) = firstValue {
+            
+            var fontSize: Double?
+            var isLayerDimensionType = false
+                        
+            // Extract fontSize from different PortValueDescription formats
+            if let directNumber = portValueDescription.value as? Double {
+                // value_type: "number", value: 36.0
+                log("DEBUG: Extracted as Double: \(directNumber)")
+                fontSize = directNumber
+                isLayerDimensionType = false
+            } else if let numberString = portValueDescription.value as? String,
+                      let parsedNumber = Double(numberString) {
+                // value_type: "layerDimension", value: "36"
+                log("DEBUG: Extracted from String: \(parsedNumber)")
+                fontSize = parsedNumber
+                isLayerDimensionType = true
+            }
+            
+            // TODO: a smarter way to parse the `portValueDescription.value` as a StitchAISizeDimension ? Or parse as a string or number instead of type-casting ?
+            else if let sizeDimension = (portValueDescription.value as? StitchAISizeDimension_V0.StitchAISizeDimension) {
+                // value_type: "layerDimension", value: StitchAISizeDimension with nested number
+                log("DEBUG: Extracted as StitchAISizeDimension_V0")
+                switch sizeDimension.value {
+                case .number(let number):
+                    fontSize = number
+                    isLayerDimensionType = true
+                default:
+                    break // Handle other StitchAISizeDimension cases if needed
+                }
+            }
+            
+            else if let sizeDimension = portValueDescription.value as? StitchAISizeDimension_V1.StitchAISizeDimension {
+                // value_type: "layerDimension", value: StitchAISizeDimension with nested number
+                log("DEBUG: Extracted as StitchAISizeDimension_V1")
+                switch sizeDimension.value {
+                case .number(let number):
+                    fontSize = number
+                    isLayerDimensionType = true
+                default:
+                    break // Handle other StitchAISizeDimension cases if needed
+                }
+            }
+            
+            if let fontSize = fontSize {
+                // Create font events with extracted font size and default font
+                let defaultFont = StitchFont(fontChoice: .sf, fontWeight: .SF_regular)
+                
+                // Create fontSize value with correct type based on PortValueDescription
+                let fontSizeValue: CurrentAIGraphData.PortValue = isLayerDimensionType 
+                    ? .layerDimension(.number(fontSize))
+                    : .number(fontSize)
+                
+                return [
+                    ASTCustomInputValue(input: .textFont, value: .textFont(defaultFont)),
+                    ASTCustomInputValue(input: .fontSize, value: fontSizeValue)
+                ]
+            }
         }
     }
     

--- a/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/CodeExamples.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/CodeExamples.swift
@@ -71,6 +71,7 @@ extension MappingExamples {
         FontCodeExamples.fontWithColorAndWeight,
         FontCodeExamples.stackWithDifferentFonts,
         FontCodeExamples.fontInScrollView,
+        FontCodeExamples.fontWithPortValueDescription,
         
         // ScrollView
         ScrollViewCodeExamples.scrollViewVStack,
@@ -117,6 +118,7 @@ extension MappingExamples {
         PortValueDescriptionCodeExamples.textWithOpacityPVD,
         PortValueDescriptionCodeExamples.rectangleWithBlurPVD,
         PortValueDescriptionCodeExamples.stackWithPortValueDescriptions,
+        PortValueDescriptionCodeExamples.textWithFontSizePVD,
         
         // Rotation with PortValueDescription examples
         RotationModifierCodeExamples.rotationEffectPortValueDescription,

--- a/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/FontCodeExamples.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/FontCodeExamples.swift
@@ -274,4 +274,13 @@ ScrollView {
 }
 """
     )
+    
+    static let fontWithPortValueDescription = MappingCodeExample(
+        title: "Font with PortValueDescription Size",
+        code:
+"""
+Text("Dynamic Font Size")
+    .font([PortValueDescription(value_type: "number", value: 28)])
+"""
+    )
 }

--- a/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/PortValueDescriptionCodeExamples.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/PortValueDescriptionCodeExamples.swift
@@ -59,4 +59,12 @@ VStack {
 }
 """
     )
+    
+    static let textWithFontSizePVD = MappingCodeExample(
+        title: "Text with PortValueDescription font size",
+        code: """
+Text("love")
+    .font([PortValueDescription(value_type: "number", value: 36)])
+"""
+    )
 }

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayerInputPort.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayerInputPort.swift
@@ -230,7 +230,8 @@ extension SyntaxViewModifierName {
         case .background:
             return nil
         case .font:
-            return .simple(.textFont)
+            // return .simple(.textFont)
+            return .simple(.fontSize)
         case .multilineTextAlignment:
             throw SwiftUISyntaxError.unsupportedViewModifier(self)
             

--- a/Stitch/Graph/StitchAI/Mapping/VPLToCode/LayerVPLToCode.swift
+++ b/Stitch/Graph/StitchAI/Mapping/VPLToCode/LayerVPLToCode.swift
@@ -484,9 +484,9 @@ extension LayerInputPort {
             return .font
             
         case .fontSize:
-            // FontSize should not create a separate font modifier when textFont exists
-            // The textFont case handles both font family/weight and size together
-            return nil
+            // FontSize should create a font modifier when it contains PortValueDescription
+            // This handles the case where fontSize comes from PortValueDescription
+            return .font
         case .rotationX:
             // For now, treat rotationX as unsupported
             return nil

--- a/Stitch/Graph/StitchAI/PromptGenerator/AICodeGenSystemPromptGenerator.swift
+++ b/Stitch/Graph/StitchAI/PromptGenerator/AICodeGenSystemPromptGenerator.swift
@@ -13,7 +13,7 @@ extension StitchAIManager {
             .map(\.rawValue)
         
         return """
-# \(requestType.systemPromptTitle)
+# "SwiftUI Code Builder from Stitch Graph Data"
 
 You are producing SwiftUI code. Strictly and exactly follow every instruction in this prompt. **Do not include any elements or logic that are not explicitly allowed or described.** Pay careful attention to all must/only/never rules, and handle each requirement precisely as written.
 


### PR DESCRIPTION
<img width="1434" height="538" alt="Screenshot 2025-08-27 at 8 13 21 PM" src="https://github.com/user-attachments/assets/078c90f8-60f1-4eaa-9c75-61d853544b61" />
<img width="1428" height="513" alt="Screenshot 2025-08-27 at 8 13 08 PM" src="https://github.com/user-attachments/assets/a7bed852-6a52-4c82-934a-bdb717ab2344" />
