### PR TITLE
Support for PortValue assignments from AI code response

### DIFF
--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
@@ -33,7 +33,7 @@ private struct LayerWorkItem {
 extension Array where Element == AIGraphData_V0.LayerData {
     func createLayerNodes(layerGroupId: UUID?,
                           nodesDict: inout [UUID: NodeEntity],
-                          stateVarConnections: inout [String: [NodeIOCoordinate]],
+                          stateVarConnections: inout [String: [NodeConnectionType]],
                           isStreaming: Bool) {
         
         // MARK: VERY IMPORTANT: Use iterative approach with queue instead of recursion to avoid blowing up actor's thread-memory (512 KB; vs main thread's 8 MB)
@@ -99,7 +99,6 @@ struct StitchAIGraphEntityResult {
 extension SwiftSyntaxActionsResult {
     @MainActor
     func applyAIGraph(to document: StitchDocumentViewModel,
-                      viewStatePatchConnections: [String : [NodeIOCoordinate]],
                       currentGraphEntity: GraphEntity,
                       isStreaming: Bool) {
         // User prompt-based requests are always assumed to be edit requests, which completely replace existing graph data

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AIRequestDeps.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AIRequestDeps.swift
@@ -148,7 +148,6 @@ extension StitchAICodeCreator {
                     
                     actionsResult
                         .applyAIGraph(to: document,
-                                      viewStatePatchConnections: actionsResult.graphData.viewStatePatchConnections,
                                       currentGraphEntity: newCurrentGraphEntity,
                                       isStreaming: false)
                     

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIGraphData/AIGraphDataUtil_V0.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIGraphData/AIGraphDataUtil_V0.swift
@@ -40,7 +40,7 @@ extension AIGraphData_V0.GraphData {
         }
         
         // Maps upstream patch output coordinate to some new created @State var name
-        var viewStatePatchConnections: [String : [NodeIOCoordinate]] = [:]
+        var viewStatePatchConnections: [String : [NodeConnectionType]] = [:]
         
         // Maps interactions to layers, used to determine gestures to create
         // Key = Patch, Value = Layer
@@ -128,7 +128,7 @@ extension Array where Element == AIGraphData_V0.SidebarLayerData {
     func createAIData(nodesDict: [UUID : AIGraphData_V0.NodeEntity],
                       patchToLayerAssignmentMap: [UUID : UUID],
                       upstreamConnectionToInteraction: inout [NodeIOCoordinate : NodeIOCoordinate],
-                      viewStatePatchConnections: inout [String : [NodeIOCoordinate]]) throws -> [AIGraphData_V0.LayerData] {
+                      viewStatePatchConnections: inout [String : [NodeConnectionType]]) throws -> [AIGraphData_V0.LayerData] {
         try self.map { sidebarData in
             try .init(from: sidebarData,
                       nodesDict: nodesDict,
@@ -152,7 +152,7 @@ extension AIGraphData_V0.LayerData {
          nodesDict: [UUID : AIGraphData_V0.NodeEntity],
          patchToLayerAssignmentMap: [UUID : UUID],
          upstreamConnectionToInteraction: inout [NodeIOCoordinate : NodeIOCoordinate],
-         viewStatePatchConnections: inout [String : [NodeIOCoordinate]]) throws {
+         viewStatePatchConnections: inout [String : [NodeConnectionType]]) throws {
         guard let node = nodesDict.get(sidebarData.id),
               let layerData = node.layerNodeEntity else {
             throw AICodeGenError.nodeDataNotFound
@@ -210,7 +210,7 @@ extension AIGraphData_V0.LayerData {
                     
                     // Update state dict
                     viewStatePatchConnections
-                        .updateValue(upstream,
+                        .updateValue(.upstreamConnection(upstream),
                                      forKey: stateVarName)
                     
                     // Track interaction data
@@ -257,7 +257,7 @@ extension AIGraphData_V0.LayerData {
                         
                         // Update state dict
                         viewStatePatchConnections
-                            .updateValue(upstream,
+                            .updateValue(.upstreamConnection(upstream),
                                          forKey: stateVarName)
                     }
                 }
@@ -309,7 +309,7 @@ extension AIGraphData_V0.LayerData {
                             return
                         }
                         
-                        if viewStateUpstreamCoordinate == interactionOutputCoordinate {
+                        if viewStateUpstreamCoordinate.upstreamConnection == interactionOutputCoordinate {
                             // Update key
                             result.removeValue(forKey: oldKey)
                             result.updateValue(viewStateUpstreamCoordinate,

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIGraphData/AIGraphData_V0.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/SchemaVersions/V0/AIGraphData/AIGraphData_V0.swift
@@ -16,7 +16,7 @@ enum AIGraphData_V0 {
         let patchNodes: [NodeEntity]
 
         // Maps upstream patch output coordinate to some new created @State var name
-        let viewStatePatchConnections: [String : [NodeIOCoordinate]]
+        let viewStatePatchConnections: [String : [NodeConnectionType]]
     }
     
     struct GraphDataSchema: Encodable {

--- a/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/StitchToPatchData.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ActionsToSyntax/StitchToPatchData.swift
@@ -18,7 +18,7 @@ struct StitchPatchCodeConversionResult {
 
 extension GraphEntity {
     func createBindingDeclarations(nodeIdsInTopologicalOrder: [UUID],
-                                   viewStatePatchConnections: [String : [NodeIOCoordinate]]) throws -> StitchPatchCodeConversionResult {
+                                   viewStatePatchConnections: [String : [NodeConnectionType]]) throws -> StitchPatchCodeConversionResult {
         // Maps node IDs to a new var name
         var varIdNameMap: [UUID: String] = [:]
         
@@ -76,7 +76,7 @@ extension GraphEntity {
         let layerStateAssignments = viewStatePatchConnections.compactMap { (stateVarName, patchOutputCoordinates) -> String? in
             // Only multiple count here when parsing AI code
             assertInDebug(patchOutputCoordinates.count == 1)
-            guard let patchOutputCoordinate = patchOutputCoordinates.first else { return nil }
+            guard let patchOutputCoordinate = patchOutputCoordinates.first?.upstreamConnection else { return nil }
             
             let patchId = patchOutputCoordinate.nodeId
 

--- a/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewEvent.swift
+++ b/Stitch/Graph/StitchAI/Mapping/Syntax/SyntaxView/SyntaxViewEvent.swift
@@ -84,7 +84,7 @@ extension SyntaxViewEvent {
                                                 nodeId: self.unpackPositionNodeId)
             
             // Most downstream reference used for node ID
-            gestureReceiverEvent = .stateWrite(varName, unpackOutput)
+            gestureReceiverEvent = .stateWrite(varName, .upstreamConnection(unpackOutput))
         }
         
         let connection = PortEdgeData(
@@ -142,7 +142,7 @@ extension SyntaxViewEvent {
                     ]
                     
                     if let varName = varName {
-                        let gestureReceiverEvent = PatchSyntaxResultType.stateWrite(varName, patchOutput)
+                        let gestureReceiverEvent = PatchSyntaxResultType.stateWrite(varName, .upstreamConnection(patchOutput))
                         results.append(gestureReceiverEvent)
                     }
                     
@@ -183,7 +183,7 @@ extension SyntaxViewEvent {
                                                nodeId: self.interactionPatchNodeId)
             
             if let varName = varName {
-                gestureReceiverEvent = .stateWrite(varName, pressOutput)
+                gestureReceiverEvent = .stateWrite(varName, .upstreamConnection(pressOutput))
             }
             
             // Assume 0 until we handle cases with position

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
@@ -19,7 +19,7 @@ struct SwiftSyntaxLayerActionsResult {
 struct SwiftSyntaxPatchActionsResult {
     var nodes: [NodeEntity]
     
-    var stateVarConnections: [String: [NodeIOCoordinate]]
+    var stateVarConnections: [String: [NodeConnectionType]]
     
     var caughtErrors: [SwiftUISyntaxError]
 }
@@ -331,7 +331,7 @@ extension Dictionary where Key == String, Value == SwiftPatchCodeType {
                                             varName: String,
                                             portIndex: Int? = nil,
                                             varNameToCode: [String: SwiftPatchCodeType],
-                                            existingStateVarConnections: [String: [NodeIOCoordinate]],
+                                            existingStateVarConnections: [String: [NodeConnectionType]],
                                             nodesDict: [UUID: NodeEntity],
                                             viewEvent: SyntaxViewEvent?,
                                             isStreaming: Bool) throws -> [PatchSyntaxResultType] {
@@ -357,7 +357,7 @@ extension Dictionary where Key == String, Value == SwiftPatchCodeType {
             } else if let upstreamStateVarCoordinate = existingStateVarConnections.get(ref)?.first {
                 // Connection to some interaction patch node
                 return [
-                    .portData(.upstreamConnection(upstreamStateVarCoordinate))
+                    .portData(upstreamStateVarCoordinate)
                 ]
             } else if let upstreamRef = self.get(ref) {
                 // Fallback explores if this ref points to another ref
@@ -452,7 +452,7 @@ extension Dictionary where Key == String, Value == SwiftPatchCodeType {
                                             varName: String,
                                             portIndex: Int? = nil,
                                             varNameToCode: [String: SwiftPatchCodeType],
-                                            existingStateVarConnections: [String: [NodeIOCoordinate]],
+                                            existingStateVarConnections: [String: [NodeConnectionType]],
                                             nodesDict: [UUID: NodeEntity],
                                             viewEvent: SyntaxViewEvent?,
                                             isStreaming: Bool) throws -> [PatchSyntaxResultType] {
@@ -519,7 +519,7 @@ struct SwiftPatchNodeInputsResult {
 extension Array where Element == SwiftPatchCodeType {
     func createSchemaList(nodeId: UUID,
                           varNameToCode: [String: SwiftPatchCodeType],
-                          existingStateVarConnections: [String: [NodeIOCoordinate]],
+                          existingStateVarConnections: [String: [NodeConnectionType]],
                           nodesDict: [UUID: NodeEntity],
                           viewEvent: SyntaxViewEvent?,
                           isStreaming: Bool) throws -> SwiftPatchNodeInputsResult {
@@ -643,7 +643,7 @@ enum PatchSyntaxResultType {
     case connectionToLayerInput(String)
     
     // State writes (var name, patch node output)
-    case stateWrite(String, NodeIOCoordinate)
+    case stateWrite(String, NodeConnectionType)
     
     case jsSettings(PatchSyntaxJSResult)
 }
@@ -690,7 +690,7 @@ extension SwiftPatchNodeCode {
     func defaultNodeEntityData(varName: String,
                                varNameToCode: [String: SwiftPatchCodeType],
                                groupNodeId: UUID?,
-                               existingStateVarConnections: [String: [NodeIOCoordinate]],
+                               existingStateVarConnections: [String: [NodeConnectionType]],
                                nodesDict: [UUID: NodeEntity],
                                viewEvent: SyntaxViewEvent?,
                                jsSettings: JavaScriptNodeSettings? = nil,
@@ -936,7 +936,7 @@ extension SwiftPatchCodeType {
     func derivePatchDataSync(varName: String?,
                             varNameToCode: [String: SwiftPatchCodeType],
                             viewEvent: SyntaxViewEvent?,
-                            existingStateVarConnections: [String: [NodeIOCoordinate]],
+                            existingStateVarConnections: [String: [NodeConnectionType]],
                             nodesDict: [UUID: NodeEntity],
                             isStreaming: Bool) throws -> [PatchSyntaxResultType] {
         switch self {
@@ -1052,7 +1052,7 @@ extension SwiftPatchCodeType {
                          varName: String?,
                          varNameToCode: [String: SwiftPatchCodeType],
                          viewEvent: SyntaxViewEvent?,
-                         existingStateVarConnections: [String: [NodeIOCoordinate]],
+                         existingStateVarConnections: [String: [NodeConnectionType]],
                          nodesDict: [UUID: NodeEntity],
                          isStreaming: Bool) async throws -> [PatchSyntaxResultType] {
         // Handle the async jsRef case
@@ -1207,8 +1207,8 @@ extension Array where Element == SwiftPatchClosureType {
     }
 }
 
-extension Dictionary where Key == String, Value == [NodeIOCoordinate] {
-    mutating func updateValue(_ value: NodeIOCoordinate, forKey key: String) {
+extension Dictionary where Key == String, Value == [NodeConnectionType] {
+    mutating func updateValue(_ value: NodeConnectionType, forKey key: String) {
         var currentValues = self.get(key) ?? []
         currentValues.append(value)
         self = self.updatedValue(currentValues, forKey: key)
@@ -1219,7 +1219,7 @@ extension Dictionary where Key == UUID, Value == NodeEntity {
     mutating func updateWithEventData(_ event: PatchSyntaxResultType,
                                       layerInputCoordinate: NodeIOCoordinate?,
                                       varName: String?,
-                                      stateVarConnections: inout [String: [NodeIOCoordinate]],
+                                      stateVarConnections: inout [String: [NodeConnectionType]],
                                       isStreaming: Bool) throws {
         switch event {
         case .node(let nodeResult):
@@ -1243,21 +1243,10 @@ extension Dictionary where Key == UUID, Value == NodeEntity {
             }
             
         case .portData(let portData):
-            switch portData {
-            case .upstreamConnection(let upstreamCoordinate):
-                guard let varName = varName else {
-                    if !isStreaming {
-                        fatalErrorIfDebug()
-                    }
-                    return
-                }
-                
+            if let varName = varName {
                 // Update state var connections so we know which layer is pointed to by this variable name
-                stateVarConnections.updateValue(upstreamCoordinate,
+                stateVarConnections.updateValue(portData,
                                                 forKey: varName)
-                
-            case .values:
-                break
             }
             
             // Layer data case
@@ -1333,35 +1322,44 @@ extension Dictionary where Key == UUID, Value == NodeEntity {
             
             // Multiple upstream coordinates means an unpacking scenario
             if upstreamPatchCoordinates.count > 1 {
-                try upstreamPatchCoordinates.enumerated().forEach { index, upstreamPatchCoordinate in
-                    var layerInputCoordinate = layerInputCoordinate
-                    guard let unapckedPortType = UnpackedPortType(rawValue: index),
-                          var layerKeyPath = layerInputCoordinate.keyPath else {
-                        if !isStreaming {
-                            fatalErrorIfDebug()
+                try upstreamPatchCoordinates.enumerated().forEach { index, portData in
+                    switch portData {
+                    case .values:
+                        // Unexpected
+                        fatalErrorIfDebug()
+                        
+                    case .upstreamConnection(let upstreamPatchCoordinate):
+                        var layerInputCoordinate = layerInputCoordinate
+                        guard let unapckedPortType = UnpackedPortType(rawValue: index),
+                              var layerKeyPath = layerInputCoordinate.keyPath else {
+                            if !isStreaming {
+                                fatalErrorIfDebug()
+                            }
+                            return
                         }
-                        return
+                        
+                        layerKeyPath.portType = .unpacked(unapckedPortType)
+                        layerInputCoordinate = .init(portType: .keyPath(layerKeyPath),
+                                                     nodeId: layerInputCoordinate.nodeId)
+                        
+                        // Recursively call with extrapolated upstream patch data
+                        let event = PatchSyntaxResultType.connection(
+                            .init(from: upstreamPatchCoordinate,
+                                  to: layerInputCoordinate))
+                        return try self
+                            .updateWithEventData(event,
+                                                 layerInputCoordinate: layerInputCoordinate,
+                                                 varName: stateName,
+                                                 stateVarConnections: &stateVarConnections,
+                                                 isStreaming: isStreaming)
                     }
-                    
-                    layerKeyPath.portType = .unpacked(unapckedPortType)
-                    layerInputCoordinate = .init(portType: .keyPath(layerKeyPath),
-                                                 nodeId: layerInputCoordinate.nodeId)
-                    
-                    // Recursively call with extrapolated upstream patch data
-                    let event = PatchSyntaxResultType.connection(.init(from: upstreamPatchCoordinate,
-                                                                       to: layerInputCoordinate))
-                    return try self
-                        .updateWithEventData(event,
-                                             layerInputCoordinate: layerInputCoordinate,
-                                             varName: stateName,
-                                             stateVarConnections: &stateVarConnections,
-                                             isStreaming: isStreaming)
                 }
             }
             
             // Packed scenario
             else {
-                guard let upstreamPatchCoordinate = upstreamPatchCoordinates.first else {
+                guard let upstreamPatchCoordinate = upstreamPatchCoordinates.first?
+                    .upstreamConnection else {
                     if !isStreaming {
                         fatalErrorIfDebug()
                     }
@@ -1414,14 +1412,14 @@ extension Dictionary where Key == UUID, Value == NodeEntity {
             nodeEntity.nodeTypeEntity = .patch(newPatchNode)
             self.updateValue(nodeEntity, forKey: nodeEntity.id)
         
-        case .stateWrite(let varName, let upstreamOutputCoordinate):
-            stateVarConnections.updateValue(upstreamOutputCoordinate, forKey: varName)
+        case .stateWrite(let varName, let portData):
+            stateVarConnections.updateValue(portData, forKey: varName)
         }
     }
 }
 
 extension Array where Element == (String, SwiftPatchCodeType) {
-    func derivePatchNodesSync(existingStateVarConnections: [String: [NodeIOCoordinate]],
+    func derivePatchNodesSync(existingStateVarConnections: [String: [NodeConnectionType]],
                              existingNodesDict: [UUID: NodeEntity],
                              viewEvent: SyntaxViewEvent?,
                              isStreaming: Bool) -> SwiftSyntaxPatchActionsResult {
@@ -1434,7 +1432,7 @@ extension Array where Element == (String, SwiftPatchCodeType) {
         var nodesDict = [UUID: NodeEntity]()
         
         // Tracks connections to state variables, used as layer inputs later
-        var stateVarConnections = [String: [NodeIOCoordinate]]()
+        var stateVarConnections = [String: [NodeConnectionType]]()
         
         var caughtErrors = [SwiftUISyntaxError]()
         
@@ -1489,7 +1487,7 @@ extension Array where Element == (String, SwiftPatchCodeType) {
     
     @MainActor
     func derivePatchNodes(document: StitchDocumentViewModel,
-                          existingStateVarConnections: [String: [NodeIOCoordinate]],
+                          existingStateVarConnections: [String: [NodeConnectionType]],
                           existingNodesDict: [UUID: NodeEntity],
                           viewEvent: SyntaxViewEvent?,
                           isStreaming: Bool) async -> SwiftSyntaxPatchActionsResult {
@@ -1515,7 +1513,7 @@ extension Array where Element == (String, SwiftPatchCodeType) {
         var nodesDict = [UUID: NodeEntity]()
         
         // Tracks connections to state variables, used as layer inputs later
-        var stateVarConnections = [String: [NodeIOCoordinate]]()
+        var stateVarConnections = [String: [NodeConnectionType]]()
         
         var caughtErrors = [SwiftUISyntaxError]()
         

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
@@ -1179,42 +1179,27 @@ extension Array where Element == SwiftPatchClosureType {
 
             switch closureType {
             case .swiftPatchLogic(let codeStatements):
-                
-                do {
-                    let patchResult = try await codeStatements
-                        .derivePatchNodes(document: document,
-                                          existingStateVarConnections: result.stateVarConnections,
-                                          existingNodesDict: existingNodesDict,
-                                          viewEvent: nil,
-                                          isStreaming: isStreaming)
-                    result += patchResult
-                } catch let error as SwiftUISyntaxError {
-                    result.caughtErrors.append(error)
-                } catch {
-                    // Handle other errors if needed
-                    log("derivePatchNodes error: \(error.localizedDescription)")
-                }
+                let patchResult = await codeStatements
+                    .derivePatchNodes(document: document,
+                                      existingStateVarConnections: result.stateVarConnections,
+                                      existingNodesDict: existingNodesDict,
+                                      viewEvent: nil,
+                                      isStreaming: isStreaming)
+                result += patchResult
             
             case .viewEvent(let swiftPatchViewEvent):
                 let viewEventData = swiftPatchViewEvent.viewEvent
                 
                 // Get data from closure actions
-                do {
-                    let closureActionsResult = try await swiftPatchViewEvent
-                        .codeStatements
-                        .derivePatchNodes(document: document,
-                                          existingStateVarConnections: result.stateVarConnections,
-                                          existingNodesDict: existingNodesDict,
-                                          viewEvent: viewEventData,
-                                          isStreaming: isStreaming)
-                    
-                    result += closureActionsResult
-                } catch let error as SwiftUISyntaxError {
-                    result.caughtErrors.append(error)
-                } catch {
-                    // Handle other errors if needed
-                    log("derivePatchNodes viewEvent error: \(error.localizedDescription)")
-                }
+                let closureActionsResult = await swiftPatchViewEvent
+                    .codeStatements
+                    .derivePatchNodes(document: document,
+                                      existingStateVarConnections: result.stateVarConnections,
+                                      existingNodesDict: existingNodesDict,
+                                      viewEvent: viewEventData,
+                                      isStreaming: isStreaming)
+                
+                result += closureActionsResult
             }
         }
         

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveActions.swift
@@ -1323,25 +1323,34 @@ extension Dictionary where Key == UUID, Value == NodeEntity {
             // Multiple upstream coordinates means an unpacking scenario
             if upstreamPatchCoordinates.count > 1 {
                 try upstreamPatchCoordinates.enumerated().forEach { index, portData in
+                    var layerInputCoordinate = layerInputCoordinate
+                    guard let unapckedPortType = UnpackedPortType(rawValue: index),
+                          var layerKeyPath = layerInputCoordinate.keyPath else {
+                        if !isStreaming {
+                            fatalErrorIfDebug()
+                        }
+                        return
+                    }
+                    
+                    layerKeyPath.portType = .unpacked(unapckedPortType)
+                    layerInputCoordinate = .init(portType: .keyPath(layerKeyPath),
+                                                 nodeId: layerInputCoordinate.nodeId)
+
                     switch portData {
-                    case .values:
-                        // Unexpected
-                        fatalErrorIfDebug()
+                    case .values(let values):
+                        let event = PatchSyntaxResultType.portValues(
+                            .init(inputCoordinate: layerInputCoordinate,
+                                  values: values)
+                        )
+                        
+                        return try self
+                            .updateWithEventData(event,
+                                                 layerInputCoordinate: layerInputCoordinate,
+                                                 varName: stateName,
+                                                 stateVarConnections: &stateVarConnections,
+                                                 isStreaming: isStreaming)
                         
                     case .upstreamConnection(let upstreamPatchCoordinate):
-                        var layerInputCoordinate = layerInputCoordinate
-                        guard let unapckedPortType = UnpackedPortType(rawValue: index),
-                              var layerKeyPath = layerInputCoordinate.keyPath else {
-                            if !isStreaming {
-                                fatalErrorIfDebug()
-                            }
-                            return
-                        }
-                        
-                        layerKeyPath.portType = .unpacked(unapckedPortType)
-                        layerInputCoordinate = .init(portType: .keyPath(layerKeyPath),
-                                                     nodeId: layerInputCoordinate.nodeId)
-                        
                         // Recursively call with extrapolated upstream patch data
                         let event = PatchSyntaxResultType.connection(
                             .init(from: upstreamPatchCoordinate,
@@ -1358,23 +1367,39 @@ extension Dictionary where Key == UUID, Value == NodeEntity {
             
             // Packed scenario
             else {
-                guard let upstreamPatchCoordinate = upstreamPatchCoordinates.first?
-                    .upstreamConnection else {
+                guard let portData = upstreamPatchCoordinates.first else {
                     if !isStreaming {
                         fatalErrorIfDebug()
                     }
                     return
                 }
                 
-                // Recursively call with extrapolated upstream patch data
-                let event = PatchSyntaxResultType.connection(.init(from: upstreamPatchCoordinate,
-                                                                   to: layerInputCoordinate))
-                return try self
-                    .updateWithEventData(event,
-                                         layerInputCoordinate: layerInputCoordinate,
-                                         varName: stateName,
-                                         stateVarConnections: &stateVarConnections,
-                                         isStreaming: isStreaming)
+                switch portData {
+                case .upstreamConnection(let upstreamPatchCoordinate):
+                    // Recursively call with extrapolated upstream patch data
+                    let event = PatchSyntaxResultType.connection(.init(from: upstreamPatchCoordinate,
+                                                                       to: layerInputCoordinate))
+                    return try self
+                        .updateWithEventData(event,
+                                             layerInputCoordinate: layerInputCoordinate,
+                                             varName: stateName,
+                                             stateVarConnections: &stateVarConnections,
+                                             isStreaming: isStreaming)
+                    
+                case .values(let values):
+                    let event = PatchSyntaxResultType.portValues(
+                        .init(inputCoordinate: layerInputCoordinate,
+                              values: values)
+                    )
+                    
+                    return try self
+                        .updateWithEventData(event,
+                                             layerInputCoordinate: layerInputCoordinate,
+                                             varName: stateName,
+                                             stateVarConnections: &stateVarConnections,
+                                             isStreaming: isStreaming)
+                }
+                
             }
             
         case .portValues(let data):

--- a/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
+++ b/Stitch/Graph/StitchAI/Mapping/SyntaxToActions/deriveLayer.swift
@@ -1057,7 +1057,8 @@ func parseMathExpressionToPatchNodes(
            if case .stateWrite = $0 { return true }
            return false
        }),
-       case .stateWrite(_, let coord) = stateWrite {
+       case .stateWrite(_, let portData) = stateWrite,
+       let coord = portData.upstreamConnection {
         lhsOutput = coord
     }
 

--- a/Stitch/Graph/StitchAI/Mapping/VPLToCode/PatchVPLToCode.swift
+++ b/Stitch/Graph/StitchAI/Mapping/VPLToCode/PatchVPLToCode.swift
@@ -68,7 +68,7 @@ extension GraphState {
             
             assertInDebug(nodeIndexCoordiantes.count == 1)
             
-            guard let nodeIndexCoordiante = nodeIndexCoordiantes.first else {
+            guard let nodeIndexCoordiante = nodeIndexCoordiantes.first?.upstreamConnection else {
                 return
             }
             result.updateValue(variableName, forKey: nodeIndexCoordiante)

--- a/Stitch/Graph/StitchAI/StitchAITrainingDataInspectionOverlay.swift
+++ b/Stitch/Graph/StitchAI/StitchAITrainingDataInspectionOverlay.swift
@@ -269,7 +269,6 @@ struct StitchAITrainingDataInspectionOverlay: View {
                 await MainActor.run {
                     actionsResult
                         .applyAIGraph(to: document,
-                                      viewStatePatchConnections: actionsResult.graphData.viewStatePatchConnections,
                                       currentGraphEntity: document.graph.createSchema(),
                                       isStreaming: false)
                 }


### PR DESCRIPTION
This PR supports PortValue assignments to state variables in AI code responses. Previously, we always assumed some connection from a patch to layer. This supports code like the following:

```swift
@State var rectangleColor: [PortValueDescription] = []
...
rectangleColor = [PortValueDescription(value: "#A389EDFF", value_type: "color")]
```

The fix was replacing `NodeIOCoordinate` with `NodeConnectionType` in our parsing data structures.

Fuller example:
```swift
struct ContentView: View {
    @State var rectangleZIndex: [PortValueDescription] = []
    @State var rectangleColor: [PortValueDescription] = []

    var body: some View {
        ScrollView([PortValueDescription(value: "vertical", value_type: "orientation")]) {
            VStack([PortValueDescription(value: "8", value_type: "spacing")]) {
                Rectangle()
                    .fill(rectangleColor)
                    .frame([PortValueDescription(value: ["width": "350.0", "height": "80.0"], value_type: "size")])
                    .zIndex(rectangleZIndex)
            }
        }
    }

    func updateLayerInputs() {
        let loop_outputs = NATIVE_STITCH_PATCH_FUNCTIONS["loop || Patch"]([
            [PortValueDescription(value: 100, value_type: "number")]
        ])
        
        rectangleZIndex = loop_outputs[0]
        rectangleColor = [PortValueDescription(value: "#A389EDFF", value_type: "color")]
    }
}
```