### PR TITLE
Add back missing max expression logic

### DIFF
--- a/Stitch/Graph/StitchAI/GraphPrompting/API/ClaudeGraphGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/ClaudeGraphGenRequest.swift
@@ -645,7 +645,6 @@ extension GraphEntity {
                                               changedNodeIds: changedNodeIds,
                                               existingNodeIds: Set(existingNodesMap.keys))
         }
-                
         // let currentLog = self.nodes.reduce(into: "mergeWithStreamedGraph: current nodes:") { stringBuilder, node in
         //     stringBuilder += "\n\(node.id):\tkind: \(node.kind)\tlayer group: \(node.layerNodeEntity?.layerGroupId?.uuidString ?? "nil")"
         // }

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AIRequestDeps.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AIRequestDeps.swift
@@ -179,7 +179,7 @@ extension StitchAICodeCreator {
         let swiftUICode = try await self
             .createCode(document: document,
                         aiManager: aiManager)
-        
+
         log("userPrompt: \(userPrompt)") // Very helpful to see user-prompt here again
         log("StitchAICodeCreator swiftUICode:\n\(swiftUICode)")
 

--- a/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchUtil.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToSyntax/CodeToStitchUtil.swift
@@ -199,7 +199,32 @@ extension SwiftUIViewVisitor {
         else if let closureExpr = expression.as(ClosureExprSyntax.self) {
             return .closure(closureExpr.getClosureData())
         }
-        
+
+        // Handle math expressions (simple binary ops only)
+        else if let sequenceExpr = expression.as(SequenceExprSyntax.self) {
+            let elements = Array(sequenceExpr.elements)
+
+            log("🔵 SequenceExprSyntax detected: \(elements.count) elements")
+
+            // Only handle simple binary: lhs op rhs
+            if elements.count == 3,
+               let binaryOp = elements[1].as(BinaryOperatorExprSyntax.self) {
+
+                let op = binaryOp.operator.text
+                log("🔵 Binary operator: '\(op)', LHS: \(elements[0].trimmedDescription), RHS: \(elements[2].trimmedDescription)")
+
+                let lhs = try parseArgumentType(from: elements[0], isStreaming: isStreaming)
+                let rhs = try parseArgumentType(from: elements[2], isStreaming: isStreaming)
+
+                log("🔵 Successfully parsed math expression: \(lhs) \(op) \(rhs)")
+
+                return .mathExpression(SyntaxViewMathSyntax(lhs: lhs, op: op, rhs: rhs))
+            }
+
+            // More complex expressions not supported yet
+            throw SwiftUISyntaxError.unsupportedSyntaxArgumentKind(expression.trimmedDescription)
+        }
+
         guard let syntaxKind = SyntaxArgumentKind.fromExpression(expression) else {
             throw SwiftUISyntaxError.unsupportedSyntaxArgumentKind(expression.trimmedDescription)
         }

--- a/Stitch/Graph/StitchAI/Mapping/CodeToVPL/Declarative/DeclarativeUtils.swift
+++ b/Stitch/Graph/StitchAI/Mapping/CodeToVPL/Declarative/DeclarativeUtils.swift
@@ -281,9 +281,11 @@ extension SyntaxViewModifierArgumentType {
         // TODO: does this even make sense with a view which is used as an argument ?
         case .view(let view):
             return nil
+        case .mathExpression(_):
+            return nil
         }
     }
-    
+
     var stateAccess: String? {
         switch self {
         case .stateAccess(let member):

--- a/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/CodeExamples.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/CodeExamples.swift
@@ -26,10 +26,14 @@ struct MappingCodeExample: Sendable {
 }
 
 extension MappingExamples {
-    
+
     // TODO: break into separate pieces
     static let codeExamples: [MappingCodeExample] = [
-        
+
+        // Math expressions in PortValueDescription - TESTING NEW FEATURE
+        PortValueDescriptionCodeExamples.rectangleWithDragGestureMathExpressions,
+        PortValueDescriptionCodeExamples.ellipseWithStaticMathExpressions,
+
         // Background examples - testing background to ZStack transformation
         BackgroundCodeExamples.simpleBackgroundFunctionCall,
         BackgroundCodeExamples.simpleBackgroundClosure,

--- a/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/PortValueDescriptionCodeExamples.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Examples/CodeExamples/PortValueDescriptionCodeExamples.swift
@@ -8,10 +8,36 @@
 import Foundation
 
 /// Examples showing SwiftUI code using PortValueDescription format
-/// These demonstrate how arguments can be wrapped in PortValueDescription 
+/// These demonstrate how arguments can be wrapped in PortValueDescription
 /// for the visual programming system
 struct PortValueDescriptionCodeExamples {
-    
+
+    static let rectangleWithDragGestureMathExpressions = MappingCodeExample(
+        title: "Rectangle with Math Expressions in Drag Gesture",
+        code: """
+struct ContentView: View {
+
+    var body: some View {
+        Rectangle()
+            .simultaneousGesture(
+                DragGesture()
+                    .onChanged { value in
+                        rectanglePosition = [PortValueDescription(value: ["x": value.location.x - 196.5, "y": value.location.y - 426], value_type: "position")]
+                    }
+            )
+    }
+}
+"""
+    )
+
+    static let ellipseWithStaticMathExpressions = MappingCodeExample(
+        title: "Ellipse with Static Math Expressions",
+        code: """
+Ellipse()
+    .offset([PortValueDescription(value: ["x": 500 - 196.5, "y": 500 - 426], value_type: "position")])
+"""
+    )
+
     static let rectangleWithColorPVD = MappingCodeExample(
         title: "Rectangle with PortValueDescription color",
         code: """

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxUtils.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxUtils.swift
@@ -55,9 +55,12 @@ extension SyntaxViewModifierArgumentType {
         
         case .viewEvent(let viewEvent):
             return "\(viewEvent)"
-        
+
         case .view(let x):
             return "\(x)"
+
+        case .mathExpression(let x):
+            return x.description
         }
     }
 }
@@ -99,6 +102,9 @@ func describe(_ argType: SyntaxViewModifierArgumentType) -> String {
     case .view(let view):
         // TODO: revisit this?
         return view.name
+
+    case .mathExpression(let x):
+        return x.description
     }
 }
 

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewModifier.swift
@@ -128,6 +128,16 @@ struct SyntaxViewModifierClosureData: Sendable, Encodable {
     let script: String
 }
 
+struct SyntaxViewMathSyntax: Sendable {
+    let lhs: SyntaxViewModifierArgumentType
+    let op: String  // "+", "-", "*", "/", etc.
+    let rhs: SyntaxViewModifierArgumentType
+
+    var description: String {
+        "\(self.lhs.description) \(self.op) \(self.rhs.description)"
+    }
+}
+
 /*
  A single given parameter (i.e. a single label)
  could have a complex (more than just string) value or even multiple associated values, e.g.
@@ -161,9 +171,12 @@ indirect enum SyntaxViewModifierArgumentType: Sendable {
     case closure(SyntaxViewModifierClosureData)
     
     case viewEvent(SyntaxViewModifierViewEvent)
-    
+
     // SwiftUI view with proper hierarchy (e.g. VStack with children in modifier argument)
     case view(SyntaxView)
+
+    // Math expression (e.g. value.location.x - 196.5)
+    case mathExpression(SyntaxViewMathSyntax)
 }
 
 // Non-recursive sub-enum of `SyntaxViewModifierArgumentType` for when we are working in contexts where we have already flattened the nested argument-types like `tuple` and `array`
@@ -218,6 +231,9 @@ extension SyntaxViewModifierArgumentType {
             return []
         case .view(let x):
             return [.view(x)]
+        case .mathExpression(let x):
+            // Math expressions need to be flattened recursively
+            return x.lhs.toSyntaxViewModifierArgumentFlatType + x.rhs.toSyntaxViewModifierArgumentFlatType
         }
     }
 }
@@ -274,7 +290,17 @@ extension SyntaxViewModifierArgumentType {
         switch self {
         case .viewEvent(let x):
             return x
-            
+
+        default:
+            return nil
+        }
+    }
+
+    var mathExpression: SyntaxViewMathSyntax? {
+        switch self {
+        case .mathExpression(let x):
+            return x
+
         default:
             return nil
         }
@@ -539,8 +565,14 @@ extension SyntaxViewModifierArgumentType {
         case .viewEvent:
             fatalError()
 //            return AnyEncodable(x)
+
         case .view(_):
             fatalError()
+
+        case .mathExpression(let x):
+//            return AnyEncodable(x)
+            fatalError()
+            // Math Expressions are never directly encoded as `PortValueDescription`
         }
     }
 }

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
@@ -893,8 +893,29 @@ extension SyntaxViewName {
             
         case .stateAccess(let stateAccessRef):
             return [.connectionToLayerInput(stateAccessRef)]
-            
-        case .memberAccess, .closure, .viewEvent, .view:
+
+        case .mathExpression(let mathSyntax):
+            return try parseMathExpressionToPatchNodes(
+                mathSyntax,
+                varName: varName,
+                viewEvent: viewEvent,
+                nodesDict: nodesDict,
+                isStreaming: isStreaming
+            )
+
+        case .memberAccess(let memberAccess):
+            // Check if this is a gesture event reference (like value.location.x)
+            if let viewEvent = viewEvent {
+                return memberAccess.createConnectedPatchData(
+                    viewEvent: viewEvent,
+                    varName: varName
+                )
+            } else {
+                // No viewEvent context - treat as state access/connection
+                return [.connectionToLayerInput(memberAccess.trimmedDescription)]
+            }
+
+        case .closure, .viewEvent, .view:
             throw SwiftUISyntaxError.portValueDecodingError(.portValueDecodingError(describe(argument)))
         }
     }

--- a/Stitch/Graph/StitchAI/Mapping/VPLToCode/PortValue/PortValueToCode.swift
+++ b/Stitch/Graph/StitchAI/Mapping/VPLToCode/PortValue/PortValueToCode.swift
@@ -209,6 +209,9 @@ func extractValueForPortValueDescription(_ arg: SyntaxViewModifierArgumentType) 
     case .view(let x):
         fatalErrorIfDebug()
         return ""
+    case .mathExpression(_):
+        fatalErrorIfDebug()
+        return ""
     }
 }
 
@@ -314,6 +317,9 @@ func renderArgWithoutPortValueDescription(_ arg: SyntaxViewModifierArgumentType)
         // What is this, actually?
         fatalErrorIfDebug()
         return "VIEW: \(view.name)"
+    case .mathExpression(_):
+        fatalErrorIfDebug()
+        return "MATH EXPR"
     }
 }
 


### PR DESCRIPTION
Due to a force push, `development` was actually missing some logic from this PR: https://github.com/StitchDesign/Stitch/pull/1715

This PR reintroduces the logic.