### PR TITLE
Improved layer unpacking logic + padding fix

### DIFF
--- a/Stitch/App/StitchApp.swift
+++ b/Stitch/App/StitchApp.swift
@@ -41,8 +41,8 @@ struct StitchApp: App {
         FirebaseApp.configure()
     }
 
-#if FAKE_FLAG
-//#if DEV_DEBUG
+//#if FAKE_FLAG
+#if DEV_DEBUG
     var body: some Scene {
         WindowGroup {
              ASTExplorerView()

--- a/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
+++ b/Stitch/Graph/Node/Layer/Model/LayerNodeData.swift
@@ -253,7 +253,11 @@ extension LayerInputObserver {
     func update(from schema: LayerInputEntity,
                 layerInputType: LayerInputPort,
                 layerNode: LayerNodeViewModel,
-                nodeId: NodeId) {        
+                nodeId: NodeId) {
+        if self.port == .layerPadding {
+            log("HI")
+        }
+        
         let portObserver = layerNode[keyPath: layerInputType.layerNodeKeyPath]
         let unpackedObservers = portObserver._unpackedData.allPorts
         

--- a/Stitch/Graph/StitchAI/Mapping/CodeToVPL/Declarative/DeclarativeViewConstructors.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToVPL/Declarative/DeclarativeViewConstructors.swift
@@ -1923,7 +1923,7 @@ struct FrameViewModifier: PortValuesPackModifiable {
     static let layerInputPort = LayerInputPort.size
     static let nodeType = NodeType.size
     
-    let args: [SyntaxViewModifierArgumentType]
+    let args: [SyntaxViewArgumentData]
 }
 
 // MARK: - Color View Modifiers
@@ -2090,77 +2090,23 @@ struct PositionViewModifier: PortValuesPackModifiable {
     static let layerInputPort = LayerInputPort.position
     static let nodeType = NodeType.position
     
-    let args: [SyntaxViewModifierArgumentType]
+    let args: [SyntaxViewArgumentData]
 }
 
 struct OffsetViewModifier: PortValuesPackModifiable {
     static let layerInputPort = LayerInputPort.position
     static let nodeType = NodeType.position
     
-    let args: [SyntaxViewModifierArgumentType]
+    let args: [SyntaxViewArgumentData]
 }
 
 // MARK: - Layout View Modifiers
 
-struct PaddingViewModifier: FromSwiftUIViewModifierToStitch {
-    let edges: SyntaxViewModifierArgumentType?
-    let length: SyntaxViewModifierArgumentType?
+struct PaddingViewModifier: PortValuesPackModifiable {
+    static let layerInputPort: LayerInputPort = .layerPadding
+    static let nodeType: NodeType = .padding
     
-    func createCustomValueEvents() throws -> [LayerPortDerivation] {
-        // For now, handle uniform padding only
-        guard let length = length else {
-            return [
-                LayerPortDerivation(
-                    input: .padding,
-                    value: .padding(StitchPadding(
-                        top: 16,
-                        right: 16,
-                        bottom: 16,
-                        left: 16
-                    ))
-                )
-            ]
-        }
-        
-        guard let lengthPortValue = try length.derivePortValues().first?.value,
-              let paddingValue: StitchPadding = lengthPortValue.getPadding else {
-            throw SwiftUISyntaxError.portValueNotFound(argument: length)
-        }
-   
-        return [LayerPortDerivation(input: .padding,
-                                    value: .padding(paddingValue))]
-    }
-    
-    static func from(_ arguments: [SyntaxViewArgumentData],
-                     modifierName: SyntaxViewModifierName) -> PaddingViewModifier? {
-        var edges: SyntaxViewModifierArgumentType?
-        var length: SyntaxViewModifierArgumentType?
-        
-        for arg in arguments {
-            switch arg.label {
-            case "edges", nil where edges == nil:
-                edges = arg.value
-            case "length", nil where length == nil:
-                length = arg.value
-            default: break
-            }
-        }
-        
-        // Handle .padding() with no arguments - uniform 16pt padding
-        if arguments.isEmpty {
-            let defaultPadding = SyntaxViewModifierArgumentType.simple(
-                SyntaxViewSimpleData(value: "16", syntaxKind: .literal(.float))
-            )
-            return PaddingViewModifier(edges: nil, length: defaultPadding)
-        }
-        
-        // Handle .padding(X) - uniform X padding
-        if arguments.count == 1 && arguments.first?.label == nil {
-            length = arguments.first?.value
-        }
-        
-        return PaddingViewModifier(edges: edges, length: length)
-    }
+    let args: [SyntaxViewArgumentData]
 }
 
 struct ClippedViewModifier: FromSwiftUIViewModifierToStitch {
@@ -2661,7 +2607,7 @@ func createKnownViewModifier(modifierName: SyntaxViewModifierName,
         return CornerRadiusViewModifier.from(arguments, modifierName: modifierName)
             .map { .cornerRadius($0) }
     case .frame:
-        return FrameViewModifier.from(arguments, modifierName: modifierName)
+        return FrameViewModifier.from(arguments)
             .map { .frame($0) }
     case .foregroundColor:
         return ForegroundColorViewModifier.from(arguments, modifierName: modifierName)
@@ -2685,13 +2631,13 @@ func createKnownViewModifier(modifierName: SyntaxViewModifierName,
         return ColorInvertViewModifier.from(arguments, modifierName: modifierName)
             .map { .colorInvert($0) }
     case .position:
-        return PositionViewModifier.from(arguments, modifierName: modifierName)
+        return PositionViewModifier.from(arguments)
             .map { .position($0) }
     case .offset:
-        return OffsetViewModifier.from(arguments, modifierName: modifierName)
+        return OffsetViewModifier.from(arguments)
             .map { .offset($0) }
     case .padding:
-        return PaddingViewModifier.from(arguments, modifierName: modifierName)
+        return PaddingViewModifier.from(arguments)
             .map { .padding($0) }
     case .clipped:
         return ClippedViewModifier.from(arguments, modifierName: modifierName)

--- a/Stitch/Graph/StitchAI/Mapping/CodeToVPL/Declarative/SwiftUItoStitch.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToVPL/Declarative/SwiftUItoStitch.swift
@@ -36,17 +36,19 @@ protocol PortValuesPackModifiable: FromSwiftUIViewModifierToStitch {
     
     static var nodeType: NodeType { get }
     
-    init(args: [SyntaxViewModifierArgumentType])
+    init(args: [SyntaxViewArgumentData])
     
-    var args: [SyntaxViewModifierArgumentType] { get }
+    var args: [SyntaxViewArgumentData] { get }
 }
 
 extension PortValuesPackModifiable {
     func createCustomValueEvents() throws -> [LayerPortDerivation] {
-        // Handle each argument argument
-        let layerPortEvents: [PatchSyntaxResultType] = try self.args.flatMap {
-            try $0.derivePortValues()
-        }
+        // Reorder arguments to match layer unpack ordering
+        let layerPortEvents = try self.args
+            .reorderUnapckedValues(varName: nil,
+                                   viewEvent: nil,
+                                   nodesDict: [:],
+                                   nodeType: Self.nodeType)
         
         let parsedValues = layerPortEvents.compactMap { event -> PortValue? in
             guard let value = event.portData?.values?.first else { return nil }
@@ -82,9 +84,14 @@ extension PortValuesPackModifiable {
                   value: packedValue)
         ]
     }
+
+    static func from(_ arguments: [SyntaxViewArgumentData]) -> Self? {
+        self.init(args: arguments)
+    }
     
+    // Required for protocol
     static func from(_ arguments: [SyntaxViewArgumentData],
                      modifierName: SyntaxViewModifierName) -> Self? {
-        self.init(args: arguments.map(\.value))
+        self.init(args: arguments)
     }
 }

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/SyntaxToActionsUtils.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/SyntaxToActionsUtils.swift
@@ -96,6 +96,11 @@ func deterministicUUID(from name: String) -> UUID {
 
 extension NodeType {
     func reorganizePortValueArgs(valuesMap: OrderedDictionary<String, [PatchSyntaxResultType]>) -> [PatchSyntaxResultType] {
+        let defaultOrder = valuesMap.flatMap { $0.value }
+        
+        // Ignore if any keys are empty
+        guard !valuesMap.keys.contains("") else { return defaultOrder }
+        
         switch self {
         case .position:
             guard let xValue = valuesMap["x"],
@@ -113,11 +118,49 @@ extension NodeType {
             
             return widthValue + heightValue
             
+        case .padding:
+            guard let top = valuesMap["top"],
+                  let right = valuesMap["right"],
+                  let bottom = valuesMap["bottom"],
+                  let left = valuesMap["left"] else {
+                break
+            }
+             
+            return top + right + bottom + left
+            
         default:
+            fatalError("Please fill in types we aren't supporting here!")
             break
         }
         
         // Backup just returns list in order
-        return valuesMap.flatMap { $0.value }
+        return defaultOrder
+    }
+}
+
+extension Array where Element == SyntaxViewArgumentData {
+    func reorderUnapckedValues(varName: String?,
+                               viewEvent: SyntaxViewEvent?,
+                               nodesDict: [UUID: NodeEntity],
+                               nodeType: NodeType? = nil) throws -> [PatchSyntaxResultType] {
+        // Recursively determine PortValue of each arg for key label
+        let orderedDict = OrderedDictionary<String, [PatchSyntaxResultType]>()
+        let portValuesMap = try self.reduce(into: orderedDict) { result, arg in
+            let results = try SyntaxViewName.derivePortValues(
+                from: arg.value,
+                varName: varName,
+                viewEvent: viewEvent,
+                nodesDict: nodesDict,
+                nodeType: nodeType)
+            
+            result.updateValue(results, forKey: arg.label?.stripQuotes() ?? "")
+        }
+        
+        guard let nodeType = nodeType else {
+            return portValuesMap.flatMap { $0.value }
+        }
+        
+        // Regoranize arguments to ensure packing works correctly
+        return nodeType.reorganizePortValueArgs(valuesMap: portValuesMap)
     }
 }

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
@@ -818,25 +818,11 @@ extension SyntaxViewName {
                                                  nodesDict: nodesDict)
             
         case .tuple(let tupleArgs):
-            // Recursively determine PortValue of each arg for key label
-            let orderedDict = OrderedDictionary<String, [PatchSyntaxResultType]>()
-            let tuplePortValuesMap = try tupleArgs.reduce(into: orderedDict) { result, arg in
-                let results = try Self.derivePortValues(
-                    from: arg.value,
-                    varName: varName,
-                    viewEvent: viewEvent,
-                    nodesDict: nodesDict,
-                    nodeType: nodeType)
-                
-                result.updateValue(results, forKey: arg.label?.stripQuotes() ?? "")
-            }
-            
-            guard let nodeType = nodeType else {
-                return tuplePortValuesMap.flatMap { $0.value }
-            }
-            
-            // Regoranize arguments to ensure packing works correctly
-            return nodeType.reorganizePortValueArgs(valuesMap: tuplePortValuesMap)
+            return try tupleArgs
+                .reorderUnapckedValues(varName: varName,
+                                       viewEvent: viewEvent,
+                                       nodesDict: nodesDict,
+                                       nodeType: nodeType)
             
         case .array(let arrayArgs):
             // Recursively determine PortValue of each arg

--- a/Stitch/Graph/StitchAI/Mapping/VPLToCode/LayerVPLToCode.swift
+++ b/Stitch/Graph/StitchAI/Mapping/VPLToCode/LayerVPLToCode.swift
@@ -584,7 +584,7 @@ extension LayerInputPort {
             return nil // Special case - handled elsewhere
         case .offsetInGroup:
             return .offset
-        case .padding:
+        case .layerPadding:
             return .padding
         case .isClipped:
             return .clipped


### PR DESCRIPTION
2 fixes:
1. Changed padding to use `layerPadding` instead of `padding` layer input port
2. Brings newly introduced logic for reading argument labels in an unpacked context, allowing us to reorder arguments