### PR TITLE
Fixed issue where AI results incorrectly assign nil layer groups

### DIFF
--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIGraphData/AIGraphData_V0.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIGraphData/AIGraphData_V0.swift
@@ -306,9 +306,13 @@ extension AIGraphData_V0.PortValue {
 
 extension AIGraphData_V0.LayerData {
     func createSidebarLayerData() -> SidebarLayerData {
+        // Ensure groups always have children
+        let isLayerGroup = self.node_name.value.layer?.canHaveChildren ?? false
+        let defaultChildren: [SidebarLayerData]? = isLayerGroup ? [] : nil
+        
         let children = self.children?.map {
             $0.createSidebarLayerData()
-        }
+        } ?? defaultChildren
 
         assertInDebug(UUID(self.node_id) != nil)
 


### PR DESCRIPTION
Layer groups expect to have empty arrays instead of nil. Fixing this resolved issues with sidebar helpers which couldn't insert children due to missing arrays.
