### PR TITLE
Use `.controlSize(.extraLarge)` for Catalyst nav bar buttons

### DIFF
--- a/Stitch/Graph/Toolbar/View/CatalystNavBarButtonView.swift
+++ b/Stitch/Graph/Toolbar/View/CatalystNavBarButtonView.swift
@@ -19,6 +19,7 @@ struct CatalystNavBarButtonWithMenu<MenuContentView: View>: View {
             Button(toolTip,
                    systemImage: systemName,
                    action: { })
+            .controlSize(.extraLarge)
         }
         .menuIndicator(.hidden)
     }
@@ -51,6 +52,7 @@ struct CatalystNavBarButton: View {
                action: action)
         .rotation3DEffect(Angle(degrees: rotationZ),
                           axis: (x: 0, y: 0, z: rotationZ))
+        .controlSize(.extraLarge)
     }
 }
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/eb84f8d8-642e-465f-9cd0-0dfe796daa63

