### PR TITLE
Skip parsing (whether streaming or not) if no `ContentView`

### DIFF
--- a/Stitch/Graph/StitchAI/GraphPrompting/API/ClaudeGraphGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/ClaudeGraphGenRequest.swift
@@ -300,10 +300,15 @@ final actor ClaudeStreamingActor {
                             // log("📝 Text delta received: '\(text)' (length: \(text.count))")
                             accumulatedContent += text
                             log("accumulated text: \n\(accumulatedContent)")
-                            
+
+                            // Skip parsing if no ContentView present (explanatory text only)
+                            guard accumulatedContent.contains("ContentView") else {
+                                continue
+                            }
+
                             // MARK: code building in-progress graphs is expensive, we delay work so long as no active update task is running
                             guard self.updateTask == nil else { break }
-                            
+
                             let codeParserResult = SwiftUIViewVisitor.parseSwiftUICode(accumulatedContent, isStreaming: true)
                             
                             // Syntax → Actions

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AIRequestDeps.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AIRequestDeps.swift
@@ -183,10 +183,13 @@ extension StitchAICodeCreator {
         log("userPrompt: \(userPrompt)") // Very helpful to see user-prompt here again
         log("StitchAICodeCreator swiftUICode:\n\(swiftUICode)")
 
-        // Check if the AI returned empty code or code without ContentView
+        // Check if the AI returned empty code or code without ContentView (and we're not streaming)
         let trimmedCode = swiftUICode.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmedCode.isEmpty || !trimmedCode.contains("ContentView") {
-            log("ERROR: AI returned invalid code (empty or missing ContentView) for prompt: \(userPrompt)")
+        if trimmedCode.isEmpty {
+            log("ERROR: AI returned invalid code (empty) for prompt: \(userPrompt)")
+            throw StitchAIManagerError.emptyAIResponse
+        } else if (!trimmedCode.contains("ContentView") && !isStreaming) {
+            log("ERROR: AI returned invalid code (missing ContentView) for prompt: \(userPrompt)")
             throw StitchAIManagerError.emptyAIResponse
         }
 

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AIRequestDeps.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AIRequestDeps.swift
@@ -183,9 +183,10 @@ extension StitchAICodeCreator {
         log("userPrompt: \(userPrompt)") // Very helpful to see user-prompt here again
         log("StitchAICodeCreator swiftUICode:\n\(swiftUICode)")
 
-        // Check if the AI returned empty code
-        if swiftUICode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            log("ERROR: AI returned empty code for prompt: \(userPrompt)")
+        // Check if the AI returned empty code or code without ContentView
+        let trimmedCode = swiftUICode.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedCode.isEmpty || !trimmedCode.contains("ContentView") {
+            log("ERROR: AI returned invalid code (empty or missing ContentView) for prompt: \(userPrompt)")
             throw StitchAIManagerError.emptyAIResponse
         }
 


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7509

Note: ideally we could just exit early, but `processRequest`'s signature does not allow that.
