### PR TITLE
iPad OS 26: fix toolbar safe area and spacing with iPad prototype window, node menu and layer inspector

### DIFF
--- a/Stitch/App/Util/Constants.swift
+++ b/Stitch/App/Util/Constants.swift
@@ -44,14 +44,7 @@ let PREVIEW_SHOWN_DEFAULT_STATE: Bool = true
 
 let PROJECTSVIEW_ITEM_TEXT_HEIGHT: CGFloat = 24
 
-#if targetEnvironment(macCatalyst)
 let PREVIEW_WINDOW_Y_PADDING: CGFloat = 16
-#else
-
-// Think about pre-OS 26 though
-//let PREVIEW_WINDOW_Y_PADDING: CGFloat = 120 //48
-let PREVIEW_WINDOW_Y_PADDING: CGFloat = 96 //48
-#endif
 
 let DEFAULT_TIMESCALE = CMTimeScale(NSEC_PER_SEC)
 

--- a/Stitch/App/Util/Constants.swift
+++ b/Stitch/App/Util/Constants.swift
@@ -44,7 +44,14 @@ let PREVIEW_SHOWN_DEFAULT_STATE: Bool = true
 
 let PROJECTSVIEW_ITEM_TEXT_HEIGHT: CGFloat = 24
 
+#if targetEnvironment(macCatalyst)
 let PREVIEW_WINDOW_Y_PADDING: CGFloat = 16
+#else
+
+// Think about pre-OS 26 though
+//let PREVIEW_WINDOW_Y_PADDING: CGFloat = 120 //48
+let PREVIEW_WINDOW_Y_PADDING: CGFloat = 96 //48
+#endif
 
 let DEFAULT_TIMESCALE = CMTimeScale(NSEC_PER_SEC)
 

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWithModalBackground.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWithModalBackground.swift
@@ -77,8 +77,10 @@ struct InsertNodeMenuWithModalBackground: View {
                 #else
                 // TODO: why does this differ for Catalyst vs iPad ?
 //                    .offset(y: 48)
+//                    .offset(y: 62)
+                    .offset(y: 60)
 //                    .offset(y: 12)
-                    .offset(y: 8)
+//                    .offset(y: 8)
                     .offset(y: document.visibleGraph.graphYPosition)
                 #endif
                 

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWithModalBackground.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWithModalBackground.swift
@@ -62,6 +62,8 @@ struct InsertNodeMenuWithModalBackground: View {
             // Disable gestures that would otherwise block graph interaction during an AI request
             .disabled(isLoadingAIRequest)
             
+            logInView("document.visibleGraph.graphYPosition: \(document.visibleGraph.graphYPosition)")
+            
             // Insert Node Menu view
             if showMenu {
                 
@@ -75,19 +77,27 @@ struct InsertNodeMenuWithModalBackground: View {
                 // Padding from top, per Figma
                     .offset(y: 24)
                 #else
-                // TODO: why does this differ for Catalyst vs iPad ?
-//                    .offset(y: 48)
-//                    .offset(y: 62)
-                    .offset(y: 60)
-//                    .offset(y: 12)
-//                    .offset(y: 8)
+                // Use different offset for iOS 26+ due to toolbar changes
+//                    .modifier(InsertNodeMenuOffsetModifier())
+                    .offset(y: 8)
                     .offset(y: document.visibleGraph.graphYPosition)
+//                    .offset(y: 24)
                 #endif
                 
                 // Preserve position when we've collapsed the node menu body because of an active AI request
                 // Alternatively?: use VStack { menu, Spacer }
                     .offset(y: menuYOffset)
             }
+        }
+    }
+}
+
+struct InsertNodeMenuOffsetModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content.offset(y: 62)
+        } else {
+            content.offset(y: 8)
         }
     }
 }

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWithModalBackground.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWithModalBackground.swift
@@ -72,16 +72,12 @@ struct InsertNodeMenuWithModalBackground: View {
                     .shadow(radius: 8, x: 4, y: 2)
                     .animation(.default, value: document.insertNodeMenuState.show)
                     .animation(.default, value: isLoadingAIRequest)
-                    
-                #if targetEnvironment(macCatalyst)
+                
                 // Padding from top, per Figma
                     .offset(y: 24)
-                #else
-                // Use different offset for iOS 26+ due to toolbar changes
-//                    .modifier(InsertNodeMenuOffsetModifier())
-                    .offset(y: 8)
-                    .offset(y: document.visibleGraph.graphYPosition)
-//                    .offset(y: 24)
+                #if !targetEnvironment(macCatalyst)
+                // Note: use to be full y position, not half; changed with different handling of safe areas on iPad OS 26
+                    .offset(y: document.visibleGraph.graphYPosition / 2)
                 #endif
                 
                 // Preserve position when we've collapsed the node menu body because of an active AI request

--- a/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWithModalBackground.swift
+++ b/Stitch/Graph/Menu/InsertNodeMenu/View/InsertNodeMenuWithModalBackground.swift
@@ -62,8 +62,6 @@ struct InsertNodeMenuWithModalBackground: View {
             // Disable gestures that would otherwise block graph interaction during an AI request
             .disabled(isLoadingAIRequest)
             
-            logInView("document.visibleGraph.graphYPosition: \(document.visibleGraph.graphYPosition)")
-            
             // Insert Node Menu view
             if showMenu {
                 

--- a/Stitch/Graph/View/ProjectNavigationView.swift
+++ b/Stitch/Graph/View/ProjectNavigationView.swift
@@ -31,7 +31,6 @@ struct ProjectNavigationView: View {
         // Use a ZStack so SwiftUI can animate insertion/removal with `.transition`
         ZStack {
             graphView
-                .ignoresSafeArea()
                 .transition(.opacity)
                 .id(ProjectTab.patch)   // ← make the views distinct
             
@@ -120,9 +119,22 @@ struct ProjectNavigationView: View {
             
             LayerInspectorView(graph: graph,
                                document: document)
-            .ignoresSafeArea()
+            // Note: we actually want to respect the safe area on iPad OS 26 with LayerInspector
+            .modifier(ConditionalIgnoreSafeAreaModifier())
             .width(Self.iPadSidebarWidth)
         }
     }
 #endif
+}
+
+struct ConditionalIgnoreSafeAreaModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            // On iOS 26+, don't ignore safe area to respect toolbar
+            content
+        } else {
+            // On earlier versions, ignore safe area for the shimmer effect
+            content.ignoresSafeArea()
+        }
+    }
 }


### PR DESCRIPTION
## before 

![DE835669-3904-4CD9-9B79-1BDD56E405B5_1_102_o](https://github.com/user-attachments/assets/aab1077c-3a22-4180-880a-562405f88aed)


## after

![E2CB484D-9FB9-48B4-97D5-843D15D38F44_1_102_o](https://github.com/user-attachments/assets/b3358eea-a924-434b-8803-81fe2bbba3f6)

## inspector: before

![D546AC18-1BB1-4F59-83B8-801D6AB8A8C5_1_102_o](https://github.com/user-attachments/assets/39253df7-0e45-469e-a8a5-3c4366f1648f)

## inspector: after

![35A17D40-7829-499F-B089-7C8FC41CE6BD_1_102_o](https://github.com/user-attachments/assets/e8c02ada-c4f3-46a6-90a4-aa67ba617019)
