### PR TITLE
Fixed issue where AI stream end causes graph jump

### DIFF
--- a/Stitch/Graph/StitchAI/GraphPrompting/API/AIRequestFunctions.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/AIRequestFunctions.swift
@@ -48,7 +48,7 @@ func makeAIRequest(
     document: StitchDocumentViewModel,
     aiManager: StitchAIManager,
     currentGraphEntity: GraphEntity,
-    viewPortCenter: CGPoint,
+    graphPositionAnchorPoint: CGPoint,
     groupNodeFocused: UUID?
 ) async throws -> String {
     switch model {
@@ -71,7 +71,7 @@ func makeAIRequest(
                 model: claudeModel,
                 document: document,
                 currentGraphEntity: currentGraphEntity,
-                viewPortCenter: viewPortCenter,
+                graphPositionAnchorPoint: graphPositionAnchorPoint,
                 groupNodeFocused: groupNodeFocused
             )
     }

--- a/Stitch/Graph/StitchAI/GraphPrompting/API/ClaudeGraphGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/ClaudeGraphGenRequest.swift
@@ -47,7 +47,7 @@ final actor ClaudeStreamingActor {
         model: ClaudeModel,
         document: StitchDocumentViewModel,
         currentGraphEntity: GraphEntity,
-        viewPortCenter: CGPoint,
+        graphPositionAnchorPoint: CGPoint,
         groupNodeFocused: UUID?
     ) async throws -> String {
         var currentGraphEntity = currentGraphEntity
@@ -320,7 +320,7 @@ final actor ClaudeStreamingActor {
                             let result = stitchActionsResult
                                 .createAIGraph(from: currentGraphEntity,
                                                docId: currentGraphEntity.id,
-                                               viewPortCenter: viewPortCenter,
+                                               graphPositionAnchorPoint: graphPositionAnchorPoint,
                                                groupNodeFocused: groupNodeFocused,
                                                isStreaming: true)
                             

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
@@ -100,10 +100,12 @@ extension SwiftSyntaxActionsResult {
     @MainActor
     func applyAIGraph(to document: StitchDocumentViewModel,
                       currentGraphEntity: GraphEntity,
+                      graphPositionAnchorPoint: CGPoint,
                       isStreaming: Bool) {
         // User prompt-based requests are always assumed to be edit requests, which completely replace existing graph data
         self.processAIGraph(document: document,
                             currentGraphEntity: currentGraphEntity,
+                            graphPositionAnchorPoint: graphPositionAnchorPoint,
                             isStreaming: isStreaming)
         document.encodeProjectInBackground()
     }
@@ -111,12 +113,13 @@ extension SwiftSyntaxActionsResult {
     @MainActor
     func processAIGraph(document: StitchDocumentViewModel,
                         currentGraphEntity: GraphEntity,
+                        graphPositionAnchorPoint: CGPoint,
                         isStreaming: Bool) {
 
         let processLogic = {
             let result = self.createAIGraph(from: currentGraphEntity,
                                             docId: document.graph.id.value,
-                                            viewPortCenter: document.viewPortCenter,
+                                            graphPositionAnchorPoint: graphPositionAnchorPoint,
                                             groupNodeFocused: document.groupNodeFocused?.groupNodeId,
                                             isStreaming: isStreaming)
             
@@ -144,7 +147,7 @@ extension SwiftSyntaxActionsResult {
     
     func createAIGraph(from currentGraphEntity: GraphEntity,
                        docId: UUID,
-                       viewPortCenter: CGPoint,
+                       graphPositionAnchorPoint: CGPoint,
                        groupNodeFocused: UUID?,
                        isStreaming: Bool) -> StitchAIGraphEntityResult {
         var viewStatePatchConnections = self.graphData.viewStatePatchConnections
@@ -200,8 +203,9 @@ extension SwiftSyntaxActionsResult {
         
         // Can't build the depth map from the `patch_data`,
         // since those UUIDs have not been remapped yet
-        let repositionedNodes = graphEntity.nodes.positionAIGeneratedNodesDuringApply(
-            viewPortCenter: viewPortCenter)
+        let repositionedNodes = graphEntity.nodes
+            .positionAIGeneratedNodesDuringApply(
+                graphPositionAnchorPoint: graphPositionAnchorPoint)
         graphEntity.nodes = repositionedNodes
         
         // TODO: come back to sidebar selection

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AIRequestDeps.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/CodeGenRequest/AIRequestDeps.swift
@@ -95,7 +95,7 @@ struct AIRequestDeps: StitchAICodeCreator {
             document: document,
             aiManager: aiManager,
             currentGraphEntity: document.graph.createSchema(),
-            viewPortCenter: document.viewPortCenter,
+            graphPositionAnchorPoint: document.viewPortCenter,
             groupNodeFocused: document.groupNodeFocused?.groupNodeId
         )
         
@@ -117,6 +117,7 @@ extension StitchAICodeCreator {
         log("getRequestTask: user prompt: \(userPrompt)")
         
         let request = self
+        let graphPositionAnchorPoint = document.viewPortCenter
         
         return Task(priority: .high) { [weak document] in
             guard let document = document,
@@ -149,6 +150,7 @@ extension StitchAICodeCreator {
                     actionsResult
                         .applyAIGraph(to: document,
                                       currentGraphEntity: newCurrentGraphEntity,
+                                      graphPositionAnchorPoint: graphPositionAnchorPoint,
                                       isStreaming: false)
                     
                     // Note: task clearing and menu hiding are handled by resetStreamingUIState() called by AI providers

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/StepApplication.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/StepApplication.swift
@@ -70,7 +70,7 @@ extension StitchDocumentViewModel {
         // Only adjust node positions if actions were valid and successfully applied
 //        positionAIGeneratedNodes(convertedActions: convertedActions,
 //                                 nodes: self.visibleGraph.visibleNodesViewModel,
-//                                 viewPortCenter: self.newCanvasItemInsertionLocation,
+//                                 graphPositionAnchorPoint: self.newCanvasItemInsertionLocation,
 //                                 graph: graph)
         
         self.graphUpdaterId = .randomId() // NOT NEEDED, ACTUALLY?
@@ -341,7 +341,7 @@ extension Array where Element == NodeEntity {
         }.map { $0.node }
     }
 
-    func positionAIGeneratedNodesDuringApply(viewPortCenter: CGPoint) -> Self {
+    func positionAIGeneratedNodesDuringApply(graphPositionAnchorPoint: CGPoint) -> Self {
 
         // Performance instrumentation - start timing
         let startTime = CFAbsoluteTimeGetCurrent()
@@ -443,8 +443,8 @@ extension Array where Element == NodeEntity {
 
                 // Pre-calculated position for this node
                 let basePosition = CGPoint(
-                    x: viewPortCenter.x + centeringOffset + layout.cumulativeXOffset,
-                    y: viewPortCenter.y + CGFloat(rowIndex) * layout.rowHeight
+                    x: graphPositionAnchorPoint.x + centeringOffset + layout.cumulativeXOffset,
+                    y: graphPositionAnchorPoint.y + CGFloat(rowIndex) * layout.rowHeight
                 )
 
                 // Store base position for use in barycenter calculation for children

--- a/Stitch/Graph/StitchAI/Mapping/ASTExplorerView.swift
+++ b/Stitch/Graph/StitchAI/Mapping/ASTExplorerView.swift
@@ -435,6 +435,7 @@ struct ASTExplorerView: View {
                 stitchActionsResult
                     .processAIGraph(document: fakeDoc,
                                     currentGraphEntity: fakeDoc.graph.createSchema(),
+                                    graphPositionAnchorPoint: fakeDoc.viewPortCenter,
                                     isStreaming: false)
     
                 stitchActions = stitchActionsResult

--- a/Stitch/Graph/StitchAI/StitchAITrainingDataInspectionOverlay.swift
+++ b/Stitch/Graph/StitchAI/StitchAITrainingDataInspectionOverlay.swift
@@ -270,6 +270,7 @@ struct StitchAITrainingDataInspectionOverlay: View {
                     actionsResult
                         .applyAIGraph(to: document,
                                       currentGraphEntity: document.graph.createSchema(),
+                                      graphPositionAnchorPoint: document.viewPortCenter,
                                       isStreaming: false)
                 }
                 

--- a/Stitch/Graph/StitchAI/View/StitchAIProjectViewer.swift
+++ b/Stitch/Graph/StitchAI/View/StitchAIProjectViewer.swift
@@ -46,6 +46,7 @@ struct StitchAIProjectViewer: View {
                 stitchActionsResult
                     .processAIGraph(document: document,
                                     currentGraphEntity: currentGraphEntity,
+                                    graphPositionAnchorPoint: document.viewPortCenter,
                                     isStreaming: false)
             }
         }


### PR DESCRIPTION
Issue manifests when user scrolls away from the graph location where request originated. Fix here is to persist that original location.