### PR TITLE
Fix static inputs we missed when migrating the remaining patches to new patch-node definition style

### DIFF
--- a/Stitch/Graph/Node/Patch/Type/ConvertPositionNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/ConvertPositionNode.swift
@@ -15,27 +15,34 @@ struct ConvertPositionPatchNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = nil
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? .position
+        let defaultValue = effectiveType.defaultPortValue
+
+        return .init(
             inputs: [
                 .init(
                     defaultValues: [.assignedLayer(nil)],
-                    label: "From Parent"
+                    label: "From Parent",
+                    isTypeStatic: true
                 ),
                 .init(
                     defaultValues: [.anchoring(.defaultAnchoring)],
-                    label: "From Anchor"
+                    label: "From Anchor",
+                    isTypeStatic: true
                 ),
                 .init(
-                    defaultValues: [.position(StitchPosition.zero)],
+                    defaultValues: [defaultValue],
                     label: "Point"
                 ),
                 .init(
                     defaultValues: [.assignedLayer(nil)],
-                    label: "To Parent"
+                    label: "To Parent",
+                    isTypeStatic: true
                 ),
                 .init(
                     defaultValues: [.anchoring(.defaultAnchoring)],
-                    label: "To Anchor"
+                    label: "To Anchor",
+                    isTypeStatic: true
                 )
             ],
             outputs: [

--- a/Stitch/Graph/Node/Patch/Type/Data/IndexOf.swift
+++ b/Stitch/Graph/Node/Patch/Type/Data/IndexOf.swift
@@ -19,7 +19,8 @@ struct IndexOfPatchNode: PatchNodeDefinition {
             inputs: [
                 .init(
                     defaultValues: [.json(emptyStitchJSONObject)],
-                    label: "Array"
+                    label: "Array",
+                    isTypeStatic: true
                 ),
                 .init(
                     defaultValues: [.string(.init(""))],

--- a/Stitch/Graph/Node/Patch/Type/Data/SetValueForKeyNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Data/SetValueForKeyNode.swift
@@ -19,11 +19,13 @@ struct SetValueForKeyPatchNode: PatchNodeDefinition {
             inputs: [
                 .init(
                     defaultValues: [.json(emptyStitchJSONObject)],
-                    label: "Object"
+                    label: "Object",
+                    isTypeStatic: true
                 ),
                 .init(
                     defaultValues: [.string(.init(""))],
-                    label: "Key"
+                    label: "Key",
+                    isTypeStatic: true
                 ),
                 .init(
                     defaultValues: [numberDefaultFalse],

--- a/Stitch/Graph/Node/Patch/Type/Logic/AndNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Logic/AndNode.swift
@@ -14,14 +14,17 @@ struct AndPatchNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = nil
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? .bool
+        let defaultValue = effectiveType.defaultPortValue
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [.bool(false)],
+                    defaultValues: [defaultValue],
                     label: ""
                 ),
                 .init(
-                    defaultValues: [.bool(false)],
+                    defaultValues: [defaultValue],
                     label: ""
                 )
             ],

--- a/Stitch/Graph/Node/Patch/Type/Logic/EqualsExactly.swift
+++ b/Stitch/Graph/Node/Patch/Type/Logic/EqualsExactly.swift
@@ -11,17 +11,20 @@ import StitchSchemaKit
 
 struct EqualsExactlyPatchNode: PatchNodeDefinition {
     static let patch = Patch.equalsExactly
-    static let defaultUserVisibleType: UserVisibleType? = .number
+    static let defaultUserVisibleType: UserVisibleType? = nil
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? .number
+        let defaultValue = effectiveType.defaultPortValue
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [defaultValue],
                     label: ""
                 ),
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [defaultValue],
                     label: ""
                 )
             ],

--- a/Stitch/Graph/Node/Patch/Type/Logic/NotNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Logic/NotNode.swift
@@ -14,10 +14,13 @@ struct NotPatchNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = nil
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? .bool
+        let defaultValue = effectiveType.defaultPortValue
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [.bool(false)],
+                    defaultValues: [defaultValue],
                     label: ""
                 )
             ],

--- a/Stitch/Graph/Node/Patch/Type/Logic/OrNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Logic/OrNode.swift
@@ -14,14 +14,17 @@ struct OrPatchNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = nil
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? .bool
+        let defaultValue = effectiveType.defaultPortValue
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [.bool(false)],
+                    defaultValues: [defaultValue],
                     label: ""
                 ),
                 .init(
-                    defaultValues: [.bool(false)],
+                    defaultValues: [defaultValue],
                     label: ""
                 )
             ],

--- a/Stitch/Graph/Node/Patch/Type/Loop/AnyPatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Loop/AnyPatchNode.swift
@@ -13,10 +13,13 @@ struct AnyPatchNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = nil
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? .bool
+        let defaultValue = effectiveType.defaultPortValue
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [boolDefaultFalse],
+                    defaultValues: [defaultValue],
                     label: "Loop"
                 ),
                 .init(

--- a/Stitch/Graph/Node/Patch/Type/Loop/LoopCountNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Loop/LoopCountNode.swift
@@ -13,10 +13,13 @@ struct LoopCountPatchNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = nil
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? .number
+        let defaultValue = effectiveType.defaultPortValue
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [defaultValue],
                     label: "Loop"
                 )
             ],

--- a/Stitch/Graph/Node/Patch/Type/Loop/LoopDedupeNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Loop/LoopDedupeNode.swift
@@ -13,17 +13,20 @@ struct LoopDedupePatchNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = .number
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? .number
+        let defaultValue = effectiveType.defaultPortValue
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [defaultValue],
                     label: "Loop"
                 )
             ],
             outputs: [
                 .init(
                     label: "Loop",
-                    type: type ?? .number
+                    type: effectiveType
                 ),
                 .init(
                     label: "Index",

--- a/Stitch/Graph/Node/Patch/Type/Loop/LoopFilterNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Loop/LoopFilterNode.swift
@@ -14,21 +14,25 @@ struct LoopFilterPatchNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = .string
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? .string
+        let defaultValue = effectiveType.defaultPortValue
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [.string(.init(""))],
+                    defaultValues: [defaultValue],
                     label: "Input"
                 ),
                 .init(
                     defaultValues: [.number(1)],
-                    label: "Include"
+                    label: "Include",
+                    isTypeStatic: true
                 )
             ],
             outputs: [
                 .init(
                     label: "Loop",
-                    type: type ?? .string
+                    type: effectiveType
                 ),
                 .init(
                     label: "Index",
@@ -53,17 +57,17 @@ func loopFilterEval(inputs: PortValuesList,
     let extendedIncludeLoop = lengthenArray(loop: includeLoop,
                                             length: longestLoopLength)
 
-    //    log("loopFilterEval: inputLoop: \(inputLoop)")
-    //    log("loopFilterEval: includeLoop: \(includeLoop)")
-    //    log("loopFilterEval: longestLoopLength: \(longestLoopLength)")
-    //    log("loopFilterEval: extendedInputLoop: \(extendedInputLoop)")
-    //    log("loopFilterEval: extendedIncludeLoop: \(extendedIncludeLoop)")
+    log("loopFilterEval: inputLoop: \(inputLoop)")
+    log("loopFilterEval: includeLoop: \(includeLoop)")
+    log("loopFilterEval: longestLoopLength: \(longestLoopLength)")
+    log("loopFilterEval: extendedInputLoop: \(extendedInputLoop)")
+    log("loopFilterEval: extendedIncludeLoop: \(extendedIncludeLoop)")
 
     let result = loopFilter(input: extendedInputLoop,
                             include: extendedIncludeLoop,
                             originalInputLoopLength: inputLoop.count)
 
-    //    log("loopFilterEval: result: \(result)")
+    log("loopFilterEval: result: \(result)")
 
     // If the result is empty, then we should return a default false result.
     if result.isEmpty,

--- a/Stitch/Graph/Node/Patch/Type/Loop/LoopFilterNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Loop/LoopFilterNode.swift
@@ -57,17 +57,17 @@ func loopFilterEval(inputs: PortValuesList,
     let extendedIncludeLoop = lengthenArray(loop: includeLoop,
                                             length: longestLoopLength)
 
-    log("loopFilterEval: inputLoop: \(inputLoop)")
-    log("loopFilterEval: includeLoop: \(includeLoop)")
-    log("loopFilterEval: longestLoopLength: \(longestLoopLength)")
-    log("loopFilterEval: extendedInputLoop: \(extendedInputLoop)")
-    log("loopFilterEval: extendedIncludeLoop: \(extendedIncludeLoop)")
+    // log("loopFilterEval: inputLoop: \(inputLoop)")
+    // log("loopFilterEval: includeLoop: \(includeLoop)")
+    // log("loopFilterEval: longestLoopLength: \(longestLoopLength)")
+    // log("loopFilterEval: extendedInputLoop: \(extendedInputLoop)")
+    // log("loopFilterEval: extendedIncludeLoop: \(extendedIncludeLoop)")
 
     let result = loopFilter(input: extendedInputLoop,
                             include: extendedIncludeLoop,
                             originalInputLoopLength: inputLoop.count)
 
-    log("loopFilterEval: result: \(result)")
+    // log("loopFilterEval: result: \(result)")
 
     // If the result is empty, then we should return a default false result.
     if result.isEmpty,

--- a/Stitch/Graph/Node/Patch/Type/Loop/LoopReverseNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Loop/LoopReverseNode.swift
@@ -13,17 +13,20 @@ struct LoopReversePatchNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = .number
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? .number
+        let defaultValue = effectiveType.defaultPortValue
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [defaultValue],
                     label: "Loop"
                 )
             ],
             outputs: [
                 .init(
                     label: "",
-                    type: type ?? .number
+                    type: effectiveType
                 )
             ]
         )

--- a/Stitch/Graph/Node/Patch/Type/Loop/LoopSumNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Loop/LoopSumNode.swift
@@ -13,10 +13,13 @@ struct LoopSumPatchNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = nil
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? .number
+        let defaultValue = effectiveType.defaultPortValue
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [defaultValue],
                     label: "Loop"
                 )
             ],

--- a/Stitch/Graph/Node/Patch/Type/Loop/LoopToArrayNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Loop/LoopToArrayNode.swift
@@ -14,10 +14,13 @@ struct LoopToArrayPatchNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = .number
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? .number
+        let defaultValue = effectiveType.defaultPortValue
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [defaultValue],
                     label: "Loop"
                 )
             ],

--- a/Stitch/Graph/Node/Patch/Type/Loop/RunningTotalNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Loop/RunningTotalNode.swift
@@ -13,10 +13,13 @@ struct RunningTotalPatchNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = nil
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? .number
+        let defaultValue = effectiveType.defaultPortValue
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [defaultValue],
                     label: "Loop"
                 )
             ],

--- a/Stitch/Graph/Node/Patch/Type/Math/AddNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Math/AddNode.swift
@@ -16,14 +16,17 @@ struct AddPatchNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = .number
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? .number
+        let defaultValue = effectiveType.defaultPortValue
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [defaultValue],
                     label: ""
                 ),
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [defaultValue],
                     label: ""
                 )
             ],

--- a/Stitch/Graph/Node/Patch/Type/Math/DivideNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Math/DivideNode.swift
@@ -16,14 +16,17 @@ struct DividePatchNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = .number
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? .number
+        let defaultValue = effectiveType.defaultPortValue
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [defaultValue],
                     label: ""
                 ),
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [defaultValue],
                     label: ""
                 )
             ],

--- a/Stitch/Graph/Node/Patch/Type/Math/MultiplyNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Math/MultiplyNode.swift
@@ -16,14 +16,17 @@ struct MultiplyPatchNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = .number
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? .number
+        let defaultValue = effectiveType.defaultPortValue
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [defaultValue],
                     label: ""
                 ),
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [defaultValue],
                     label: ""
                 )
             ],

--- a/Stitch/Graph/Node/Patch/Type/Math/RoundNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Math/RoundNode.swift
@@ -29,7 +29,8 @@ struct RoundPatchNode: PatchNodeDefinition {
                 ),
                 .init(
                     defaultValues: [.bool(false)],
-                    label: "Rounded Up"
+                    label: "Rounded Up",
+                    isTypeStatic: true
                 )
             ],
             outputs: [

--- a/Stitch/Graph/Node/Patch/Type/Math/SubtractNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Math/SubtractNode.swift
@@ -16,14 +16,17 @@ struct SubtractPatchNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = .number
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? .number
+        let defaultValue = effectiveType.defaultPortValue
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [defaultValue],
                     label: ""
                 ),
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [defaultValue],
                     label: ""
                 )
             ],

--- a/Stitch/Graph/Node/Patch/Type/OptionEqualsNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/OptionEqualsNode.swift
@@ -18,7 +18,8 @@ struct OptionEqualsPatchNode: PatchNodeDefinition {
             inputs: [
                 .init(
                     defaultValues: [.string(.init("a"))],
-                    label: "Option"
+                    label: "Option",
+                    isTypeStatic: true
                 ),
                 .init(
                     defaultValues: [.string(.init("a"))],

--- a/Stitch/Graph/Node/Patch/Type/OptionPickerNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/OptionPickerNode.swift
@@ -17,7 +17,10 @@ struct OptionPickerPatchNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = .number
     
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? .number
+        let defaultValue = effectiveType.defaultPortValue
+
+        return .init(
             inputs: [
                 .init(
                     defaultValues: [.number(0)],
@@ -25,18 +28,18 @@ struct OptionPickerPatchNode: PatchNodeDefinition {
                     isTypeStatic: true
                 ),
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [defaultValue],
                     label: ""
                 ),
                 .init(
-                    defaultValues: [.number(1)],
+                    defaultValues: [defaultValue],
                     label: ""
                 )
             ],
             outputs: [
                 .init(
                     label: "",
-                    type: .number
+                    type: effectiveType
                 )
             ]
         )

--- a/Stitch/Graph/Node/Patch/Type/OptionSenderNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/OptionSenderNode.swift
@@ -17,7 +17,8 @@ struct OptionSenderPatchNode: PatchNodeDefinition {
             inputs: [
                 .init(
                     defaultValues: [numberDefaultFalse],
-                    label: "Option"
+                    label: "Option",
+                    isTypeStatic: true
                 ),
                 .init(
                     defaultValues: [numberDefaultFalse],

--- a/Stitch/Graph/Node/Patch/Type/Text/SplitTextNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Text/SplitTextNode.swift
@@ -13,14 +13,17 @@ struct SplitTextPatchNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = nil
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? .string
+        let defaultValue = effectiveType.defaultPortValue
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [.string(.init(""))],
+                    defaultValues: [defaultValue],
                     label: "Text"
                 ),
                 .init(
-                    defaultValues: [.string(.init(""))],
+                    defaultValues: [defaultValue],
                     label: "Token"
                 )
             ],

--- a/Stitch/Graph/Node/Patch/Type/Text/TextReplaceNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Text/TextReplaceNode.swift
@@ -13,23 +13,27 @@ struct TextReplacePatchNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = nil
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? .string
+        let defaultValue = effectiveType.defaultPortValue
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [.string(.init(""))],
+                    defaultValues: [defaultValue],
                     label: "Text"
                 ),
                 .init(
-                    defaultValues: [.string(.init(""))],
+                    defaultValues: [defaultValue],
                     label: "Find"
                 ),
                 .init(
-                    defaultValues: [.string(.init(""))],
+                    defaultValues: [defaultValue],
                     label: "Replace"
                 ),
                 .init(
                     defaultValues: [.bool(false)],
-                    label: "Case Sensitive"
+                    label: "Case Sensitive",
+                    isTypeStatic: true
                 )
             ],
             outputs: [

--- a/Stitch/Graph/Node/Patch/Type/Value/SplitterPatchNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Value/SplitterPatchNode.swift
@@ -17,17 +17,20 @@ struct SplitterPatchNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = .number
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? .number
+        let defaultValue = effectiveType.defaultPortValue
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [defaultValue],
                     label: ""
                 )
             ],
             outputs: [
                 .init(
                     label: "",
-                    type: type ?? .number
+                    type: effectiveType
                 )
             ]
         )

--- a/Stitch/Graph/Node/Patch/Type/WirelessBroadcasterNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/WirelessBroadcasterNode.swift
@@ -15,17 +15,20 @@ struct WirelessBroadcasterPatchNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = .number
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? .number
+        let defaultValue = effectiveType.defaultPortValue
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [defaultValue],
                     label: ""
                 )
             ],
             outputs: [
                 .init(
                     label: "",
-                    type: type ?? .number
+                    type: effectiveType
                 )
             ]
         )

--- a/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
+++ b/Stitch/Graph/Node/Patch/ViewModel/PatchNodeViewModel.swift
@@ -56,22 +56,26 @@ final class PatchNodeViewModel: Sendable {
     @MainActor
     init(from schema: PatchNodeEntity) {
         let kind = NodeKind.patch(schema.patch)
-        
+
+        // Get the patch's default type as fallback for loading from schema
+        let patchGraphNode = PatchOrLayer.patch(schema.patch).graphNode
+        let effectiveUserVisibleType = schema.userVisibleType ?? patchGraphNode.defaultUserVisibleType
+
         self.id = schema.id
         self.patch = schema.patch
-        self.userVisibleType = schema.userVisibleType
+        self.userVisibleType = effectiveUserVisibleType
         self.mathExpression = schema.mathExpression
         self.splitterNode = schema.splitterNode
-        
+
         // Create initial inputs and outputs using default data
         let rowDefinitions = PatchOrLayer.patch(schema.patch)
-            .rowDefinitions(for: schema.userVisibleType)
+            .rowDefinitions(for: effectiveUserVisibleType)
         
         // Must set inputs before calling eval below
         let inputsObservers = schema.inputs
             .createInputObservers(nodeId: schema.id,
                                   kind: kind,
-                                  userVisibleType: schema.userVisibleType)
+                                  userVisibleType: effectiveUserVisibleType)
 
         let outputsObservers = rowDefinitions
             .createEmptyOutputObservers(nodeId: schema.id)

--- a/Stitch/Graph/Node/Util/NodeViewModelUtils.swift
+++ b/Stitch/Graph/Node/Util/NodeViewModelUtils.swift
@@ -17,8 +17,8 @@ extension NodeViewModel {
                                         parentGroupNodeId: GroupNodeId? = nil,
                                         graphDelegate: GraphState?) {
         let kind = T.graphKind.kind
-        let userVisibleType = kind.graphNode.graphKind.patch?.defaultUserVisibleType
-        
+        let userVisibleType = T.defaultUserVisibleType
+
         let defaultInputs = kind.rowDefinitions(for: userVisibleType).inputs
             .enumerated()
             .map { portId, inputData in


### PR DESCRIPTION
Also tries to use the default node type to retrieve the default value for an input, except in cases where we purposefully chose a non-default value. (Might be redundant given our input-type-change logic?)