### PR TITLE
Fix edge rendering jitter during AI streaming

### DIFF
--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -549,6 +549,7 @@ extension GraphState {
         }
 
         // Only apply deterministic sorting during AI streaming to prevent visual jitter
+        // TODO: Consider a more perf-friendly solution for future larger graphs
         if self.shouldAnimateForStreaming {
             return edges.sorted { edge1, edge2 in
                 // Sort by downstream node ID first, then port ID for deterministic ordering

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -532,7 +532,7 @@ extension GraphState {
             return input.rowDelegate?.containsUpstreamConnection ?? false
         }
         
-        return connectedInputs.compactMap { (downstreamInput: InputNodeRowViewModel) in
+        let edges = connectedInputs.compactMap { (downstreamInput: InputNodeRowViewModel) in
 
             guard let downstreamInputNode = self.getNode(downstreamInput.id.nodeId),
                   let upstreamOutputObserver = downstreamInput.rowDelegate?.upstreamOutputObserver,
@@ -547,13 +547,19 @@ extension GraphState {
                                      downstreamInput: downstreamInput,
                                      downstreamInputNode: downstreamInputNode)
         }
-        .sorted { edge1, edge2 in
-            // Sort by downstream node ID first, then port ID for deterministic ordering
-            if edge1.id.nodeId != edge2.id.nodeId {
-                return edge1.id.nodeId < edge2.id.nodeId
+
+        // Only apply deterministic sorting during AI streaming to prevent visual jitter
+        if self.shouldAnimateForStreaming {
+            return edges.sorted { edge1, edge2 in
+                // Sort by downstream node ID first, then port ID for deterministic ordering
+                if edge1.id.nodeId != edge2.id.nodeId {
+                    return edge1.id.nodeId < edge2.id.nodeId
+                }
+                return edge1.id.portId < edge2.id.portId
             }
-            return edge1.id.portId < edge2.id.portId
         }
+
+        return edges
     }
 }
 

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -532,7 +532,7 @@ extension GraphState {
             return input.rowDelegate?.containsUpstreamConnection ?? false
         }
         
-        let edges = connectedInputs.compactMap { (downstreamInput: InputNodeRowViewModel) in
+        let edges: [ConnectedEdgeData] = connectedInputs.compactMap { (downstreamInput: InputNodeRowViewModel) in
 
             guard let downstreamInputNode = self.getNode(downstreamInput.id.nodeId),
                   let upstreamOutputObserver = downstreamInput.rowDelegate?.upstreamOutputObserver,

--- a/Stitch/Graph/ViewModel/GraphState.swift
+++ b/Stitch/Graph/ViewModel/GraphState.swift
@@ -533,7 +533,7 @@ extension GraphState {
         }
         
         return connectedInputs.compactMap { (downstreamInput: InputNodeRowViewModel) in
-            
+
             guard let downstreamInputNode = self.getNode(downstreamInput.id.nodeId),
                   let upstreamOutputObserver = downstreamInput.rowDelegate?.upstreamOutputObserver,
                   let upstreamOutputPortUIViewModel = upstreamOutputObserver.rowViewModelForCanvasItemAtThisTraversalLevel?.portUIViewModel,
@@ -541,11 +541,18 @@ extension GraphState {
                 // log("no connected edge data for downstreamInput \(downstreamInput.id)")
                 return nil
             }
-            
+
             return ConnectedEdgeData(upstreamCanvasItem: upstreamCanvasItem,
                                      upstreamOutputPortUIViewModel: upstreamOutputPortUIViewModel,
                                      downstreamInput: downstreamInput,
                                      downstreamInputNode: downstreamInputNode)
+        }
+        .sorted { edge1, edge2 in
+            // Sort by downstream node ID first, then port ID for deterministic ordering
+            if edge1.id.nodeId != edge2.id.nodeId {
+                return edge1.id.nodeId < edge2.id.nodeId
+            }
+            return edge1.id.portId < edge2.id.portId
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds deterministic edge sorting during AI streaming to prevent visual jitter
- Edges sorted by downstream node ID, then port ID
- Only applies during streaming (`shouldAnimateForStreaming`), preserves natural ordering otherwise

## Technical Details
Previously, edges rendered in non-deterministic order due to dictionary iteration, causing visual instability during AI graph updates. This adds O(n log n) sorting only when streaming is active.

## Performance Note
Added TODO for future optimization when working with larger graphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)