### PR TITLE
Introduce feature flag  for whether we place a child's center (SwiftUI) or its edge (legacy Stitch) at the parent's edge

### DIFF
--- a/Stitch/App/FeatureFlags.swift
+++ b/Stitch/App/FeatureFlags.swift
@@ -12,17 +12,27 @@ import StitchSchemaKit
 struct FeatureFlags {
     static let USE_COMMENT_BOX_FLAG: Bool = false
     static let USE_COMPONENTS = false
-    static let USE_AI_MODE = true
     
-    // For changes that move Stitch's implementation details closer to SwiftUI,
-    // but which may not be good to expose to most beta testers quite yet.
-    // TODO: set false for
+    /*
+     Used for changes that move Stitch closer to SwiftUI's implementation details.
+     
+     May or may not be good to expose to most beta testers.
+     */
     static let USE_SWIFTUI_IMPLEMENTATION: Bool = true
 //    static let USE_SWIFTUI_IMPLEMENTATION: Bool = false
     
-    // TODO: SET FALSE BEFORE NEXT RELEASE / just use Stitch AI Reasoning ?
-    static let SHOW_AI_TABLE_ROWS_VIEWER = true
-
+    /*
+     Traditionally, Stitch `position = 0,0 + anchoring = .topLeft` placed the child's TOP LEFT EDGE on the top left corner of the parent.
+     
+     However, SwiftUI `child.position(0,0)` places the child's CENTER on the top left corner of the parent.
+     
+     For best AI support, we want to follow SwiftUI as closely as possible. But switching from anchoring a child's edge to its center is a noticeable break of legacy projects.
+     
+     See `adjustPosition`.
+     */
+    // static let PLACE_CENTER_OF_VIEW_AT_ANCHORING_POINT: Bool = true
+    static let PLACE_CENTER_OF_VIEW_AT_ANCHORING_POINT: Bool = false
+    
     // TODO: why did the `Stitch AI Reasoning` build-scheme
     // TODO: remove before proper release
     // TODO: put this behind a different compiler flag? ... Want to make available for Adam as well.

--- a/Stitch/App/FeatureFlags.swift
+++ b/Stitch/App/FeatureFlags.swift
@@ -30,8 +30,11 @@ struct FeatureFlags {
      
      See `adjustPosition`.
      */
-    // static let PLACE_CENTER_OF_VIEW_AT_ANCHORING_POINT: Bool = true
+#if DEBUG || DEV_DEBUG
+     static let PLACE_CENTER_OF_VIEW_AT_ANCHORING_POINT: Bool = true
+#else
     static let PLACE_CENTER_OF_VIEW_AT_ANCHORING_POINT: Bool = false
+#endif
     
     // TODO: why did the `Stitch AI Reasoning` build-scheme
     // TODO: remove before proper release

--- a/Stitch/Graph/Node/Port/Model/PortValue/Type/Anchoring/Anchoring.swift
+++ b/Stitch/Graph/Node/Port/Model/PortValue/Type/Anchoring/Anchoring.swift
@@ -158,7 +158,8 @@ func adjustPosition(size: CGSize, // child's size
                     parentSize: CGSize,
                     ignoreOffsetTransform: Bool = false) -> CGPoint {
 
-    if FeatureFlags.USE_SWIFTUI_IMPLEMENTATION {
+//    if FeatureFlags.USE_SWIFTUI_IMPLEMENTATION {
+    if FeatureFlags.USE_SWIFTUI_IMPLEMENTATION && FeatureFlags.PLACE_CENTER_OF_VIEW_AT_ANCHORING_POINT {
         if anchor == .topLeft {
             // AI used .position(x,y) which places CENTER of child at (x,y) from top-left
             // Convert to center-origin coordinates for .offset()

--- a/Stitch/Graph/StitchAI/Mapping/VPLToCode/LayerVPLToCode.swift
+++ b/Stitch/Graph/StitchAI/Mapping/VPLToCode/LayerVPLToCode.swift
@@ -102,8 +102,8 @@ extension LayerNodeEntity {
         // ───────── Not yet handled ─────────
         case .shape, .colorFill, .hitArea, .canvasSketch, .progressIndicator, .switchLayer, .videoStreaming:
             fatalErrorIfDebug("Gradient layers (\(self.layer)) require proper color extraction implementation")
-//            throw SwiftUISyntaxError.unsupportedSyntaxViewLayer(self.layer)
-            return nil
+            throw SwiftUISyntaxError.unsupportedSyntaxViewLayer(self.layer)
+            // return nil
         }
     }
     


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7495

<img width="1902" height="551" alt="Screenshot 2025-09-22 at 11 21 54 AM" src="https://github.com/user-attachments/assets/a6467bee-c08a-44fa-adf2-9fced632509e" />