### PR TITLE
Discouraging checking if `@State var`'s list is empty

### DIFF
--- a/Stitch/App/Resources/stitch_static_prompt.txt
+++ b/Stitch/App/Resources/stitch_static_prompt.txt
@@ -12952,7 +12952,7 @@ You are an assistant that **generates source code for a SwiftUI view** for the S
 **Critical Code Structure:**
 * All logic must be broken down into clearly separated patches and follow the only specified component structure:
 - **Single `var body`**: All view declarations must happen inside this. No extra view structs.
-- **@State variables**: Only permitted for dynamic logic and must be `[PortValueDescription]` (strictly adhere to this type).
+- **@State variables**: Only permitted for dynamic logic and must be `[PortValueDescription]` (strictly adhere to this type). `@State var`s always start out *empty*, and must be populated by the `updateLayerInput` function. Just populate the `@State var`s. NEVER EVER check if a `@State var` is empty.
 - **`updateLayerInputs(...)` function**: The program's runtime, called upon every frame.
 - **Patch Functions**: Every function (other than `updateLayerInputs`) can have only a single input of type `[[PortValueDescription]]`, and must return `[[PortValueDescription]]`. Helper or intermediate functions are not permitted -- logic must be in the patch function. Patch functions **cannot** invoke one another.
 - **Never use a `ContentView: View` extension.**

--- a/Stitch/Graph/StitchAI/SystemPrompts/AICodeGenSystemPromptGenerator.swift
+++ b/Stitch/Graph/StitchAI/SystemPrompts/AICodeGenSystemPromptGenerator.swift
@@ -40,7 +40,7 @@ You are an assistant that **generates source code for a SwiftUI view** for the S
 **Critical Code Structure:**
 * All logic must be broken down into clearly separated patches and follow the only specified component structure:
 - **Single `var body`**: All view declarations must happen inside this. No extra view structs.
-- **@State variables**: Only permitted for dynamic logic and must be `[PortValueDescription]` (strictly adhere to this type).
+- **@State variables**: Only permitted for dynamic logic and must be `[PortValueDescription]` (strictly adhere to this type). `@State var`s always start out *empty*, and must be populated by the `updateLayerInput` function. Just populate the `@State var`s. NEVER EVER check if a `@State var` is empty.
 - **`updateLayerInputs(...)` function**: The program's runtime, called upon every frame.
 - **Patch Functions**: Every function (other than `updateLayerInputs`) can have only a single input of type `[[PortValueDescription]]`, and must return `[[PortValueDescription]]`. Helper or intermediate functions are not permitted -- logic must be in the patch function. Patch functions **cannot** invoke one another.
 - **Never use a `ContentView: View` extension.**


### PR DESCRIPTION
Noticed a couple code-gens where we checked if State vars were empty -- either via a ternary expression (unsupported) or an `if xyz.isEmpty` check.

The `isEmpty` check itself doesn't always seem to cause a failure, but can get us involved in code that creates problems?

Seems a safe thing to discourage.