### PR TITLE
Programmatic support for custom value types from AI

### DIFF
--- a/Stitch/App/StitchApp.swift
+++ b/Stitch/App/StitchApp.swift
@@ -41,8 +41,8 @@ struct StitchApp: App {
         FirebaseApp.configure()
     }
 
-#if FAKE_FLAG
-//#if DEV_DEBUG
+//#if FAKE_FLAG
+#if DEV_DEBUG
     var body: some Scene {
         WindowGroup {
             ASTExplorerView()

--- a/Stitch/App/StitchApp.swift
+++ b/Stitch/App/StitchApp.swift
@@ -41,8 +41,8 @@ struct StitchApp: App {
         FirebaseApp.configure()
     }
 
-//#if FAKE_FLAG
-#if DEV_DEBUG
+#if FAKE_FLAG
+//#if DEV_DEBUG
     var body: some Scene {
         WindowGroup {
             ASTExplorerView()

--- a/Stitch/Graph/Node/Port/Util/TypeChange/NodeTypeChangedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/TypeChange/NodeTypeChangedActions.swift
@@ -143,3 +143,19 @@ extension GraphState {
     }
 }
 
+extension Patch {
+    /// Refers to input ports whose types change given a conditional node value type. Returns nil if the node doesn't support type changing.
+    @MainActor
+    var nonStaticTypedInputPorts: [Int]? {
+        guard let patchNodeDefinition = self.graphNode,
+              let defaultType = patchNodeDefinition.defaultUserVisibleType else {
+            // No type changing support
+            return nil
+        }
+        
+        let valueDynamicRows = patchNodeDefinition.rowDefinitions(for: defaultType).inputs
+            .map { !$0.isTypeStatic }
+            .enumerated().map { $0.0 }
+        return valueDynamicRows
+    }
+}

--- a/Stitch/Graph/Node/Port/Util/TypeChange/NodeTypeChangedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/TypeChange/NodeTypeChangedActions.swift
@@ -146,7 +146,7 @@ extension GraphState {
 extension Patch {
     /// Refers to input ports whose types change given a conditional node value type. Returns nil if the node doesn't support type changing.
     @MainActor
-    var nonStaticTypedInputPorts: [Int]? {
+    var nonStaticTypedInputPorts: Set<Int>? {
         guard let patchNodeDefinition = self.graphNode,
               let defaultType = patchNodeDefinition.defaultUserVisibleType else {
             // No type changing support
@@ -159,6 +159,43 @@ extension Patch {
             .compactMap { index, isTypeStatic in
                 isTypeStatic ? nil : index
             }
-        return valueDynamicRows
+        
+        return Set(valueDynamicRows)
+    }
+}
+
+extension SwiftParserPatchData {
+    @MainActor
+    static func processIncomingConnectionData(upstreamCoordinate: AIGraphData_V0.NodeIndexedCoordinate,
+                                              downstreamCoordinate: AIGraphData_V0.NodeIndexedCoordinate,
+                                              nativePatchNodes: [String: CurrentAIGraphData.PatchNode],
+                                              nativePatchValueTypeSettings: inout [String: CurrentAIGraphData.NativePatchNodeValueTypeSetting],
+                                              patchConnections: inout [CurrentAIGraphData.PatchConnection]) {
+        guard let patch = nativePatchNodes.get(downstreamCoordinate.node_id)?.node_name.value.patch else {
+            fatalErrorIfDebug()
+            return
+        }
+        
+        let nodeValueTypeDynamicPortIndices = patch.nonStaticTypedInputPorts ?? .init()
+        
+        // Determine a custom node value type if this node supports value types and no value has yet been set here
+        let checkForValueTypeHere = nodeValueTypeDynamicPortIndices.contains(downstreamCoordinate.port_index) && !nativePatchValueTypeSettings.keys.contains(downstreamCoordinate.node_id)
+        
+        // Determine node type by examining upstream node
+        if checkForValueTypeHere {
+           if let upstreamValueType = upstreamCoordinate
+            .determineOutputNodeValueType(nativePatchNodes: nativePatchNodes,
+                                          nativePatchValueTypeSettings: nativePatchValueTypeSettings) {
+               nativePatchValueTypeSettings.updateValue(.init(node_id: upstreamCoordinate.node_id,
+                                                              value_type: .init(value: upstreamValueType)) ,
+                                                        forKey: upstreamCoordinate.node_id)
+           }
+        }
+        
+        // Create connection data
+        patchConnections.append(
+            .init(src_port: upstreamCoordinate,
+                  dest_port: downstreamCoordinate)
+        )
     }
 }

--- a/Stitch/Graph/Node/Port/Util/TypeChange/NodeTypeChangedActions.swift
+++ b/Stitch/Graph/Node/Port/Util/TypeChange/NodeTypeChangedActions.swift
@@ -154,8 +154,11 @@ extension Patch {
         }
         
         let valueDynamicRows = patchNodeDefinition.rowDefinitions(for: defaultType).inputs
-            .map { !$0.isTypeStatic }
-            .enumerated().map { $0.0 }
+            .map { $0.isTypeStatic }
+            .enumerated()
+            .compactMap { index, isTypeStatic in
+                isTypeStatic ? nil : index
+            }
         return valueDynamicRows
     }
 }

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AICodeGenRequest.swift
@@ -157,6 +157,7 @@ extension StitchAICodeCreator {
         }
     }
 
+    @MainActor
     private func processRequest(userPrompt: String,
                                 document: StitchDocumentViewModel,
                                 aiManager: StitchAIManager,
@@ -182,7 +183,7 @@ extension StitchAICodeCreator {
         
         logToServerIfRelease("StitchAICodeCreator codeParserResult:\n\(codeParserResult)")
         
-        let actionsResult = try codeParserResult.deriveStitchActions(bindingDeclarations: codeParserResult.bindingDeclarations)
+        let actionsResult = codeParserResult.deriveStitchActions(bindingDeclarations: codeParserResult.bindingDeclarations)
         
         print("Derived Stitch layer data:\n\((try? actionsResult.encodeToPrintableString()) ?? "")")
         

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/StitchAIFunctionRequestable.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/StitchAIFunctionRequestable.swift
@@ -43,6 +43,7 @@ protocol StitchAICodeCreator {
     
     static var type: StitchAIRequestBuilder_V0.StitchAIRequestType { get }
     
+    @MainActor
     func createCode(document: StitchDocumentViewModel,
                     aiManager: StitchAIManager,
                     dataGlossaryPrompt: String) async throws -> String

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchModel.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchModel.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 struct SwiftUIViewParserResult {
     let viewStack: [SyntaxView]
-    let bindingDeclarations: [String : SwiftParserInitializerType]
+    let bindingDeclarations: [(String, SwiftParserInitializerType)]
     let caughtErrors: [SwiftUISyntaxError]
 }
 

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchPatchData.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchPatchData.swift
@@ -291,7 +291,7 @@ extension SwiftParserInitializerType {
     func parseStitchActions(varName: String,
                             varNameIdMap: [String : String],
                             varNameOutputPortMap: [String : SwiftParserSubscript],
-    customPatchInputValues: inout [CurrentAIGraphData.CustomPatchInputValue],
+                            customPatchInputValues: inout [String: CurrentAIGraphData.CustomPatchInputValue],
                             varNamePatchNodeRefMap: [String : String],
                             stateVarToInteractionOutputsMap: [String: CurrentAIGraphData.NodeIndexedCoordinate],
                             patchConnections: inout [CurrentAIGraphData.PatchConnection],
@@ -337,12 +337,13 @@ extension SwiftParserInitializerType {
                     for portData in portDataList {
                         switch portData {
                         case .value(let portValue):
-                            customPatchInputValues.append(
+                            customPatchInputValues.updateValue(
                                 .init(patch_input_coordinate: .init(
                                     node_id: patchNodeData.id,
                                     port_index: portIndex),
                                       value: portValue.value,
-                                      value_type: portValue.value_type)
+                                      value_type: portValue.value_type),
+                                forKey: patchNodeData.id
                             )
                             
                         case .stateRef(let ref):

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchPatchData.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchPatchData.swift
@@ -288,6 +288,8 @@ extension SwiftUIViewVisitor {
 }
 
 extension SwiftParserInitializerType {
+    /// Creates custom input values, edges, and custom node types for patch graph data.
+    /// Optional parameter `downstreamNodeIdCaller` called in scenarios where recursion is used.
     @MainActor
     func parseStitchActions(varName: String,
                             varNameIdMap: [String : String],
@@ -310,12 +312,11 @@ extension SwiftParserInitializerType {
                 return
             }
             
-            let nodeValueTypeDynamicPortIndices = patch.nonStaticTypedInputPorts
-            // Selected port subject to change if off chance of an upstream JS node
-            var portIndexToCheckForNodeType = nodeValueTypeDynamicPortIndices?.first
+            let nodeValueTypeDynamicPortIndices = patch.nonStaticTypedInputPorts ?? .init()
             
             for (portIndex, arg) in patchNodeData.args.enumerated() {
-                let checkForValueTypeHere = portIndex == portIndexToCheckForNodeType
+                // Determine a custom node value type if this node supports value types and no value has yet been set here
+                let checkForValueTypeHere = nodeValueTypeDynamicPortIndices.contains(portIndex) && !nativePatchValueTypeSettings.keys.contains(patchNodeData.id)
                 
                 switch arg {
                 case .binding(let refName):
@@ -340,31 +341,13 @@ extension SwiftParserInitializerType {
                         continue
                     }
                     
-                    // Determine node type by examining upstream node
-                    if checkForValueTypeHere {
-                       guard let upstreamValueType = upstreamCoordinate
-                        .determineOutputNodeValueType(nativePatchNodes: nativePatchNodes,
-                                                      nativePatchValueTypeSettings: nativePatchValueTypeSettings) else {
-                           // Check next port if native patch node isn't upstream (i.e. a js node instead)
-                           if let _portIndexToCheckForNodeType = portIndexToCheckForNodeType,
-                              let indexOfElem = nodeValueTypeDynamicPortIndices?
-                               .firstIndex(of: _portIndexToCheckForNodeType) {
-                               portIndexToCheckForNodeType = nodeValueTypeDynamicPortIndices?[safe: indexOfElem + 1]
-                           }
-                           
-                           continue
-                       }
-                        
-                        nativePatchValueTypeSettings.updateValue(.init(node_id: patchNodeData.id,
-                                                                       value_type: .init(value: upstreamValueType)) ,
-                                                                 forKey: patchNodeData.id)
-                    }
-                    
-                    patchConnections.append(
-                        .init(src_port: upstreamCoordinate,
-                              dest_port: .init(node_id: patchNodeData.id,
-                                               port_index: portIndex))
-                    )
+                    SwiftParserPatchData
+                        .processIncomingConnectionData(upstreamCoordinate: upstreamCoordinate,
+                                                       downstreamCoordinate: .init(node_id: patchNodeData.id,
+                                                                                   port_index: portIndex),
+                                                       nativePatchNodes: nativePatchNodes,
+                                                       nativePatchValueTypeSettings: &nativePatchValueTypeSettings,
+                                                       patchConnections: &patchConnections)
                     
                 case .value(let argType):
                     let portDataList = try argType.derivePortValues()
@@ -492,10 +475,14 @@ extension SwiftParserInitializerType {
                     return
                 }
                 
-                patchConnections.append(
-                    .init(src_port: .init(node_id: destNodeId,                          port_index: subscriptData.portIndex),
-                          dest_port: destCoordinate)
-                )
+                SwiftParserPatchData
+                    .processIncomingConnectionData(
+                        upstreamCoordinate: .init(node_id: destNodeId,
+                                                  port_index: subscriptData.portIndex),
+                        downstreamCoordinate: destCoordinate,
+                        nativePatchNodes: nativePatchNodes,
+                        nativePatchValueTypeSettings: &nativePatchValueTypeSettings,
+                        patchConnections: &patchConnections)
             }
         
         case .jsNodeScript(let script):

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchPatchData.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchPatchData.swift
@@ -288,20 +288,35 @@ extension SwiftUIViewVisitor {
 }
 
 extension SwiftParserInitializerType {
+    @MainActor
     func parseStitchActions(varName: String,
                             varNameIdMap: [String : String],
                             varNameOutputPortMap: [String : SwiftParserSubscript],
     customPatchInputValues: inout [CurrentAIGraphData.CustomPatchInputValue],
                             varNamePatchNodeRefMap: [String : String],
                             stateVarToInteractionOutputsMap: [String: CurrentAIGraphData.NodeIndexedCoordinate],
+                            nativePatchNodes: [String: CurrentAIGraphData.PatchNode],
                             patchConnections: inout [CurrentAIGraphData.PatchConnection],
                             viewStatePatchConnections: inout [String : AIGraphData_V0.NodeIndexedCoordinate],
+                            nativePatchValueTypeSettings: inout [String: CurrentAIGraphData.NativePatchNodeValueTypeSetting],
                             preprocessedJSNodes: inout [CurrentAIGraphData.PreprocessedJSPatchNode],
                             varNameJsFnMap: inout [String: String],
                             subscriptParentInfo: AIGraphData_V0.NodeIndexedCoordinate? = nil) throws {
         switch self {
         case .patchNode(let patchNodeData):
+            // Marks an input port to check for a custom node type, if supported by this node
+            guard let patch = nativePatchNodes.get(patchNodeData.id)?.node_name.value.patch else {
+                fatalErrorIfDebug()
+                return
+            }
+            
+            let nodeValueTypeDynamicPortIndices = patch.nonStaticTypedInputPorts
+            // Selected port subject to change if off chance of an upstream JS node
+            var portIndexToCheckForNodeType = nodeValueTypeDynamicPortIndices?.first
+            
             for (portIndex, arg) in patchNodeData.args.enumerated() {
+                let checkForValueTypeHere = portIndex == portIndexToCheckForNodeType
+                
                 switch arg {
                 case .binding(let refName):
                     // Get edge data
@@ -323,6 +338,26 @@ extension SwiftParserInitializerType {
                     
                     else {
                         continue
+                    }
+                    
+                    // Determine node type by examining upstream node
+                    if checkForValueTypeHere {
+                       guard let upstreamValueType = upstreamCoordinate
+                        .determineOutputNodeValueType(nativePatchNodes: nativePatchNodes,
+                                                      nativePatchValueTypeSettings: nativePatchValueTypeSettings) else {
+                           // Check next port if native patch node isn't upstream (i.e. a js node instead)
+                           if let _portIndexToCheckForNodeType = portIndexToCheckForNodeType,
+                              let indexOfElem = nodeValueTypeDynamicPortIndices?
+                               .firstIndex(of: _portIndexToCheckForNodeType) {
+                               portIndexToCheckForNodeType = nodeValueTypeDynamicPortIndices?[safe: indexOfElem + 1]
+                           }
+                           
+                           continue
+                       }
+                        
+                        nativePatchValueTypeSettings.updateValue(.init(node_id: patchNodeData.id,
+                                                                       value_type: .init(value: upstreamValueType)) ,
+                                                                 forKey: patchNodeData.id)
                     }
                     
                     patchConnections.append(
@@ -354,8 +389,10 @@ extension SwiftParserInitializerType {
                                                         varNameOutputPortMap: varNameOutputPortMap,
                                                         customPatchInputValues: &customPatchInputValues, varNamePatchNodeRefMap: varNamePatchNodeRefMap,
                                                         stateVarToInteractionOutputsMap: stateVarToInteractionOutputsMap,
+                                                        nativePatchNodes: nativePatchNodes,
                                                         patchConnections: &patchConnections,
                                                         viewStatePatchConnections: &viewStatePatchConnections,
+                                                        nativePatchValueTypeSettings: &nativePatchValueTypeSettings,
                                                         preprocessedJSNodes: &preprocessedJSNodes,
                                                         varNameJsFnMap: &varNameJsFnMap,
                                                         subscriptParentInfo: .init(node_id: patchNodeData.id,
@@ -376,8 +413,10 @@ extension SwiftParserInitializerType {
                                             customPatchInputValues: &customPatchInputValues,
                                             varNamePatchNodeRefMap: varNamePatchNodeRefMap,
                                             stateVarToInteractionOutputsMap: stateVarToInteractionOutputsMap,
+                                            nativePatchNodes: nativePatchNodes,
                                             patchConnections: &patchConnections,
                                             viewStatePatchConnections: &viewStatePatchConnections,
+                                            nativePatchValueTypeSettings: &nativePatchValueTypeSettings,
                                             preprocessedJSNodes: &preprocessedJSNodes,
                                             varNameJsFnMap: &varNameJsFnMap,
                                             subscriptParentInfo: .init(node_id: patchNodeData.id,
@@ -429,8 +468,10 @@ extension SwiftParserInitializerType {
                                         customPatchInputValues: &customPatchInputValues,
                                         varNamePatchNodeRefMap: varNamePatchNodeRefMap,
                                         stateVarToInteractionOutputsMap: stateVarToInteractionOutputsMap,
+                                        nativePatchNodes: nativePatchNodes,
                                         patchConnections: &patchConnections,
                                         viewStatePatchConnections: &viewStatePatchConnections,
+                                        nativePatchValueTypeSettings: &nativePatchValueTypeSettings,
                                         preprocessedJSNodes: &preprocessedJSNodes,
                                         varNameJsFnMap: &varNameJsFnMap,)
                 
@@ -466,5 +507,31 @@ extension SwiftParserInitializerType {
         case .viewBuilder, .patchNodeRef, .declrRef, .arraySyntax:
             return
         }
+    }
+}
+
+extension AIGraphData_V0.NodeIndexedCoordinate {
+    /// Determines a custom value type of some node given data from its upstream node connection.
+    @MainActor
+    func determineOutputNodeValueType(nativePatchNodes: [String: CurrentAIGraphData.PatchNode],
+                                      nativePatchValueTypeSettings: [String: CurrentAIGraphData.NativePatchNodeValueTypeSetting]) -> StitchAIPortValue_V1.NodeType? {
+        guard let upstreamNode = nativePatchNodes.get(self.node_id) else {
+
+            
+            return nil
+        }
+        
+        let upstreamNodeType = nativePatchValueTypeSettings.get(self.node_id)?.value_type.value
+        guard let upstreamPatch = upstreamNode.node_name.value.patch else {
+            fatalErrorIfDebug()
+            return nil
+        }
+        
+        guard let upstreamOutput = upstreamPatch.graphNode?.rowDefinitions(for: upstreamNodeType).outputs[safe: self.port_index] else {
+            fatalErrorIfDebug()
+            return nil
+        }
+        
+        return upstreamOutput.value.nodeType
     }
 }

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchPatchData.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchPatchData.swift
@@ -291,7 +291,7 @@ extension SwiftParserInitializerType {
     func parseStitchActions(varName: String,
                             varNameIdMap: [String : String],
                             varNameOutputPortMap: [String : SwiftParserSubscript],
-                            customPatchInputValues: inout [String: CurrentAIGraphData.CustomPatchInputValue],
+    customPatchInputValues: inout [CurrentAIGraphData.CustomPatchInputValue],
                             varNamePatchNodeRefMap: [String : String],
                             stateVarToInteractionOutputsMap: [String: CurrentAIGraphData.NodeIndexedCoordinate],
                             patchConnections: inout [CurrentAIGraphData.PatchConnection],
@@ -337,13 +337,12 @@ extension SwiftParserInitializerType {
                     for portData in portDataList {
                         switch portData {
                         case .value(let portValue):
-                            customPatchInputValues.updateValue(
+                            customPatchInputValues.append(
                                 .init(patch_input_coordinate: .init(
                                     node_id: patchNodeData.id,
                                     port_index: portIndex),
                                       value: portValue.value,
-                                      value_type: portValue.value_type),
-                                forKey: patchNodeData.id
+                                      value_type: portValue.value_type)
                             )
                             
                         case .stateRef(let ref):

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchPatchData.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchPatchData.swift
@@ -380,6 +380,15 @@ extension SwiftParserInitializerType {
                                       value_type: portValue.value_type)
                             )
                             
+                            // Update node's custom value type if relevant at this port
+                            if checkForValueTypeHere {
+                                let valueType = portValue.value_type
+                                nativePatchValueTypeSettings
+                                    .updateValue(.init(node_id: patchNodeData.id,
+                                                       value_type: valueType),
+                                                 forKey: patchNodeData.id)
+                            }
+                            
                         case .stateRef(let ref):
                             // Check for edges here
                             if let upstreamData = varNameOutputPortMap.get(ref) {

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
@@ -29,7 +29,7 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
     }
 
     // Top-level declarations of patch data
-    var bindingDeclarations = [String : SwiftParserInitializerType]()
+    var bindingDeclarations = [(String, SwiftParserInitializerType)]()
     
     var viewStack: [SyntaxView] = []
     
@@ -70,7 +70,7 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
             }
             
             self.bindingDeclarations
-                .updateValue(.patchNode(patchNode), forKey: currentLHS)
+                .append((currentLHS, .patchNode(patchNode)))
             
             return .skipChildren
         }
@@ -80,8 +80,7 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
             // Subscript reference to some existing outputs
             let subscriptData = self.visitSubscriptData(subscriptCallExpr: subscriptCallExpr)
             self.bindingDeclarations
-                .updateValue(subscriptData,
-                             forKey: currentLHS)
+                .append((currentLHS, subscriptData))
             
             return .skipChildren
         }
@@ -130,24 +129,21 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
         if let subscriptExpr = assinmentElem.as(SubscriptCallExprSyntax.self) {
             let subscriptRef = self.deriveSubscriptData(subscriptCallExpr: subscriptExpr)
             self.bindingDeclarations
-                .updateValue(.stateMutation(subscriptRef),
-                             forKey: refName)
+                .append((refName, .stateMutation(subscriptRef)))
             return .skipChildren
         }
         
         else if let declRefExpr = assinmentElem.as(DeclReferenceExprSyntax.self) {
             let declLabel = declRefExpr.baseName.trimmedDescription
             self.bindingDeclarations
-                .updateValue(.stateMutation(.declrRef(declLabel)),
-                             forKey: refName)
+                .append((refName, .stateMutation(.declrRef(declLabel))))
             return .skipChildren
         }
         
         // Captures arrays of PortValueDescription
         else if let arrayExpr = assinmentElem.as(ArrayExprSyntax.self) {
             self.bindingDeclarations
-                .updateValue(.stateMutation(.arraySyntax(arrayExpr)),
-                             forKey: refName)
+                .append((refName, .stateMutation(.arraySyntax(arrayExpr))))
             return .skipChildren
         }
         
@@ -183,8 +179,7 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
                 // View builder function
                 if let someOrAnyReturnType = funcDeclSyntax.signature.returnClause?.type.as(SomeOrAnyTypeSyntax.self),
                    someOrAnyReturnType.constraint.trimmedDescription == "View" {
-                    self.bindingDeclarations.updateValue(.viewBuilder(bodyScript),
-                                                         forKey: funcName)
+                    self.bindingDeclarations.append((funcName, .viewBuilder(bodyScript)))
                     
                     return .skipChildren
                 }
@@ -192,7 +187,7 @@ final class SwiftUIViewVisitor: SyntaxVisitor {
                 
                 // JS node case
                 else {
-                    self.bindingDeclarations.updateValue(.jsNodeScript(bodyScript), forKey: funcName)
+                    self.bindingDeclarations.append((funcName, .jsNodeScript(bodyScript)))
                     return .skipChildren
                 }
             }

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewName.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewName.swift
@@ -64,7 +64,7 @@ extension SyntaxViewName {
                                    args: nil,
                                    modifiers: [],
                                    childrenLayers: [],
-                                   bindingDeclarations: [:])) != nil
+                                   bindingDeclarations: [])) != nil
     }
 }
 

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
@@ -32,7 +32,7 @@ struct SwiftSyntaxActionsResult: Encodable {
 
 extension Array where Element == SyntaxView {
     @MainActor
-    func deriveStitchActions(bindingDeclarations: [String : SwiftParserInitializerType]) -> SwiftSyntaxLayerActionsResult {
+    func deriveStitchActions(bindingDeclarations: [(String, SwiftParserInitializerType)]) -> SwiftSyntaxLayerActionsResult {
         var result = SwiftSyntaxLayerActionsResult(actions: [],
                                                    caughtErrors: [])
         
@@ -48,7 +48,7 @@ extension Array where Element == SyntaxView {
 
 extension SwiftUIViewParserResult {
     @MainActor
-    func deriveStitchActions(bindingDeclarations: [String : SwiftParserInitializerType]) -> SwiftSyntaxActionsResult {
+    func deriveStitchActions(bindingDeclarations: [(String, SwiftParserInitializerType)]) -> SwiftSyntaxActionsResult {
         // Extract layer data
         let layerResults = self.viewStack.deriveStitchActions(bindingDeclarations: bindingDeclarations)
 
@@ -142,7 +142,11 @@ extension Array where Element == AIGraphData_V0.LayerData {
     }
 }
 
-extension Dictionary where Key == String, Value == SwiftParserInitializerType {
+extension Array where Element == (String, SwiftParserInitializerType) {
+    func get(_ name: String) -> SwiftParserInitializerType? {
+        self.first { $0.0 == name }?.1
+    }
+    
     @MainActor
     func deriveStitchActions(layers: [AIGraphData_V0.LayerData]) -> SwiftSyntaxPatchActionsResult {
         // MARK: data we use as tracking
@@ -263,8 +267,8 @@ extension Dictionary where Key == String, Value == SwiftParserInitializerType {
         
         return .init(actions: AIGraphData_V0
             .PatchData(javascript_patches: preprocessedJSNodes,
-                       native_patches: Array(nativePatchNodes.values),
-                       native_patch_value_type_settings: Array(nativePatchValueTypeSettings.values),
+                       native_patches: Array<CurrentAIGraphData.PatchNode>(nativePatchNodes.values),
+                       native_patch_value_type_settings: Array<CurrentAIGraphData.NativePatchNodeValueTypeSetting>(nativePatchValueTypeSettings.values),
                        patch_connections: patchConnections,
                        custom_patch_input_values: customPatchInputValues),
                      viewStatePatchConnections: viewStatePatchConnections,
@@ -309,7 +313,7 @@ extension Array where Element == String {
 
 extension SyntaxView {
     @MainActor
-    func deriveStitchActions(bindingDeclarations: [String : SwiftParserInitializerType]) -> SwiftSyntaxLayerActionsResult? {
+    func deriveStitchActions(bindingDeclarations: [(String, SwiftParserInitializerType)]) -> SwiftSyntaxLayerActionsResult? {
         // Tracks all silent errors
         var silentErrors = [SwiftUISyntaxError]()
         

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
@@ -31,6 +31,7 @@ struct SwiftSyntaxActionsResult: Encodable {
 }
 
 extension Array where Element == SyntaxView {
+    @MainActor
     func deriveStitchActions(bindingDeclarations: [String : SwiftParserInitializerType]) -> SwiftSyntaxLayerActionsResult {
         var result = SwiftSyntaxLayerActionsResult(actions: [],
                                                    caughtErrors: [])
@@ -46,6 +47,7 @@ extension Array where Element == SyntaxView {
 }
 
 extension SwiftUIViewParserResult {
+    @MainActor
     func deriveStitchActions(bindingDeclarations: [String : SwiftParserInitializerType]) -> SwiftSyntaxActionsResult {
         // Extract layer data
         let layerResults = self.viewStack.deriveStitchActions(bindingDeclarations: bindingDeclarations)
@@ -64,7 +66,7 @@ extension Array where Element == AIGraphData_V0.LayerData {
     /// Roles:
     /// 1. Determines interaction patch nodes to make based on view events attached to view modifiers.
     /// 2. Returns dictionary of a state var name to a newly created patch node's output coordinate.
-    func createStateVarToInteractionNodeMap(nativePatchNodes: inout [CurrentAIGraphData.PatchNode],
+    func createStateVarToInteractionNodeMap(nativePatchNodes: inout [String: CurrentAIGraphData.PatchNode],
                                             customPatchInputValues: inout [CurrentAIGraphData.CustomPatchInputValue],
                                             viewStatePatchConnections: inout [String : AIGraphData_V0.NodeIndexedCoordinate],
                                             patchConnections: inout [CurrentAIGraphData.PatchConnection]) -> [String: CurrentAIGraphData.NodeIndexedCoordinate] {
@@ -107,7 +109,8 @@ extension Array where Element == AIGraphData_V0.LayerData {
             
             // Add any created patch nodes to the native nodes list
             createdPatchesAtThisNode.values.forEach { patchNode in
-                nativePatchNodes.append(patchNode)
+                nativePatchNodes.updateValue(patchNode,
+                                             forKey: patchNode.node_id)
             }
             
             // Recursively explore children
@@ -140,6 +143,7 @@ extension Array where Element == AIGraphData_V0.LayerData {
 }
 
 extension Dictionary where Key == String, Value == SwiftParserInitializerType {
+    @MainActor
     func deriveStitchActions(layers: [AIGraphData_V0.LayerData]) -> SwiftSyntaxPatchActionsResult {
         // MARK: data we use as tracking
         // Maps some variable name to a node ID string
@@ -159,8 +163,8 @@ extension Dictionary where Key == String, Value == SwiftParserInitializerType {
         
         // MARK: data to be returned
         var caughtErrors: [SwiftUISyntaxError] = []
-        var nativePatchNodes = [CurrentAIGraphData.PatchNode]()
-        var nativePatchValueTypeSettings = [CurrentAIGraphData.NativePatchNodeValueTypeSetting]()
+        var nativePatchNodes = [String: CurrentAIGraphData.PatchNode]()
+        var nativePatchValueTypeSettings = [String: CurrentAIGraphData.NativePatchNodeValueTypeSetting]()
         var patchConnections = [CurrentAIGraphData.PatchConnection]()
         var customPatchInputValues = [CurrentAIGraphData.CustomPatchInputValue]()
         var preprocessedJSNodes = [CurrentAIGraphData.PreprocessedJSPatchNode]()
@@ -186,7 +190,8 @@ extension Dictionary where Key == String, Value == SwiftParserInitializerType {
                     .createStitchData(varName: varName,
                                       varNameIdMap: &varNameIdMap,
                                       varNameJsFnMap: &varNameJsFnMap)
-                nativePatchNodes.append(newPatchNode)
+                nativePatchNodes.updateValue(newPatchNode,
+                                             forKey: newPatchNode.node_id)
                 
             case .subscriptRef(let subscriptData):
                 // Track top-level bindings of some output port data
@@ -199,7 +204,8 @@ extension Dictionary where Key == String, Value == SwiftParserInitializerType {
                         .createStitchData(varName: varName,
                                           varNameIdMap: &varNameIdMap,
                                           varNameJsFnMap: &varNameJsFnMap)
-                    nativePatchNodes.append(newPatchNode)
+                    nativePatchNodes.updateValue(newPatchNode,
+                                                 forKey: newPatchNode.node_id)
                     
                 case .ref:
                     continue
@@ -242,8 +248,10 @@ extension Dictionary where Key == String, Value == SwiftParserInitializerType {
                                         customPatchInputValues: &customPatchInputValues,
                                         varNamePatchNodeRefMap: varNamePatchNodeRefMap,
                                         stateVarToInteractionOutputsMap: stateVarToInteractionOutputsMap,
+                                        nativePatchNodes: nativePatchNodes,
                                         patchConnections: &patchConnections,
                                         viewStatePatchConnections: &viewStatePatchConnections,
+                                        nativePatchValueTypeSettings: &nativePatchValueTypeSettings,
                                         preprocessedJSNodes: &preprocessedJSNodes,
                                         varNameJsFnMap: &varNameJsFnMap)
             } catch let error as SwiftUISyntaxError {
@@ -255,8 +263,8 @@ extension Dictionary where Key == String, Value == SwiftParserInitializerType {
         
         return .init(actions: AIGraphData_V0
             .PatchData(javascript_patches: preprocessedJSNodes,
-                       native_patches: nativePatchNodes,
-                       native_patch_value_type_settings: nativePatchValueTypeSettings,
+                       native_patches: Array(nativePatchNodes.values),
+                       native_patch_value_type_settings: Array(nativePatchValueTypeSettings.values),
                        patch_connections: patchConnections,
                        custom_patch_input_values: customPatchInputValues),
                      viewStatePatchConnections: viewStatePatchConnections,
@@ -266,6 +274,7 @@ extension Dictionary where Key == String, Value == SwiftParserInitializerType {
 
 extension Array where Element == String {
     /// Derives actions from an array of script strings.
+    @MainActor
     func deriveStitchActions() -> SwiftSyntaxLayerActionsResult {
         let actionsResults = self.flatMap { script in
             let result = SwiftUIViewVisitor.parseSwiftUICode(script)
@@ -299,6 +308,7 @@ extension Array where Element == String {
 }
 
 extension SyntaxView {
+    @MainActor
     func deriveStitchActions(bindingDeclarations: [String : SwiftParserInitializerType]) -> SwiftSyntaxLayerActionsResult? {
         // Tracks all silent errors
         var silentErrors = [SwiftUISyntaxError]()

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
@@ -65,7 +65,7 @@ extension Array where Element == AIGraphData_V0.LayerData {
     /// 1. Determines interaction patch nodes to make based on view events attached to view modifiers.
     /// 2. Returns dictionary of a state var name to a newly created patch node's output coordinate.
     func createStateVarToInteractionNodeMap(nativePatchNodes: inout [CurrentAIGraphData.PatchNode],
-                                            customPatchInputValues: inout [CurrentAIGraphData.CustomPatchInputValue],
+                                            customPatchInputValues: inout [String: CurrentAIGraphData.CustomPatchInputValue],
                                             viewStatePatchConnections: inout [String : AIGraphData_V0.NodeIndexedCoordinate],
                                             patchConnections: inout [CurrentAIGraphData.PatchConnection]) -> [String: CurrentAIGraphData.NodeIndexedCoordinate] {
         self.reduce(into: [String: CurrentAIGraphData.NodeIndexedCoordinate]()) { result, layerData in
@@ -86,11 +86,12 @@ extension Array where Element == AIGraphData_V0.LayerData {
                 }
                 
                 // Update layer assignment for node
-                customPatchInputValues.append(
+                customPatchInputValues.updateValue(
                     .init(patch_input_coordinate: .init(node_id: patchNode.node_id,
                                                         port_index: 0),
                           value: layerData.node_id,
-                          value_type: .init(value: .interactionId))
+                          value_type: .init(value: .interactionId)),
+                    forKey: patchNode.node_id
                 )
                 
                 // Update view state connections
@@ -161,8 +162,9 @@ extension Dictionary where Key == String, Value == SwiftParserInitializerType {
         var caughtErrors: [SwiftUISyntaxError] = []
         var nativePatchNodes = [CurrentAIGraphData.PatchNode]()
         var nativePatchValueTypeSettings = [CurrentAIGraphData.NativePatchNodeValueTypeSetting]()
+        
         var patchConnections = [CurrentAIGraphData.PatchConnection]()
-        var customPatchInputValues = [CurrentAIGraphData.CustomPatchInputValue]()
+        var customPatchInputValues = [String: CurrentAIGraphData.CustomPatchInputValue]()
         var preprocessedJSNodes = [CurrentAIGraphData.PreprocessedJSPatchNode]()
         
         // Because patch data is decoded before layer data, we don't yet know the destination ports for layer edges, therefore, we just track the source patch to some state variable
@@ -253,12 +255,14 @@ extension Dictionary where Key == String, Value == SwiftParserInitializerType {
             }
         }
         
+        // Third pass: derive custom node value types for native patch nodes
+        
         return .init(actions: AIGraphData_V0
             .PatchData(javascript_patches: preprocessedJSNodes,
                        native_patches: nativePatchNodes,
                        native_patch_value_type_settings: nativePatchValueTypeSettings,
                        patch_connections: patchConnections,
-                       custom_patch_input_values: customPatchInputValues),
+                       custom_patch_input_values: Array(customPatchInputValues.values)),
                      viewStatePatchConnections: viewStatePatchConnections,
                      caughtErrors: caughtErrors)
     }

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
@@ -65,7 +65,7 @@ extension Array where Element == AIGraphData_V0.LayerData {
     /// 1. Determines interaction patch nodes to make based on view events attached to view modifiers.
     /// 2. Returns dictionary of a state var name to a newly created patch node's output coordinate.
     func createStateVarToInteractionNodeMap(nativePatchNodes: inout [CurrentAIGraphData.PatchNode],
-                                            customPatchInputValues: inout [String: CurrentAIGraphData.CustomPatchInputValue],
+                                            customPatchInputValues: inout [CurrentAIGraphData.CustomPatchInputValue],
                                             viewStatePatchConnections: inout [String : AIGraphData_V0.NodeIndexedCoordinate],
                                             patchConnections: inout [CurrentAIGraphData.PatchConnection]) -> [String: CurrentAIGraphData.NodeIndexedCoordinate] {
         self.reduce(into: [String: CurrentAIGraphData.NodeIndexedCoordinate]()) { result, layerData in
@@ -86,12 +86,11 @@ extension Array where Element == AIGraphData_V0.LayerData {
                 }
                 
                 // Update layer assignment for node
-                customPatchInputValues.updateValue(
+                customPatchInputValues.append(
                     .init(patch_input_coordinate: .init(node_id: patchNode.node_id,
                                                         port_index: 0),
                           value: layerData.node_id,
-                          value_type: .init(value: .interactionId)),
-                    forKey: patchNode.node_id
+                          value_type: .init(value: .interactionId))
                 )
                 
                 // Update view state connections
@@ -162,9 +161,8 @@ extension Dictionary where Key == String, Value == SwiftParserInitializerType {
         var caughtErrors: [SwiftUISyntaxError] = []
         var nativePatchNodes = [CurrentAIGraphData.PatchNode]()
         var nativePatchValueTypeSettings = [CurrentAIGraphData.NativePatchNodeValueTypeSetting]()
-        
         var patchConnections = [CurrentAIGraphData.PatchConnection]()
-        var customPatchInputValues = [String: CurrentAIGraphData.CustomPatchInputValue]()
+        var customPatchInputValues = [CurrentAIGraphData.CustomPatchInputValue]()
         var preprocessedJSNodes = [CurrentAIGraphData.PreprocessedJSPatchNode]()
         
         // Because patch data is decoded before layer data, we don't yet know the destination ports for layer edges, therefore, we just track the source patch to some state variable
@@ -255,14 +253,12 @@ extension Dictionary where Key == String, Value == SwiftParserInitializerType {
             }
         }
         
-        // Third pass: derive custom node value types for native patch nodes
-        
         return .init(actions: AIGraphData_V0
             .PatchData(javascript_patches: preprocessedJSNodes,
                        native_patches: nativePatchNodes,
                        native_patch_value_type_settings: nativePatchValueTypeSettings,
                        patch_connections: patchConnections,
-                       custom_patch_input_values: Array(customPatchInputValues.values)),
+                       custom_patch_input_values: customPatchInputValues),
                      viewStatePatchConnections: viewStatePatchConnections,
                      caughtErrors: caughtErrors)
     }

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
@@ -138,9 +138,9 @@ extension SyntaxViewModifier {
             // Find first line of code with state mutation
             let mutatedStateVar = parsedCode.bindingDeclarations
                 .compactMap {
-                    switch $0.value {
+                    switch $0.1 {
                     case .stateMutation:
-                        return $0.key
+                        return $0.0
                     default:
                         return nil
                     }
@@ -269,7 +269,7 @@ extension SyntaxViewName {
                          args: ViewConstructorType?,
                          modifiers: [SyntaxViewModifier],
                          childrenLayers: [CurrentAIGraphData.LayerData],
-                         bindingDeclarations: [String : SwiftParserInitializerType]) throws -> LayerDerivationResult {
+                         bindingDeclarations: [(String, SwiftParserInitializerType)]) throws -> LayerDerivationResult {
         var silentErrors = [SwiftUISyntaxError]()
         var layerData: CurrentAIGraphData.LayerData
         let layerType: CurrentAIGraphData.Layer


### PR DESCRIPTION
This PR brings back custom node value type support from AI responses, this time in a programmatic fashion. Using custom input values and edge info we can discern the value type, given inputs which support custom value type changes.