### PR TITLE
FeatureFlag: fully enable AI features

### DIFF
--- a/Stitch/App/FeatureFlags.swift
+++ b/Stitch/App/FeatureFlags.swift
@@ -41,7 +41,8 @@ struct FeatureFlags {
 #if DEV_DEBUG
     static let PLACE_CENTER_OF_VIEW_AT_ANCHORING_POINT: Bool = true
 #else
-    static let PLACE_CENTER_OF_VIEW_AT_ANCHORING_POINT: Bool = false
+//    static let PLACE_CENTER_OF_VIEW_AT_ANCHORING_POINT: Bool = false
+    static let PLACE_CENTER_OF_VIEW_AT_ANCHORING_POINT: Bool = true
 #endif
     
     


### PR DESCRIPTION
# Gets us closest to how SwiftUI + LLM actually works. Can flip off after demo videos, when we implement backward compatibility logic / a smoother handling here. 


# `PLACE_CENTER_OF_VIEW_AT_ANCHORING_POINT = true` 

## attempt 1

<img width="1440" height="900" alt="Screenshot 2025-10-04 at 10 19 46 AM" src="https://github.com/user-attachments/assets/04c0a0a8-7367-4f8a-8cb8-ed7e6b578dae" />

** userPrompt: create a rectangle in the top left corner
** StitchAICodeCreator swiftUICode:
```swift
struct ContentView: View {

    var body: some View {
        Rectangle()
            .fill([PortValueDescription(value: "#A389EDFF", value_type: "color")])
            .frame([PortValueDescription(value: ["width": "100.0", "height": "100.0"], value_type: "size")])
            .position([PortValueDescription(value: ["x": 50, "y": 50], value_type: "position")])
    }

    func updateLayerInputs() {
        
    }

}
```


## attempt 2

<img width="1440" height="900" alt="Screenshot 2025-10-04 at 10 35 10 AM" src="https://github.com/user-attachments/assets/86ec3358-3a83-4964-b0f5-fae018053b46" />

** 🎯 Total usage: 108 input + 786 output = 894 tokens
** Claude streaming cache performance - Created: 0, Read: 104164, Total: 894
** 🔚 Finished processing Claude stream - Total lines: 210, Events: 105
** Claude streaming completed successfully
** Final content length: 431 characters
** Total thinking length: 2056 characters
** 📝 Thinking steps received: 87
** 🧠 All thinking deltas received as text block:
** The user wants  to create a rectangle in the top left corner.  

Key requirements:
1. Use Rectangle() view
2. Position  it in the top left corner
3. Use `.position ` modifier (since it uses top left as  0,0)
4. All  values must use [PortValueDescription]
5. No  logic other than patch function calls and state updates in updateLayerInputs 
6. The screen is 393.0 wide an d 852.0 tall

For a rectangle in the top left corner :
- Use Rectangle()
- Use . position modifier with x: 0, y: 0  (top left corner reference)
- Nee d to give it a size with .frame
- Shoul d give it a color with .fill

Let me create  the code:

```swift
struct ContentView: View  {

    var body: some View {
        Rectangle()
            .fill ([PortValueDescription(value: "# A389EDFF", value_type: "color ")])
            .frame([PortValueDescription(value: [" width": "100.0", "height": "100. 0"], value_type: "size ")])
            .position([PortValueDescription(value: [" x": 0, "y": 0], value_type: " position")])
    }

    func updateLayerInputs() { 
        
    }

}
```

Wait, I nee d to check the position. The . position modifier uses the parent's top left corner as 0,0.  But it positions the CENTER of the view  at that coordinate. So if I want the  rectangle's top left corner to be at 0,0, I need to offset  it by half its width and height.

Actually, looking  at the instructions more carefully:
- `.position` uses implicit  top left anchoring (0,0 is top left of parent)
- `.offset ` uses implicit center anchoring (0, 0 is center of parent) 

So for top left corner, I should use `.position` with coordinates  (0, 0).  

I 'll  adjust  my understanding  of  view  positioning to  ensure  the  rectangle  precisely  aligns with the top  left corner.  The  nu ance d behavior  of `. position` requires  careful  consideration of view  anchoring and coordinate  systems. 

Positioning  the rectangle involves  understanding  how  Sw iftUI interp rets coordinate  placement ,  particularly  the  default  center - base d positioning  of  views. I 'll need to carefully  calculate  the exact  coordinates  to achieve  the desired top- left alignment .
TopologicalData init
** StitchUIScrollView: update
** ⏱️ AI Request completed in 17.89 seconds using Claude Sonnet 4.5
** userPrompt: create a rectangle in the top left corner
** StitchAICodeCreator swiftUICode:
```swift
struct ContentView: View {

    var body: some View {
        Rectangle()
            .fill([PortValueDescription(value: "#A389EDFF", value_type: "color")])
            .frame([PortValueDescription(value: ["width": "100.0", "height": "100.0"], value_type: "size")])
            .position([PortValueDescription(value: ["x": 50, "y": 50], value_type: "position")])
    }

    func updateLayerInputs() {
        
    }

}
```


## attempt 3

<img width="1440" height="900" alt="Screenshot 2025-10-04 at 10 36 30 AM" src="https://github.com/user-attachments/assets/6d6ce1e3-74b8-401f-947b-03993ff7c643" />

** 🧠 All thinking deltas received as text block:
** The user wants to  create a rectangle in the top left corner. 

Looking at the rules:
1. I  need to create a Rectangle view
2. For  positioning, I should use `.position`  modifier since it uses top left as 0,0
3. The rectangle  should be at position (0,0) to be  in the top left corner
4. I need to use `[ PortValueDescription]` for all values 
5. The view needs to fit within  393.0 wide and 852.0 tall screen 

For a rectangle in the top left corner:
- Position: (0,  0) using `.position` modifier (since `.position ` uses top left as anchor)
- I should give it some  size using `.frame`
- Default color is fine,  or I can add a fill color

Let me create this: 

```swift
struct ContentView: View {

    var body: some View {
        Rectangle ()
            .frame([PortValueDescription(value: [" width": "100.0", "height": "100. 0"], value_type: "size")])
            .position([ PortValueDescription(value: ["x": 0, "y":  0], value_type: "position")])
     }

    func updateLayerInputs() { 

    }

}
```

Wait , I need to check the rules for `.position`. According  to the rules:
- `.position` uses top left corner  as 0,0 (implicit top left anchoring)
- To  place something in the top left corner, position shoul d be (0, 0)

But  actually, let me reconsider. The `.position` modifier in  SwiftUI places the CENTER of the view at the specifie d coordinates. But the rules say it uses "top left corner as 0,0 ". Let me re-read...

The rules state: "Sw iftUI's `.position` view modifier places a view using  the parent's TOP LEFT CORNER as 0,0." 
   
I 'll  adjust  my understanding  of  positioning  the  rectangle.  The  example  suggests  positioning  at  (0 ,0) directly  places  the view  in the top left corner ,  contrary  to my  previous assumption  about  view  centers . This  means  I can  simply  use  ( 0,0) coordinates  to  align  the rectangle precisely  where  neede d.
** ⏱️ AI Request completed in 17.40 seconds using Claude Sonnet 4.5
** userPrompt: create a rectangle in the top left corner
** StitchAICodeCreator swiftUICode:
```swift
struct ContentView: View {

    var body: some View {
        Rectangle()
            .frame([PortValueDescription(value: ["width": "100.0", "height": "100.0"], value_type: "size")])
            .position([PortValueDescription(value: ["x": 0, "y": 0], value_type: "position")])
    }

    func updateLayerInputs() {

    }

}
```


## attempt 4
<img width="1440" height="900" alt="Screenshot 2025-10-04 at 10 41 12 AM" src="https://github.com/user-attachments/assets/76113d4c-a222-4806-81f3-7b448eb8b589" />

** Total thinking length: 2240 characters
** 📝 Thinking steps received: 108
** 🧠 All thinking deltas received as text block:
** The user wants  to create a rectangle in the top left corner . Let me break down what I need to do:

1. Create  a Rectangle view inside the body
2. Place it in the top left corner using  `.position` modifier
3. The screen size is 393.0 wide an d 852.0 tall
4. Top  left corner would be at position (0, 0) when  using `.position` modifier (which uses top -left as origin)
5. I  need to give the rectangle a size using `.frame `
6. All values must use ` [PortValueDescription]` format

According to the rules :
- SwiftUI's `. position` uses top left corner as 0,0
- I  should use `.position` for placement
- No  need for @State variables since this is static 
- No logic needed in updateLayerInputs for  a static rectangle
- Default size coul d be something reasonable like 100x100 
- Should give it a color using `.fill`  modifier

Let me construct the code: 

```swift
struct ContentView: View  {

    var body: some View { 
        Rectangle()
            .fill ([PortValueDescription(value: "# A389EDFF", value_type: "color ")])
            .frame([ PortValueDescription(value: [" width": "100.0", "height": "100. 0"], value_type: "size")])
             .position([PortValueDescription(value: [" x": 0, "y":  0], value_type: "position")])
    } 

    func updateLayerInputs() { 
        // No dynamic updates needed for static design 
    }

}
```

Wait, I nee d to think about the position. If I use `.position`  with (0, 0), that  will place the CENTER of the rectangle at ( 0, 0), which means half of the rectangle will  be off-screen. To properly  place it in the top left corner with  the rectangle fully visible, I should position  it at (50, 50) if  the rectangle is 100x100,  so that its center is 50 points  from the edges.
 

I 'll adjust  my  positioning  strategy  to  ensure  the rectangle is fully visible  in the top- left area .  Since  `. position` centers  the view ,  I'll offset  the coordinates  to  keep  the entire  rectangle on  screen .  This  means  using  (50, 50 ) for a  100x100  rectangle,  which places  its  center slightly  in ward from  the screen 's  edges.

The  key  consideration  is bal ancing the view 's center  point  with the desire  to keep  the entire  rectangle visible. By  positioning  at  (50, 50 ), I ensure  the rectangle appears  in  the top- left region  while  maintaining  full  visibility.
** ⏱️ AI Request completed in 19.00 seconds using Claude Sonnet 4.5
** userPrompt: create a rectangle in the top left corner
** StitchAICodeCreator swiftUICode:
```swift
struct ContentView: View {

    var body: some View {
        Rectangle()
            .fill([PortValueDescription(value: "#A389EDFF", value_type: "color")])
            .frame([PortValueDescription(value: ["width": "100.0", "height": "100.0"], value_type: "size")])
            .position([PortValueDescription(value: ["x": 50, "y": 50], value_type: "position")])
    }

    func updateLayerInputs() {
        // No dynamic updates needed for static design
    }

}
```





# `PLACE_CENTER_OF_VIEW_AT_ANCHORING_POINT = false` 

<img width="1434" height="863" alt="Screenshot 2025-10-04 at 10 17 25 AM" src="https://github.com/user-attachments/assets/a82b4f03-0858-419f-ba4a-d7286164e614" />


## attempt 2 (saved code)

<img width="1440" height="900" alt="Screenshot 2025-10-04 at 10 24 17 AM" src="https://github.com/user-attachments/assets/927b8ab9-eb50-49eb-88cf-19e4ee0fc783" />

** 🧠 All thinking deltas received as text block:
** The user wants to  create a rectangle in the top left corner  of the screen.

Key points:
1. The screen  is 393.0 wide an d 852.0 tall with backgroun d color #FFFFFFFF
2 . I need to place a rectangle in the top left corner 
3. Top left corner means position (0, 0)  using the `.position` modifier (since  `.position` uses top-left as  the anchor point)
4. I  should use a Rectangle view with appropriate  modifiers
5. I need to use  PortValueDescription for all values
6. I need an  @State variable if the rectangle needs dynamic  properties
7. The `updateLayerInputs`  function should be present but may be  empty if there's no dynamic  behavior

Since this is a simple static rectangle placement , I don't need any state  variables or logic in updateLayerInputs. 

For the rectangle:
- Use Rectangle() view 
- Add a `.fill` modifier for color  (let's use a default color)
- Add a `.frame ` modifier for size
- Add a `.position` modifier to  place it at top-left (0, 0) 

Let me write the code: 

```swift
struct ContentView: View  {

    var body: some View {
        Rectangle ()
            .fill([PortValueDescription(value: "# A389EDFF", value_type: "color ")])
            .frame(width : [PortValueDescription(value: " 100.0", value_type: " layerDimension")],
                   height: [Port ValueDescription(value: "100. 0", value_type: "layerDimension")])
             .position([PortValueDescription(value: [" x": 0, "y": 0 ], value_type: "position" )])
    }

    func updateLayerInputs() { 

    }

}
```

Wait, I  need to reconsider the position. The `.position` modifier in  SwiftUI places the CENTER of the view at the specified coordinates . However, according to the rules:
 

I 'll  adjust  the positioning  to account  for the view 's center  placement .  To  ensure  the rectangle 's  top -left corner is at  (0, 0 ), I'll nee d to offset  the position  by half  the rectangle 's width and height.  This  means  positioning  the rectangle's  center  at (50 , 50) to  have  its top-left corner  align  with (0,  0).

The  key  insight  is understanding  how  SwiftUI's positioning  mo difiers work. The `. position` modifier uses the  view 's center ,  so I 'll calculate  the position  accordingly  to  achieve  the desired top-left  corner placement.
** ⏱️ AI Request completed in 19.23 seconds using Claude Sonnet 4.5
** userPrompt: create a rectangle in the top left corner
** StitchAICodeCreator swiftUICode:
```swift
struct ContentView: View {

    var body: some View {
        Rectangle()
            .fill([PortValueDescription(value: "#A389EDFF", value_type: "color")])
            .frame(width: [PortValueDescription(value: "100.0", value_type: "layerDimension")],
                   height: [PortValueDescription(value: "100.0", value_type: "layerDimension")])
            .position([PortValueDescription(value: ["x": 0, "y": 0], value_type: "position")])
    }

    func updateLayerInputs() {

    }

}
```


## attempt 3

<img width="1440" height="900" alt="Screenshot 2025-10-04 at 10 25 52 AM" src="https://github.com/user-attachments/assets/31a362f3-d951-47db-bbde-62f3a9bcee53" />

** 🧠 All thinking deltas received as text block:
** The user wants  to create a rectangle in the top left corner  of the screen.

Looking at the rules:
- The screen is 393 .0 wide and 852.0 tall
- I  need to use SwiftUI views with  PortValueDescription arrays
- For positioning, I shoul d use `.position` modifier
- `. position` uses the parent's TOP LEFT  CORNER as 0,0 (as  stated in the rules)
- The rectangle should be anch ored at top-left, which  means I want its position to be near  (0,0)

Let  me create a simple Rectangle and position it at the  top left corner.

From the rules:
- Rectangle  is an allowed view
- I need to use PortValueDescription for  all values
- `.position` modifier  is allowed
- For a rectangle to appear  in the top-left, I shoul d position it at (0,0) or  close to it
- I should give it a size using  `.frame`

Let me write the code: 

```swift
struct ContentView: View {

    var body: some View { 
        Rectangle()
            .fill([PortValueDescription(value: "# A389EDFF", value_type: "color ")])
            .frame([PortValueDescription(value: [" width": "100. 0", "height": "100.0"], value_type: "size ")])
            .position([PortValueDescription(value: [" x": 50, "y": 50], value_ type: "position")])
    } 

    func updateLayerInputs() { 

    }

}
```

Wait, I need to think  about the positioning more carefully. The `.position` modifier places  the CENTER of the view at the specified coordinates. And it  uses the parent's top-left as (0,0). 

So if I want a 100x100 rectangle with  its top-left corner at (0,0), I need to position  its center at (50, 50).

Actually , looking at the rules more carefully - it says `. position` uses an implicit *top left*  anchoring.  

I  realize  the  rectangle 's  positioning  requires  precise  calculation .  Since  the view 's  center determines  its  placement , positioning  at  (50, 50 ) ensures  the rectangle's  top -left corner al igns with the screen 's origin . This  means  half  the rectangle's  width and height will  be offset  from  the ( 0,0) point ,  creating  the desired top-left  placement .

I 'll  carefully  construct  the  PortValueDescription to  match  the exact  positioning requirements,  ensuring  the rectangle appears  exactly  where intende d.
** ⏱️ AI Request completed in 17.78 seconds using Claude Sonnet 4.5
** userPrompt: create a rectangle in the top left corner
** StitchAICodeCreator swiftUICode:
```swift
struct ContentView: View {

    var body: some View {
        Rectangle()
            .fill([PortValueDescription(value: "#A389EDFF", value_type: "color")])
            .frame([PortValueDescription(value: ["width": "100.0", "height": "100.0"], value_type: "size")])
            .position([PortValueDescription(value: ["x": 50, "y": 50], value_type: "position")])
    }

    func updateLayerInputs() {

    }

}
```


## attempt 4

<img width="1440" height="900" alt="Screenshot 2025-10-04 at 10 26 43 AM" src="https://github.com/user-attachments/assets/a49a649f-3282-43ef-85a4-a37245da3e96" />

** 🧠 All thinking deltas received as text block:
** The user wants to  create a rectangle in the top left corner. 

Let  me think about the requirements:
1. I  need to create a Rectangle view
2. It should be positione d in the top left corner
3. According to the rules, I  should use `.position` modifier for placement since it uses  top-left as the origin (0,0)
4. I  need to use `[PortValueDescription]` for all  values
5. The rectangle needs basic properties like size and color

Since  it's in the top left corner, I'll use `.position` with x : 0, y: 0. However, I need to account  for the rectangle's anchor point. By default, views  are anchored at center, so if I want  the top-left corner of the rectangle to be at (0,0), I need to offset  by half its size, or I can position it at (width /2, height/2).

Actually, looking  at the rules more carefully, `.position` uses  the top-left corner as (0,0), but the view itself is still  anchored at its center by default. So if I want the rectangle 's top-left corner at (0, 0), I should position it at (width/2, height /2) of the rectangle.

Let me create a simple  rectangle with a default size of maybe 100x100, and position it so  its top-left corner is at (0, 0).

I'll set the position to x : 50, y: 50  (half of 100x100)  so the rectangle's center is at that  point, making its top-left corner at (0,0).

Let  me write the code:

```swift
struct ContentView: View  {
    
    var body: some View { 
        Rectangle()
            .fill([PortValueDescription(value: "# A389EDFF", value_type: "color ")])
            .frame([PortValueDescription(value: [" width": "100.0", "height": "100. 0"], value_type: "size")])
             .position([ PortValueDescription(value : ["x":  50, "y":  50], value_ type: "position" )])
    } 
    
    func update LayerInputs()  {
        // No  dynamic updates needed for static  rectangle
    } 
}
```

I 'll  position  the rectangle precisely  at the  screen 's  top-left corner by  calculating  its  center point.  The   50, 50 coordinates  ensure  the  100x100 rectangle  al igns perfectly  with the origin .
TopologicalData init
** StitchUIScrollView: update
** ⏱️ AI Request completed in 14.48 seconds using Claude Sonnet 4.5
** userPrompt: create a rectangle in the top left corner
** StitchAICodeCreator swiftUICode:
```swift
struct ContentView: View {

    var body: some View {
        Rectangle()
            .fill([PortValueDescription(value: "#A389EDFF", value_type: "color")])
            .frame([PortValueDescription(value: ["width": "100.0", "height": "100.0"], value_type: "size")])
            .position([PortValueDescription(value: ["x": 50, "y": 50], value_type: "position")])
    }

    func updateLayerInputs() {
        // No dynamic updates needed for static rectangle
    }
}
```