### PR TITLE
Catalyst: Let graph go into top safe area; move preview window and layer inspector down

### DIFF
--- a/Stitch/App/Util/Constants.swift
+++ b/Stitch/App/Util/Constants.swift
@@ -44,7 +44,11 @@ let PREVIEW_SHOWN_DEFAULT_STATE: Bool = true
 
 let PROJECTSVIEW_ITEM_TEXT_HEIGHT: CGFloat = 24
 
+#if targetEnvironment(macCatalyst)
+let PREVIEW_WINDOW_Y_PADDING: CGFloat = 68 //56
+#else
 let PREVIEW_WINDOW_Y_PADDING: CGFloat = 16
+#endif
 
 let DEFAULT_TIMESCALE = CMTimeScale(NSEC_PER_SEC)
 

--- a/Stitch/Graph/LayerInspector/LayerInspectorView.swift
+++ b/Stitch/Graph/LayerInspector/LayerInspectorView.swift
@@ -116,6 +116,10 @@ The Layer Inspector displays inputs for\na selected layer from the layer sidebar
                                            font: stitchFont(.LAYER_INSPECTOR_TITLE_FONT_SIZE))
                                 .textCase(nil)
                                 .bold()
+                        #if targetEnvironment(macCatalyst)
+                                .padding(.top, PREVIEW_WINDOW_Y_PADDING - 12)
+                        #endif
+                        
                 ) {
                     EmptyView() // no rows here
                 }

--- a/Stitch/Graph/View/ContentView.swift
+++ b/Stitch/Graph/View/ContentView.swift
@@ -72,6 +72,8 @@ struct ContentView: View, KeyboardReadable {
 #if !targetEnvironment(macCatalyst)
                 .ignoresSafeArea(edges: showFullScreen.isTrue ? [.all] : [.bottom])
                 .ignoresSafeArea([.keyboard])
+#else
+                .ignoresSafeArea()
 #endif
         }
         


### PR DESCRIPTION
<img width="1440" height="900" alt="Screenshot 2025-10-07 at 7 02 31 PM" src="https://github.com/user-attachments/assets/11b45058-b936-444e-bb27-235db1102cc5" />
