### PR TITLE
Fix canvas input edits; dragging edge to layer inspector to add layer input to canvas

### DIFF
--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AIRequestDeps.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AIRequestDeps.swift
@@ -179,7 +179,7 @@ extension StitchAICodeCreator {
             .deriveStitchActions(bindingDeclarations: codeParserResult.bindingDeclarations,
                                  document: document)
         
-        print("Derived Stitch layer data:\n\(actionsResult)")
+        log("Derived Stitch layer data:\n\(actionsResult)")
         
         return actionsResult
     }

--- a/Stitch/Graph/Util/GraphUIActions.swift
+++ b/Stitch/Graph/Util/GraphUIActions.swift
@@ -143,9 +143,6 @@ struct ToggleSidebars: StitchStoreEvent {
         let inspectorOpen = store.showsLayerInspector
         let layerSidebarOpen = state.leftSidebarOpen
 
-        // Suppress UIKitWrapper during sidebar animation for smooth transitions
-        state.isSidebarAnimating = true
-
         // Animate both together
         withAnimation {
             if !inspectorOpen && !layerSidebarOpen {
@@ -157,11 +154,6 @@ struct ToggleSidebars: StitchStoreEvent {
                 store.showsLayerInspector = false
                 state.leftSidebarOpen = false
             }
-        }
-
-        // Restore UIKitWrapper after animation completes (0.5s for smoother animation)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            state.isSidebarAnimating = false
         }
 
         return .noChange

--- a/Stitch/Graph/Util/GraphUIActions.swift
+++ b/Stitch/Graph/Util/GraphUIActions.swift
@@ -137,12 +137,15 @@ struct TogglePreviewWindow: StitchDocumentEvent {
 struct ToggleSidebars: StitchStoreEvent {
     func handle(store: StitchStore) -> ReframeResponse<NoState> {
         guard let state = store.currentDocument else { return .noChange }
-        
+
         // Opens both if both are already closed;
         // else closes both.
         let inspectorOpen = store.showsLayerInspector
         let layerSidebarOpen = state.leftSidebarOpen
-        
+
+        // Suppress UIKitWrapper during sidebar animation for smooth transitions
+        state.isSidebarAnimating = true
+
         // Animate both together
         withAnimation {
             if !inspectorOpen && !layerSidebarOpen {
@@ -155,7 +158,12 @@ struct ToggleSidebars: StitchStoreEvent {
                 state.leftSidebarOpen = false
             }
         }
-        
+
+        // Restore UIKitWrapper after animation completes (0.5s for smoother animation)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            state.isSidebarAnimating = false
+        }
+
         return .noChange
     }
 }

--- a/Stitch/Graph/View/ContentView.swift
+++ b/Stitch/Graph/View/ContentView.swift
@@ -44,26 +44,20 @@ struct ContentView: View, KeyboardReadable {
 
     var nodeAndMenu: some View {
         ZStack {
-            if !document.isSidebarAnimating {
-                // UIKitWrapper always (for TAB key detection), except during sidebar animations
-                UIKitWrapper(ignoresKeyCommands: true,
-                             isOnlyForTextFieldHelp: true,
-                             inputTextFieldFocused: document.reduxFocusedField?.inputTextFieldWithNumberIsFocused(document.graph) ?? false,
-                             name: .mainGraph) {
-                    contentView // the graph
-                }
-            } else {
-                // No wrapper during sidebar animations for smooth transitions
+            // TODO: (1) use fixed sizes for the various flyouts and attached UIKitWrapper there instead, would give smoother animations for toggling sidebar, or (2) find better Mac Catalyst key-press-listening
+            UIKitWrapper(ignoresKeyCommands: true,
+                         isOnlyForTextFieldHelp: true,
+                         inputTextFieldFocused: document.reduxFocusedField?.inputTextFieldWithNumberIsFocused(document.graph) ?? false,
+                         name: .mainGraph) {
                 contentView // the graph
             }
         }
     }
-
+    
     var body: some View {
         ZStack {
 
-            // probably the best location for listening to how iPad's on-screen keyboard reduces available height for node menu ?
-
+            // Probably the best location for listening to how iPad's on-screen keyboard reduces available height for node menu ?
 
             // Must respect keyboard safe-area
             ProjectWindowSizeReader(previewWindowSizing: previewWindowSizing,

--- a/Stitch/Graph/View/ContentView.swift
+++ b/Stitch/Graph/View/ContentView.swift
@@ -44,8 +44,8 @@ struct ContentView: View, KeyboardReadable {
 
     var nodeAndMenu: some View {
         ZStack {
-            if document.visibleGraph.propertySidebar.flyoutState != nil {
-                // UIKitWrapper only when flyout is active (for TAB key detection)
+            if !document.isSidebarAnimating {
+                // UIKitWrapper always (for TAB key detection), except during sidebar animations
                 UIKitWrapper(ignoresKeyCommands: true,
                              isOnlyForTextFieldHelp: true,
                              inputTextFieldFocused: document.reduxFocusedField?.inputTextFieldWithNumberIsFocused(document.graph) ?? false,
@@ -53,7 +53,7 @@ struct ContentView: View, KeyboardReadable {
                     contentView // the graph
                 }
             } else {
-                // No wrapper when no flyout (smooth sidebar animations)
+                // No wrapper during sidebar animations for smooth transitions
                 contentView // the graph
             }
         }

--- a/Stitch/Graph/View/GraphBaseView.swift
+++ b/Stitch/Graph/View/GraphBaseView.swift
@@ -111,27 +111,33 @@ struct GraphBaseView: View {
             nodesView
         } // ZStack
         
-        .modifier(ActivelyDrawnEdge(graph: graph,
-                                    scale: document.graphMovement.zoomData))
-        .coordinateSpace(name: Self.coordinateNamespace)
-        
-        #if targetEnvironment(macCatalyst)
+#if targetEnvironment(macCatalyst)
         .overlay(alignment: .trailing) {
             if store.showsLayerInspector {
                 LayerInspectorView(graph: graph,
                                    document: document)
                 .frame(width: LayerInspectorView.LAYER_INSPECTOR_WIDTH)
-                .transition(.move(edge: .trailing))
-//                .transition(.slideInAndOut)
+                .transition(
+                    .asymmetric(
+                        insertion: .move(edge: .trailing),
+                        removal: .move(edge: .trailing).combined(with: .opacity)
+                    )
+                )
             }
         }
-        
-        //        .inspector(isPresented: $store.showsLayerInspector) {
-//                    LayerInspectorView(graph: graph,
-//                                       document: document)
-        //        }
-        #endif
 
+        //        .inspector(isPresented: $store.showsLayerInspector) {
+        //                    LayerInspectorView(graph: graph,
+        //                                       document: document)
+        //        }
+#endif
+
+        
+        .modifier(ActivelyDrawnEdge(graph: graph,
+                                    scale: document.graphMovement.zoomData))
+        .coordinateSpace(name: Self.coordinateNamespace)
+        
+       
         
         .bottomCenterToast(willShow: document.llmRecording.showRatingToast,
                            config: .init(duration: 15),

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -129,9 +129,6 @@ final class StitchDocumentViewModel: Sendable {
     
     @MainActor var leftSidebarOpen = false
 
-    // Tracks whether sidebars are currently animating; used to suppress UIKitWrapper during animation for smooth transitions
-    @MainActor var isSidebarAnimating = false
-
     // Note: important to use `OrderedSet` rather than just list, so that we never have duplicate traversal-levels, see: https://github.com/StitchDesign/Stitch--Old/issues/7038
     // Tracks group breadcrumbs when group nodes are visited
     @MainActor var groupNodeBreadcrumbs: OrderedSet<GroupNodeType> = .init()

--- a/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
+++ b/Stitch/Graph/ViewModel/StitchDocumentViewModel.swift
@@ -129,6 +129,9 @@ final class StitchDocumentViewModel: Sendable {
     
     @MainActor var leftSidebarOpen = false
 
+    // Tracks whether sidebars are currently animating; used to suppress UIKitWrapper during animation for smooth transitions
+    @MainActor var isSidebarAnimating = false
+
     // Note: important to use `OrderedSet` rather than just list, so that we never have duplicate traversal-levels, see: https://github.com/StitchDesign/Stitch--Old/issues/7038
     // Tracks group breadcrumbs when group nodes are visited
     @MainActor var groupNodeBreadcrumbs: OrderedSet<GroupNodeType> = .init()


### PR DESCRIPTION
Two fixes:
1. fix input edits by using `UIKitWrapper` in `ContentView` all the time (note: leaves us with bad sidebar animations again but I have an idea for a fix later)
2. fix 'drag edge to inspector' by placing the .overlay-inspector beneath the actively-drawn-edge


