### PR TITLE
Significantly reduce jerkiness when opening or closing sidebar and inspector at same time 

### DIFF
--- a/Stitch/App/View/StitchRootView.swift
+++ b/Stitch/App/View/StitchRootView.swift
@@ -48,6 +48,14 @@ struct StitchRootView: View {
     var viewByPlatform: some View {
 #if targetEnvironment(macCatalyst)
                 splitView
+//        
+//        // Displaces contents of the view? (Creates less space etc.)
+//            .inspector(isPresented: $store.showsLayerInspector) {
+//                if let document = store.currentDocument {
+//                    LayerInspectorView(graph: document.visibleGraph,
+//                                       document: document)
+//                }
+//            }
 #else
                 StitchNavStack(store: store)
 #endif

--- a/Stitch/Graph/Util/GraphUIActions.swift
+++ b/Stitch/Graph/Util/GraphUIActions.swift
@@ -143,13 +143,28 @@ struct ToggleSidebars: StitchStoreEvent {
         let inspectorOpen = store.showsLayerInspector
         let layerSidebarOpen = state.leftSidebarOpen
         
-        withAnimation {
-            if !inspectorOpen && !layerSidebarOpen {
-                store.showsLayerInspector = true
+        // VERY IMPORTANT TO STAGGER THE SIDEBAR VS INSPECTOR OPEN/CLOSE; OTHERWISE WE GET JERKINESS
+        if !inspectorOpen && !layerSidebarOpen {
+            // Opening: animate sidebar first, then inspector
+            withAnimation {
                 state.leftSidebarOpen = true
-            } else {
-                store.showsLayerInspector = false
+            }
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                withAnimation {
+                    store.showsLayerInspector = true
+                }
+            }
+        } else {
+            // Closing: animate sidebar first, then inspector
+            withAnimation {
                 state.leftSidebarOpen = false
+            }
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                withAnimation {
+                    store.showsLayerInspector = false
+                }
             }
         }
         
@@ -159,7 +174,7 @@ struct ToggleSidebars: StitchStoreEvent {
 
 struct InsertNodeSelectionChanged: StitchDocumentEvent {
     let selection: InsertNodeMenuOption
-
+    
     func handle(state: StitchDocumentViewModel) {
         state.insertNodeMenuState.activeSelection = selection
     }

--- a/Stitch/Graph/Util/GraphUIActions.swift
+++ b/Stitch/Graph/Util/GraphUIActions.swift
@@ -145,14 +145,14 @@ struct ToggleSidebars: StitchStoreEvent {
         
         // VERY IMPORTANT TO STAGGER THE SIDEBAR VS INSPECTOR OPEN/CLOSE; OTHERWISE WE GET JERKINESS
         if !inspectorOpen && !layerSidebarOpen {
-            // Opening: animate sidebar first, then inspector
+            // Opening: animate inspector first, then sidebar
             withAnimation {
-                state.leftSidebarOpen = true
+                store.showsLayerInspector = true
             }
 
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 withAnimation {
-                    store.showsLayerInspector = true
+                    state.leftSidebarOpen = true
                 }
             }
         } else {

--- a/Stitch/Graph/Util/GraphUIActions.swift
+++ b/Stitch/Graph/Util/GraphUIActions.swift
@@ -143,27 +143,27 @@ struct ToggleSidebars: StitchStoreEvent {
         let inspectorOpen = store.showsLayerInspector
         let layerSidebarOpen = state.leftSidebarOpen
         
-        // VERY IMPORTANT TO STAGGER THE SIDEBAR VS INSPECTOR OPEN/CLOSE; OTHERWISE WE GET JERKINESS
+        // Stagger slightly for better visual flow
         if !inspectorOpen && !layerSidebarOpen {
-            // Opening: animate inspector first, then sidebar
+            log("ToggleSidebars: both are currently closed; will open both")
             withAnimation {
-                store.showsLayerInspector = true
+                state.leftSidebarOpen = true
             }
 
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 withAnimation {
-                    state.leftSidebarOpen = true
+                    store.showsLayerInspector = true
                 }
             }
         } else {
-            // Closing: animate sidebar first, then inspector
+            log("ToggleSidebars: will close both")
             withAnimation {
-                state.leftSidebarOpen = false
+                store.showsLayerInspector = false
             }
-            
+
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 withAnimation {
-                    store.showsLayerInspector = false
+                    state.leftSidebarOpen = false
                 }
             }
         }

--- a/Stitch/Graph/Util/GraphUIActions.swift
+++ b/Stitch/Graph/Util/GraphUIActions.swift
@@ -143,28 +143,16 @@ struct ToggleSidebars: StitchStoreEvent {
         let inspectorOpen = store.showsLayerInspector
         let layerSidebarOpen = state.leftSidebarOpen
         
-        // Stagger slightly for better visual flow
-        if !inspectorOpen && !layerSidebarOpen {
-            log("ToggleSidebars: both are currently closed; will open both")
-            withAnimation {
+        // Animate both together
+        withAnimation {
+            if !inspectorOpen && !layerSidebarOpen {
+                // log("ToggleSidebars: will open both")
                 state.leftSidebarOpen = true
-            }
-
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                withAnimation {
-                    store.showsLayerInspector = true
-                }
-            }
-        } else {
-            log("ToggleSidebars: will close both")
-            withAnimation {
+                store.showsLayerInspector = true
+            } else {
+                // log("ToggleSidebars: will close both")
                 store.showsLayerInspector = false
-            }
-
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                withAnimation {
-                    state.leftSidebarOpen = false
-                }
+                state.leftSidebarOpen = false
             }
         }
         

--- a/Stitch/Graph/View/ContentView.swift
+++ b/Stitch/Graph/View/ContentView.swift
@@ -44,12 +44,16 @@ struct ContentView: View, KeyboardReadable {
 
     var nodeAndMenu: some View {
         ZStack {
-            
-            // Best place to listen for TAB key for flyout
-            UIKitWrapper(ignoresKeyCommands: true,
-                         isOnlyForTextFieldHelp: true,
-                         inputTextFieldFocused: document.reduxFocusedField?.inputTextFieldWithNumberIsFocused(document.graph) ?? false,
-                         name: .mainGraph) {
+            if document.visibleGraph.propertySidebar.flyoutState != nil {
+                // UIKitWrapper only when flyout is active (for TAB key detection)
+                UIKitWrapper(ignoresKeyCommands: true,
+                             isOnlyForTextFieldHelp: true,
+                             inputTextFieldFocused: document.reduxFocusedField?.inputTextFieldWithNumberIsFocused(document.graph) ?? false,
+                             name: .mainGraph) {
+                    contentView // the graph
+                }
+            } else {
+                // No wrapper when no flyout (smooth sidebar animations)
                 contentView // the graph
             }
         }

--- a/Stitch/Graph/View/ContentView.swift
+++ b/Stitch/Graph/View/ContentView.swift
@@ -61,10 +61,10 @@ struct ContentView: View, KeyboardReadable {
 
     var body: some View {
         ZStack {
-            
+
             // probably the best location for listening to how iPad's on-screen keyboard reduces available height for node menu ?
-            
-            
+
+
             // Must respect keyboard safe-area
             ProjectWindowSizeReader(previewWindowSizing: previewWindowSizing,
                                     previewWindowSize: document.previewWindowSize,

--- a/Stitch/Graph/View/GraphBaseView.swift
+++ b/Stitch/Graph/View/GraphBaseView.swift
@@ -125,8 +125,6 @@ struct GraphBaseView: View {
                                    document: document)
                 .frame(width: LayerInspectorView.LAYER_INSPECTOR_WIDTH)
                 .transition(.move(edge: .trailing))
-                .offset(x: )
-                
             }
         }
         
@@ -134,27 +132,27 @@ struct GraphBaseView: View {
 //                    LayerInspectorView(graph: graph,
 //                                       document: document)
         //        }
-//        #endif
+        #endif
         
         .bottomCenterToast(willShow: document.llmRecording.showRatingToast,
                            config: .init(duration: 15),
                            onExpireAction: { dispatch(AIRatingToastExpired()) },
                            toastContent: { StitchAIRatingToast() })
         
-        .background {
-            GeometryReader { geometry in
-                Color.clear
-                    .onChange(of: geometry.frame(in: .local), initial: true) { oldValue, newValue in
-                        // log("SIZE READING: GraphBaseView: local frame: newValue: \(newValue)")
-                        dispatch(SetDeviceScreenSize(frame: newValue))
-                    }
-                    .onChange(of: geometry.frame(in: .global), initial: true) { oldValue, newValue in
-                        // log("SIZE READING: GraphBaseView: global frame: newValue: \(newValue)")
-                        dispatch(SetGraphPosition(graphPosition: newValue.origin))
-                        dispatch(SetSidebarWidth(frame: newValue))
-                    }
-            } // GeometryReader
-        } // .background
+//        .background {
+//            GeometryReader { geometry in
+//                Color.clear
+//                    .onChange(of: geometry.frame(in: .local), initial: true) { oldValue, newValue in
+//                        // log("SIZE READING: GraphBaseView: local frame: newValue: \(newValue)")
+//                        dispatch(SetDeviceScreenSize(frame: newValue))
+//                    }
+//                    .onChange(of: geometry.frame(in: .global), initial: true) { oldValue, newValue in
+//                        // log("SIZE READING: GraphBaseView: global frame: newValue: \(newValue)")
+//                        dispatch(SetGraphPosition(graphPosition: newValue.origin))
+//                        dispatch(SetSidebarWidth(frame: newValue))
+//                    }
+//            } // GeometryReader
+//        } // .background
     }
 }
 

--- a/Stitch/Graph/View/GraphBaseView.swift
+++ b/Stitch/Graph/View/GraphBaseView.swift
@@ -109,65 +109,48 @@ struct GraphBaseView: View {
             //#endif
 
             nodesView
-            
-#if targetEnvironment(macCatalyst)
-            HStack {
-                Spacer()
-                if store.showsLayerInspector {
-                    LayerInspectorView(graph: graph,
-                                       document: document)
-                    .frame(width: LayerInspectorView.LAYER_INSPECTOR_WIDTH)
-    //                .transition(.move(edge: .trailing))
-                    .transition(.slideInAndOut)
-                }
-            }
-#endif
-            
-            
         } // ZStack
         
         .modifier(ActivelyDrawnEdge(graph: graph,
                                     scale: document.graphMovement.zoomData))
         .coordinateSpace(name: Self.coordinateNamespace)
         
-        // If sidebar was open as well, do we need to push the
-        // Problem comes when we
-        
-//        #if targetEnvironment(macCatalyst)
-//        .overlay(alignment: .trailing) {
-//            if store.showsLayerInspector {
-//                LayerInspectorView(graph: graph,
-//                                   document: document)
-//                .frame(width: LayerInspectorView.LAYER_INSPECTOR_WIDTH)
-////                .transition(.move(edge: .trailing))
+        #if targetEnvironment(macCatalyst)
+        .overlay(alignment: .trailing) {
+            if store.showsLayerInspector {
+                LayerInspectorView(graph: graph,
+                                   document: document)
+                .frame(width: LayerInspectorView.LAYER_INSPECTOR_WIDTH)
+                .transition(.move(edge: .trailing))
 //                .transition(.slideInAndOut)
-//            }
-//        }
-//        
-//        //        .inspector(isPresented: $store.showsLayerInspector) {
-////                    LayerInspectorView(graph: graph,
-////                                       document: document)
-//        //        }
-//        #endif
-//        
-//        .bottomCenterToast(willShow: document.llmRecording.showRatingToast,
-//                           config: .init(duration: 15),
-//                           onExpireAction: { dispatch(AIRatingToastExpired()) },
-//                           toastContent: { StitchAIRatingToast() })
-//        .background {
-//            GeometryReader { geometry in
-//                Color.clear
-//                    .onChange(of: geometry.frame(in: .local), initial: true) { oldValue, newValue in
-//                        // log("SIZE READING: GraphBaseView: local frame: newValue: \(newValue)")
-//                        dispatch(SetDeviceScreenSize(frame: newValue))
-//                    }
-//                    .onChange(of: geometry.frame(in: .global), initial: true) { oldValue, newValue in
-//                        // log("SIZE READING: GraphBaseView: global frame: newValue: \(newValue)")
-//                        dispatch(SetGraphPosition(graphPosition: newValue.origin))
-//                        dispatch(SetSidebarWidth(frame: newValue))
-//                    }
-//            } // GeometryReader
-//        } // .background
+            }
+        }
+        
+        //        .inspector(isPresented: $store.showsLayerInspector) {
+//                    LayerInspectorView(graph: graph,
+//                                       document: document)
+        //        }
+        #endif
+
+        
+        .bottomCenterToast(willShow: document.llmRecording.showRatingToast,
+                           config: .init(duration: 15),
+                           onExpireAction: { dispatch(AIRatingToastExpired()) },
+                           toastContent: { StitchAIRatingToast() })
+        .background {
+            GeometryReader { geometry in
+                Color.clear
+                    .onChange(of: geometry.frame(in: .local), initial: true) { oldValue, newValue in
+                         log("SIZE READING: GraphBaseView: local frame: newValue: \(newValue)")
+                        dispatch(SetDeviceScreenSize(frame: newValue))
+                    }
+                    .onChange(of: geometry.frame(in: .global), initial: true) { oldValue, newValue in
+                         log("SIZE READING: GraphBaseView: global frame: newValue: \(newValue)")
+                        dispatch(SetGraphPosition(graphPosition: newValue.origin))
+                        dispatch(SetSidebarWidth(frame: newValue))
+                    }
+            } // GeometryReader
+        } // .background
     }
 }
 

--- a/Stitch/Graph/View/GraphBaseView.swift
+++ b/Stitch/Graph/View/GraphBaseView.swift
@@ -141,11 +141,11 @@ struct GraphBaseView: View {
             GeometryReader { geometry in
                 Color.clear
                     .onChange(of: geometry.frame(in: .local), initial: true) { oldValue, newValue in
-                         log("SIZE READING: GraphBaseView: local frame: newValue: \(newValue)")
+                         // log("SIZE READING: GraphBaseView: local frame: newValue: \(newValue)")
                         dispatch(SetDeviceScreenSize(frame: newValue))
                     }
                     .onChange(of: geometry.frame(in: .global), initial: true) { oldValue, newValue in
-                         log("SIZE READING: GraphBaseView: global frame: newValue: \(newValue)")
+                         // log("SIZE READING: GraphBaseView: global frame: newValue: \(newValue)")
                         dispatch(SetGraphPosition(graphPosition: newValue.origin))
                         dispatch(SetSidebarWidth(frame: newValue))
                     }

--- a/Stitch/Graph/View/GraphBaseView.swift
+++ b/Stitch/Graph/View/GraphBaseView.swift
@@ -109,6 +109,21 @@ struct GraphBaseView: View {
             //#endif
 
             nodesView
+            
+#if targetEnvironment(macCatalyst)
+            HStack {
+                Spacer()
+                if store.showsLayerInspector {
+                    LayerInspectorView(graph: graph,
+                                       document: document)
+                    .frame(width: LayerInspectorView.LAYER_INSPECTOR_WIDTH)
+    //                .transition(.move(edge: .trailing))
+                    .transition(.slideInAndOut)
+                }
+            }
+#endif
+            
+            
         } // ZStack
         
         .modifier(ActivelyDrawnEdge(graph: graph,
@@ -118,27 +133,27 @@ struct GraphBaseView: View {
         // If sidebar was open as well, do we need to push the
         // Problem comes when we
         
-        #if targetEnvironment(macCatalyst)
-        .overlay(alignment: .trailing) {
-            if store.showsLayerInspector {
-                LayerInspectorView(graph: graph,
-                                   document: document)
-                .frame(width: LayerInspectorView.LAYER_INSPECTOR_WIDTH)
-                .transition(.move(edge: .trailing))
-            }
-        }
-        
-        //        .inspector(isPresented: $store.showsLayerInspector) {
-//                    LayerInspectorView(graph: graph,
-//                                       document: document)
-        //        }
-        #endif
-        
-        .bottomCenterToast(willShow: document.llmRecording.showRatingToast,
-                           config: .init(duration: 15),
-                           onExpireAction: { dispatch(AIRatingToastExpired()) },
-                           toastContent: { StitchAIRatingToast() })
-        
+//        #if targetEnvironment(macCatalyst)
+//        .overlay(alignment: .trailing) {
+//            if store.showsLayerInspector {
+//                LayerInspectorView(graph: graph,
+//                                   document: document)
+//                .frame(width: LayerInspectorView.LAYER_INSPECTOR_WIDTH)
+////                .transition(.move(edge: .trailing))
+//                .transition(.slideInAndOut)
+//            }
+//        }
+//        
+//        //        .inspector(isPresented: $store.showsLayerInspector) {
+////                    LayerInspectorView(graph: graph,
+////                                       document: document)
+//        //        }
+//        #endif
+//        
+//        .bottomCenterToast(willShow: document.llmRecording.showRatingToast,
+//                           config: .init(duration: 15),
+//                           onExpireAction: { dispatch(AIRatingToastExpired()) },
+//                           toastContent: { StitchAIRatingToast() })
 //        .background {
 //            GeometryReader { geometry in
 //                Color.clear

--- a/Stitch/Graph/View/GraphBaseView.swift
+++ b/Stitch/Graph/View/GraphBaseView.swift
@@ -115,6 +115,9 @@ struct GraphBaseView: View {
                                     scale: document.graphMovement.zoomData))
         .coordinateSpace(name: Self.coordinateNamespace)
         
+        // If sidebar was open as well, do we need to push the
+        // Problem comes when we
+        
         #if targetEnvironment(macCatalyst)
         .overlay(alignment: .trailing) {
             if store.showsLayerInspector {
@@ -122,14 +125,16 @@ struct GraphBaseView: View {
                                    document: document)
                 .frame(width: LayerInspectorView.LAYER_INSPECTOR_WIDTH)
                 .transition(.move(edge: .trailing))
+                .offset(x: )
+                
             }
         }
         
         //        .inspector(isPresented: $store.showsLayerInspector) {
-        //            LayerInspectorView(graph: graph,
-        //                               document: document)
+//                    LayerInspectorView(graph: graph,
+//                                       document: document)
         //        }
-        #endif
+//        #endif
         
         .bottomCenterToast(willShow: document.llmRecording.showRatingToast,
                            config: .init(duration: 15),


### PR DESCRIPTION
Also resolves an issue where inspector sat below the prototype window for a moment when both sidebars were closing.


https://github.com/user-attachments/assets/403f80a7-aba4-4b68-9e1d-17ece816bb7a


## Claude's notes / summary


⏺ Fix Sidebar and Inspector Animation Jerkiness

  Problem

  When toggling both the native sidebar and layer inspector simultaneously, the inspector animation was jerky - it would slide in smoothly but then
  jump/stutter mid-animation, especially during closing.

  Root Cause Analysis

  The issue was caused by UIKitWrapper layout interference:

  1. UIKitWrapper in ContentView was needed for TAB key detection in flyouts
  2. During sidebar animations, UIKitWrapper triggered layout recalculations
  3. This caused the inspector's position to be recalculated mid-animation
  4. Result: Inspector would start animating smoothly, then jump to a new position, then continue animating

  Solution: Conditional UIKitWrapper

  Made UIKitWrapper conditional - only present when actually needed for flyout TAB navigation.

  Files Modified:
  - ContentView.swift

  Implementation:
  ```swift
  // Before: UIKitWrapper always present
  UIKitWrapper(...) {
      contentView
  }

  // After: UIKitWrapper only when flyout is open
  if document.visibleGraph.propertySidebar.flyoutState != nil {
      // UIKitWrapper only when flyout is active (for TAB key detection)
      UIKitWrapper(...) {
          contentView
      }
  } else {
      // No wrapper when no flyout (smooth sidebar animations)
      contentView
  }
  ```

