### PR TITLE
Fixed AI tap gesture regression

### DIFF
--- a/Stitch/App/StitchApp.swift
+++ b/Stitch/App/StitchApp.swift
@@ -51,8 +51,8 @@ struct StitchApp: App {
         FirebaseApp.configure()
     }
 
-//#if FAKE_FLAG
-#if DEV_DEBUG
+#if FAKE_FLAG
+//#if DEV_DEBUG
     var body: some Scene {
         WindowGroup {
              ASTExplorerView()

--- a/Stitch/App/StitchApp.swift
+++ b/Stitch/App/StitchApp.swift
@@ -51,8 +51,8 @@ struct StitchApp: App {
         FirebaseApp.configure()
     }
 
-#if FAKE_FLAG
-//#if DEV_DEBUG
+//#if FAKE_FLAG
+#if DEV_DEBUG
     var body: some Scene {
         WindowGroup {
              ASTExplorerView()

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewEvent.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewEvent.swift
@@ -230,7 +230,8 @@ extension SyntaxViewModifierViewEvent {
                              isStreaming: Bool) throws -> SwiftPatchViewEvent? {
         // Check for onChange handlers
         guard let viewName = SyntaxViewEventType(rawValue: self.eventName),
-              let onChangeHandler = self.eventModifiers.get("onChanged") else {
+              // MARK: we just want to ignore onEnded, we don't support that yet
+                let onChangeHandler = self.eventModifiers.get("onChanged") ?? self.eventModifiers.values.first else {
             return nil
         }
         


### PR DESCRIPTION
Our checks mandated an `onChanged` handler for gestures. Tap gestures may not have onChanged and should should still be allowed.