### PR TITLE
Fix AI node positioning when many layer nodes are present

### DIFF
--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/StepApplication.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/StepApplication.swift
@@ -431,6 +431,7 @@ extension Array where Element == NodeEntity {
                 ? Self.sortNodesByBarycenter(nodes: layout.nodes, parentMap: parentMap, nodePositions: nodePositions)
                 : layout.nodes
 
+
             var rowIndex = 0
 
             for node in sortedNodes {
@@ -445,7 +446,6 @@ extension Array where Element == NodeEntity {
                     x: viewPortCenter.x + centeringOffset + layout.cumulativeXOffset,
                     y: viewPortCenter.y + CGFloat(rowIndex) * layout.rowHeight
                 )
-                rowIndex += 1
 
                 // Store base position for use in barycenter calculation for children
                 nodePositions[node.id] = basePosition
@@ -469,6 +469,10 @@ extension Array where Element == NodeEntity {
                     sizeCache: sizeCache,
                     updateCanvasPosition: updateCanvasPosition
                 )
+
+                // Increment rowIndex by actual canvas items created, not by 1 for every node
+                // This prevents layer nodes with 0 canvas items from taking up vertical space
+                rowIndex += canvasItemIndex
 
                 updatedNodes.append(updatedNode)
             }


### PR DESCRIPTION
<img width="1440" height="900" alt="PNG image" src="https://github.com/user-attachments/assets/d178fefd-5570-40d7-b3a2-5024e875dd53" />

<img width="1440" height="900" alt="PNG image" src="https://github.com/user-attachments/assets/3d2a06b2-93b1-4aa3-bcb4-d155bb0a389d" />

<img width="1440" height="900" alt="PNG image" src="https://github.com/user-attachments/assets/9b850b04-26f6-416e-8730-0813bfe8e72b" />


## Summary
- Fixed issue where patch nodes (like Press Interaction) were positioned too far down during AI streaming when many layer nodes were present
- Root cause: `rowIndex` was incrementing for every NodeEntity (including layer nodes with 0 canvas items), causing patch nodes to be pushed down
- Solution: Increment `rowIndex` based on actual canvas items created, not by NodeEntity count

🤖 Generated with [Claude Code](https://claude.com/claude-code)