### PR TITLE
Fixed mismatched port UI colors during AI stream

### DIFF
--- a/Stitch/Graph/StitchAI/GraphPrompting/API/ClaudeGraphGenRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/API/ClaudeGraphGenRequest.swift
@@ -24,14 +24,25 @@ final actor ClaudeStreamingActor {
             // Perform actual update on main actor
             await MainActor.run { [weak document] in
                 guard let document = document else { return }
-                document.graph.update(from: mergedGraphEntity,
-                                      fromAIStream: true)
-                document.graph.updateGraphData(document)
+                Self.updateGraphData(document: document,
+                                     graphEntity: mergedGraphEntity,
+                                     isStream: true)
             }
 
             // Clear task when done
             await self?.clearTask()
         }
+    }
+    
+    @MainActor static func updateGraphData(document: StitchDocumentViewModel,
+                                           graphEntity: GraphEntity,
+                                           isStream: Bool) {
+        document.graph.update(from: graphEntity,
+                              fromAIStream: isStream)
+        document.graph.updateGraphData(document)
+        
+        // TODO: debug issues with proper graph eval after a streaming request ends; theoretically a prototype restart should not be necessary
+        document.onPrototypeRestart(document: document)
     }
 
     /// Clear the task when completed (actor-isolated)

--- a/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
+++ b/Stitch/Graph/StitchAI/GraphPrompting/Model/RequestTypes/AIPatchBuilderRequest.swift
@@ -121,15 +121,14 @@ extension SwiftSyntaxActionsResult {
                                             isStreaming: isStreaming)
             
             // Update topological data--needs to be forced here because of script building using this data
-            document.graph.update(from: result.graph)
-            document.graph.updateGraphData(document)
-            
+            ClaudeStreamingActor
+                .updateGraphData(document: document,
+                                 graphEntity: result.graph,
+                                 isStream: false)
+
             // Report errors
             if !isStreaming {
                 result.errors.displayErrors(document: document)
-                
-                // TODO: debug issues with proper graph eval after a streaming request ends; theoretically a prototype restart should not be necessary
-                document.onPrototypeRestart(document: document)
             }
         }
         


### PR DESCRIPTION
The fix here is using the same prototype restart hack used at the end of the request, and using it during the stream.