### PR TITLE
"Update iPad graph and Catalyst top bar buttons for OS 26 glass effects"

### DIFF
--- a/Stitch/App/Resources/Assets.xcassets/Icons/discord.imageset/Contents.json
+++ b/Stitch/App/Resources/Assets.xcassets/Icons/discord.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Stitch/App/Resources/Assets.xcassets/Icons/github.imageset/Contents.json
+++ b/Stitch/App/Resources/Assets.xcassets/Icons/github.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Stitch/App/Util/Constants.swift
+++ b/Stitch/App/Util/Constants.swift
@@ -107,11 +107,13 @@ let RESTART_PROTOTYPE_ACTION = { dispatch(PrototypeRestartedAction()) }
 let PREVIEW_FULL_SCREEN_ACTION = { dispatch(ToggleFullScreenEvent()) }
 
 let UNDO_ICON_LABEL = "Undo"
+let UNDO_ICON_NAME_STRING: String = "arrow.uturn.backward.square"
 let UNDO_ICON_NAME: IconName = .sfSymbol("arrow.uturn.backward.square") // .svgIcon("Undo")
 @MainActor
 let UNDO_ACTION = { @MainActor in dispatch(UndoEvent()) }
 
 let REDO_ICON_LABEL = "Redo"
+let REDO_ICON_NAME_STRING = "arrow.uturn.forward.square"
 let REDO_ICON_NAME: IconName = .sfSymbol("arrow.uturn.forward.square") //.svgIcon("Redo")
 @MainActor
 let REDO_ACTION = { @MainActor in dispatch(RedoEvent()) }

--- a/Stitch/App/Util/Constants.swift
+++ b/Stitch/App/Util/Constants.swift
@@ -92,7 +92,8 @@ let PREVIEW_SHOW_TOGGLE_ACTION = { dispatch(TogglePreviewWindow()) }
 
 let FILE_IMPORT_LABEL = "Import File"
 //let FILE_IMPORT_ICON_NAME: IconName = .svgIcon("Doc")
- let FILE_IMPORT_ICON_NAME: IconName = .sfSymbol("document")
+let FILE_IMPORT_ICON_NAME_STRING = "document"
+let FILE_IMPORT_ICON_NAME: IconName = .sfSymbol("document")
 
 @MainActor
 let FILE_IMPORT_ACTION = { @MainActor in dispatch(ShowFileImportModal()) }

--- a/Stitch/Graph/Toolbar/View/CatalystNavBarButtonView.swift
+++ b/Stitch/Graph/Toolbar/View/CatalystNavBarButtonView.swift
@@ -13,24 +13,14 @@ struct CatalystNavBarButtonWithMenu<MenuContentView: View>: View {
     @ViewBuilder var menuContentViews: () -> MenuContentView
     
     var body: some View {
-        // HACK to get tooltips working on Mac Catalyst; can't use SwiftUI `.help`
-//        ZStack {
-//            CatalystToolTipButton(systemImageName: systemName,
-//                                  tooltipText: toolTip) { }
-//            .fixedSize()
-            
-            Menu {
-                menuContentViews()
-            } label: {
-//                EmptyView()
-                Button(toolTip,
-                       systemImage: systemName,
-                       action: { })
-            }
-            .menuIndicator(.hidden)
-        
-//            .modifier(CatalystTopBarButtonStyle())
-//        }
+        Menu {
+            menuContentViews()
+        } label: {
+            Button(toolTip,
+                   systemImage: systemName,
+                   action: { })
+        }
+        .menuIndicator(.hidden)
     }
 }
 

--- a/Stitch/Graph/Toolbar/View/CatalystNavBarButtonView.swift
+++ b/Stitch/Graph/Toolbar/View/CatalystNavBarButtonView.swift
@@ -14,18 +14,23 @@ struct CatalystNavBarButtonWithMenu<MenuContentView: View>: View {
     
     var body: some View {
         // HACK to get tooltips working on Mac Catalyst; can't use SwiftUI `.help`
-        ZStack {
-            CatalystToolTipButton(systemImageName: systemName,
-                                  tooltipText: toolTip) { }
-            .fixedSize()
+//        ZStack {
+//            CatalystToolTipButton(systemImageName: systemName,
+//                                  tooltipText: toolTip) { }
+//            .fixedSize()
             
             Menu {
                 menuContentViews()
             } label: {
-                EmptyView()
+//                EmptyView()
+                Button(toolTip,
+                       systemImage: systemName,
+                       action: { })
             }
-            .modifier(CatalystTopBarButtonStyle())
-        }
+            .menuIndicator(.hidden)
+        
+//            .modifier(CatalystTopBarButtonStyle())
+//        }
     }
 }
 
@@ -51,27 +56,11 @@ struct CatalystNavBarButton: View {
     let action: () -> Void
         
     var body: some View {
-        
-        // HACK to get tooltips working on Mac Catalyst; can't use SwiftUI `.help`
-        ZStack {
-            CatalystToolTipButton(systemImageName: systemName,
-                                  tooltipText: toolTip) { }
-            .fixedSize()
-            
-            Menu {
-                // 'Empty menu' so that nothing happens when we tap the Menu's label
-                EmptyView()
-            } label: {
-                EmptyView()
-            }
-            // rotation3DEffect must be applied here
-            .rotation3DEffect(Angle(degrees: rotationZ),
-                              axis: (x: 0, y: 0, z: rotationZ))
-            .modifier(CatalystTopBarButtonStyle())
-            .simultaneousGesture(TapGesture().onEnded({ _ in
-                action()
-            }))
-        }
+        Button(toolTip,
+               systemImage: systemName,
+               action: action)
+        .rotation3DEffect(Angle(degrees: rotationZ),
+                          axis: (x: 0, y: 0, z: rotationZ))
     }
 }
 

--- a/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
+++ b/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
@@ -41,7 +41,7 @@ extension String {
     static let SHARE_ICON_SF_SYMBOL_NAME = "square.and.arrow.up"
 
     // NO, NOT USED ON CATALYST
-    static let MISCELLANEOUS_OPTIONS_SF_SYMBOL_MAME = "ellipsis.circle"
+    static let MISCELLANEOUS_OPTIONS_SF_SYMBOL_NAME = "ellipsis.circle"
 
     // on Graph, sits inside the misc options button
     // on Homescreen
@@ -128,9 +128,6 @@ struct CatalystTopBarGraphButtons: View {
                     dispatch(ToggleFullScreenEvent())
                 }
             }
-            
-//            TopBarSharingButtonsView(document: document)
-//                .modifier(CatalystTopBarButtonStyle())
             
             TopBarFeedbackButtonsView(document: self.document)
                 .modifier(CatalystTopBarButtonStyle())

--- a/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
+++ b/Stitch/Graph/Toolbar/View/CatalystNavigationBarHelperViews.swift
@@ -83,14 +83,6 @@ struct CatalystTopBarGraphButtons: View {
             // OpenAI Configuration Picker - only show in debug builds
             #if DEV_DEBUG || STITCH_AI_TESTING
             OpenAIConfigurationPicker(document: document)
-            
-//            // AI Examples button
-//            CatalystNavBarButton("list.bullet.rectangle",
-//                                 toolTip: "AI Examples") {
-//                withAnimation(.easeInOut(duration: 0.3)) {
-//                    document.showAITrainingExamplesOverlay.toggle()
-//                }
-//            }
             #endif
             
             CatalystNavBarButton(.ADD_NODE_SF_SYMBOL_NAME,

--- a/Stitch/Graph/Toolbar/View/OpenAIConfigurationPicker.swift
+++ b/Stitch/Graph/Toolbar/View/OpenAIConfigurationPicker.swift
@@ -106,11 +106,13 @@ struct OpenAIConfigurationPicker: View {
                 Text(currentModelDisplayName)
                     .lineLimit(1)
 //                    .frame(width: 300)
-                    .frame(width: 180)
+//                    .frame(width: 180)
+//                    .frame(width: 80)
             }
         }
-        .modifier(iPadTopBarButtonStyle())
+//        .modifier(iPadTopBarButtonStyle())
 //        .frame(width: 300)
-        .frame(width: 180)
+//        .frame(width: 180)
+//        .frame(width: 80)
     }
 }

--- a/Stitch/Graph/Toolbar/View/TopBarButtonView.swift
+++ b/Stitch/Graph/Toolbar/View/TopBarButtonView.swift
@@ -5,6 +5,7 @@
 //  Created by Christian J Clampitt on 4/12/23.
 //
 
+import Foundation
 import SwiftUI
 import StitchSchemaKit
 
@@ -53,27 +54,16 @@ struct iPadTopBarButtonStyle: ViewModifier {
     }
 }
 
-// Hack: use `Menu(primaryAction:)` to get native size and hover effect on iPad
 struct iPadNavBarButton: View {
+    let iconName: String
+    let tooltip: String
     let action: () -> Void
-    let iconName: IconName
     var rotationZ: CGFloat = 0 // some icons stay the same but just get rotated
 
     var body: some View {
-        Menu {
-            // 'Empty menu' so that nothing happens when we tap the Menu's label
-            EmptyView()
-        } label: {
-            Button(action: {}) {
-                // TODO: any .resizable(), .fixedSize() etc. needed?
-                iconName.image
-                // TODO: why is this rotation changes sometimes animated, sometimes not?
-                //                    .rotation3DEffect(Angle(degrees: rotationZ),
-                //                                      axis: (x: 0, y: 0, z: rotationZ))
-            }
-        } primaryAction: {
-            action()
-        }
+        Button(tooltip,
+               systemImage: iconName,
+               action: action)
         .rotation3DEffect(Angle(degrees: rotationZ),
                           axis: (x: 0, y: 0, z: rotationZ))
     }
@@ -120,13 +110,16 @@ struct iPadGraphTopBarButtons: View {
     let isPreviewWindowShown: Bool // = true
     let restartPrototypeWindowIconRotationZ: CGFloat
     
-    @ViewBuilder
-    var miscButton: some View {
-        iPadGraphTopBarMiscMenu(document: document)
-    }
+//    @ViewBuilder
+//    var miscButton: some View {
+//        iPadGraphTopBarMiscMenu(document: document)
+//    }
     
     var body: some View {
-        Group {
+        
+        
+        
+        ControlGroup {
             Picker("", selection: $document.selectedTab) {
                 ForEach(ProjectTab.allCases) { projectTab in
                     Image(systemName: projectTab.systemIcon)
@@ -134,109 +127,156 @@ struct iPadGraphTopBarButtons: View {
                 }
             }
             .pickerStyle(.segmented)
-                        
-            // go up a traversal level
-            iPadNavBarButton(action: { dispatch(GoUpOneTraversalLevel()) },
-                             iconName: .sfSymbol(.GO_UP_ONE_TRAVERSAL_LEVEL_SF_SYMBOL_NAME))
-            .disabled(hasActiveGroupFocused ? false : true)
-            
-            iPadTopBarButtonWithMenu(iconName: .sfSymbol(.AI_MAGIC_TEMP_MENU_SF_SYMBOL_NAME)) {
-                StitchButton {
-                    dispatch(ShowAINodePromptEntryModal())
-                } label: {
-                    Label(String.CREATE_CUSTOM_NODE_WITH_AI,
-                          systemImage: "rectangle")
-                }
-                StitchButton {
-                    dispatch(ToggleInsertNodeMenu())
-                } label: {
-                    Label("Add Nodes",
-                          systemImage: "rectangle.on.rectangle")
-                }
-            }
-            
-            // OpenAI Configuration Picker - only show in debug builds
-            #if DEV_DEBUG || STITCH_AI_TESTING
-            OpenAIConfigurationPicker(document: document)
-            
-//            // AI Examples button
-//            iPadNavBarButton(action: { 
-//                withAnimation(.easeInOut(duration: 0.3)) {
-//                    document.showAITrainingExamplesOverlay.toggle()
-//                }
-//            }, iconName: .sfSymbol("list.bullet.rectangle"))
-            #endif
-            
-            iPadNavBarButton(action: { dispatch(ToggleInsertNodeMenu()) },
-                             iconName: .sfSymbol(.ADD_NODE_SF_SYMBOL_NAME))
-            
-            //            if isDebugMode,
-            //               FeatureFlags.SHOW_TRAINING_EXAMPLE_GENERATION_BUTTON {
-            //
-            ////                iPadNavBarButton(action: {
-            ////                    dispatch(ShowCreateTrainingDataFromExistingGraphModal())
-            ////                }, iconName: .sfSymbol(.DEBUG_SUBMIT_EXISTING_GRAPH_AS_TRAINING_DATA_SF_SYMBOL_NAME))
-            //
-            //            }
-            
-            // toggle preview window
-            iPadNavBarButton(
-                action: PREVIEW_SHOW_TOGGLE_ACTION,
-                iconName: .sfSymbol(isPreviewWindowShown ? .HIDE_PREVIEW_WINDOW_SF_SYMBOL_NAME : .SHOW_PREVIEW_WINDOW_SF_SYMBOL_NAME))
-            
-            // refresh prototype
-            iPadNavBarButton(action: RESTART_PROTOTYPE_ACTION,
-                             iconName: .sfSymbol(.RESTART_PROTOTYPE_SF_SYMBOL_NAME),
-                             rotationZ: restartPrototypeWindowIconRotationZ)
-            
-            // full screen
-            iPadNavBarButton(
-                action: PREVIEW_FULL_SCREEN_ACTION,
-                iconName: .sfSymbol(isFullscreen ? .SHRINK_FROM_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME : .EXPAND_TO_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME))
-
-            // the misc (...) button
-            miscButton
-                .popoverTip(document.stitchAITrainingTip, arrowEdge: .top)
         }
+        
+        
+        
+        // go up a traversal level
+        iPadNavBarButton(iconName: .GO_UP_ONE_TRAVERSAL_LEVEL_SF_SYMBOL_NAME,
+                         tooltip: "Go up one traversal level",
+                         action: { dispatch(GoUpOneTraversalLevel()) })
+        .disabled(hasActiveGroupFocused ? false : true)
+//        
+//        iPadTopBarButtonWithMenu(iconName: .sfSymbol(.AI_MAGIC_TEMP_MENU_SF_SYMBOL_NAME)) {
+//            StitchButton {
+//                dispatch(ShowAINodePromptEntryModal())
+//            } label: {
+//                Label(String.CREATE_CUSTOM_NODE_WITH_AI,
+//                      systemImage: "rectangle")
+//            }
+//            StitchButton {
+//                dispatch(ToggleInsertNodeMenu())
+//            } label: {
+//                Label("Add Nodes",
+//                      systemImage: "rectangle.on.rectangle")
+//            }
+//        }
+        
+//        // OpenAI Configuration Picker - only show in debug builds
+//#if DEV_DEBUG || STITCH_AI_TESTING
+////        ToolbarItem {
+//            //            ControlGroup {
+//            OpenAIConfigurationPicker(document: document)
+//            //            }
+////        }
+//        
+//#endif
+        
+        iPadNavBarButton(iconName: .ADD_NODE_SF_SYMBOL_NAME,
+                         tooltip: "Add Node",
+                         action: { dispatch(ToggleInsertNodeMenu()) })
+        
+        // toggle preview window
+        iPadNavBarButton(
+            iconName: isPreviewWindowShown ? .HIDE_PREVIEW_WINDOW_SF_SYMBOL_NAME : .SHOW_PREVIEW_WINDOW_SF_SYMBOL_NAME,
+            tooltip: "Toggle Prototype Window",
+            action: PREVIEW_SHOW_TOGGLE_ACTION)
+        
+        // refresh prototype
+        iPadNavBarButton(iconName: .RESTART_PROTOTYPE_SF_SYMBOL_NAME,
+                         tooltip: "Restart Prototype",
+                         action: RESTART_PROTOTYPE_ACTION,
+                         rotationZ: restartPrototypeWindowIconRotationZ)
+        
+        iPadTopBarButtonWithMenu(iconName: .sfSymbol(.AI_MAGIC_TEMP_MENU_SF_SYMBOL_NAME)) {
+            StitchButton {
+                dispatch(ShowAINodePromptEntryModal())
+            } label: {
+                Label(String.CREATE_CUSTOM_NODE_WITH_AI,
+                      systemImage: "rectangle")
+            }
+            StitchButton {
+                dispatch(ToggleInsertNodeMenu())
+            } label: {
+                Label("Add Nodes",
+                      systemImage: "rectangle.on.rectangle")
+            }
+        }
+        
+        // full screen
+        iPadNavBarButton(
+            iconName: isFullscreen ? .SHRINK_FROM_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME : .EXPAND_TO_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME,
+            tooltip: "Toggle Fullscreen",
+            action: PREVIEW_FULL_SCREEN_ACTION)
+        
+        // the misc (...) button
+//        miscButton
+//        iPadGraphTopBarMiscMenu()
+        //                .popoverTip(document.stitchAITrainingTip, arrowEdge: .top)
+        
+        
+//        iPadTopBarButtonWithMenu(iconName: .sfSymbol(.AI_MAGIC_TEMP_MENU_SF_SYMBOL_NAME)) {
+//            StitchButton {
+//                dispatch(ShowAINodePromptEntryModal())
+//            } label: {
+//                Label(String.CREATE_CUSTOM_NODE_WITH_AI,
+//                      systemImage: "rectangle")
+//            }
+//            StitchButton {
+//                dispatch(ToggleInsertNodeMenu())
+//            } label: {
+//                Label("Add Nodes",
+//                      systemImage: "rectangle.on.rectangle")
+//            }
+//        }
+        
+        
     }
 }
 #endif
 
 struct iPadGraphTopBarMiscMenu: View {
-    @Bindable var document: StitchDocumentViewModel
     
     var body: some View {
         Menu {
-            iPadTopBarButton(action: { dispatch(FindSomeCanvasItemOnGraph())},
-                             iconName: .sfSymbol(.FIND_NODE_ON_GRAPH),
-                             label: "Find Node")
             
-            iPadTopBarButton(action: UNDO_ACTION,
-                             iconName: UNDO_ICON_NAME,
-                             label: UNDO_ICON_LABEL)
-
-            iPadTopBarButton(action: REDO_ACTION,
-                             iconName: REDO_ICON_NAME,
-                             label: REDO_ICON_LABEL)
-
-            iPadTopBarButton(action: FILE_IMPORT_ACTION,
-                             iconName: FILE_IMPORT_ICON_NAME,
-                             label: FILE_IMPORT_LABEL)
+//            iPadNavBarButton(
+//                iconName: .EXPAND_TO_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME,
+//                tooltip: "Love me",
+//                action: { })
             
-//            TopBarSharingButtonsView(document: document)
+            Button("love",
+                   systemImage: .EXPAND_TO_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME,
+                   action: { })
+            
+//            iPadTopBarButton(action: { dispatch(FindSomeCanvasItemOnGraph())},
+//                             iconName: .sfSymbol(.FIND_NODE_ON_GRAPH),
+//                             label: "Find Node")
+//            
+//            iPadTopBarButton(action: UNDO_ACTION,
+//                             iconName: UNDO_ICON_NAME,
+//                             label: UNDO_ICON_LABEL)
+//
+//            iPadTopBarButton(action: REDO_ACTION,
+//                             iconName: REDO_ICON_NAME,
+//                             label: REDO_ICON_LABEL)
+//
+//            iPadTopBarButton(action: FILE_IMPORT_ACTION,
+//                             iconName: FILE_IMPORT_ICON_NAME,
+//                             label: FILE_IMPORT_LABEL)
+//            
+////            TopBarSharingButtonsView(document: document)
+////                .modifier(iPadTopBarButtonStyle())
+//
+//            TopBarFeedbackButtonsView(document: self.document)
 //                .modifier(iPadTopBarButtonStyle())
-
-            TopBarFeedbackButtonsView(document: self.document)
-                .modifier(iPadTopBarButtonStyle())
-            
-            iPadTopBarButton(action: PROJECT_SETTINGS_ACTION,
-                             iconName: PROJECT_SETTINGS_ICON_NAME,
-                             label: PROJECT_SETTINGS_LABEL)
+//            
+//            iPadTopBarButton(action: PROJECT_SETTINGS_ACTION,
+//                             iconName: PROJECT_SETTINGS_ICON_NAME,
+//                             label: PROJECT_SETTINGS_LABEL)
         } label: {
-            Button(action: {}) {
-                // TODO: any .resizable(), .fixedSize() etc. needed?
-                TOP_BAR_MENU_ICON_NAME.image
+            Button(action: {} ) {
+                Image(systemName: "ellipsis.circle")
             }
+            
+//            Button("More",
+//                   systemImage: "ellipsis.circle",
+//                   action: { })
+            
+//            Button(action: {}) {
+//                // TODO: any .resizable(), .fixedSize() etc. needed?
+//                TOP_BAR_MENU_ICON_NAME.image
+//            }
         } // menu
     }
 }

--- a/Stitch/Graph/Toolbar/View/TopBarButtonView.swift
+++ b/Stitch/Graph/Toolbar/View/TopBarButtonView.swift
@@ -9,40 +9,42 @@ import Foundation
 import SwiftUI
 import StitchSchemaKit
 
-// legacy; used for potentially-labeled buttons,
-// including those that appear in the top bar's dropdown menu
 struct iPadTopBarButtonWithMenu<MenuContent: View>: View {
-//    let action: @MainActor () -> Void
-    let iconName: IconName
-    // var label: String? // non-nil show label
+    let iconName: String
+    let tooltip: String
     @ViewBuilder var menuContent: () -> MenuContent
 
     var body: some View {
         Menu {
-            // 'Empty menu' so that nothing happens when we tap the Menu's label
             menuContent()
         } label: {
-            Button(action: { }) {
-                iconName.image
-            }
+            Button(tooltip,
+                   systemImage: iconName,
+                   action: { })
+            //            .buttonStyle(.borderless)
         }
     }
 }
 
 
-// legacy; used for potentially-labeled buttons,
-// including those that appear in the top bar's dropdown menu
 struct iPadTopBarButton: View {
+    let iconName: String
+    let tooltip: String
     let action: @MainActor () -> Void
-    let iconName: IconName
-    var label: String? // non-nil show label
+    var label: String? // non-nil show label for menu items
 
     var body: some View {
-        StitchButton(action: action) {
-            TopBarImageButton(iconName: iconName,
-                              label: label)
+        if let label = label {
+            Button(action: action) {
+                Label(label, systemImage: iconName)
+            }
+            //            .buttonStyle(.borderless)
+        } else {
+            Button(tooltip,
+                   systemImage: iconName,
+                   action: action)
+            //            .buttonStyle(.borderless)
         }
-        .modifier(iPadTopBarButtonStyle())
     }
 }
 
@@ -64,41 +66,12 @@ struct iPadNavBarButton: View {
         Button(tooltip,
                systemImage: iconName,
                action: action)
+        //        .buttonStyle(.borderless)
         .rotation3DEffect(Angle(degrees: rotationZ),
                           axis: (x: 0, y: 0, z: rotationZ))
     }
 }
 
-// Generic helper button
-struct TopBarImageButton: View {
-    let iconName: IconName
-    var label: String?
-
-    var body: some View {
-        if let label = label {
-            Label {
-                StitchTextView(string: label)
-            } icon: {
-                iconImage
-            }
-        } else {
-            iconImage
-        }
-    }
-
-    var iconImage: some View {
-        // special case where we have to flip 90 degrees an existing SF Symbol
-        let rotationZ: CGFloat = iconName == PREVIEW_HIDE_ICON_NAME ? 90 : 0
-
-        return iconName.image
-            .resizable()
-            .scaledToFit()
-            .foregroundColor(TOP_BAR_IMAGE_BUTTON_FOREGROUND_COLOR)
-            .rotation3DEffect(Angle(degrees: rotationZ),
-                              axis: (x: 0, y: 0, z: rotationZ))
-            .fixedSize()
-    }
-}
 
 #if !targetEnvironment(macCatalyst)
 struct iPadGraphTopBarButtons: View {
@@ -109,33 +82,30 @@ struct iPadGraphTopBarButtons: View {
     let isFullscreen: Bool // = false
     let isPreviewWindowShown: Bool // = true
     let restartPrototypeWindowIconRotationZ: CGFloat
-    
-//    @ViewBuilder
-//    var miscButton: some View {
-//        iPadGraphTopBarMiscMenu(document: document)
-//    }
+
+    @ViewBuilder
+    var miscButton: some View {
+        iPadGraphTopBarMiscMenu(document: document)
+    }
     
     var body: some View {
+                        
+//        ControlGroup {
+//            Picker("", selection: $document.selectedTab) {
+//                ForEach(ProjectTab.allCases) { projectTab in
+//                    Image(systemName: projectTab.systemIcon)
+//                        .tag(projectTab)
+//                }
+//            }
+//            .pickerStyle(.segmented)
+//        }
         
         
-        
-        ControlGroup {
-            Picker("", selection: $document.selectedTab) {
-                ForEach(ProjectTab.allCases) { projectTab in
-                    Image(systemName: projectTab.systemIcon)
-                        .tag(projectTab)
-                }
-            }
-            .pickerStyle(.segmented)
-        }
-        
-        
-        
-        // go up a traversal level
-        iPadNavBarButton(iconName: .GO_UP_ONE_TRAVERSAL_LEVEL_SF_SYMBOL_NAME,
-                         tooltip: "Go up one traversal level",
-                         action: { dispatch(GoUpOneTraversalLevel()) })
-        .disabled(hasActiveGroupFocused ? false : true)
+//        // go up a traversal level
+//        iPadNavBarButton(iconName: .GO_UP_ONE_TRAVERSAL_LEVEL_SF_SYMBOL_NAME,
+//                         tooltip: "Go up one traversal level",
+//                         action: { dispatch(GoUpOneTraversalLevel()) })
+//        .disabled(hasActiveGroupFocused ? false : true)
 //        
 //        iPadTopBarButtonWithMenu(iconName: .sfSymbol(.AI_MAGIC_TEMP_MENU_SF_SYMBOL_NAME)) {
 //            StitchButton {
@@ -162,50 +132,24 @@ struct iPadGraphTopBarButtons: View {
 //        
 //#endif
         
-        iPadNavBarButton(iconName: .ADD_NODE_SF_SYMBOL_NAME,
-                         tooltip: "Add Node",
-                         action: { dispatch(ToggleInsertNodeMenu()) })
+//        iPadNavBarButton(iconName: .ADD_NODE_SF_SYMBOL_NAME,
+//                         tooltip: "Add Node",
+//                         action: { dispatch(ToggleInsertNodeMenu()) })
+//        
+//        // toggle preview window
+//        iPadNavBarButton(
+//            iconName: isPreviewWindowShown ? .HIDE_PREVIEW_WINDOW_SF_SYMBOL_NAME : .SHOW_PREVIEW_WINDOW_SF_SYMBOL_NAME,
+//            tooltip: "Toggle Prototype Window",
+//            action: PREVIEW_SHOW_TOGGLE_ACTION)
         
-        // toggle preview window
-        iPadNavBarButton(
-            iconName: isPreviewWindowShown ? .HIDE_PREVIEW_WINDOW_SF_SYMBOL_NAME : .SHOW_PREVIEW_WINDOW_SF_SYMBOL_NAME,
-            tooltip: "Toggle Prototype Window",
-            action: PREVIEW_SHOW_TOGGLE_ACTION)
+//        // refresh prototype
+//        iPadNavBarButton(iconName: .RESTART_PROTOTYPE_SF_SYMBOL_NAME,
+//                         tooltip: "Restart Prototype",
+//                         action: RESTART_PROTOTYPE_ACTION,
+//                         rotationZ: restartPrototypeWindowIconRotationZ)
         
-        // refresh prototype
-        iPadNavBarButton(iconName: .RESTART_PROTOTYPE_SF_SYMBOL_NAME,
-                         tooltip: "Restart Prototype",
-                         action: RESTART_PROTOTYPE_ACTION,
-                         rotationZ: restartPrototypeWindowIconRotationZ)
-        
-        iPadTopBarButtonWithMenu(iconName: .sfSymbol(.AI_MAGIC_TEMP_MENU_SF_SYMBOL_NAME)) {
-            StitchButton {
-                dispatch(ShowAINodePromptEntryModal())
-            } label: {
-                Label(String.CREATE_CUSTOM_NODE_WITH_AI,
-                      systemImage: "rectangle")
-            }
-            StitchButton {
-                dispatch(ToggleInsertNodeMenu())
-            } label: {
-                Label("Add Nodes",
-                      systemImage: "rectangle.on.rectangle")
-            }
-        }
-        
-        // full screen
-        iPadNavBarButton(
-            iconName: isFullscreen ? .SHRINK_FROM_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME : .EXPAND_TO_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME,
-            tooltip: "Toggle Fullscreen",
-            action: PREVIEW_FULL_SCREEN_ACTION)
-        
-        // the misc (...) button
-//        miscButton
-//        iPadGraphTopBarMiscMenu()
-        //                .popoverTip(document.stitchAITrainingTip, arrowEdge: .top)
-        
-        
-//        iPadTopBarButtonWithMenu(iconName: .sfSymbol(.AI_MAGIC_TEMP_MENU_SF_SYMBOL_NAME)) {
+//        iPadTopBarButtonWithMenu(iconName: .AI_MAGIC_TEMP_MENU_SF_SYMBOL_NAME,
+//                                 tooltip: "Create with AI") {
 //            StitchButton {
 //                dispatch(ShowAINodePromptEntryModal())
 //            } label: {
@@ -220,63 +164,60 @@ struct iPadGraphTopBarButtons: View {
 //            }
 //        }
         
+//        // full screen
+//        iPadNavBarButton(
+//            iconName: isFullscreen ? .SHRINK_FROM_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME : .EXPAND_TO_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME,
+//            tooltip: "Toggle Fullscreen",
+//            action: PREVIEW_FULL_SCREEN_ACTION)
         
+        // the misc (...) button
+//        miscButton
+        //                .popoverTip(document.stitchAITrainingTip, arrowEdge: .top)
+                
     }
 }
 #endif
 
 struct iPadGraphTopBarMiscMenu: View {
-    
+    @Bindable var document: StitchDocumentViewModel
+
     var body: some View {
         Menu {
             
-//            iPadNavBarButton(
-//                iconName: .EXPAND_TO_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME,
-//                tooltip: "Love me",
-//                action: { })
-            
-            Button("love",
-                   systemImage: .EXPAND_TO_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME,
-                   action: { })
-            
-//            iPadTopBarButton(action: { dispatch(FindSomeCanvasItemOnGraph())},
-//                             iconName: .sfSymbol(.FIND_NODE_ON_GRAPH),
-//                             label: "Find Node")
-//            
-//            iPadTopBarButton(action: UNDO_ACTION,
-//                             iconName: UNDO_ICON_NAME,
-//                             label: UNDO_ICON_LABEL)
-//
-//            iPadTopBarButton(action: REDO_ACTION,
-//                             iconName: REDO_ICON_NAME,
-//                             label: REDO_ICON_LABEL)
-//
-//            iPadTopBarButton(action: FILE_IMPORT_ACTION,
-//                             iconName: FILE_IMPORT_ICON_NAME,
-//                             label: FILE_IMPORT_LABEL)
-//            
-////            TopBarSharingButtonsView(document: document)
-////                .modifier(iPadTopBarButtonStyle())
-//
-//            TopBarFeedbackButtonsView(document: self.document)
+            iPadTopBarButton(iconName: .FIND_NODE_ON_GRAPH,
+                             tooltip: "Find Node",
+                             action: { dispatch(FindSomeCanvasItemOnGraph())},
+                             label: "Find Node")
+
+            iPadTopBarButton(iconName: UNDO_ICON_NAME_STRING,
+                             tooltip: "Undo",
+                             action: UNDO_ACTION,
+                             label: UNDO_ICON_LABEL)
+
+            iPadTopBarButton(iconName: REDO_ICON_NAME_STRING,
+                             tooltip: "Redo",
+                             action: REDO_ACTION,
+                             label: REDO_ICON_LABEL)
+
+            iPadTopBarButton(iconName: "document",
+                             tooltip: "Import File",
+                             action: FILE_IMPORT_ACTION,
+                             label: FILE_IMPORT_LABEL)
+
+            TopBarSharingButtonsView(document: document)
 //                .modifier(iPadTopBarButtonStyle())
-//            
-//            iPadTopBarButton(action: PROJECT_SETTINGS_ACTION,
-//                             iconName: PROJECT_SETTINGS_ICON_NAME,
-//                             label: PROJECT_SETTINGS_LABEL)
+
+            TopBarFeedbackButtonsView(document: self.document)
+//                .modifier(iPadTopBarButtonStyle())
+
+            iPadTopBarButton(iconName: .SETTINGS_SF_SYMBOL_NAME,
+                             tooltip: "Settings",
+                             action: PROJECT_SETTINGS_ACTION,
+                             label: PROJECT_SETTINGS_LABEL)
         } label: {
             Button(action: {} ) {
                 Image(systemName: "ellipsis.circle")
             }
-            
-//            Button("More",
-//                   systemImage: "ellipsis.circle",
-//                   action: { })
-            
-//            Button(action: {}) {
-//                // TODO: any .resizable(), .fixedSize() etc. needed?
-//                TOP_BAR_MENU_ICON_NAME.image
-//            }
         } // menu
     }
 }

--- a/Stitch/Graph/Toolbar/View/TopBarButtonView.swift
+++ b/Stitch/Graph/Toolbar/View/TopBarButtonView.swift
@@ -199,7 +199,7 @@ struct iPadGraphTopBarMiscMenu: View {
                              action: REDO_ACTION,
                              label: REDO_ICON_LABEL)
 
-            iPadTopBarButton(iconName: "document",
+            iPadTopBarButton(iconName: FILE_IMPORT_ICON_NAME_STRING,
                              tooltip: "Import File",
                              action: FILE_IMPORT_ACTION,
                              label: FILE_IMPORT_LABEL)

--- a/Stitch/Graph/Toolbar/View/TopBarSharingButtonsView.swift
+++ b/Stitch/Graph/Toolbar/View/TopBarSharingButtonsView.swift
@@ -262,23 +262,26 @@ Platform: \(Self.platform)
     }
     
     var macView: some View {
-        ZStack {
-            CatalystToolTipButton(
-                systemImageName: Self.iconName,
-                tooltipText: "Contact Us"
-            ) {
-                // log("my action here")
-            }
-            .fixedSize()
+//        ZStack {
+//            CatalystToolTipButton(
+//                systemImageName: Self.iconName,
+//                tooltipText: "Contact Us"
+//            ) {
+//                // log("my action here")
+//            }
+//            .fixedSize()
+            
+           
             
             Menu {
                 menuContent
             } label: {
-                EmptyView()
+//                EmptyView()
+                Button("Contact Us", systemImage: Self.iconName, action: { })
             }
             // Note: *must* provide explicit frame
-            .frame(width: 30, height: 30)
-        }
+//            .frame(width: 30, height: 30)
+//        }
     }
     
     var body: some View {

--- a/Stitch/Graph/Toolbar/View/TopBarSharingButtonsView.swift
+++ b/Stitch/Graph/Toolbar/View/TopBarSharingButtonsView.swift
@@ -262,26 +262,11 @@ Platform: \(Self.platform)
     }
     
     var macView: some View {
-//        ZStack {
-//            CatalystToolTipButton(
-//                systemImageName: Self.iconName,
-//                tooltipText: "Contact Us"
-//            ) {
-//                // log("my action here")
-//            }
-//            .fixedSize()
-            
-           
-            
-            Menu {
-                menuContent
-            } label: {
-//                EmptyView()
-                Button("Contact Us", systemImage: Self.iconName, action: { })
-            }
-            // Note: *must* provide explicit frame
-//            .frame(width: 30, height: 30)
-//        }
+        Menu {
+            menuContent
+        } label: {
+            Button("Contact Us", systemImage: Self.iconName, action: { })
+        }
     }
     
     var body: some View {

--- a/Stitch/Graph/View/ProjectToolbar.swift
+++ b/Stitch/Graph/View/ProjectToolbar.swift
@@ -88,6 +88,8 @@ struct ProjectToolbarViewModifier: ViewModifier {
                 // .primaryAction = right side
                 // .secondaryAction = center
                 ToolbarItemGroup(placement: .primaryAction) {
+                    
+                    // Need to break these up?
                     iPadGraphTopBarButtons(
                         document: document,
                         isDebugMode: document.isDebugMode,

--- a/Stitch/Graph/View/ProjectToolbar.swift
+++ b/Stitch/Graph/View/ProjectToolbar.swift
@@ -214,6 +214,7 @@ struct ProjectToolbarViewModifier: ViewModifier {
                     Text("")
                 }
                 
+                // TODO: HOW TO GET THESE BUTTONS TO BE THE SAME SIZE AS THE SIDEBAR TOGGLE BUTTON? USING SEPARATE `ToolbarItemGroup` DID NOT HELP
                 ToolbarItemGroup(placement: .primaryAction) {
                     ControlGroup {
                         CatalystTopBarGraphButtons(

--- a/Stitch/Graph/View/ProjectToolbar.swift
+++ b/Stitch/Graph/View/ProjectToolbar.swift
@@ -29,7 +29,23 @@ struct ProjectToolbarViewModifier: ViewModifier {
     var hideToolbar: Bool {
         StitchDocumentViewModel.isPhoneDevice || (!isCatalyst && document.isFullScreenMode)
     }
-
+    
+    var hasActiveGroupFocused: Bool {
+        document.groupNodeFocused.isDefined
+    }
+    
+    var isFullscreen: Bool {
+        document.isFullScreenMode
+    }
+    
+    var isPreviewWindowShown: Bool {
+        document.showPreviewWindow
+    }
+    
+    var restartPrototypeWindowIconRotationZ: CGFloat {
+        document.restartPrototypeWindowIconRotationZ
+    }
+    
     func body(content: Content) -> some View {
         content
             .onChange(of: self.document.isLoadingAI) { oldValue, newValue in
@@ -42,88 +58,162 @@ struct ProjectToolbarViewModifier: ViewModifier {
                 isFullScreen = newValue
             }
             .toolbarRole(.editor) // no "Back" text on back button
-
-            #if !targetEnvironment(macCatalyst)
+        
+#if !targetEnvironment(macCatalyst)
             .navigationTitle(self.$graph.name)
             .navigationBarTitleDisplayMode(.inline)
-
-            // Note: an empty string hides .navigationTitle
-            //                        .navigationTitle(focusMode ? .constant("") : self.$projectTitleString)
-
-            // Note: native .navigationTitle editing only triggers this onChange *when we submit the change*
-            // So this is actually an `.onSubmit` for .navigationTitle
+        
+        // Note: an empty string hides .navigationTitle
+        //                        .navigationTitle(focusMode ? .constant("") : self.$projectTitleString)
+        
+        // Note: native .navigationTitle editing only triggers this onChange *when we submit the change*
+        // So this is actually an `.onSubmit` for .navigationTitle
             .onChange(of: self.graph.name) { _, newValue in
                 log(".onChange(of: graph.projectName): newValue: \(newValue)")
                 // Encode name changes to disk
                 graph.encodeProjectInBackground()
             }
-
-            // TODO: build out further when we can share, duplicate projects etc. from within the graph
-            //            .toolbarTitleMenu {
-            //            // TODO: why no pencil icon like Freeform?
-            //            RenameButton()
-            //            .simultaneousGesture(TapGesture().onEnded {
-            //            log("simultaneous tapped")
-            //            dispatch(ReduxFieldFocused(focusedField: .projectTitle))
-            //            })
-            //
-            //            //                Button(action: {
-            //            //                }) {
-            //            //                    Label("Duplicate", systemImage: "doc.badge.plus")
-            //            //                }
-            //            //
-            //            //                Button(action: {}, label: {
-            //            //                    Label("Share", systemImage: "square.and.arrow.up")
-            //            //                })
-            //            } // .toolbarTitleMenu
-            #endif
-
+        
+        // TODO: build out further when we can share, duplicate projects etc. from within the graph
+        //            .toolbarTitleMenu {
+        //            // TODO: why no pencil icon like Freeform?
+        //            RenameButton()
+        //            .simultaneousGesture(TapGesture().onEnded {
+        //            log("simultaneous tapped")
+        //            dispatch(ReduxFieldFocused(focusedField: .projectTitle))
+        //            })
+        //
+        //            //                Button(action: {
+        //            //                }) {
+        //            //                    Label("Duplicate", systemImage: "doc.badge.plus")
+        //            //                }
+        //            //
+        //            //                Button(action: {}, label: {
+        //            //                    Label("Share", systemImage: "square.and.arrow.up")
+        //            //                })
+        //            } // .toolbarTitleMenu
+#endif
+        
             .toolbar {
-
-                #if !targetEnvironment(macCatalyst)
-
-                // Catalyst and iPad have same button layout,
-                // but use slightly different buttons:
-
-                // .primaryAction = right side
-                // .secondaryAction = center
+                
+#if !targetEnvironment(macCatalyst)
+                
+                // TODO: put these into a smaller subview; but tricky because `ToolbarItemGroup` expects to be within a .toolbar closure; use one `.toolbar` for iPad, another for Mac Catalyst ?
+                
+                // Ideally we use separate placements for smaller groupings and thus less intrusive liquid glass menu effects.
+                // `.topBarLeading` places the tab picker to the left of the project title
+                // `.navigation` makes it disappear
+                
+                // On iPad: left side grouping, but still to the right of the project title etc.
+                // MARK: KEEP IN SEPARATE GROUP BECAUSE OTHERWISE THE MENU-COLLAPSE-EFFECT IS TOO JARRING
+                ToolbarItemGroup(placement: .secondaryAction, content: {
+                    //                    ControlGroup {
+                    Picker("", selection: $document.selectedTab) {
+                        ForEach(ProjectTab.allCases) { projectTab in
+                            Image(systemName: projectTab.systemIcon)
+                                .tag(projectTab)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    //                    }
+                    
+#if DEV_DEBUG || STITCH_AI_TESTING
+                    OpenAIConfigurationPicker(document: document)
+#endif
+                })
+                
+                
+                // TODO: A SINGLE TOOLBAR ITEM CAN BE USED TO CREATE A SEPARATE ELEMENT ?
+//                ToolbarItem(placement: .primaryAction) {
+//                    // refresh prototype
+//                    iPadNavBarButton(iconName: .RESTART_PROTOTYPE_SF_SYMBOL_NAME,
+//                                     tooltip: "Restart Prototype",
+//                                     action: RESTART_PROTOTYPE_ACTION,
+//                                     rotationZ: .zero)
+//                }
+                
+                // TODO: CAN YOU GET THESE AS SEPARATE GROUPINGS SO THAT MENU IS NOT AS 'DESTRUCTIVE' ?
                 ToolbarItemGroup(placement: .primaryAction) {
                     
-                    // Need to break these up?
-                    iPadGraphTopBarButtons(
-                        document: document,
-                        isDebugMode: document.isDebugMode,
-                        hasActiveGroupFocused: document.groupNodeFocused.isDefined,
-                        isFullscreen: document.isFullScreenMode,
-                        isPreviewWindowShown: document.showPreviewWindow,
-                        restartPrototypeWindowIconRotationZ: document.restartPrototypeWindowIconRotationZ)
+                    // go up a traversal level
+                    iPadNavBarButton(iconName: .GO_UP_ONE_TRAVERSAL_LEVEL_SF_SYMBOL_NAME,
+                                     tooltip: "Go up one traversal level",
+                                     action: { dispatch(GoUpOneTraversalLevel()) })
+                    .disabled(hasActiveGroupFocused ? false : true)
+                    
+                    // Magic AI 'create node'
+                    iPadTopBarButtonWithMenu(iconName: .AI_MAGIC_TEMP_MENU_SF_SYMBOL_NAME,
+                                             tooltip: "Create with AI") {
+                        StitchButton {
+                            dispatch(ShowAINodePromptEntryModal())
+                        } label: {
+                            Label(String.CREATE_CUSTOM_NODE_WITH_AI,
+                                  systemImage: "rectangle")
+                        }
+                        StitchButton {
+                            dispatch(ToggleInsertNodeMenu())
+                        } label: {
+                            Label("Add Nodes",
+                                  systemImage: "rectangle.on.rectangle")
+                        }
+                    }
+                    
+                    iPadNavBarButton(iconName: .ADD_NODE_SF_SYMBOL_NAME,
+                                     tooltip: "Add Node",
+                                     action: { dispatch(ToggleInsertNodeMenu()) })
                 }
-
-                #else
-               // on Mac, show project title name
-               ToolbarItem(placement: .navigationBarLeading) {
-                   CatalystNavBarProjectTitleDisplayView(graph: graph)
-               }
-
+                
+                // on iPad: Right-side grouping
+                ToolbarItemGroup(placement: .primaryAction) {
+                    
+                    // toggle preview window
+                    iPadNavBarButton(
+                        iconName: isPreviewWindowShown ? .HIDE_PREVIEW_WINDOW_SF_SYMBOL_NAME : .SHOW_PREVIEW_WINDOW_SF_SYMBOL_NAME,
+                        tooltip: "Toggle Prototype Window",
+                        action: PREVIEW_SHOW_TOGGLE_ACTION)
+                    //                    }
+                    
+                    // refresh prototype
+                    iPadNavBarButton(iconName: .RESTART_PROTOTYPE_SF_SYMBOL_NAME,
+                                     tooltip: "Restart Prototype",
+                                     action: RESTART_PROTOTYPE_ACTION,
+                                     rotationZ: .zero)
+                    
+                    // full screen
+                    iPadNavBarButton(
+                        iconName: isFullscreen ? .SHRINK_FROM_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME : .EXPAND_TO_FULL_SCREEN_PREVIEW_WINDOW_SF_SYMBOL_NAME,
+                        tooltip: "Toggle Fullscreen",
+                        action: PREVIEW_FULL_SCREEN_ACTION)
+                    
+                    // misc menu
+                    iPadGraphTopBarMiscMenu(document: document)
+                }
+                
+#else
+                // on Mac, show project title name
+                ToolbarItem(placement: .navigationBarLeading) {
+                    CatalystNavBarProjectTitleDisplayView(graph: graph)
+                }
+                
                 // Catalyst and iPad have same button layout,
                 // but use slightly different buttons:
                 // .primaryAction = right side
                 // .secondaryAction = center
-
+                
                 /*
                  On Catalyst:
                  - only .primaryAction = buttons on left
                  - only .secondaryAction = buttons in center
                  - both = .primaryAction buttons on the right, .secondaryAction buttons in center
-
+                 
                  Note: .navigationBarTrailing on Catalyst is apparently broken, always placed items on left-side ?
                  */
-
-               // Hack view to get proper placement
-               ToolbarItem(placement: .secondaryAction) {
-                   Text("")
-               }
-
+                
+                // Hack view to get proper placement
+                ToolbarItem(placement: .secondaryAction) {
+                    Text("")
+                }
+                
                 ToolbarItemGroup(placement: .primaryAction) {
                     ControlGroup {
                         CatalystTopBarGraphButtons(
@@ -135,8 +225,8 @@ struct ProjectToolbarViewModifier: ViewModifier {
                         )
                     }
                 }
-                #endif
-
+#endif
+                
             }
             .animation(.spring, value: document.restartPrototypeWindowIconRotationZ) // .animation modifier must be placed here
             .toolbarBackground(.visible, for: .automatic)

--- a/Stitch/Home/View/ProjectsHomeViewWrapper.swift
+++ b/Stitch/Home/View/ProjectsHomeViewWrapper.swift
@@ -62,8 +62,9 @@ struct ProjectsHomeViewWrapper: View {
             ToolbarItemGroup(placement: .primaryAction) {
                 if isPhoneDevice {
                     iPadTopBarButton(
-                        action: SHOW_APP_SETTINGS_ACTION,
-                        iconName: APP_SETTINGS_ICON_NAME)
+                        iconName: "gear",
+                        tooltip: "Settings",
+                        action: SHOW_APP_SETTINGS_ACTION)
                 } else {
 
                     

--- a/Stitch/Home/View/ProjectsHomeViewWrapper.swift
+++ b/Stitch/Home/View/ProjectsHomeViewWrapper.swift
@@ -15,6 +15,27 @@ struct ProjectsHomeViewWrapper: View {
     // TODO: remove for Catalyst
     @Namespace var routerNamespace
     
+    // Shown on both iPad and Catalyst but only if debug etc.
+    var aiPreviewerButton: some View {
+        CatalystNavBarButton("document.viewfinder.fill",
+                             toolTip: "Open AI Preview") { [weak store] in
+            guard let store = store else {
+                return
+            }
+            let (document, encoder) = store.createAIDocumentPreviewer()
+            if store.navPath.isEmpty {
+                store.navPath = [.aiPreviewer(document, encoder)]
+            } else {
+                store.navPath = []
+            }
+            //                            store.showAIResponseViewer.toggle()
+            
+        }
+        // Resolves issue where hover was still active after entering newly created project and then exiting
+                             .id(UUID())
+                
+    }
+    
     var body: some View {
         ProjectsHomeView(store: store,
                          namespace: routerNamespace)
@@ -37,34 +58,21 @@ struct ProjectsHomeViewWrapper: View {
             }
 #endif
             
-            ToolbarItemGroup(placement: .navigationBarTrailing) {
+//            ToolbarItemGroup(placement: .navigationBarTrailing) {
+            ToolbarItemGroup(placement: .primaryAction) {
                 if isPhoneDevice {
                     iPadTopBarButton(
                         action: SHOW_APP_SETTINGS_ACTION,
                         iconName: APP_SETTINGS_ICON_NAME)
                 } else {
-#if targetEnvironment(macCatalyst)
 
                     
-#if STITCH_AI_REASONING || DEV_DEBUG
-                    CatalystNavBarButton("document.viewfinder.fill",
-                                         toolTip: "Open AI Preview") { [weak store] in
-                        guard let store = store else {
-                            return
-                        }
-                        let (document, encoder) = store.createAIDocumentPreviewer()
-                        if store.navPath.isEmpty {
-                            store.navPath = [.aiPreviewer(document, encoder)]
-                        } else {
-                            store.navPath = []
-                        }
-                        //                            store.showAIResponseViewer.toggle()
-                        
-                    }
-                    // Resolves issue where hover was still active after entering newly created project and then exiting
-                                         .id(UUID())
+#if DEV_DEBUG || STITCH_AI_TESTING
+                    aiPreviewerButton
 #endif
                     
+                    
+#if targetEnvironment(macCatalyst)
                     ControlGroup {
                         CatalystNavBarButton(.NEW_PROJECT_SF_SYMBOL_NAME,
                                              toolTip: "New Project") { [weak store] in
@@ -93,25 +101,30 @@ struct ProjectsHomeViewWrapper: View {
                                              .id(UUID())
                     }
                     
+
+                    
 #else
                     
                     ControlGroup {
-                        iPadNavBarButton(action: { [weak store] in
+                        iPadNavBarButton(iconName: .NEW_PROJECT_SF_SYMBOL_NAME,
+                                         tooltip: "New Project",
+                                         action: { [weak store] in
                             store?.createNewProjectSideEffect(isProjectImport: false)
-                        },
-                                         iconName: NEW_PROJECT_ICON_NAME)
+                        })
                         
-                        iPadNavBarButton(action: { [weak store] in
+                        iPadNavBarButton(iconName: .OPEN_SAMPLE_PROJECTS_MODAL,
+                                         tooltip: "Open Sample Projects",
+                                         action: { [weak store] in
                             store?.conditionallToggleSampleProjectsModal()
-                        },
-                                         iconName: .sfSymbol(.OPEN_SAMPLE_PROJECTS_MODAL))
+                        })
                         
                         TopBarFeedbackButtonsView(document: nil,
                                                   showLabel: false)
                         .modifier(iPadTopBarButtonStyle())
                         
-                        iPadNavBarButton(action: SHOW_APP_SETTINGS_ACTION,
-                                         iconName: PROJECT_SETTINGS_ICON_NAME)
+                        iPadNavBarButton(iconName: .SETTINGS_SF_SYMBOL_NAME,
+                                         tooltip: "Open Settings",
+                                         action: SHOW_APP_SETTINGS_ACTION)
                     }
 #endif
                     


### PR DESCRIPTION
Improves UI of buttons on both iPad and Catalyst.
Fixes color of some icons in the 'share with us' menu.

Resolves issue where iPad's 'misc' button and several others were unresponsive

_To review: did these changes too negatively affect pre-OS-26 builds?_

## Color fix

<img width="230" height="155" alt="Screenshot 2025-09-27 at 8 33 50 PM" src="https://github.com/user-attachments/assets/6f82dff5-d025-4d78-ae2d-a6773eb6f7d6" />


## Mac Catalyst

<img width="1424" height="636" alt="Screenshot 2025-09-27 at 9 06 44 PM" src="https://github.com/user-attachments/assets/2c75a94f-cbf1-404b-9ffc-6825e4c151b4" />
<img width="1425" height="359" alt="Screenshot 2025-09-27 at 9 06 55 PM" src="https://github.com/user-attachments/assets/815c8a53-9355-45a7-87e7-e1fcefd4cb7c" />



## iPad

<img width="2388" height="1668" alt="image" src="https://github.com/user-attachments/assets/a70e7ae5-31b9-4be1-b23a-846a776c6fa4" />

<img width="2388" height="1668" alt="image" src="https://github.com/user-attachments/assets/c00aa98d-4c63-4c90-8b7d-33ee4dc91393" />


## Be aware of this remaining Catalyst issue; it's on any fresh project as well, not a Stitch issue per se
<img width="838" height="419" alt="Screenshot 2025-09-27 at 9 07 26 PM" src="https://github.com/user-attachments/assets/86a6dc2a-9be2-43f4-a714-fb12fc24c4b7" />
<img width="753" height="228" alt="Screenshot 2025-09-27 at 9 07 14 PM" src="https://github.com/user-attachments/assets/8f46f1fe-669d-44a8-9b2b-97a27edd5744" />


