### PR TITLE
Use .overlay instead of .inspector on Mac Catalyst with MacOS Tahoe

### DIFF
--- a/Stitch/Graph/View/GraphBaseView.swift
+++ b/Stitch/Graph/View/GraphBaseView.swift
@@ -116,10 +116,19 @@ struct GraphBaseView: View {
         .coordinateSpace(name: Self.coordinateNamespace)
         
         #if targetEnvironment(macCatalyst)
-        .inspector(isPresented: $store.showsLayerInspector) {
-            LayerInspectorView(graph: graph,
-                               document: document)
+        .overlay(alignment: .trailing) {
+            if store.showsLayerInspector {
+                LayerInspectorView(graph: graph,
+                                   document: document)
+                .frame(width: LayerInspectorView.LAYER_INSPECTOR_WIDTH)
+                .transition(.move(edge: .trailing))
+            }
         }
+        
+        //        .inspector(isPresented: $store.showsLayerInspector) {
+        //            LayerInspectorView(graph: graph,
+        //                               document: document)
+        //        }
         #endif
         
         .bottomCenterToast(willShow: document.llmRecording.showRatingToast,


### PR DESCRIPTION
Required to fix issue where left-sidebar toggle button is lost on Tahoe 

In the future we could try using `.inspector` again, but at the root level (where it doesn't cause the issue), has some nice UI features.

https://github.com/user-attachments/assets/9f14187d-f65a-4cbd-a0d2-4ce0b8901896

