### PR TITLE
Tahoe: iPad and Mac Catalyst: use `ControlGroup` to group nav bar buttons together

### DIFF
--- a/Stitch/Graph/View/ProjectToolbar.swift
+++ b/Stitch/Graph/View/ProjectToolbar.swift
@@ -123,19 +123,21 @@ struct ProjectToolbarViewModifier: ViewModifier {
                }
 
                 ToolbarItemGroup(placement: .primaryAction) {
-                    CatalystTopBarGraphButtons(
-                        document: document,
-                        isDebugMode: document.isDebugMode,
-                        hasActiveGroupFocused: document.groupNodeFocused.isDefined,
-                        isFullscreen: document.isFullScreenMode,
-                        isPreviewWindowShown: document.showPreviewWindow
-                    )
+                    ControlGroup {
+                        CatalystTopBarGraphButtons(
+                            document: document,
+                            isDebugMode: document.isDebugMode,
+                            hasActiveGroupFocused: document.groupNodeFocused.isDefined,
+                            isFullscreen: document.isFullScreenMode,
+                            isPreviewWindowShown: document.showPreviewWindow
+                        )
+                    }
                 }
                 #endif
 
             }
             .animation(.spring, value: document.restartPrototypeWindowIconRotationZ) // .animation modifier must be placed here
-           .toolbarBackground(.visible, for: .automatic)
-           .toolbar(hideToolbar ? .hidden : .automatic)
+            .toolbarBackground(.visible, for: .automatic)
+            .toolbar(hideToolbar ? .hidden : .automatic)
     }
 }

--- a/Stitch/Home/View/ProjectsHomeViewWrapper.swift
+++ b/Stitch/Home/View/ProjectsHomeViewWrapper.swift
@@ -9,126 +9,126 @@ import SwiftUI
 import StitchSchemaKit
 
 struct ProjectsHomeViewWrapper: View {
-
+    
     @Environment(StitchStore.self) var store: StitchStore
-
+    
     // TODO: remove for Catalyst
     @Namespace var routerNamespace
-
+    
     var body: some View {
         ProjectsHomeView(store: store,
                          namespace: routerNamespace)
-
-            #if !targetEnvironment(macCatalyst)
-            .navigationTitle("Stitch Projects")
-            .navigationBarTitleDisplayMode(.inline)
-            #endif
-
-            .toolbar {
-
-                #if targetEnvironment(macCatalyst)
-                // HACK: places an item in center of toolbar, so that trailing buttons stay on right-side even when nav bar title removed
-                ToolbarItem(placement: .secondaryAction) {
-                    StitchTextView(string: "Stitch Projects",
-                                   font: WINDOW_NAVBAR_FONT)
-                    // Hack also works if we hide this view
-                    //                    .width(1).opacity(0)
-                }
-                #endif
-
-                ToolbarItemGroup(placement: .navigationBarTrailing) {
-                    if isPhoneDevice {
-                        iPadTopBarButton(
-                            action: SHOW_APP_SETTINGS_ACTION,
-                            iconName: APP_SETTINGS_ICON_NAME)
-                    } else {
+        
+#if !targetEnvironment(macCatalyst)
+        .navigationTitle("Stitch Projects")
+        .navigationBarTitleDisplayMode(.inline)
+#endif
+        
+        .toolbar {
+            
 #if targetEnvironment(macCatalyst)
-
-//                        if FeatureFlags.SHOW_AI_TABLE_ROWS_VIEWER {
-//                            CatalystNavBarButton("tablecells",
-//                                                 toolTip: "Open AI Table Viewer") { [weak store] in
-//                                store?.navPath = [.graphGenerationTableView]
-//                            }
-//                            // Resolves issue where hover was still active after entering newly created project and then exiting
-//                            .id(UUID())
-//                        }
-                        
-#if STITCH_AI_REASONING || DEV_DEBUG
-                        CatalystNavBarButton("document.viewfinder.fill",
-                                             toolTip: "Open AI Preview") { [weak store] in
-                            guard let store = store else {
-                                return
-                            }
-                            let (document, encoder) = store.createAIDocumentPreviewer()
-                            if store.navPath.isEmpty {
-                                store.navPath = [.aiPreviewer(document, encoder)]
-                            } else {
-                                store.navPath = []
-                            }
-                            //                            store.showAIResponseViewer.toggle()
-                            
-                        }
-                        // Resolves issue where hover was still active after entering newly created project and then exiting
-                        .id(UUID())
- #endif
-                        
-                        CatalystNavBarButton(.NEW_PROJECT_SF_SYMBOL_NAME,
-                                             toolTip: "New Project") { [weak store] in
-                            store?.createNewProjectSideEffect(isProjectImport: false)
-                        }
-                    // Resolves issue where hover was still active after entering newly created project and then exiting
-                    .id(UUID())
-                        
-                        CatalystNavBarButton(.OPEN_SAMPLE_PROJECTS_MODAL,
-                                             toolTip: "Open Sample Projects") { [weak store] in
-                            store?.conditionallToggleSampleProjectsModal()
-                        }
-                        // Resolves issue where hover was still active after entering newly created project and then exiting
-                        .id(UUID())
-                                                
-                        TopBarFeedbackButtonsView(document: nil)
-                        // Hides the little arrow on Catalyst
-                            .menuIndicator(.hidden)
-                            .buttonStyle(.borderless)
-                            .id(UUID())
-                        
-                        CatalystNavBarButton(.SETTINGS_SF_SYMBOL_NAME,
-                                             toolTip: "Open Settings") {
-                            SHOW_APP_SETTINGS_ACTION()
-                        }
-                                             .id(UUID())
-                                                
-#else
-                        
-                        
-#if STITCH_AI_REASONING || DEV_DEBUG
-//                        iPadNavBarButton(action: { [weak store] in
-//                            store?.navPath = [.graphGenerationTableView]
-//                        },
-//                                         iconName: .sfSymbol("tablecells"))
+            // HACK: places an item in center of toolbar, so that trailing buttons stay on right-side even when nav bar title removed
+            ToolbarItem(placement: .secondaryAction) {
+                StitchTextView(string: "Stitch Projects",
+                               font: WINDOW_NAVBAR_FONT)
+                // Hack also works if we hide this view
+                //                    .width(1).opacity(0)
+            }
 #endif
-                        
-                        iPadNavBarButton(action: { [weak store] in
-                            store?.createNewProjectSideEffect(isProjectImport: false)
-                        },
-                                         iconName: NEW_PROJECT_ICON_NAME)
-                        
-                        iPadNavBarButton(action: { [weak store] in
-                            store?.conditionallToggleSampleProjectsModal()
-                        },
-                                         iconName: .sfSymbol(.OPEN_SAMPLE_PROJECTS_MODAL))
-                        
-                        TopBarFeedbackButtonsView(document: nil,
-                                                  showLabel: false)
-                            .modifier(iPadTopBarButtonStyle())
-                        
-                        iPadNavBarButton(action: SHOW_APP_SETTINGS_ACTION,
-                                         iconName: PROJECT_SETTINGS_ICON_NAME)
-#endif
+            
+            ToolbarItemGroup(placement: .navigationBarTrailing) {
+                if isPhoneDevice {
+                    iPadTopBarButton(
+                        action: SHOW_APP_SETTINGS_ACTION,
+                        iconName: APP_SETTINGS_ICON_NAME)
+                } else {
+#if targetEnvironment(macCatalyst)
+                    
+                    //                        if FeatureFlags.SHOW_AI_TABLE_ROWS_VIEWER {
+                    //                            CatalystNavBarButton("tablecells",
+                    //                                                 toolTip: "Open AI Table Viewer") { [weak store] in
+                    //                                store?.navPath = [.graphGenerationTableView]
+                    //                            }
+                    //                            // Resolves issue where hover was still active after entering newly created project and then exiting
+                    //                            .id(UUID())
+                    //                        }
+                    
+#if STITCH_AI_REASONING || DEV_DEBUG
+                    CatalystNavBarButton("document.viewfinder.fill",
+                                         toolTip: "Open AI Preview") { [weak store] in
+                        guard let store = store else {
+                            return
+                        }
+                        let (document, encoder) = store.createAIDocumentPreviewer()
+                        if store.navPath.isEmpty {
+                            store.navPath = [.aiPreviewer(document, encoder)]
+                        } else {
+                            store.navPath = []
+                        }
+                        //                            store.showAIResponseViewer.toggle()
                         
                     }
+                    // Resolves issue where hover was still active after entering newly created project and then exiting
+                                         .id(UUID())
+#endif
+                    
+                    CatalystNavBarButton(.NEW_PROJECT_SF_SYMBOL_NAME,
+                                         toolTip: "New Project") { [weak store] in
+                        store?.createNewProjectSideEffect(isProjectImport: false)
+                    }
+                    // Resolves issue where hover was still active after entering newly created project and then exiting
+                                         .id(UUID())
+                    
+                    CatalystNavBarButton(.OPEN_SAMPLE_PROJECTS_MODAL,
+                                         toolTip: "Open Sample Projects") { [weak store] in
+                        store?.conditionallToggleSampleProjectsModal()
+                    }
+                    // Resolves issue where hover was still active after entering newly created project and then exiting
+                                         .id(UUID())
+                    
+                    TopBarFeedbackButtonsView(document: nil)
+                    // Hides the little arrow on Catalyst
+                        .menuIndicator(.hidden)
+                        .buttonStyle(.borderless)
+                        .id(UUID())
+                    
+                    CatalystNavBarButton(.SETTINGS_SF_SYMBOL_NAME,
+                                         toolTip: "Open Settings") {
+                        SHOW_APP_SETTINGS_ACTION()
+                    }
+                                         .id(UUID())
+                    
+#else
+                    
+                    
+#if STITCH_AI_REASONING || DEV_DEBUG
+                    //                        iPadNavBarButton(action: { [weak store] in
+                    //                            store?.navPath = [.graphGenerationTableView]
+                    //                        },
+                    //                                         iconName: .sfSymbol("tablecells"))
+#endif
+                    
+                    iPadNavBarButton(action: { [weak store] in
+                        store?.createNewProjectSideEffect(isProjectImport: false)
+                    },
+                                     iconName: NEW_PROJECT_ICON_NAME)
+                    
+                    iPadNavBarButton(action: { [weak store] in
+                        store?.conditionallToggleSampleProjectsModal()
+                    },
+                                     iconName: .sfSymbol(.OPEN_SAMPLE_PROJECTS_MODAL))
+                    
+                    TopBarFeedbackButtonsView(document: nil,
+                                              showLabel: false)
+                    .modifier(iPadTopBarButtonStyle())
+                    
+                    iPadNavBarButton(action: SHOW_APP_SETTINGS_ACTION,
+                                     iconName: PROJECT_SETTINGS_ICON_NAME)
+#endif
+                    
                 }
             }
+        }
     }
 }
 

--- a/Stitch/Home/View/ProjectsHomeViewWrapper.swift
+++ b/Stitch/Home/View/ProjectsHomeViewWrapper.swift
@@ -31,6 +31,7 @@ struct ProjectsHomeViewWrapper: View {
             ToolbarItem(placement: .secondaryAction) {
                 StitchTextView(string: "Stitch Projects",
                                font: WINDOW_NAVBAR_FONT)
+                .padding(.horizontal)
                 // Hack also works if we hide this view
                 //                    .width(1).opacity(0)
             }
@@ -43,15 +44,7 @@ struct ProjectsHomeViewWrapper: View {
                         iconName: APP_SETTINGS_ICON_NAME)
                 } else {
 #if targetEnvironment(macCatalyst)
-                    
-                    //                        if FeatureFlags.SHOW_AI_TABLE_ROWS_VIEWER {
-                    //                            CatalystNavBarButton("tablecells",
-                    //                                                 toolTip: "Open AI Table Viewer") { [weak store] in
-                    //                                store?.navPath = [.graphGenerationTableView]
-                    //                            }
-                    //                            // Resolves issue where hover was still active after entering newly created project and then exiting
-                    //                            .id(UUID())
-                    //                        }
+
                     
 #if STITCH_AI_REASONING || DEV_DEBUG
                     CatalystNavBarButton("document.viewfinder.fill",
@@ -72,58 +65,54 @@ struct ProjectsHomeViewWrapper: View {
                                          .id(UUID())
 #endif
                     
-                    CatalystNavBarButton(.NEW_PROJECT_SF_SYMBOL_NAME,
-                                         toolTip: "New Project") { [weak store] in
-                        store?.createNewProjectSideEffect(isProjectImport: false)
+                    ControlGroup {
+                        CatalystNavBarButton(.NEW_PROJECT_SF_SYMBOL_NAME,
+                                             toolTip: "New Project") { [weak store] in
+                            store?.createNewProjectSideEffect(isProjectImport: false)
+                        }
+                        // Resolves issue where hover was still active after entering newly created project and then exiting
+                                             .id(UUID())
+                        
+                        CatalystNavBarButton(.OPEN_SAMPLE_PROJECTS_MODAL,
+                                             toolTip: "Open Sample Projects") { [weak store] in
+                            store?.conditionallToggleSampleProjectsModal()
+                        }
+                        // Resolves issue where hover was still active after entering newly created project and then exiting
+                                             .id(UUID())
+                        
+                        TopBarFeedbackButtonsView(document: nil)
+                        // Hides the little arrow on Catalyst
+                            .menuIndicator(.hidden)
+                            .buttonStyle(.borderless)
+                            .id(UUID())
+                        
+                        CatalystNavBarButton(.SETTINGS_SF_SYMBOL_NAME,
+                                             toolTip: "Open Settings") {
+                            SHOW_APP_SETTINGS_ACTION()
+                        }
+                                             .id(UUID())
                     }
-                    // Resolves issue where hover was still active after entering newly created project and then exiting
-                                         .id(UUID())
-                    
-                    CatalystNavBarButton(.OPEN_SAMPLE_PROJECTS_MODAL,
-                                         toolTip: "Open Sample Projects") { [weak store] in
-                        store?.conditionallToggleSampleProjectsModal()
-                    }
-                    // Resolves issue where hover was still active after entering newly created project and then exiting
-                                         .id(UUID())
-                    
-                    TopBarFeedbackButtonsView(document: nil)
-                    // Hides the little arrow on Catalyst
-                        .menuIndicator(.hidden)
-                        .buttonStyle(.borderless)
-                        .id(UUID())
-                    
-                    CatalystNavBarButton(.SETTINGS_SF_SYMBOL_NAME,
-                                         toolTip: "Open Settings") {
-                        SHOW_APP_SETTINGS_ACTION()
-                    }
-                                         .id(UUID())
                     
 #else
                     
-                    
-#if STITCH_AI_REASONING || DEV_DEBUG
-                    //                        iPadNavBarButton(action: { [weak store] in
-                    //                            store?.navPath = [.graphGenerationTableView]
-                    //                        },
-                    //                                         iconName: .sfSymbol("tablecells"))
-#endif
-                    
-                    iPadNavBarButton(action: { [weak store] in
-                        store?.createNewProjectSideEffect(isProjectImport: false)
-                    },
-                                     iconName: NEW_PROJECT_ICON_NAME)
-                    
-                    iPadNavBarButton(action: { [weak store] in
-                        store?.conditionallToggleSampleProjectsModal()
-                    },
-                                     iconName: .sfSymbol(.OPEN_SAMPLE_PROJECTS_MODAL))
-                    
-                    TopBarFeedbackButtonsView(document: nil,
-                                              showLabel: false)
-                    .modifier(iPadTopBarButtonStyle())
-                    
-                    iPadNavBarButton(action: SHOW_APP_SETTINGS_ACTION,
-                                     iconName: PROJECT_SETTINGS_ICON_NAME)
+                    ControlGroup {
+                        iPadNavBarButton(action: { [weak store] in
+                            store?.createNewProjectSideEffect(isProjectImport: false)
+                        },
+                                         iconName: NEW_PROJECT_ICON_NAME)
+                        
+                        iPadNavBarButton(action: { [weak store] in
+                            store?.conditionallToggleSampleProjectsModal()
+                        },
+                                         iconName: .sfSymbol(.OPEN_SAMPLE_PROJECTS_MODAL))
+                        
+                        TopBarFeedbackButtonsView(document: nil,
+                                                  showLabel: false)
+                        .modifier(iPadTopBarButtonStyle())
+                        
+                        iPadNavBarButton(action: SHOW_APP_SETTINGS_ACTION,
+                                         iconName: PROJECT_SETTINGS_ICON_NAME)
+                    }
 #endif
                     
                 }


### PR DESCRIPTION
<img width="1056" height="349" alt="Screenshot 2025-09-25 at 6 30 16 PM" src="https://github.com/user-attachments/assets/505474d9-4816-46b4-b2e9-51952dfbb632" />
<img width="216" height="79" alt="Screenshot 2025-09-25 at 6 30 21 PM" src="https://github.com/user-attachments/assets/fb500a22-277d-4ceb-94c7-50453a8a600e" />
