### PR TITLE
Wrap `var body` children in single root `VStack` (if children not already in a single root view)

### DIFF
--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchSyntax.swift
@@ -240,9 +240,9 @@ extension SwiftUIViewVisitor {
         let sourceFile = Parser.parse(source: preprocessedCode)
         
 //#if DEV_DEBUG
-//        print("\n==== DEBUG: SOURCE FILE STRUCTURE ====\n")
+//        log("\n==== DEBUG: SOURCE FILE STRUCTURE ====\n")
 //        dump(sourceFile)
-//        print("\n==== END DEBUG DUMP ====\n")
+//        log("\n==== END DEBUG DUMP ====\n")
 //#endif
         
         // Create a visitor that will extract the view structure
@@ -368,36 +368,146 @@ extension SwiftUIViewVisitor {
         guard context == .topLevel else {
             return code
         }
-        
-        // Simple approach: if the code doesn't have var body, it's just raw views - wrap them
-        if !code.contains("var body") {
-            // Count top-level SwiftUI view declarations
-            let topLevelViewCount = countTopLevelViewDeclarations(in: code)
-            
-            if topLevelViewCount > 1 {
-                // Multiple top-level views - wrap in VStack  
-                let indentedContent = code.components(separatedBy: .newlines)
-                    .map { line in line.isEmpty ? line : "    \(line)" }
-                    .joined(separator: "\n")
-                return "VStack {\n\(indentedContent)\n}"
-            }
+
+        // If code has var body, check if we need to wrap its contents
+        if code.contains("var body") {
+            return wrapVarBodyIfNeeded(code)
         }
-        
+
+        // Otherwise, handle raw views without var body wrapper
+        let topLevelViewCount = countTopLevelViewDeclarations(in: code)
+
+        if topLevelViewCount > 1 {
+            // Multiple top-level views - wrap in VStack
+            let indentedContent = code.components(separatedBy: .newlines)
+                .map { line in line.isEmpty ? line : "    \(line)" }
+                .joined(separator: "\n")
+            return "VStack {\n\(indentedContent)\n}"
+        }
+
+        return code
+    }
+
+    /// Wraps var body content in VStack if it contains multiple root views
+    private static func wrapVarBodyIfNeeded(_ code: String) -> String {
+        // Find "var body" and extract its content
+        guard let bodyRange = code.range(of: "var body") else {
+            return code
+        }
+
+        // Find opening brace after "var body: some View"
+        let afterBody = code[bodyRange.upperBound...]
+        guard let openBraceRange = afterBody.range(of: "{") else {
+            return code
+        }
+
+        let contentStart = openBraceRange.upperBound
+
+        // Find matching closing brace using brace counting
+        var braceCount = 1
+        var inString = false
+        var inSingleLineComment = false
+        var inMultiLineComment = false
+        var escapeNext = false
+        var currentIndex = contentStart
+
+        while currentIndex < code.endIndex && braceCount > 0 {
+            let char = code[currentIndex]
+            let nextIndex = code.index(after: currentIndex)
+
+            if escapeNext {
+                escapeNext = false
+                currentIndex = nextIndex
+                continue
+            }
+
+            if !inString && !inSingleLineComment && !inMultiLineComment {
+                if char == "/" && nextIndex < code.endIndex {
+                    let nextChar = code[nextIndex]
+                    if nextChar == "/" {
+                        inSingleLineComment = true
+                        currentIndex = code.index(after: nextIndex)
+                        continue
+                    } else if nextChar == "*" {
+                        inMultiLineComment = true
+                        currentIndex = code.index(after: nextIndex)
+                        continue
+                    }
+                }
+
+                if char == "\"" {
+                    inString = true
+                    currentIndex = nextIndex
+                    continue
+                }
+
+                if char == "{" {
+                    braceCount += 1
+                } else if char == "}" {
+                    braceCount -= 1
+                }
+            } else if inString {
+                if char == "\\" {
+                    escapeNext = true
+                } else if char == "\"" {
+                    inString = false
+                }
+            } else if inSingleLineComment {
+                if char == "\n" {
+                    inSingleLineComment = false
+                }
+            } else if inMultiLineComment {
+                if char == "*" && nextIndex < code.endIndex && code[nextIndex] == "/" {
+                    inMultiLineComment = false
+                    currentIndex = code.index(after: nextIndex)
+                    continue
+                }
+            }
+
+            currentIndex = nextIndex
+        }
+
+        guard braceCount == 0 else {
+            return code
+        }
+
+        let closeBraceIndex = code.index(before: currentIndex)
+        let bodyContent = String(code[contentStart..<closeBraceIndex])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Count top-level views in body content
+        let viewCount = countTopLevelViewDeclarations(in: bodyContent)
+
+        if viewCount > 1 {
+            // Multiple views - wrap in VStack with proper indentation
+            let indentedContent = bodyContent.components(separatedBy: .newlines)
+                .map { line in line.isEmpty ? line : "        \(line)" }
+                .joined(separator: "\n")
+
+            let wrappedBody = "        VStack {\n\(indentedContent)\n        }"
+
+            // Reconstruct the code
+            let beforeBody = String(code[..<contentStart])
+            let afterBody = String(code[currentIndex...])
+
+            return beforeBody + "\n" + wrappedBody + "\n    " + afterBody
+        }
+
         return code
     }
     
     /// Counts actual top-level SwiftUI view declarations (not lines)
     private static func countTopLevelViewDeclarations(in code: String) -> Int {
-        let swiftUIViews = ["Text", "Rectangle", "Ellipse", "Circle", "Image", "VStack", "HStack", "ZStack", "ScrollView", "Button"]
+        let swiftUIViews = SyntaxViewName.allCases.map { $0.rawValue }
         var count = 0
         var braceDepth = 0
         var inString = false
         var escapeNext = false
-        
+
         var i = code.startIndex
         while i < code.endIndex {
             let char = code[i]
-            
+
             // Handle string literals
             if escapeNext {
                 escapeNext = false
@@ -412,7 +522,7 @@ extension SwiftUIViewVisitor {
                 } else if char == "}" {
                     braceDepth -= 1
                 }
-                
+
                 // Check for SwiftUI view at top level (braceDepth == 0)
                 if braceDepth == 0 {
                     for viewName in swiftUIViews {
@@ -423,10 +533,10 @@ extension SwiftUIViewVisitor {
                     }
                 }
             }
-            
+
             i = code.index(after: i)
         }
-        
+
         return count
     }
 


### PR DESCRIPTION

# PROBLEM: for a project with e.g. a top level rect and a top level oval, our AI code after an edit was only parsing a single (the *first* ) `SyntaxView`

### original SwiftUI code

```swift
struct ContentView: View {

 @State var ovalPosition: [PortValueDescription] = []
 @State var rectanglePosition: [PortValueDescription] = []

 var body: some View {
   Ellipse()
    .fill([PortValueDescription(value: "#FF383CFF", value_type: "color")])
    .position(ovalPosition)
    .simultaneousGesture(
     DragGesture()
      .onChanged { value in
       ovalPosition = [PortValueDescription(value: ["x": value.location.x, "y": value.location.y], value_type: "position")]
      }
    )

   Rectangle()
    .position(rectanglePosition)
    .simultaneousGesture(
     DragGesture()
      .onChanged { value in
       rectanglePosition = [PortValueDescription(value: ["x": value.location.x, "y": value.location.y], value_type: "position")]
      }
    )

 }

 func updateLayerInputs() {

 }


}
```

### our parsed `SyntaxView` is missing the Rectangle

```swift
SyntaxView(
    name: "Ellipse",
    constructorArguments: 
[]
    modifiers: 
[Stitch.SyntaxViewModifier(name: Stitch.SyntaxViewModifierName.simultaneousGesture, arguments: Stitch.ViewConstructorType.other([Stitch.SyntaxViewArgumentData(label: nil, value: Stitch.SyntaxViewModifierArgumentType.viewEvent(Stitch.SyntaxViewModifierViewEvent(eventName: "DragGesture", eventConstructorArgs: [], eventModifiers: ["onChanged": Stitch.SyntaxViewModifierClosureData(paramVars: ["value"], script: "ovalPosition = [PortValueDescription(value: [\"x\": value.location.x, \"y\": value.location.y], value_type: \"position\")]")])))])), Stitch.SyntaxViewModifier(name: Stitch.SyntaxViewModifierName.position, arguments: Stitch.ViewConstructorType.other([Stitch.SyntaxViewArgumentData(label: nil, value: Stitch.SyntaxViewModifierArgumentType.stateAccess("ovalPosition"))])), Stitch.SyntaxViewModifier(name: Stitch.SyntaxViewModifierName.fill, arguments: Stitch.ViewConstructorType.other([Stitch.SyntaxViewArgumentData(label: nil, value: Stitch.SyntaxViewModifierArgumentType.array([Stitch.SyntaxViewModifierArgumentType.complex(Stitch.SyntaxViewModifierComplexType(typeName: "PortValueDescription", arguments: [Stitch.SyntaxViewArgumentData(label: Optional("value"), value: Stitch.SyntaxViewModifierArgumentType.simple(Stitch.SyntaxViewSimpleData(value: "\"#FF383CFF\"", syntaxKind: Stitch.SyntaxArgumentKind.literal(Stitch.SyntaxArgumentLiteralKind.string)))), Stitch.SyntaxViewArgumentData(label: Optional("value_type"), value: Stitch.SyntaxViewModifierArgumentType.simple(Stitch.SyntaxViewSimpleData(value: "\"color\"", syntaxKind: Stitch.SyntaxArgumentKind.literal(Stitch.SyntaxArgumentLiteralKind.string))))]))]))]))]
    children: [],
    id: "81BFD55D-5211-4EEC-9225-0DAC390E367D"
)
```

# multiple views in a SwiftUI `var body` are implicitly in a `VStack`

<img width="1440" height="900" alt="Screenshot 2025-10-02 at 5 39 41 PM" src="https://github.com/user-attachments/assets/d33aa80e-e7c6-44c6-a6b4-ff20c9b29c9f" />


# multiple views in Stitch’s sidebar are implicitly in a `ZStack` (i.e. layer group without orientation)

<img width="2388" height="1668" alt="image" src="https://github.com/user-attachments/assets/0cc477aa-2782-40d4-80bf-6f9338fc6f27" />


# to match SwiftUI, we wrap multiple views in a `VStack` (i.e. layer group with vertical orientation)


Incomplete work from https://github.com/StitchDesign/Stitch/pull/1537

<img width="789" height="747" alt="Screenshot 2025-10-02 at 5 41 06 PM" src="https://github.com/user-attachments/assets/a9832661-a3e7-4b02-b879-04682c43611f" />

<img width="1440" height="900" alt="Screenshot 2025-10-02 at 5 34 48 PM" src="https://github.com/user-attachments/assets/f0ab6139-fcd2-449b-97cc-8a13e36effc6" />
<img width="1440" height="900" alt="Screenshot 2025-10-02 at 5 34 42 PM" src="https://github.com/user-attachments/assets/3c54d09e-94b5-4b1e-b1fd-ca0b25fc8b4b" />
<img width="1440" height="900" alt="Screenshot 2025-10-02 at 5 34 39 PM" src="https://github.com/user-attachments/assets/3844fe3a-5485-4125-9b81-df3ed6d67167" />
<img width="1440" height="900" alt="Screenshot 2025-10-02 at 5 34 36 PM" src="https://github.com/user-attachments/assets/736a86c5-490b-4009-99c9-d15ed1290eb8" />

