### PR TITLE
Streaming: do not crash when handling nested layers on actor

### DIFF
--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
@@ -19,9 +19,15 @@ struct AIPatchBuilderFunctionInputs: Codable {
 
 struct AIPatchBuilderFunctionInputsSchema: Encodable {
     let swiftui_source_code = OpenAISchema(type: .string)
-    
+
     // MARK: string because no nesting support in structured outputs
     let layer_data_list = OpenAISchema(type: .string)
+}
+
+// MARK: - Work item for iterative layer processing
+private struct LayerWorkItem {
+    let layers: [AIGraphData_V0.LayerData]
+    let parentId: UUID?
 }
 
 extension Array where Element == AIGraphData_V0.LayerData {
@@ -29,53 +35,57 @@ extension Array where Element == AIGraphData_V0.LayerData {
                           nodesDict: inout [UUID: NodeEntity],
                           stateVarConnections: inout [String: [NodeIOCoordinate]],
                           isStreaming: Bool) {
-        self.forEach { layerData in
-            guard let layer = layerData.node_name.value.layer else {
-                if !isStreaming {
-                    fatalErrorIfDebug()
-                }
-                return
-            }
-            
-            let layerNodeEntity = layer
-                .createDefaultLayerNodeEntity(nodeId: UUID(layerData.node_id) ?? UUID(),
-                                              layerGroupId: layerGroupId)
-            
-            let nodeEntity = NodeEntity(id: layerNodeEntity.id,
-                                        nodeTypeEntity: .layer(layerNodeEntity),
-                                        title: layerData.suggested_title ?? "")
-            
-            nodesDict.updateValue(nodeEntity,
-                                  forKey: layerNodeEntity.id)
 
-            layerData.custom_layer_input_values.forEach { portDerivation in
-                let coordinate = portDerivation.coordinate
-                
-                portDerivation.inputData.forEach { inputData in
-                    do {
-                        // Parse actions at this input, which may include patch data in the event of view events
-                        try nodesDict.updateWithEventData(inputData,
-                                                          layerInputCoordinate: .init(portType: .keyPath(coordinate),
-                                                                                      nodeId: layerNodeEntity.id),
-                                                          varName: nil,
-                                                          stateVarConnections: &stateVarConnections,
-                                                          isStreaming: isStreaming)
-                    } catch {
-                        if !isStreaming {
-                            // TODO: need to handle errors silently
-                            fatalErrorIfDebug("createLayerNodes error: \(error)")
+        // MARK: VERY IMPORTANT: Use iterative approach with queue instead of recursion to avoid blowing up actor's thread-memory (512 KB; vs main thread's 8 MB)
+        var queue = [LayerWorkItem(layers: self, parentId: layerGroupId)]
+
+        while !queue.isEmpty {
+            let workItem = queue.removeFirst()
+
+            for layerData in workItem.layers {
+                guard let layer = layerData.node_name.value.layer else {
+                    if !isStreaming {
+                        fatalErrorIfDebug()
+                    }
+                    continue
+                }
+
+                let layerNodeEntity = layer
+                    .createDefaultLayerNodeEntity(nodeId: UUID(layerData.node_id) ?? UUID(),
+                                                  layerGroupId: workItem.parentId)
+
+                let nodeEntity = NodeEntity(id: layerNodeEntity.id,
+                                            nodeTypeEntity: .layer(layerNodeEntity),
+                                            title: layerData.suggested_title ?? "")
+
+                nodesDict.updateValue(nodeEntity,
+                                      forKey: layerNodeEntity.id)
+
+                for portDerivation in layerData.custom_layer_input_values {
+                    let coordinate = portDerivation.coordinate
+
+                    for inputData in portDerivation.inputData {
+                        do {
+                            // Parse actions at this input, which may include patch data in the event of view events
+                            try nodesDict.updateWithEventData(inputData,
+                                                              layerInputCoordinate: .init(portType: .keyPath(coordinate),
+                                                                                          nodeId: layerNodeEntity.id),
+                                                              varName: nil,
+                                                              stateVarConnections: &stateVarConnections,
+                                                              isStreaming: isStreaming)
+                        } catch {
+                            if !isStreaming {
+                                // TODO: need to handle errors silently
+                                fatalErrorIfDebug("createLayerNodes error: \(error)")
+                            }
                         }
                     }
                 }
-            }
-            
-            
-            if let children = layerData.children {
-                children
-                    .createLayerNodes(layerGroupId: layerNodeEntity.id,
-                                      nodesDict: &nodesDict,
-                                      stateVarConnections: &stateVarConnections,
-                                      isStreaming: isStreaming)
+
+                // Add children to queue instead of recursing
+                if let children = layerData.children {
+                    queue.append(LayerWorkItem(layers: children, parentId: layerNodeEntity.id))
+                }
             }
         }
     }


### PR DESCRIPTION
Actor threads are smaller than the main thread (~512 KB, vs 8 MB), so deeper recursion on large structs (`NodeEntity` contains `LayerNodeEntity` which has many properties) can cause EXC_BAD_ACCESS. 

(Another solution: put eager parsing on the main thread -- no EXC_BAD_ACCESS crashes.)


### Claude notes

Fix: Stack Overflow in AI Streaming Layer Creation

  Problem

  EXC_BAD_ACCESS crashes during AI streaming when processing nested layer hierarchies, occurring at shallow depths (6 levels) with relatively few nodes
  (13 total).

  Root Cause

  Recursive createLayerNodes function caused excessive struct copying on actor's 512 KB stack:
  - Each recursive call passed large dictionaries containing NodeEntity structs (~100 ports each)
  - Swift's copy-on-write triggered during parameter passing and returns
  - Crash in initializeWithCopy indicated stack exhaustion during dictionary copy operations
  - Actor thread stack (512 KB) vs main thread (8 MB) made the issue worse

  Solution

  Converted createLayerNodes from recursive to iterative queue-based approach:
  - Single function frame (constant stack usage)
  - No recursive parameter passing (eliminates copy operations)
  - Breadth-first processing through work queue
  - Maintains identical functionality with inout parameters

  Changes

  - Added LayerWorkItem struct to track processing queue
  - Replaced recursive calls with queue.append()
  - Changed nested forEach to regular for loops

  Result

  ✅ Handles arbitrarily deep layer nesting without stack overflow
  ✅ Works on actor thread (no main thread blocking)
  ✅ Reduces memory allocation overhead