### PR TITLE
Properly handle view modifiers on a view that is an arguments to view  modifier (e.g. .overlay, .background)

### DIFF
--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchUtil.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchUtil.swift
@@ -16,9 +16,20 @@ extension SwiftUIViewVisitor {
         let swiftUIViews = [
             "VStack", "HStack", "ZStack", "LazyVStack", "LazyHStack",
             "ScrollView", "List", "NavigationView", "NavigationStack",
-            "TabView", "Group", "Section", "Form", "GeometryReader"
+            "TabView", "Group", "Section", "Form", "GeometryReader",
+            "Text", "Image", "Button", "Rectangle", "Circle", "Ellipse"
         ]
         return swiftUIViews.contains(typeName)
+    }
+    
+    /// Check if a type name represents a SwiftUI event/gesture (not a regular view)
+    static func isViewEventType(_ typeName: String) -> Bool {
+        let eventTypes = [
+            "TapGesture", "LongPressGesture", "PanGesture", "DragGesture",
+            "MagnificationGesture", "RotationGesture", "ExclusiveGesture",
+            "SimultaneousGesture", "SequenceGesture"
+        ]
+        return eventTypes.contains(typeName)
     }
     
     /// Parse child views from a closure expression
@@ -26,6 +37,13 @@ extension SwiftUIViewVisitor {
         let visitor = SwiftUIViewVisitor(willParseView: true)
         visitor.walk(closure)
         return visitor.viewStack
+    }
+    
+    /// Parse a single view expression using the existing SwiftUIViewVisitor
+    static func parseViewFromExpression(_ funcExpr: FunctionCallExprSyntax) -> SyntaxView? {
+        let visitor = SwiftUIViewVisitor(willParseView: true)
+        visitor.walk(funcExpr)
+        return visitor.viewStack.first
     }
     
     // Parse arguments from function call
@@ -71,8 +89,10 @@ extension SwiftUIViewVisitor {
                 try Self.parseArgument(expr)
             }
         
+        // Check if this is an actual event/gesture (not a regular view)
         if let memberAccessExpr = funcExpr.calledExpression.as(MemberAccessExprSyntax.self),
-           let viewEventName = funcExpr.getViewEventName() {
+           let viewEventName = funcExpr.getViewEventName(),
+           isViewEventType(viewEventName) {
             
             var modifierClosures = [String: SyntaxViewModifierClosureData]()
             try funcExpr.reduceModifierClosureData(funcExpr: funcExpr,
@@ -82,6 +102,17 @@ extension SwiftUIViewVisitor {
             return .viewEvent(.init(eventName: viewEventName,
                                     eventConstructorArgs: complexTypeArgs,
                                     eventModifiers: modifierClosures))
+        }
+        
+        // Check if this is a regular SwiftUI view with modifiers
+        if let memberAccessExpr = funcExpr.calledExpression.as(MemberAccessExprSyntax.self),
+           let baseViewName = funcExpr.getViewEventName(),
+           isSwiftUIViewType(baseViewName) {
+            
+            // Use existing SwiftUIViewVisitor to parse the entire expression properly
+            if let syntaxView = parseViewFromExpression(funcExpr) {
+                return .view(syntaxView)
+            }
         }
         
         // Check if this is a SwiftUI view with a trailing closure (like VStack, HStack, etc.)

--- a/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/BackgroundExamples.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/BackgroundExamples.swift
@@ -80,4 +80,29 @@ Rectangle()
     }
 """
     )
+    
+    // New background examples with modifiers - testing the fix for Text with .foregroundColor
+    static let backgroundTextWithForegroundColor = MappingCodeExample(
+        title: "Background Text with ForegroundColor",
+        code: """
+        Ellipse()
+            .background(
+                Text("A")
+                    .foregroundColor(.blue)
+            )
+        """
+    )
+    
+    static let backgroundVStackWithModifiers = MappingCodeExample(
+        title: "Background VStack with Frame Modifier",
+        code: """
+        Ellipse()
+            .background(
+                VStack {
+                    Text("A")
+                        .foregroundColor(.blue)
+                }.frame(width: 100, height: 200)
+            )
+        """
+    )
 }

--- a/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/CodeExamples.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/CodeExamples.swift
@@ -38,6 +38,10 @@ extension MappingExamples {
         BackgroundCodeExamples.complexBackgroundWithModifiers,
         BackgroundCodeExamples.nestedBackground,
         
+        // New background examples with modifiers - testing the fix for view modifier parsing
+        BackgroundCodeExamples.backgroundTextWithForegroundColor,
+        BackgroundCodeExamples.backgroundVStackWithModifiers,
+        
         // Overlay examples - testing overlay to ZStack transformation
         OverlayCodeExamples.simpleOverlayFunctionCall,
         OverlayCodeExamples.simpleOverlayClosure,
@@ -45,6 +49,13 @@ extension MappingExamples {
         OverlayCodeExamples.vstackOverlay,
         OverlayCodeExamples.complexOverlayWithModifiers,
         OverlayCodeExamples.nestedOverlay,
+        
+        // New overlay examples with modifiers - testing the fix for view modifier parsing
+        OverlayCodeExamples.overlayTextWithForegroundColor,
+        OverlayCodeExamples.overlayVStackWithModifiers,
+        OverlayCodeExamples.overlayTextWithPortValueDescription,
+        OverlayCodeExamples.overlayWithFrameModifier,
+        OverlayCodeExamples.overlayWithClosureSyntax,
                 
         // OLDER
         ViewModifierCodeExamples.colorInitInFillModifier,

--- a/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/OverlayExamples.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/OverlayExamples.swift
@@ -79,4 +79,64 @@ struct OverlayCodeExamples {
             }
         """
     )
+    
+    // New overlay examples with modifiers - testing the fix for Text with .foregroundColor
+    static let overlayTextWithForegroundColor = MappingCodeExample(
+        title: "Overlay Text with ForegroundColor",
+        code: """
+        Ellipse()
+            .overlay(
+                Text("A")
+                    .foregroundColor(.blue)
+            )
+        """
+    )
+    
+    static let overlayVStackWithModifiers = MappingCodeExample(
+        title: "Overlay VStack with Frame Modifier",
+        code: """
+        Ellipse()
+            .overlay(
+                VStack {
+                    Text("A")
+                        .foregroundColor(.blue)
+                }.frame(width: 100, height: 200)
+            )
+        """
+    )
+    
+    static let overlayTextWithPortValueDescription = MappingCodeExample(
+        title: "Overlay Text with PortValueDescription",
+        code: """
+        Ellipse()
+            .overlay(
+                Text([PortValueDescription(value: "*", value_type: "string")])
+                    .foregroundColor([PortValueDescription(value: "#000000FF", value_type: "color")])
+            )
+        """
+    )
+    
+    static let overlayWithFrameModifier = MappingCodeExample(
+        title: "Overlay with Frame on Base View",
+        code: """
+        Ellipse()
+            .overlay(
+                Text("A")
+                    .foregroundColor(.blue)
+            )
+            .frame(width: 100, height: 200)
+        """
+    )
+    
+    static let overlayWithClosureSyntax = MappingCodeExample(
+        title: "Overlay with Closure Syntax",
+        code: """
+        Ellipse()
+            .overlay {
+                Text("A")
+                    .foregroundColor(.blue)
+            }
+            .frame(width: 100, height: 200)
+        """
+    )
 }


### PR DESCRIPTION
resolves https://github.com/StitchDesign/Stitch--Old/issues/7460

handles cases like: 

```swift
Ellipse()
	.background(
		Text("A")
			.foregroundColor(.blue)
    )
```


```swift
Ellipse()
	.overlay(
		Text("A")
			.foregroundColor(.blue)
    )
```

```swift
Ellipse()
	.overlay(
		Text([PortValueDescription(value: "*", value_type: "string")])
			.foregroundColor([PortValueDescription(value: "#000000FF", value_type: "color")])
    )
```

```swift
Ellipse()
	.overlay(
		Text("A")
			.foregroundColor(.blue)
    )
	.frame(width: 100, height: 200)
```



