### PR TITLE
In AI Previewer, use `TextEditor` so that comments do not block out code

### DIFF
--- a/Stitch/Graph/StitchAI/View/StitchAIProjectViewer.swift
+++ b/Stitch/Graph/StitchAI/View/StitchAIProjectViewer.swift
@@ -30,7 +30,7 @@ struct StitchAIProjectViewer: View {
     let store: StitchStore
     @Bindable var document: StitchDocumentViewModel
 
-    func validateJSON() {        
+    func validateJSON() {
         let codeParserResult = SwiftUIViewVisitor.parseSwiftUICode(swiftUICode)
         
         // Apply AI result to fake document
@@ -56,13 +56,19 @@ struct StitchAIProjectViewer: View {
                               alertState: store.alertState)
             VStack {
                 HStack {
-                    TextField("Insert SwiftUI Code",
-                              text: $swiftUICode)
-                    .focusedValue(\.focusedField, .aiPreviewerTextField)
-                    .onSubmit {
+                    
+//                    TextField("Insert SwiftUI Code",
+//                              text: $swiftUICode)
+                    
+                    // IMPORTANT: use `TextEditor` so that new lines are preserved when pasting code; otherwise code comments will wipe out genuine code
+                    TextEditor(text: $swiftUICode)
+                        .focusedValue(\.focusedField, .aiPreviewerTextField)
+
+                    Button("Submit") {
                         validateJSON()
                     }
                 }
+                .frame(height: 120)
                 .padding()
                 .background(.ultraThinMaterial)
                 


### PR DESCRIPTION
Resolves the confusion behind https://github.com/StitchDesign/Stitch--Old/issues/7497

Resolves https://github.com/StitchDesign/Stitch--Old/issues/7497

<img width="744" height="623" alt="Screenshot 2025-09-21 at 10 31 49 PM" src="https://github.com/user-attachments/assets/cf9ced87-7c56-4b44-a23d-ca9966afa598" />
