### PR TITLE
Use the passed-in `type: UserVisibleType?` more often with node row definitions

### DIFF
--- a/Stitch/Graph/Node/Patch/Type/Animation/ClassicAnimation.swift
+++ b/Stitch/Graph/Node/Patch/Type/Animation/ClassicAnimation.swift
@@ -67,10 +67,12 @@ struct ClassicAnimationNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = Self._defaultUserVisibleType
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? Self._defaultUserVisibleType
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [defaultNumber],
+                    defaultValues: [effectiveType.defaultPortValue],
                     label: "Value"
                 ),
                 .init(
@@ -87,7 +89,7 @@ struct ClassicAnimationNode: PatchNodeDefinition {
             outputs: [
                 .init(
                     label: "",
-                    type: type ?? .number
+                    type: effectiveType
                 )
             ]
         )

--- a/Stitch/Graph/Node/Patch/Type/Animation/CubicBezierAnimationNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Animation/CubicBezierAnimationNode.swift
@@ -17,37 +17,44 @@ struct CubicBezierAnimationNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = .number
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType: UserVisibleType = type ?? Self.defaultUserVisibleType ?? .number
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [effectiveType.defaultPortValue],
                     label: "Value"
                 ),
                 .init(
                     defaultValues: [.number(1)],
-                    label: "Duration"
+                    label: "Duration",
+                    isTypeStatic: true
                 ),
                 .init(
                     defaultValues: [.number(0.17)],
-                    label: "1st Control Point X"
+                    label: "1st Control Point X",
+                    isTypeStatic: true
                 ),
                 .init(
                     defaultValues: [.number(0.17)],
-                    label: "1st Control Point Y"
+                    label: "1st Control Point Y",
+                    isTypeStatic: true
                 ),
                 .init(
                     defaultValues: [.number(0)],
-                    label: "2nd Control Point X"
+                    label: "2nd Control Point X",
+                    isTypeStatic: true
                 ),
                 .init(
                     defaultValues: [.number(1)],
-                    label: "2nd Control Point y"
+                    label: "2nd Control Point y",
+                    isTypeStatic: true
                 )
             ],
             outputs: [
                 .init(
                     label: "",
-                    type: .number
+                    type: effectiveType
                 ),
                 .init(
                     label: "Path",

--- a/Stitch/Graph/Node/Patch/Type/Animation/spring+and+pop+animations/PopAnimationNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Animation/spring+and+pop+animations/PopAnimationNode.swift
@@ -19,10 +19,12 @@ struct PopAnimationNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = Self._defaultUserVisibleType
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? Self._defaultUserVisibleType
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [effectiveType.defaultPortValue],
                     label: "Value"
                 ),
                 .init(
@@ -39,7 +41,7 @@ struct PopAnimationNode: PatchNodeDefinition {
             outputs: [
                 .init(
                     label: "",
-                    type: type ?? .number
+                    type: effectiveType
                 )
             ]
         )

--- a/Stitch/Graph/Node/Patch/Type/Animation/spring+and+pop+animations/SpringAnimationNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Animation/spring+and+pop+animations/SpringAnimationNode.swift
@@ -20,10 +20,12 @@ struct SpringAnimationNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = Self._defaultUserVisibleType
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? Self._defaultUserVisibleType
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [effectiveType.defaultPortValue],
                     label: "Value"
                 ),
                 .init(
@@ -45,7 +47,7 @@ struct SpringAnimationNode: PatchNodeDefinition {
             outputs: [
                 .init(
                     label: "",
-                    type: .number
+                    type: effectiveType
                 )
             ]
         )

--- a/Stitch/Graph/Node/Patch/Type/ClipNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/ClipNode.swift
@@ -16,25 +16,27 @@ struct ClipPatchNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = .number
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? Self.defaultUserVisibleType ?? .number
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [effectiveType.defaultPortValue],
                     label: "Value"
                 ),
                 .init(
-                    defaultValues: [.number(-5)],
+                    defaultValues: [effectiveType.defaultPortValue],
                     label: "Min"
                 ),
                 .init(
-                    defaultValues: [.number(5)],
+                    defaultValues: [effectiveType.defaultPortValue],
                     label: "Max"
                 )
             ],
             outputs: [
                 .init(
                     label: "",
-                    type: type ?? .number
+                    type: effectiveType
                 )
             ]
         )

--- a/Stitch/Graph/Node/Patch/Type/Data/JSONArrayNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Data/JSONArrayNode.swift
@@ -16,9 +16,11 @@ struct JSONArrayNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = .number
     
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(inputs: [
-            .init(label: "", defaultType: .number),
-            .init(label: "", defaultType: .number)
+        let effectiveType = type ?? Self.defaultUserVisibleType ?? .number
+
+        return .init(inputs: [
+            .init(label: "", defaultType: effectiveType),
+            .init(label: "", defaultType: effectiveType)
         ],
               outputs: [
                 .init(label: "Array",

--- a/Stitch/Graph/Node/Patch/Type/Data/JSONObjectNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Data/JSONObjectNode.swift
@@ -16,9 +16,11 @@ struct JSONObjectNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = .number
     
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(inputs: [
+        let effectiveType = type ?? Self.defaultUserVisibleType ?? .number
+
+        return .init(inputs: [
             .init(label: "Key", staticType: .string),
-            .init(label: "Value", defaultType: .number)
+            .init(label: "Value", defaultType: effectiveType)
         ],
               outputs: [
                 .init(label: "Object",

--- a/Stitch/Graph/Node/Patch/Type/Delay/DelayNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/Delay/DelayNode.swift
@@ -22,10 +22,12 @@ struct DelayPatchNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType? = Self._defaultUserVisibleType
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? Self._defaultUserVisibleType
+
+        return .init(
             inputs: [
                 .init(
-                    defaultValues: [.number(0)],
+                    defaultValues: [effectiveType.defaultPortValue],
                     label: "Value",
                     canDirectlyCopyUpstreamValues: true
                 ),
@@ -43,7 +45,7 @@ struct DelayPatchNode: PatchNodeDefinition {
             outputs: [
                 .init(
                     label: "Value",
-                    type: .number
+                    type: effectiveType
                 )
             ]
         )

--- a/Stitch/Graph/Node/Patch/Type/DelayOneNode.swift
+++ b/Stitch/Graph/Node/Patch/Type/DelayOneNode.swift
@@ -13,14 +13,16 @@ struct DelayOneNode: PatchNodeDefinition {
     static let defaultUserVisibleType: UserVisibleType = .number
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(
+        let effectiveType = type ?? Self.defaultUserVisibleType
+
+        return .init(
             inputs: [
-                .init(defaultType: .number,
+                .init(defaultType: effectiveType,
                      canDirectlyCopyUpstreamValues: true)
             ],
             outputs: [
                 .init(
-                    type: .number
+                    type: effectiveType
                 )
             ]
         )

--- a/Stitch/Graph/Node/Patch/Type/Loop/LoopBuilder.swift
+++ b/Stitch/Graph/Node/Patch/Type/Loop/LoopBuilder.swift
@@ -12,20 +12,22 @@ import StitchSchemaKit
 struct LoopBuilderNode: PatchNodeDefinition {
     static let patch: Patch = .loopBuilder
     
-    static let defaultUserVisibleType: UserVisibleType? = .number
+    static let defaultUserVisibleType: UserVisibleType? = UserVisibleType.number
 
     static func rowDefinitions(for type: UserVisibleType?) -> NodeRowDefinitions {
-        .init(inputs: [
-            .init(label: "", defaultType: .number),
-            .init(label: "", defaultType: .number),
-            .init(label: "", defaultType: .number),
-            .init(label: "", defaultType: .number),
-            .init(label: "", defaultType: .number)
+        let effectiveType: UserVisibleType = type ?? Self.defaultUserVisibleType ?? UserVisibleType.number
+
+        return .init(inputs: [
+            .init(label: "", defaultType: effectiveType),
+            .init(label: "", defaultType: effectiveType),
+            .init(label: "", defaultType: effectiveType),
+            .init(label: "", defaultType: effectiveType),
+            .init(label: "", defaultType: effectiveType)
         ], outputs: [
             .init(label: "Index",
                   type: .number),
             .init(label: "Values",
-                  type: type ?? Self.defaultUserVisibleType ?? .number)
+                  type: effectiveType)
         ])
     }
     


### PR DESCRIPTION
Resolves https://github.com/StitchDesign/Stitch--Old/issues/7512

We still create 5 rather than 3 rectangles; but at least the types are okay.

<img width="1647" height="671" alt="Screenshot 2025-10-07 at 11 07 48 AM" src="https://github.com/user-attachments/assets/2d30731d-9089-4f57-bfc8-79b388a4a81b" />
