### PR TITLE
Reset graph when AI streaming ends

### DIFF
--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
@@ -118,6 +118,9 @@ extension SwiftSyntaxActionsResult {
             // Report errors
             if !isStreaming {
                 result.errors.displayErrors(document: document)
+                
+                // TODO: debug issues with proper graph eval after a streaming request ends; theoretically a prototype restart should not be necessary
+                document.onPrototypeRestart(document: document)
             }
         }
         

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -519,6 +519,7 @@ extension StitchDocumentViewModel {
         self.createSchema()
     }
     
+    // Note: this awkward signature (passing `document: StitchDocumentViewModel` to a StitchDocumentViewModel itself) comes from the required signature on the `onPrototypeRestart` protocol
     @MainActor func onPrototypeRestart(document: StitchDocumentViewModel) {
         self.graphStepManager.resetGraphStepState()
         


### PR DESCRIPTION
## before (prototype window's rectangles were either all one color, or two colors)
## after (prototype window's rectangles all different colors, edge colors are correct etc.)
https://github.com/user-attachments/assets/c2e69975-093f-487e-835f-116d7ea97673

