### PR TITLE
Fixed data loss on AI stream end

### DIFF
--- a/Stitch/Graph/StitchAI/GraphPrompting/API/ClaudeGraphGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/ClaudeGraphGenRequest.swift
@@ -495,8 +495,7 @@ extension GraphEntity {
                                       isLayerStreamingComplete: Bool,
                                       newNodesMap: inout [UUID: NodeEntity],
                                       candidateCurrentPatchNodes: inout Set<NodeEntity>,
-                                      candidateCurrentLayerNodes: inout Set<NodeEntity>,
-                                      claimedExistingIds: inout Set<UUID>) {
+                                      candidateCurrentLayerNodes: inout Set<NodeEntity>) {
         let streamedNodeMatchesIncompleteLayer = incompleteStreamedLayerIds.contains(streamed.id)
         
         // Only use current data when layer streaming is incomplete and part of last leaf node data
@@ -526,7 +525,6 @@ extension GraphEntity {
         // Use entire streamed data, no merging with current data
         else {
             newNodesMap[current.id] = streamed
-            claimedExistingIds.insert(current.id)
         }
     }
     
@@ -567,9 +565,6 @@ extension GraphEntity {
                 result.updateValue(data.0, forKey: data.1.id)
         }
         
-        // Tracks which existing node ids have already been matched to avoid duplicates
-        var claimedExistingIds = Set<UUID>()
-        
         // Tracks new/replaced nodes by id
         var newNodesMap = [UUID: NodeEntity]()
         
@@ -586,8 +581,7 @@ extension GraphEntity {
                                    isLayerStreamingComplete: isLayerStreamingComplete,
                                    newNodesMap: &newNodesMap,
                                    candidateCurrentPatchNodes: &candidateCurrentPatchNodes,
-                                   candidateCurrentLayerNodes: &candidateCurrentLayerNodes,
-                                   claimedExistingIds: &claimedExistingIds)
+                                   candidateCurrentLayerNodes: &candidateCurrentLayerNodes)
                 
                 continue
             }
@@ -598,7 +592,6 @@ extension GraphEntity {
             
             func consider(_ candidates: Set<NodeEntity>) {
                 for candidate in candidates {
-                    if claimedExistingIds.contains(candidate.id) { continue }
                     let score = similarityScore(between: streamed,
                                                 and: candidate,
                                                 aLayerIndexOf: inProgressLayerIndexOf,
@@ -626,8 +619,7 @@ extension GraphEntity {
                                    isLayerStreamingComplete: isLayerStreamingComplete,
                                    newNodesMap: &newNodesMap,
                                    candidateCurrentPatchNodes: &candidateCurrentPatchNodes,
-                                   candidateCurrentLayerNodes: &candidateCurrentLayerNodes,
-                                   claimedExistingIds: &claimedExistingIds)
+                                   candidateCurrentLayerNodes: &candidateCurrentLayerNodes)
             } else {
                 // New node — append as-is
                 newNodesMap[streamed.id] = streamed
@@ -640,18 +632,9 @@ extension GraphEntity {
         // Creates map used specifically for copy data functions
         // This ensures `createCopy` will use a real ID instead of nil for some parent groups
         let copyNodesIdMap = merged.nodes.reduce(into: changedNodeIds) { result, node in
-            if isFullStreamComplete {
-                // Add node to changedNodeIds if not already covered
-                if !result.keys.contains(node.id) {
-                    result.updateValue(node.id, forKey: node.id)
-                }
-            }
-            
-            else {
-                // Skip if already tracked
-                if !claimedExistingIds.contains(node.id) {
-                    result.updateValue(node.id, forKey: node.id)
-                }
+            // Add node to changedNodeIds if not already covered
+            if !result.keys.contains(node.id) {
+                result.updateValue(node.id, forKey: node.id)
             }
         }
         

--- a/Stitch/Graph/StitchAI/GraphPrompting/API/ClaudeGraphGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/ClaudeGraphGenRequest.swift
@@ -539,6 +539,7 @@ extension GraphEntity {
                                 incompleteStreamedLayerIds: Set<UUID>,
                                 isLayerStreamingComplete: Bool,
                                 isFullStreamComplete: Bool) -> GraphEntity {
+        // MARK: if request is complete, we bypass the logic below. If we use merge logic, we could mess up the correct topological ordering, so the only guarantee of that not happening is to use the exact graph AI returns. Unfortunately this means a large perf jump once the request finishes.
         if isFullStreamComplete {
             return inProgressGraph
         }

--- a/Stitch/Graph/StitchAI/GraphPrompting/API/ClaudeGraphGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/ClaudeGraphGenRequest.swift
@@ -636,13 +636,22 @@ extension GraphEntity {
         
         // Use streamed graph when request is complete
         var merged = isFullStreamComplete ? inProgressGraph : self
-        
+
         // Creates map used specifically for copy data functions
         // This ensures `createCopy` will use a real ID instead of nil for some parent groups
         let copyNodesIdMap = merged.nodes.reduce(into: changedNodeIds) { result, node in
-            // Skip if already tracked
-            if !claimedExistingIds.contains(node.id) {
-                result.updateValue(node.id, forKey: node.id)
+            if isFullStreamComplete {
+                // Add node to changedNodeIds if not already covered
+                if !result.keys.contains(node.id) {
+                    result.updateValue(node.id, forKey: node.id)
+                }
+            }
+            
+            else {
+                // Skip if already tracked
+                if !claimedExistingIds.contains(node.id) {
+                    result.updateValue(node.id, forKey: node.id)
+                }
             }
         }
         

--- a/Stitch/Graph/StitchAI/GraphPrompting/API/ClaudeGraphGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/ClaudeGraphGenRequest.swift
@@ -541,10 +541,8 @@ extension GraphEntity {
                                 incompleteStreamedLayerIds: Set<UUID>,
                                 isLayerStreamingComplete: Bool,
                                 isFullStreamComplete: Bool) -> GraphEntity {
-        var merged = self
-        
         // Fast lookup of existing nodes by id
-        let existingNodesMap: [UUID: NodeEntity] = merged.nodes.reduce(into: [UUID: NodeEntity]()) { result, node in
+        let existingNodesMap: [UUID: NodeEntity] = self.nodes.reduce(into: [UUID: NodeEntity]()) { result, node in
             result[node.id] = node
         }
         
@@ -635,20 +633,9 @@ extension GraphEntity {
                 newNodesMap[streamed.id] = streamed
             }
         }
-
-        // Start from existing map and overlay new/replaced nodes (avoids extra dictionary merges)
-        var resultMap: [UUID: NodeEntity]
         
-        if isFullStreamComplete {
-            // Only use new data
-            resultMap = newNodesMap
-        } else {
-            // Merge existing and new data
-            resultMap = existingNodesMap
-            for (id, node) in newNodesMap {
-                resultMap[id] = node
-            }
-        }
+        // Use streamed graph when request is complete
+        var merged = isFullStreamComplete ? inProgressGraph : self
         
         // Creates map used specifically for copy data functions
         // This ensures `createCopy` will use a real ID instead of nil for some parent groups
@@ -659,7 +646,19 @@ extension GraphEntity {
             }
         }
         
-        merged.nodes = Array(resultMap.values)
+        if isFullStreamComplete {
+            // Use node data directly from response once stream has ended
+            // We'll change node IDs later
+            merged.nodes = inProgressGraph.nodes
+        } else {
+            // Merge existing and new data
+            var resultMap = existingNodesMap
+            for (id, node) in newNodesMap {
+                resultMap[id] = node
+            }
+    
+            merged.nodes = Array(resultMap.values)
+        }
 
         // Update all node references within the graph to use the new IDs
         merged.nodes = merged.nodes.createCopy(mappableData: copyNodesIdMap,

--- a/Stitch/Graph/StitchAI/GraphPrompting/API/ClaudeGraphGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/ClaudeGraphGenRequest.swift
@@ -539,6 +539,10 @@ extension GraphEntity {
                                 incompleteStreamedLayerIds: Set<UUID>,
                                 isLayerStreamingComplete: Bool,
                                 isFullStreamComplete: Bool) -> GraphEntity {
+        if isFullStreamComplete {
+            return inProgressGraph
+        }
+        
         // Fast lookup of existing nodes by id
         let existingNodesMap: [UUID: NodeEntity] = self.nodes.reduce(into: [UUID: NodeEntity]()) { result, node in
             result[node.id] = node

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/StepApplication.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/StepApplication.swift
@@ -344,7 +344,7 @@ extension Array where Element == NodeEntity {
     func positionAIGeneratedNodesDuringApply(viewPortCenter: CGPoint) -> Self {
 
         // Performance instrumentation - start timing
-        let startTime = CFAbsoluteTimeGetCurrent()
+//        let startTime = CFAbsoluteTimeGetCurrent()
 
         // Constants
         let horizontalPadding: CGFloat = 120.0


### PR DESCRIPTION
The issue here was omitting some data from the "in progress" graph, which at the point of stream end is obviously no longer in progress.

Our merge logic is used on stream end so we can attempt to re-use node IDs. So the fix here is making sure the graph we're modifying is from the response rather than the active graph.

## Considerations

I tried to fix a problem where there’s some perf loss when the full stream ends, due to bypassing our node merge logic in favor of using the exact streamed graph. When I tried to keep the node merge logic, I noticed that any misguided merges could jeopardize the topological ordering of the graph, leading to incorrect edges. I could not find a trivial fix here given that it either requires a similarity algorithm that’s always correct (a likely impossible task), or requires a complete re-think for how node merging should work.