### PR TITLE
Fixed scroll view persistence on iPad

### DIFF
--- a/Stitch/Graph/View/ProjectNavigationView.swift
+++ b/Stitch/Graph/View/ProjectNavigationView.swift
@@ -30,21 +30,20 @@ struct ProjectNavigationView: View {
 #if !targetEnvironment(macCatalyst)
         // Use a ZStack so SwiftUI can animate insertion/removal with `.transition`
         ZStack {
-            if document.selectedTab == .patch {
-                graphView
-                    .ignoresSafeArea()
-                    .transition(.opacity)
-                    .id(ProjectTab.patch)   // ← make the views distinct
-            } else { // .layer
-                ZStack {
-                    ipadLayerView
-                    
-                    // Layer Inspector Fly‑out must sit above preview window
-                    flyout
-                }
+            graphView
+                .ignoresSafeArea()
                 .transition(.opacity)
-                .id(ProjectTab.layer)
+                .id(ProjectTab.patch)   // ← make the views distinct
+            
+            ZStack {
+                ipadLayerView
+                
+                // Layer Inspector Fly‑out must sit above preview window
+                flyout
             }
+            .opacity(document.selectedTab == .layer ? 1 : 0)
+            .transition(.opacity)
+            .id(ProjectTab.layer)
         }
         .animation(.easeInOut(duration: 0.25), value: document.selectedTab)
         .animation(.easeInOut(duration: 0.25), value: document.selectedTab)

--- a/Stitch/Graph/View/ProjectNavigationView.swift
+++ b/Stitch/Graph/View/ProjectNavigationView.swift
@@ -36,6 +36,9 @@ struct ProjectNavigationView: View {
                 .id(ProjectTab.patch)   // ← make the views distinct
             
             ZStack {
+                Stitch.APP_BACKGROUND_COLOR
+                    .edgesIgnoringSafeArea(.all)
+                
                 ipadLayerView
                 
                 // Layer Inspector Fly‑out must sit above preview window

--- a/Stitch/Graph/View/StitchProjectOverlayView.swift
+++ b/Stitch/Graph/View/StitchProjectOverlayView.swift
@@ -22,6 +22,15 @@ struct StitchProjectOverlayView: View {
         store.showsLayerInspector ? FloatingWindowView.xOffset - LayerInspectorView.LAYER_INSPECTOR_WIDTH : FloatingWindowView.xOffset
     }
     
+    // Hides previewer when layers tab is selected on iPad
+    var isIpadTabPressed: Bool {
+        #if targetEnvironment(macCatalyst)
+        true
+        #else
+        document.selectedTab == .patch
+        #endif
+    }
+    
     var body: some View {
         VStack {
             if document.groupNodeFocused?.component != nil {
@@ -57,7 +66,7 @@ struct StitchProjectOverlayView: View {
             HStack(spacing: .zero) {
                 Spacer()
                 // Floating preview kept outside NavigationSplitView for animation purposes
-                if !showFullScreen {
+                if !showFullScreen && isIpadTabPressed {
                     FloatingWindowView(
                         store: store,
                         document: document,


### PR DESCRIPTION
Scroll view instantiation resets graph position, fix here is just keeping the graph view always in the background.
