### PR TITLE
Improved node inputs merge logic during AI stream

### DIFF
--- a/Stitch/Graph/Node/Model/Definition/NodeDefinition.swift
+++ b/Stitch/Graph/Node/Model/Definition/NodeDefinition.swift
@@ -55,7 +55,6 @@ extension PatchNodeDefinition {
 }
 
 extension Layer {
-    @MainActor
     var inputDefinitions: LayerInputPortSet {
         self.layerGraphNode.inputDefinitions
     }

--- a/Stitch/Graph/Node/Model/NodeEntity.swift
+++ b/Stitch/Graph/Node/Model/NodeEntity.swift
@@ -195,6 +195,54 @@ extension NodeTypeEntity {
             return nil
         }
     }
+    
+    func mergeInputDataOnAIStream(with other: Self) -> Self {
+        switch (self, other) {
+        case (.patch(let lhs), .patch(let rhs)) where lhs.patch == rhs.patch:
+            var newPatch = rhs
+            
+            let defaultValuesList = lhs.patch.createDefaultIOValues(nodeIO: .input,
+                                                                nodeType: lhs.userVisibleType)
+            
+            newPatch.inputs = zip(lhs.inputs, rhs.inputs).enumerated().map { (index, data) -> NodePortInputEntity in
+                let defaultValues = defaultValuesList[safe: index] ?? [.number(.zero)]
+                let (lhsInput, rhsInput) = data
+                
+                // Use other data if not default
+                if rhsInput.portData.values != defaultValues {
+                    return rhsInput
+                } else {
+                    return lhsInput
+                }
+            }
+            
+            return .patch(newPatch)
+        
+        case (.layer(let lhs), .layer(let rhs)) where lhs.layer == rhs.layer:
+            var newLayer = rhs
+            
+            for layerInput in lhs.layer.inputDefinitions {
+                let defaultValue = layerInput.getDefaultValue(for: lhs.layer)
+                let rhsValues = rhs[keyPath: layerInput.schemaPortKeyPath].packedData.inputPort.values
+                
+                // Default to rhs data if not default
+                if rhsValues?.first != defaultValue {
+//                    log("mergeInputDataOnAIStream: layer \(lhs.layer)\t\(layerInput):\t\(rhsValues?.first?.display ?? "none")")
+                    
+                    continue
+                }
+                
+                // If still default data, a sign that not all data has yet merged, so use self
+                newLayer[keyPath: layerInput.schemaPortKeyPath] = lhs[keyPath: layerInput.schemaPortKeyPath]
+            }
+            
+            return .layer(newLayer)
+            
+        default:
+            fatalErrorIfDebug()
+            return self
+        }
+    }
 }
 
 extension [NodeEntity] {

--- a/Stitch/Graph/StitchAI/GraphPrompting/API/ClaudeGraphGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/ClaudeGraphGenRequest.swift
@@ -489,6 +489,32 @@ func monitorClaudeStreamingCachePerformance(usage: ClaudeUsage) async {
 }
 
 extension GraphEntity {
+    private static func mergeNodeData(current: NodeEntity,
+                                      streamed: NodeEntity,
+                                      incompleteStreamedLayerIds: Set<UUID>,
+                                      isLayerStreamingComplete: Bool,
+                                      newNodesMap: inout [UUID: NodeEntity],
+                                      candidateCurrentPatchNodes: inout Set<NodeEntity>,
+                                      candidateCurrentLayerNodes: inout Set<NodeEntity>,
+                                      claimedExistingIds: inout Set<UUID>) {
+        let streamedNodeMatchesIncompleteLayer = incompleteStreamedLayerIds.contains(streamed.id)
+        
+        // Only use current data when layer streaming is incomplete and part of last leaf node data
+        let useCurrent = !isLayerStreamingComplete && streamedNodeMatchesIncompleteLayer
+
+        // Remove candidate
+        if current.kind.isPatch {
+            candidateCurrentPatchNodes.remove(current)
+        } else {
+            candidateCurrentLayerNodes.remove(current)
+        }
+        
+        if !useCurrent {
+            newNodesMap[streamed.id] = streamed
+            claimedExistingIds.insert(current.id)
+        }
+    }
+    
     /// Merge an in-progress (streamed) graph into the current graph by matching incoming
     /// nodes to existing ones. If IDs match, they are considered the same. Otherwise, we
     /// attempt a heuristic match based on node kind, patch/layer/component specifics,
@@ -538,33 +564,17 @@ extension GraphEntity {
         // key: streamed id, value: current id (we convert everything to current graph data)
         var changedNodeIds = [UUID: UUID]()
         
-        // Reuse existing node if data incomplete
-        let useStreamedNode = { (current: NodeEntity, streamed: NodeEntity) -> Bool in
-            let streamedNodeMatchesIncompleteLayer = incompleteStreamedLayerIds.contains(streamed.id)
-            
-            // Only use current data when layer streaming is incomplete and part of last leaf node data
-            let useCurrent = !isLayerStreamingComplete && streamedNodeMatchesIncompleteLayer
-
-            // Remove candidate
-            if current.kind.isPatch {
-                candidateCurrentPatchNodes.remove(current)
-            } else {
-                candidateCurrentLayerNodes.remove(current)
-            }
-            
-            return !useCurrent
-        }
-        
         for streamed in inProgressGraph.nodes {
             // 1) Exact id match: replace directly
             if let existing = existingNodesMap[streamed.id] {
-                if useStreamedNode(existing, streamed) {
-                    newNodesMap[streamed.id] = streamed
-                    claimedExistingIds.insert(streamed.id)
-                    
-                    // Track same ID--needed for copy logic
-//                    changedNodeIds.updateValue(streamed.id, forKey: streamed.id)
-                }
+                Self.mergeNodeData(current: existing,
+                                   streamed: streamed,
+                                   incompleteStreamedLayerIds: incompleteStreamedLayerIds,
+                                   isLayerStreamingComplete: isLayerStreamingComplete,
+                                   newNodesMap: &newNodesMap,
+                                   candidateCurrentPatchNodes: &candidateCurrentPatchNodes,
+                                   candidateCurrentLayerNodes: &candidateCurrentLayerNodes,
+                                   claimedExistingIds: &claimedExistingIds)
                 
                 continue
             }
@@ -597,10 +607,14 @@ extension GraphEntity {
                 // We choose to retain IDs already existing rather use the new ID so that update methods can continue to be used.
                 changedNodeIds.updateValue(matchedId, forKey: streamed.id)
                 
-                if useStreamedNode(existing, streamed) {
-                    newNodesMap[matchedId] = streamed
-                    claimedExistingIds.insert(matchedId)
-                }
+                Self.mergeNodeData(current: existing,
+                                   streamed: streamed,
+                                   incompleteStreamedLayerIds: incompleteStreamedLayerIds,
+                                   isLayerStreamingComplete: isLayerStreamingComplete,
+                                   newNodesMap: &newNodesMap,
+                                   candidateCurrentPatchNodes: &candidateCurrentPatchNodes,
+                                   candidateCurrentLayerNodes: &candidateCurrentLayerNodes,
+                                   claimedExistingIds: &claimedExistingIds)
             } else {
                 // New node — append as-is
                 newNodesMap[streamed.id] = streamed

--- a/Stitch/Graph/StitchAI/GraphPrompting/API/ClaudeGraphGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/ClaudeGraphGenRequest.swift
@@ -509,7 +509,22 @@ extension GraphEntity {
             candidateCurrentLayerNodes.remove(current)
         }
         
-        if !useCurrent {
+        // Merge current data with streamed data
+        if useCurrent {
+            // Merge logic:
+            // 1. Use non-default value over default value
+            // 2. Use streamed data over current
+            let mergedData = current.nodeTypeEntity
+                .mergeInputDataOnAIStream(with: streamed.nodeTypeEntity)
+            
+            var current = current
+            current.nodeTypeEntity = mergedData
+            
+            newNodesMap[current.id] = current
+        }
+        
+        // Use entire streamed data, no merging with current data
+        else {
             newNodesMap[current.id] = streamed
             claimedExistingIds.insert(current.id)
         }
@@ -638,8 +653,6 @@ extension GraphEntity {
         // Creates map used specifically for copy data functions
         // This ensures `createCopy` will use a real ID instead of nil for some parent groups
         let copyNodesIdMap = merged.nodes.reduce(into: changedNodeIds) { result, node in
-            // TODO: here??
-            
             // Skip if already tracked
             if !claimedExistingIds.contains(node.id) {
                 result.updateValue(node.id, forKey: node.id)

--- a/Stitch/Graph/StitchAI/GraphPrompting/API/ClaudeGraphGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/ClaudeGraphGenRequest.swift
@@ -510,7 +510,7 @@ extension GraphEntity {
         }
         
         if !useCurrent {
-            newNodesMap[streamed.id] = streamed
+            newNodesMap[current.id] = streamed
             claimedExistingIds.insert(current.id)
         }
     }
@@ -638,6 +638,8 @@ extension GraphEntity {
         // Creates map used specifically for copy data functions
         // This ensures `createCopy` will use a real ID instead of nil for some parent groups
         let copyNodesIdMap = merged.nodes.reduce(into: changedNodeIds) { result, node in
+            // TODO: here??
+            
             // Skip if already tracked
             if !claimedExistingIds.contains(node.id) {
                 result.updateValue(node.id, forKey: node.id)


### PR DESCRIPTION
Improves input merge logic by defaulting to newly streamed data when non-equal from default data. This suggests that newly parsed data has actually been accounted for a particular input.

Negligible performance impacts observed here.