### PR TITLE
`.overlay`, `.background`: handle views as arguments to view modifiers

### DIFF
--- a/Stitch/App/StitchApp.swift
+++ b/Stitch/App/StitchApp.swift
@@ -41,8 +41,8 @@ struct StitchApp: App {
         FirebaseApp.configure()
     }
 
-#if FAKE_FLAG
-//#if DEV_DEBUG
+//#if FAKE_FLAG
+#if DEV_DEBUG
     var body: some Scene {
         WindowGroup {
              ASTExplorerView()

--- a/Stitch/App/StitchApp.swift
+++ b/Stitch/App/StitchApp.swift
@@ -41,8 +41,8 @@ struct StitchApp: App {
         FirebaseApp.configure()
     }
 
-//#if FAKE_FLAG
-#if DEV_DEBUG
+#if FAKE_FLAG
+//#if DEV_DEBUG
     var body: some Scene {
         WindowGroup {
              ASTExplorerView()

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchUtil.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchUtil.swift
@@ -11,6 +11,23 @@ import SwiftSyntaxBuilder
 import SwiftUI
 
 extension SwiftUIViewVisitor {
+    /// Check if a type name represents a SwiftUI view
+    static func isSwiftUIViewType(_ typeName: String) -> Bool {
+        let swiftUIViews = [
+            "VStack", "HStack", "ZStack", "LazyVStack", "LazyHStack",
+            "ScrollView", "List", "NavigationView", "NavigationStack",
+            "TabView", "Group", "Section", "Form", "GeometryReader"
+        ]
+        return swiftUIViews.contains(typeName)
+    }
+    
+    /// Parse child views from a closure expression
+    static func parseViewsFromClosure(_ closure: ClosureExprSyntax) -> [SyntaxView] {
+        let visitor = SwiftUIViewVisitor(willParseView: true)
+        visitor.walk(closure)
+        return visitor.viewStack
+    }
+    
     // Parse arguments from function call
     static func parseArguments(from node: FunctionCallExprSyntax) throws -> ViewConstructorType {
         // Default handling for other modifiers
@@ -67,8 +84,23 @@ extension SwiftUIViewVisitor {
                                     eventModifiers: modifierClosures))
         }
         
+        // Check if this is a SwiftUI view with a trailing closure (like VStack, HStack, etc.)
+        let typeName = funcExpr.calledExpression.trimmedDescription
+        if isSwiftUIViewType(typeName), let trailingClosure = funcExpr.trailingClosure {
+            // This is a SwiftUI view with children - parse it as a proper view hierarchy
+            let childViews = parseViewsFromClosure(trailingClosure)
+            let syntaxView = SyntaxView(
+                name: typeName,
+                constructorArguments: complexTypeArgs.isEmpty ? nil : .other(complexTypeArgs),
+                modifiers: [],
+                children: childViews,
+                id: UUID()
+            )
+            return .view(syntaxView)
+        }
+        
         let complexType = SyntaxViewModifierComplexType(
-            typeName: funcExpr.calledExpression.trimmedDescription,
+            typeName: typeName,
             arguments: complexTypeArgs)
         
         return .complex(complexType)

--- a/Stitch/Graph/StitchAI/Mapping/CodeToVPL/Declarative/DeclarativeUtils.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToVPL/Declarative/DeclarativeUtils.swift
@@ -277,6 +277,10 @@ extension SyntaxViewModifierArgumentType {
             return nil
         case .viewEvent(let syntaxViewModifierViewEvent):
             return syntaxViewModifierViewEvent.eventConstructorArgs.compactMap { $0.value.firstMemberAccess }.first
+        
+        // TODO: does this even make sense with a view which is used as an argument ?
+        case .view(let view):
+            return nil
         }
     }
     

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxUtils.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxUtils.swift
@@ -55,6 +55,9 @@ extension SyntaxViewModifierArgumentType {
         
         case .viewEvent(let viewEvent):
             return "\(viewEvent)"
+        
+        case .view(let x):
+            return "\(x)"
         }
     }
 }
@@ -92,6 +95,10 @@ func describe(_ argType: SyntaxViewModifierArgumentType) -> String {
     
     case .viewEvent(let viewEvent):
         return viewEvent.eventName
+    
+    case .view(let view):
+        // TODO: revisit this?
+        return view.name
     }
 }
 

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
@@ -41,11 +41,11 @@ extension Array where Element == SyntaxViewModifier {
                 return [SyntaxView]()
             }
             
-            // Extract complex type arguments that represent views
+            // Extract view arguments from both complex types (old parsing) and view cases (new parsing)
             return args.compactMap { arg -> SyntaxView? in
                 switch arg.value {
                 case .complex(let complexType):
-                    // Convert complex type argument to SyntaxView
+                    // Handle old parsing that created complex types
                     return SyntaxView(
                         name: complexType.typeName,
                         constructorArguments: complexType.arguments.isEmpty ? nil : .other(complexType.arguments),
@@ -53,6 +53,9 @@ extension Array where Element == SyntaxViewModifier {
                         children: [],
                         id: UUID()
                     )
+                case .view(let syntaxView):
+                    // Handle new parsing that correctly creates view arguments
+                    return syntaxView
                 default:
                     return nil
                 }
@@ -68,11 +71,11 @@ extension Array where Element == SyntaxViewModifier {
                 return [SyntaxView]()
             }
             
-            // Extract complex type arguments that represent views
+            // Extract view arguments from both complex types (old parsing) and view cases (new parsing)
             return args.compactMap { arg -> SyntaxView? in
                 switch arg.value {
                 case .complex(let complexType):
-                    // Convert complex type argument to SyntaxView
+                    // Handle old parsing that created complex types
                     return SyntaxView(
                         name: complexType.typeName,
                         constructorArguments: complexType.arguments.isEmpty ? nil : .other(complexType.arguments),
@@ -80,6 +83,9 @@ extension Array where Element == SyntaxViewModifier {
                         children: [],
                         id: UUID()
                     )
+                case .view(let syntaxView):
+                    // Handle new parsing that correctly creates view arguments
+                    return syntaxView
                 default:
                     return nil
                 }
@@ -210,8 +216,8 @@ extension SyntaxViewModifierArgumentType {
             return [.closure(code)]
         case .viewEvent(let x):
             return []
-        case .view(_):
-            return []
+        case .view(let x):
+            return [.view(x)]
         }
     }
 }

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
@@ -155,6 +155,9 @@ indirect enum SyntaxViewModifierArgumentType: Sendable {
     case closure(SyntaxViewModifierClosureData)
     
     case viewEvent(SyntaxViewModifierViewEvent)
+    
+    // SwiftUI view with proper hierarchy (e.g. VStack with children in modifier argument)
+    case view(SyntaxView)
 }
 
 // Non-recursive sub-enum of `SyntaxViewModifierArgumentType` for when we are working in contexts where we have already flattened the nested argument-types like `tuple` and `array`
@@ -165,6 +168,7 @@ enum SyntaxViewModifierArgumentFlatType: Sendable {
     case memberAccess(MemberAccessExprSyntax)
     case closure(SyntaxViewModifierClosureData)
     case viewEvent(SyntaxViewModifierViewEvent)
+    case view(SyntaxView)
     
     var toSyntaxViewModifierArgumentType: SyntaxViewModifierArgumentType {
         switch self {
@@ -180,6 +184,8 @@ enum SyntaxViewModifierArgumentFlatType: Sendable {
             return .closure(x)
         case .viewEvent(let x):
             return .viewEvent(x)
+        case .view(let x):
+            return .view(x)
         }
     }
 }
@@ -203,6 +209,8 @@ extension SyntaxViewModifierArgumentType {
         case .closure(let code):
             return [.closure(code)]
         case .viewEvent(let x):
+            return []
+        case .view(_):
             return []
         }
     }
@@ -525,6 +533,8 @@ extension SyntaxViewModifierArgumentType {
         case .viewEvent:
             fatalError()
 //            return AnyEncodable(x)
+        case .view(_):
+            fatalError()
         }
     }
 }

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
@@ -884,7 +884,7 @@ extension SyntaxViewName {
         case .stateAccess(let varName):
             return [.stateRef(varName)]
             
-        case .memberAccess, .closure, .viewEvent:
+        case .memberAccess, .closure, .viewEvent, .view:
             throw SwiftUISyntaxError.portValueDecodingError(.portValueDecodingError(describe(argument)))
         }
     }

--- a/Stitch/Graph/StitchAI/Mapping/VPLToCode/PortValue/PortValueToCode.swift
+++ b/Stitch/Graph/StitchAI/Mapping/VPLToCode/PortValue/PortValueToCode.swift
@@ -209,6 +209,9 @@ func extractValueForPortValueDescription(_ arg: SyntaxViewModifierArgumentType) 
     case .viewEvent(let x):
         fatalErrorIfDebug()
         return ""
+    case .view(let x):
+        fatalErrorIfDebug()
+        return ""
     }
 }
 
@@ -310,6 +313,10 @@ func renderArgWithoutPortValueDescription(_ arg: SyntaxViewModifierArgumentType)
             \(viewEvent.eventName)(\(constructorArgsString))
             \(viewEventClosuresString)
             """
+    case .view(let view):
+        // What is this, actually?
+        fatalErrorIfDebug()
+        return "VIEW: \(view.name)"
     }
 }
 


### PR DESCRIPTION
We had been assuming that child views always came after curly-braces `{ }`;  
but an argument to a view modifier can itself be a view, not just a value or param+value.


<img width="1414" height="845" alt="Screenshot 2025-09-10 at 5 15 33 PM" src="https://github.com/user-attachments/assets/e136df66-a1f6-4256-9c84-2d8d6c7ebe85" />
<img width="1413" height="857" alt="Screenshot 2025-09-10 at 5 07 17 PM" src="https://github.com/user-attachments/assets/1251e8aa-8523-485c-8bdc-ea2b5d6dd8e0" />
<img width="1398" height="845" alt="Screenshot 2025-09-10 at 5 07 04 PM" src="https://github.com/user-attachments/assets/67266e32-67d2-42e8-aa8f-a0f930f76ff2" />
<img width="1422" height="849" alt="Screenshot 2025-09-10 at 5 06 39 PM" src="https://github.com/user-attachments/assets/91a6ed51-a1e7-43be-a20c-7ab2f6a425c8" />
<img width="1411" height="836" alt="Screenshot 2025-09-10 at 5 05 49 PM" src="https://github.com/user-attachments/assets/cb832a18-59e1-4ca0-84ec-d7132dbc7b87" />
